### PR TITLE
BitWindow orchestrator core & sidechains (1 of 2): 15 fixes from a security review

### DIFF
--- a/bitwindow/lib/pages/settings/settings_network.dart
+++ b/bitwindow/lib/pages/settings/settings_network.dart
@@ -121,7 +121,7 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
     if (err != null) {
       showSailToast(
         context,
-        'Could not switch server (kept previous): $err',
+        'Could not switch server: $err',
         variant: SailToastVariant.destructive,
       );
       return;
@@ -142,7 +142,7 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
     if (err != null) {
       showSailToast(
         context,
-        'Could not reset server (kept previous): $err',
+        'Could not reset server: $err',
         variant: SailToastVariant.destructive,
       );
       return;
@@ -172,7 +172,7 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
     if (err != null) {
       showSailToast(
         context,
-        'Could not apply Tor config (kept previous): $err',
+        'Could not apply Tor config: $err',
         variant: SailToastVariant.destructive,
       );
       return;

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1849,6 +1849,8 @@ func (h *WalletHandler) SetElectrumServer(ctx context.Context, req *connect.Requ
 		}
 	}
 
+	prevURL, _ := h.engine.ElectrumServerURL()
+
 	tip, err := h.engine.SetElectrumServerURL(ctx, target)
 	if err != nil {
 		return nil, err
@@ -1860,7 +1862,19 @@ func (h *WalletHandler) SetElectrumServer(ctx context.Context, req *connect.Requ
 			persist = ""
 		}
 		if perr := h.orch.PersistElectrumServerURL(persist); perr != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("server switched but persisting it failed: %w", perr))
+			// The live swap already committed, so put the engine back on the
+			// previous endpoint rather than leaving it somewhere it won't
+			// remember after a restart.
+			rerr := errors.New("no previous server recorded")
+			if prevURL != "" {
+				_, rerr = h.engine.SetElectrumServerURL(ctx, prevURL)
+			}
+			if rerr != nil {
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf(
+					"persisting %s failed (%v) and restoring %s failed (%v); wallet is now on %s",
+					target, perr, prevURL, rerr, target))
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("could not persist electrum server, kept previous %s: %w", prevURL, perr))
 		}
 	}
 
@@ -1899,6 +1913,8 @@ func (h *WalletHandler) SetTorConfig(ctx context.Context, req *connect.Request[p
 		proxyAddr = orchestrator.DefaultTorProxy
 	}
 
+	prevEnabled, prevProxy, _ := h.engine.TorConfig()
+
 	tip, err := h.engine.SetTorConfig(ctx, req.Msg.Enabled, proxyAddr)
 	if err != nil {
 		return nil, err
@@ -1910,7 +1926,16 @@ func (h *WalletHandler) SetTorConfig(ctx context.Context, req *connect.Request[p
 			persistProxy = ""
 		}
 		if perr := h.orch.PersistTorConfig(req.Msg.Enabled, persistProxy); perr != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("tor routing switched but persisting it failed: %w", perr))
+			// The live swap already committed, so put the engine back on the
+			// previous routing rather than leaving it somewhere it won't
+			// remember after a restart.
+			if _, rerr := h.engine.SetTorConfig(ctx, prevEnabled, prevProxy); rerr != nil {
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf(
+					"persisting the tor config failed (%v) and restoring the previous one failed (%v); wallet is now on %s",
+					perr, rerr, torRouteDescription(req.Msg.Enabled, proxyAddr)))
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf(
+				"could not persist tor config, kept previous (%s): %w", torRouteDescription(prevEnabled, prevProxy), perr))
 		}
 	}
 
@@ -1919,6 +1944,14 @@ func (h *WalletHandler) SetTorConfig(ctx context.Context, req *connect.Request[p
 		Proxy:     proxyAddr,
 		TipHeight: int64(tip),
 	}), nil
+}
+
+// torRouteDescription names a Tor routing state for an error message.
+func torRouteDescription(enabled bool, proxyAddr string) string {
+	if !enabled {
+		return "no tor"
+	}
+	return "tor via " + proxyAddr
 }
 
 func coreVariantDisplayName(id string) string {

--- a/sidechain-orchestrator/api/wallet_handler_network_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_network_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// swappableEsplora is a psbtTestEsplora that also satisfies
+// SwappableChainSource, so the handler's runtime endpoint and proxy swaps
+// commit against it without a REST server.
+type swappableEsplora struct {
+	*psbtTestEsplora
+	urls       []string
+	torEnabled bool
+	torProxy   string
+}
+
+var _ wallet.SwappableChainSource = (*swappableEsplora)(nil)
+
+func (c *swappableEsplora) BaseURLs() []string { return append([]string(nil), c.urls...) }
+
+func (c *swappableEsplora) SetBaseURLs(urls []string) { c.urls = append([]string(nil), urls...) }
+
+func (c *swappableEsplora) ProxyConfig() (bool, string) { return c.torEnabled, c.torProxy }
+
+func (c *swappableEsplora) SetProxy(enabled bool, proxyAddr string) error {
+	c.torEnabled, c.torProxy = enabled, proxyAddr
+	return nil
+}
+
+const networkTestServerURL = "https://original.example/api"
+
+// newNetworkHandler wires the real engine over a swappable chain source, with
+// an orchestrator that has no settings store so every persist fails.
+func newNetworkHandler(t *testing.T) (*WalletHandler, *swappableEsplora) {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	svc := wallet.NewService(t.TempDir(), log)
+	require.NoError(t, svc.Init())
+	t.Cleanup(func() { svc.Close() })
+
+	net := &chaincfg.SigNetParams
+	chain := &swappableEsplora{psbtTestEsplora: &psbtTestEsplora{}, urls: []string{networkTestServerURL}}
+	eb := wallet.NewElectrumBackend(svc, chain, wallet.StaticParams(net), log)
+	engine := wallet.NewWalletEngine(svc, wallet.NewBackendRouter(svc, nil, eb), wallet.StaticParams(net), log)
+
+	h := NewWalletHandler(svc)
+	h.SetEngine(engine)
+	h.SetOrchestrator(&orchestrator.Orchestrator{})
+	return h, chain
+}
+
+// A failed persist must not leave the wallet on an endpoint it will forget at
+// the next restart: the live swap is rolled back and the error says so.
+func TestSetElectrumServerRollsBackWhenPersistFails(t *testing.T) {
+	h, chain := newNetworkHandler(t)
+
+	_, err := h.SetElectrumServer(context.Background(), connect.NewRequest(&pb.SetElectrumServerRequest{
+		Url: "https://new.example/api",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "kept previous "+networkTestServerURL)
+
+	url, uerr := h.engine.ElectrumServerURL()
+	require.NoError(t, uerr)
+	assert.Equal(t, networkTestServerURL, url)
+	assert.Equal(t, []string{networkTestServerURL}, chain.BaseURLs())
+}
+
+func TestSetTorConfigRollsBackWhenPersistFails(t *testing.T) {
+	h, chain := newNetworkHandler(t)
+
+	_, err := h.SetTorConfig(context.Background(), connect.NewRequest(&pb.SetTorConfigRequest{
+		Enabled: true,
+		Proxy:   "127.0.0.1:9050",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "kept previous (no tor)")
+
+	enabled, proxyAddr, terr := h.engine.TorConfig()
+	require.NoError(t, terr)
+	assert.False(t, enabled)
+	assert.Empty(t, proxyAddr)
+
+	onChain, _ := chain.ProxyConfig()
+	assert.False(t, onChain)
+}

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -20,6 +20,25 @@ const bitcoinConfVersionCommentPrefix = "# bitwindow-bitcoin-conf-version="
 // authoritative for the orchestrator on the next group swap.
 const datadirSlotCommentPrefix = "# bitwindow-datadir-"
 
+// multiValuedKeys are the options Bitcoin Core reads every occurrence of, so a
+// section may legitimately carry several lines for them.
+var multiValuedKeys = map[string]bool{
+	"addnode":     true,
+	"bind":        true,
+	"connect":     true,
+	"externalip":  true,
+	"includeconf": true,
+	"loadblock":   true,
+	"onlynet":     true,
+	"rpcallowip":  true,
+	"rpcauth":     true,
+	"rpcbind":     true,
+	"seednode":    true,
+	"wallet":      true,
+	"whitebind":   true,
+	"whitelist":   true,
+}
+
 // BitcoinConfig represents a parsed Bitcoin Core configuration file.
 //
 // Order matters: the conf editor and the user expect the on-disk order to be
@@ -31,7 +50,11 @@ type BitcoinConfig struct {
 	GlobalOrder     []string
 	NetworkSettings map[string]map[string]string // "main", "test", "signet", "regtest"
 	NetworkOrder    map[string][]string
-	ConfigVersion   int
+	// GlobalMulti/NetworkMulti hold every value of a multiValuedKeys key, in
+	// the order it was set. The settings maps above keep the first one.
+	GlobalMulti   map[string][]string
+	NetworkMulti  map[string]map[string][]string
+	ConfigVersion int
 	// DatadirSlots holds the per-group datadir snapshots read from / written
 	// to # bitwindow-datadir-<group>= comment lines. Keyed by DatadirGroup
 	// value ("default", "forknet"). Empty string = unset/cleared.
@@ -53,6 +76,13 @@ func NewBitcoinConfig() *BitcoinConfig {
 			"test":    nil,
 			"signet":  nil,
 			"regtest": nil,
+		},
+		GlobalMulti: make(map[string][]string),
+		NetworkMulti: map[string]map[string][]string{
+			"main":    {},
+			"test":    {},
+			"signet":  {},
+			"regtest": {},
 		},
 		ConfigVersion: 0,
 		DatadirSlots:  map[DatadirGroup]string{},
@@ -161,7 +191,9 @@ func (c *BitcoinConfig) Serialize() string {
 	if len(c.GlobalSettings) > 0 {
 		b.WriteString("# [common settings]\n")
 		for _, key := range c.orderedKeys("") {
-			fmt.Fprintf(&b, "%s=%s\n", key, c.GlobalSettings[key])
+			for _, value := range c.values(key, "") {
+				fmt.Fprintf(&b, "%s=%s\n", key, value)
+			}
 		}
 		b.WriteString("\n")
 	}
@@ -185,7 +217,9 @@ func (c *BitcoinConfig) Serialize() string {
 			fmt.Fprintf(&b, "# Options for %s only\n", label)
 			fmt.Fprintf(&b, "%s\n", sectionNames[network])
 			for _, key := range c.orderedKeys(network) {
-				fmt.Fprintf(&b, "%s=%s\n", key, settings[key])
+				for _, value := range c.values(key, network) {
+					fmt.Fprintf(&b, "%s=%s\n", key, value)
+				}
 			}
 			b.WriteString("\n")
 		}
@@ -225,6 +259,27 @@ func (c *BitcoinConfig) orderedKeys(section string) []string {
 	return out
 }
 
+// values returns every value stored for a key in a section (globals if
+// section == ""), in the order it was set. Single-valued keys yield one.
+func (c *BitcoinConfig) values(key, section string) []string {
+	if section != "" {
+		if vs := c.NetworkMulti[section][key]; len(vs) > 0 {
+			return vs
+		}
+		if v, ok := c.NetworkSettings[section][key]; ok {
+			return []string{v}
+		}
+		return nil
+	}
+	if vs := c.GlobalMulti[key]; len(vs) > 0 {
+		return vs
+	}
+	if v, ok := c.GlobalSettings[key]; ok {
+		return []string{v}
+	}
+	return nil
+}
+
 func (c *BitcoinConfig) GetSetting(key string, section ...string) string {
 	if len(section) > 0 && section[0] != "" {
 		if s, ok := c.NetworkSettings[section[0]]; ok {
@@ -245,6 +300,18 @@ func (c *BitcoinConfig) GetEffectiveSetting(key, network string) string {
 	return c.GlobalSettings[key]
 }
 
+// GetSettings returns every value stored for a key, in order. A multi-valued
+// key (see multiValuedKeys) may hold more than one.
+func (c *BitcoinConfig) GetSettings(key string, section ...string) []string {
+	if len(section) > 0 {
+		return c.values(key, section[0])
+	}
+	return c.values(key, "")
+}
+
+// SetSetting sets a key's value. A multi-valued key keeps the values already
+// set and appends this one, so a rewrite never drops a peer the user added;
+// use ReplaceSetting to collapse such a key to a single value.
 func (c *BitcoinConfig) SetSetting(key, value string, section ...string) {
 	if len(section) > 0 && section[0] != "" {
 		s := section[0]
@@ -253,14 +320,62 @@ func (c *BitcoinConfig) SetSetting(key, value string, section ...string) {
 		}
 		if _, exists := c.NetworkSettings[s][key]; !exists {
 			c.NetworkOrder[s] = append(c.NetworkOrder[s], key)
+			c.NetworkSettings[s][key] = value
+		} else if !multiValuedKeys[key] {
+			c.NetworkSettings[s][key] = value
 		}
-		c.NetworkSettings[s][key] = value
 	} else {
 		if _, exists := c.GlobalSettings[key]; !exists {
 			c.GlobalOrder = append(c.GlobalOrder, key)
+			c.GlobalSettings[key] = value
+		} else if !multiValuedKeys[key] {
+			c.GlobalSettings[key] = value
 		}
-		c.GlobalSettings[key] = value
 	}
+	if multiValuedKeys[key] {
+		c.appendValue(key, value, section...)
+	}
+}
+
+// ReplaceSetting sets a key to exactly this value, dropping any other values a
+// multi-valued key holds. Its position in the section is preserved.
+func (c *BitcoinConfig) ReplaceSetting(key, value string, section ...string) {
+	c.SetSetting(key, value, section...)
+	if !multiValuedKeys[key] {
+		return
+	}
+	if len(section) > 0 && section[0] != "" {
+		s := section[0]
+		c.NetworkSettings[s][key] = value
+		c.NetworkMulti[s][key] = []string{value}
+		return
+	}
+	c.GlobalSettings[key] = value
+	c.GlobalMulti[key] = []string{value}
+}
+
+// appendValue records value in the key's value list, ignoring a duplicate.
+func (c *BitcoinConfig) appendValue(key, value string, section ...string) {
+	multi := c.GlobalMulti
+	if len(section) > 0 && section[0] != "" {
+		s := section[0]
+		if c.NetworkMulti == nil {
+			c.NetworkMulti = make(map[string]map[string][]string)
+		}
+		if _, ok := c.NetworkMulti[s]; !ok {
+			c.NetworkMulti[s] = make(map[string][]string)
+		}
+		multi = c.NetworkMulti[s]
+	} else if multi == nil {
+		multi = make(map[string][]string)
+		c.GlobalMulti = multi
+	}
+	for _, v := range multi[key] {
+		if v == value {
+			return
+		}
+	}
+	multi[key] = append(multi[key], value)
 }
 
 func (c *BitcoinConfig) RemoveSetting(key string, section ...string) {
@@ -268,10 +383,12 @@ func (c *BitcoinConfig) RemoveSetting(key string, section ...string) {
 		s := section[0]
 		if settings, ok := c.NetworkSettings[s]; ok {
 			delete(settings, key)
+			delete(c.NetworkMulti[s], key)
 			c.NetworkOrder[s] = removeFromOrder(c.NetworkOrder[s], key)
 		}
 	} else {
 		delete(c.GlobalSettings, key)
+		delete(c.GlobalMulti, key)
 		c.GlobalOrder = removeFromOrder(c.GlobalOrder, key)
 	}
 }

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -186,7 +186,9 @@ func RunBitcoinConfMigrations(config *BitcoinConfig) (bool, []Network) {
 				if config.GetSetting(key, section) != value {
 					changed = true
 				}
-				config.SetSetting(key, value, section)
+				// Replace: a migration names the one value the key should
+				// carry, so appending would leave the superseded peer behind.
+				config.ReplaceSetting(key, value, section)
 			}
 		}
 		if changed {

--- a/sidechain-orchestrator/config/bitcoin_config_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Bitcoin Core reads every connect=/addnode= line, so a rewrite that keeps
+// only the last one leaves the node dialling a single peer.
+func TestSerializeKeepsEveryPeerLine(t *testing.T) {
+	conf := ParseBitcoinConfig(`chain=regtest
+
+[regtest]
+connect=10.0.0.1:18444
+connect=10.0.0.2:18444
+addnode=10.0.0.3:18444
+addnode=10.0.0.4:18444
+`)
+
+	require.Equal(t, []string{"10.0.0.1:18444", "10.0.0.2:18444"}, conf.GetSettings("connect", "regtest"))
+	require.Equal(t, "10.0.0.1:18444", conf.GetSetting("connect", "regtest"))
+
+	serialized := conf.Serialize()
+	require.Contains(t, serialized,
+		"connect=10.0.0.1:18444\nconnect=10.0.0.2:18444\naddnode=10.0.0.3:18444\naddnode=10.0.0.4:18444\n")
+
+	// A second round-trip must be stable, not accumulate or drop lines.
+	require.Equal(t, serialized, ParseBitcoinConfig(serialized).Serialize())
+}
+
+// ReplaceSetting is what a caller with a single authoritative value uses; it
+// drops the other values instead of appending to them.
+func TestReplaceSettingCollapsesAMultiValuedKey(t *testing.T) {
+	conf := ParseBitcoinConfig("[signet]\naddnode=1.2.3.4:38333\naddnode=5.6.7.8:38333\n")
+
+	conf.ReplaceSetting("addnode", "9.9.9.9:38333", "signet")
+
+	require.Equal(t, []string{"9.9.9.9:38333"}, conf.GetSettings("addnode", "signet"))
+	require.Equal(t, 1, strings.Count(conf.Serialize(), "addnode="))
+}
+
+// Every network swap and datadir pick rewrites the whole file. Single-valued
+// keys are replaced; the peers the user added must survive.
+func TestConfigRewritesKeepUserPeers(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	m := newTestManager(tmpDir)
+	m.Config = ParseBitcoinConfig(fmt.Sprintf(
+		"%s%d\nchain=signet\n\n[signet]\naddnode=1.2.3.4:38333\naddnode=5.6.7.8:38333\n",
+		bitcoinConfVersionCommentPrefix, BitcoinConfMigrationsVersion,
+	))
+
+	require.NoError(t, m.UpdateNetwork(NetworkRegtest))
+	require.NoError(t, m.UpdateDataDir(filepath.Join(tmpDir, "chain"), NetworkRegtest))
+
+	onDisk, err := os.ReadFile(m.getBitWindowConfigPath())
+	require.NoError(t, err)
+	require.Contains(t, string(onDisk), "addnode=1.2.3.4:38333\naddnode=5.6.7.8:38333\n")
+	require.Equal(t, 1, strings.Count(string(onDisk), "\nchain="))
+	require.Equal(t, 1, strings.Count(string(onDisk), "\ndatadir="))
+}

--- a/sidechain-orchestrator/config/enforcer_conf.go
+++ b/sidechain-orchestrator/config/enforcer_conf.go
@@ -35,11 +35,49 @@ var derivedEnforcerSettings = []string{
 	"network-preset",
 }
 
+// enforcerKnownKeys are the settings the shipped enforcer accepts as CLI
+// flags. Its argument parser exits on an unknown option, so GetCliArgs drops
+// anything outside this set rather than bricking the daemon on a key an old
+// conf still carries.
+var enforcerKnownKeys = map[string]bool{
+	"coinbase-recipient":             true,
+	"data-dir":                       true,
+	"enable-block-template-server":   true,
+	"enable-mempool":                 true,
+	"exit-after-sync":                true,
+	"log-directory":                  true,
+	"log-format":                     true,
+	"log-level":                      true,
+	"log-rotation":                   true,
+	"max-log-file-size-mb":           true,
+	"max-log-files":                  true,
+	"network-preset":                 true,
+	"node-blocks-dir":                true,
+	"node-rpc-addr":                  true,
+	"node-rpc-cookie-path":           true,
+	"node-rpc-pass":                  true,
+	"node-rpc-user":                  true,
+	"node-zmq-addr-sequence":         true,
+	"serve-grpc-addr":                true,
+	"serve-rpc-addr":                 true,
+	"signet-miner-bitcoin-cli-path":  true,
+	"signet-miner-bitcoin-util-path": true,
+	"signet-miner-script-debug":      true,
+	"signet-miner-script-path":       true,
+	"wallet-auto-create":             true,
+	"wallet-electrum-host":           true,
+	"wallet-electrum-port":           true,
+	"wallet-esplora-url":             true,
+	"wallet-seed-file":               true,
+	"wallet-skip-periodic-sync":      true,
+	"wallet-sync-source":             true,
+}
+
 // ---------------------------------------------------------------------------
 // Migration system (Dart: _kEnforcerConfVersion, _enforcerConfMigrations)
 // ---------------------------------------------------------------------------
 
-const enforcerConfMigrationsVersion = 3
+const enforcerConfMigrationsVersion = 4
 
 // EnforcerConfMigration represents a versioned enforcer config migration.
 type EnforcerConfMigration struct {
@@ -62,6 +100,16 @@ var enforcerConfMigrations = []EnforcerConfMigration{
 			// argv without it. A hand-set false would make the enforcer
 			// reject its own arguments.
 			config.SetSetting("enable-mempool", "true")
+		},
+	},
+	{
+		// The enforcer dropped these three flags and exits on an unknown
+		// option, so a conf that still carries one never starts.
+		Version: 4,
+		Apply: func(config *EnforcerConfig) {
+			config.RemoveSetting("serve-json-rpc-addr")
+			config.RemoveSetting("wallet-full-scan")
+			config.RemoveSetting("signet-miner-coinbase-recipient")
 		},
 	},
 }
@@ -295,6 +343,12 @@ func (m *EnforcerConfManager) GetCliArgs() []string {
 
 	if m.Config != nil {
 		for key, value := range m.Config.Settings {
+			// The enforcer exits on an unknown option, so a key it does not
+			// accept is dropped instead of bricking the whole daemon.
+			if !enforcerKnownKeys[key] {
+				m.log.Warn().Str("key", key).Msg("dropping enforcer setting the binary does not accept")
+				continue
+			}
 			switch value {
 			case "true":
 				args = append(args, fmt.Sprintf("--%s", key))

--- a/sidechain-orchestrator/config/enforcer_conf_migration_test.go
+++ b/sidechain-orchestrator/config/enforcer_conf_migration_test.go
@@ -32,3 +32,21 @@ func TestMigrationRunsTwiceAndKeepsAHandSetValue(t *testing.T) {
 	assert.Equal(t, "true", c.GetSetting("enable-mempool"),
 		"the template server needs the mempool, so clap would reject the argv without it")
 }
+
+// The enforcer dropped these flags and exits on an unknown option, so an
+// existing conf that still lists one must self-heal on load.
+func TestMigrationDropsFlagsTheEnforcerRemoved(t *testing.T) {
+	c := &EnforcerConfig{ConfigVersion: 3, Settings: map[string]string{}}
+	c.SetSetting("serve-json-rpc-addr", "127.0.0.1:8123")
+	c.SetSetting("wallet-full-scan", "true")
+	c.SetSetting("signet-miner-coinbase-recipient", "tb1qexample")
+	c.SetSetting("serve-rpc-addr", "127.0.0.1:8122")
+
+	require.True(t, RunEnforcerConfMigrations(c))
+
+	assert.Empty(t, c.GetSetting("serve-json-rpc-addr"))
+	assert.Empty(t, c.GetSetting("wallet-full-scan"))
+	assert.Empty(t, c.GetSetting("signet-miner-coinbase-recipient"))
+	assert.Equal(t, "127.0.0.1:8122", c.GetSetting("serve-rpc-addr"), "a flag it still accepts stays")
+	assert.Equal(t, 4, c.ConfigVersion)
+}

--- a/sidechain-orchestrator/config/enforcer_conf_test.go
+++ b/sidechain-orchestrator/config/enforcer_conf_test.go
@@ -232,6 +232,26 @@ func TestGetCliArgs(t *testing.T) {
 	}
 }
 
+// The enforcer exits on an unknown option, so a settings file that still
+// carries a flag it dropped must not reach the argv — one stale key would
+// otherwise keep the daemon from ever starting.
+func TestGetCliArgsDropsKeysTheEnforcerDoesNotAccept(t *testing.T) {
+	m, _ := newTestEnforcerManager(t)
+	require.NoError(t, m.LoadConfig())
+
+	m.Config.SetSetting("serve-json-rpc-addr", "127.0.0.1:8123")
+	m.Config.SetSetting("wallet-full-scan", "true")
+	m.Config.SetSetting("signet-miner-coinbase-recipient", "tb1qexample")
+	m.Config.SetSetting("serve-rpc-addr", "127.0.0.1:8122")
+
+	args := m.GetCliArgs()
+
+	rejectArgPrefix(t, args, "--serve-json-rpc-addr")
+	rejectArgPrefix(t, args, "--wallet-full-scan")
+	rejectArgPrefix(t, args, "--signet-miner-coinbase-recipient")
+	requireArg(t, args, "--serve-rpc-addr=127.0.0.1:8122")
+}
+
 // Regression for #1712 ("Enforcer startup errors due to password and cookie
 // mixups"). The enforcer dies at startup with "precisely one of rpc user and
 // cookie must be set" when --node-rpc-user / --node-rpc-pass don't reach it.
@@ -350,7 +370,7 @@ func TestEnforcerGetDefaultConfigHasVersionPrefix(t *testing.T) {
 	m, _ := newTestEnforcerManager(t)
 
 	conf := m.GetDefaultConfig()
-	prefix := "# bitwindow-enforcer-conf-version=3"
+	prefix := "# bitwindow-enforcer-conf-version=4"
 	if !strings.HasPrefix(conf, prefix) {
 		first := conf
 		if len(first) > 80 {

--- a/sidechain-orchestrator/config/sidechain_conf.go
+++ b/sidechain-orchestrator/config/sidechain_conf.go
@@ -28,6 +28,9 @@ type SidechainConfSpec struct {
 	PortStyle string
 	// DirKey is the chains_config.json key for the data directory lookup.
 	DirKey string
+	// ConfOnly marks a conf the daemon never receives on its command line.
+	// Elements takes Core-style -flags and exits on an unknown --option.
+	ConfOnly bool
 }
 
 // SidechainConfManager manages a sidechain's key-value config file.
@@ -391,7 +394,7 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		Name:           "Thunder",
 		ConfigFilename: "thunder.conf",
 		BasePort:       6009,
-		SkippedCliKeys: []string{"network"},
+		SkippedCliKeys: nil,
 		PortStyle:      "grpc",
 		DirKey:         "thunder",
 	},
@@ -415,7 +418,7 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		Name:           "ZSide",
 		ConfigFilename: "zside.conf",
 		BasePort:       6098,
-		SkippedCliKeys: []string{"network"},
+		SkippedCliKeys: nil,
 		PortStyle:      "grpc",
 		DirKey:         "zside",
 	},
@@ -423,7 +426,7 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		Name:           "Photon",
 		ConfigFilename: "photon.conf",
 		BasePort:       6099,
-		SkippedCliKeys: []string{"network"},
+		SkippedCliKeys: nil,
 		PortStyle:      "grpc",
 		DirKey:         "photon",
 	},
@@ -431,7 +434,7 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		Name:           "Truthcoin",
 		ConfigFilename: "truthcoin.conf",
 		BasePort:       6013,
-		SkippedCliKeys: []string{"network"},
+		SkippedCliKeys: nil,
 		PortStyle:      "grpc",
 		DirKey:         "truthcoin",
 	},
@@ -439,7 +442,7 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		Name:           "CoinShift",
 		ConfigFilename: "coinshift.conf",
 		BasePort:       6255,
-		SkippedCliKeys: []string{"network"},
+		SkippedCliKeys: nil,
 		PortStyle:      "grpc",
 		DirKey:         "coinshift",
 	},
@@ -450,5 +453,6 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		SkippedCliKeys: []string{"network"},
 		PortStyle:      "grpc",
 		DirKey:         "liquid-signet",
+		ConfOnly:       true,
 	},
 }

--- a/sidechain-orchestrator/config/sidechain_conf_test.go
+++ b/sidechain-orchestrator/config/sidechain_conf_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The CUSF sidechains default to signet when launched without --network, so
+// GetCliArgs has to emit the conf's value.
+func TestSidechainCliArgsCarryNetwork(t *testing.T) {
+	for _, name := range []string{"thunder", "bitassets", "bitnames", "zside", "photon", "truthcoin", "coinshift"} {
+		m := &SidechainConfManager{
+			Spec:   KnownSidechainSpecs[name],
+			Config: ParseGenericAppConfig("network=regtest\n"),
+		}
+		require.Contains(t, m.GetCliArgs(), "--network=regtest", name)
+		require.False(t, KnownSidechainSpecs[name].ConfOnly, name)
+	}
+
+	// Elements is the exception: Core-style -flags, and it exits on an
+	// unknown --option, so none of its conf may reach the command line.
+	require.True(t, KnownSidechainSpecs["liquid-signet"].ConfOnly)
+}

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -161,6 +161,18 @@ func NewConnectionMonitor(name string, checker HealthChecker, startupPatterns []
 	}
 }
 
+// ReplaceChecker rebinds the monitor to a new endpoint — a network swap moves
+// bitcoind's RPC port, and the monitor has to follow it. The ping epoch bumps
+// so a check still in flight against the old endpoint is discarded.
+func (m *ConnectionMonitor) ReplaceChecker(checker HealthChecker, startupPatterns []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.pingEpoch++
+	m.Checker = checker
+	m.startupPatterns = startupPatterns
+}
+
 // AddStartupLog appends a startup progress message. Keeps the last 20.
 // Dart: Binary.addStartupLog
 func (m *ConnectionMonitor) AddStartupLog(ts time.Time, msg string) {
@@ -342,6 +354,7 @@ func (m *ConnectionMonitor) testConnection(ctx context.Context) {
 	oldConnErr := m.connectionError
 	oldStartupErr := m.startupError
 	isConnectModeOnly := m.connectModeOnly
+	checker := m.Checker
 
 	m.mu.Unlock()
 
@@ -357,7 +370,7 @@ func (m *ConnectionMonitor) testConnection(ctx context.Context) {
 		m.mu.Unlock()
 	}()
 
-	err := m.Checker.Check(ctx)
+	err := checker.Check(ctx)
 
 	m.mu.Lock()
 

--- a/sidechain-orchestrator/connection_monitor_test.go
+++ b/sidechain-orchestrator/connection_monitor_test.go
@@ -161,6 +161,72 @@ func TestConnectionMonitor_PingEpoch_DiscardsStaleResult(t *testing.T) {
 	mon.mu.Unlock()
 }
 
+// --- ReplaceChecker tests ---
+
+// blockingChecker parks inside Check until released, so a test can swap the
+// monitor's checker while a ping is in flight.
+type blockingChecker struct {
+	calls   atomic.Int32
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingChecker) Check(_ context.Context) error {
+	b.calls.Add(1)
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
+	<-b.release
+	return nil
+}
+
+func TestConnectionMonitor_ReplaceChecker_PollsNewEndpoint(t *testing.T) {
+	// A network swap rebinds the monitor to the new network's RPC port.
+	old := &blockingChecker{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	mon := newTestMonitor(t, old, nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		mon.testConnection(context.Background())
+	}()
+	<-old.entered
+
+	fresh := &mockChecker{}
+	fresh.healthy.Store(true)
+	mon.ReplaceChecker(fresh, bitcoindStartupPatterns)
+
+	// The old endpoint's late success belongs to the previous epoch.
+	close(old.release)
+	<-done
+	assert.False(t, mon.Connected())
+
+	mon.testConnection(context.Background())
+	assert.True(t, mon.Connected())
+	assert.Equal(t, int32(1), old.calls.Load())
+}
+
+func TestGetOrCreateMonitor_CachedMonitorTakesNewChecker(t *testing.T) {
+	// Every start path builds a checker from the live config and hands it to
+	// getOrCreateMonitor. After a network swap that checker points at the new
+	// network, so a cached monitor must stop polling the old one.
+	o := newTestOrchestrator(t)
+
+	old := &mockChecker{}
+	old.healthy.Store(true)
+	mon := o.getOrCreateMonitor("bitcoind", old, bitcoindStartupPatterns)
+	mon.testConnection(context.Background())
+	require.True(t, mon.Connected())
+
+	// Nothing answers on the new network yet.
+	fresh := &mockChecker{}
+	require.Same(t, mon, o.getOrCreateMonitor("bitcoind", fresh, bitcoindStartupPatterns))
+
+	mon.testConnection(context.Background())
+	assert.False(t, mon.Connected())
+}
+
 // --- StartConnectionTimer tests ---
 
 func TestConnectionMonitor_StartConnectionTimer_ImmediateConnect(t *testing.T) {

--- a/sidechain-orchestrator/core_rpc.go
+++ b/sidechain-orchestrator/core_rpc.go
@@ -388,12 +388,9 @@ func (c *CoreStatusClient) Stop(ctx context.Context) error {
 
 // callWallet calls a method on a specific wallet using the /wallet/<name> URL path.
 func (c *CoreStatusClient) callWallet(ctx context.Context, walletName, method string, params ...interface{}) (json.RawMessage, error) {
-	origURL := c.url
-	c.url = fmt.Sprintf("%s/wallet/%s", origURL, walletName)
-	defer func() { c.url = origURL }()
-
 	if params == nil {
 		params = []interface{}{}
 	}
-	return c.call(ctx, method, params...)
+	walletURL := fmt.Sprintf("%s/wallet/%s", c.url, walletName)
+	return CallBitcoindRPC(ctx, walletURL, c.user, c.password, method, params)
 }

--- a/sidechain-orchestrator/core_rpc_test.go
+++ b/sidechain-orchestrator/core_rpc_test.go
@@ -1,0 +1,65 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callWallet must route each call to /wallet/<name> without mutating shared
+// client state — concurrent callers on one CoreStatusClient would otherwise
+// nest paths or hit the wrong wallet.
+func TestCallWalletConcurrentRouting(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"result":"addr-for%s","error":null,"id":1}`, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := &CoreStatusClient{url: srv.URL, user: "user", password: "pass"}
+
+	const iterations = 20
+	wallets := []string{"alice", "bob"}
+	got := make([]string, len(wallets)*iterations)
+
+	var wg sync.WaitGroup
+	for i, wallet := range wallets {
+		for n := 0; n < iterations; n++ {
+			wg.Add(1)
+			go func(idx int, wallet string) {
+				defer wg.Done()
+				address, err := c.GetNewAddress(context.Background(), wallet)
+				assert.NoError(t, err)
+				got[idx] = address
+			}(i*iterations+n, wallet)
+		}
+	}
+	wg.Wait()
+
+	for i, wallet := range wallets {
+		for n := 0; n < iterations; n++ {
+			assert.Equal(t, "addr-for/wallet/"+wallet, got[i*iterations+n])
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, paths, len(wallets)*iterations)
+	for _, path := range paths {
+		assert.Contains(t, []string{"/wallet/alice", "/wallet/bob"}, path)
+	}
+	assert.Equal(t, srv.URL, c.url)
+}

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -294,6 +294,17 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		case err == nil:
 			dropped = hash
 		case errors.Is(err, errNoLiveCore):
+			// A mark an earlier switch left bars a branch only a live Core can
+			// lift, and the target's own ancestor may be it. Committing would
+			// park Core under the fork with no chain left to follow.
+			if mark := o.outstandingMark(); mark != "" {
+				o.restartAfterAbort(ctx, restartL1, stoppedL2)
+				return fmt.Errorf(
+					"start bitcoin core first: block %s stays barred from an earlier switch, "+
+						"and only a live core lifts it",
+					mark,
+				)
+			}
 			// The chain stays as it is. Core reorganises to the new network on
 			// its own once it runs, and the blocks below the fork are shared.
 			o.log.Warn().Uint32("rewind_height", plan.RewindHeight).
@@ -404,6 +415,15 @@ func (o *Orchestrator) ApplyPendingEnforcerWipe() error {
 
 // errNoLiveCore says the rollback found no Bitcoin Core to talk to.
 var errNoLiveCore = errors.New("no live bitcoin core")
+
+// outstandingMark is the block an earlier switch barred and nothing has lifted,
+// empty when no branch is barred.
+func (o *Orchestrator) outstandingMark() string {
+	if o.Settings == nil {
+		return ""
+	}
+	return o.Settings.RewoundBlockHash()
+}
 
 // rewindBelowTheFork leaves the chain at height and drops what sits above it,
 // so Core follows the new eCash network from there.

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -112,6 +112,11 @@ func (o *Orchestrator) RetargetECashEnforcerConf(previousID string) {
 // follows writes bitcoin.conf and starts binaries, and both read the id from
 // here, so a stale one boots the network the user just left.
 func (o *Orchestrator) AdoptECashID(id string) {
+	// The chain is cold here, so nothing can drop what the retired fork added.
+	// Journalled instead: left on disk with no record, those blocks outrank the
+	// new network's and Core follows the chain the user just left.
+	o.journalOwedRewind(id)
+
 	// Logged, not returned: the swap that follows writes the conf sentinel, and
 	// that sentinel names the network this install runs.
 	if err := o.recordECashChain(id); err != nil {
@@ -135,6 +140,47 @@ func (o *Orchestrator) AdoptECashID(id string) {
 	if o.BitcoinConf != nil {
 		o.BitcoinConf.ECashID = id
 	}
+}
+
+// ecashChainOnDisk names the eCash network the blocks on disk belong to. A
+// cold pick moves the records and not the chain, so a drop already owed names
+// them; otherwise the chain record does.
+func (o *Orchestrator) ecashChainOnDisk() string {
+	if o.Settings == nil {
+		return ""
+	}
+	if _, _, owed := o.Settings.PendingRewind(); owed != "" {
+		return owed
+	}
+	return o.Settings.ECashChainID()
+}
+
+// journalOwedRewind records the drop a pick made from another network cannot
+// make, so the first Core that runs on the picked network makes it. Every write
+// is logged, not returned, like the chain record the callers make next.
+func (o *Orchestrator) journalOwedRewind(id string) {
+	if o.Settings == nil || id == "" {
+		return
+	}
+	from := o.ecashChainOnDisk()
+	if from == id {
+		// The pick comes back to the network that wrote the blocks, so nothing
+		// above the fork is another network's to drop.
+		if err := o.Settings.SetPendingRewind(0, "", ""); err != nil {
+			o.log.Warn().Err(err).Msg("could not clear the rewind the eCash pick no longer owes")
+		}
+		return
+	}
+	height, ok := o.sharedECashHeight(from, id)
+	if !ok {
+		return
+	}
+	if err := o.Settings.SetPendingRewind(height, id, from); err != nil {
+		o.log.Warn().Err(err).Msg("could not record the rewind the eCash pick owes")
+		return
+	}
+	o.log.Info().Str("network", id).Uint32("rewind_height", height).
+		Msg("the chain is cold, so the eCash rewind waits for the next start")
 }
 
 // resumeECashSwitch finishes a switch that moved the chain but stopped before
@@ -245,6 +291,12 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	// A tail an earlier switch left lands first. Its records still name the fork
 	// that switch moved from, and every path below can consume the note.
 	if err := o.drainECashTail(); err != nil {
+		return err
+	}
+
+	// A drop a cold pick journalled lands first: it is owed on the network this
+	// install already runs, and it stands whether or not the switch below does.
+	if err := o.applyPendingRewind(ctx); err != nil {
 		return err
 	}
 
@@ -409,6 +461,63 @@ func (o *Orchestrator) ApplyPendingEnforcerWipe() error {
 	}
 	if err := o.Settings.SetPendingEnforcerWipe(""); err != nil {
 		return fmt.Errorf("clear the journalled enforcer cleanup: %w", err)
+	}
+	return nil
+}
+
+// ApplyPendingRewind makes the drop a cold pick journalled, once a Core answers
+// on the network that pick named. Call it from the L1 boot: it is the first
+// moment anything can rewind a chain the pick could only record.
+func (o *Orchestrator) ApplyPendingRewind(ctx context.Context) error {
+	o.swapNetworkMu.Lock()
+	defer o.swapNetworkMu.Unlock()
+	return o.applyPendingRewind(ctx)
+}
+
+// applyPendingRewind is ApplyPendingRewind's body. The record stays until the
+// drop lands, so a start with no Core leaves the work for the next one.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) applyPendingRewind(ctx context.Context) error {
+	if o.Settings == nil {
+		return nil
+	}
+	height, recorded, _ := o.Settings.PendingRewind()
+	if recorded == "" {
+		return nil
+	}
+	// Off eCash the Core that answers follows another network, and a drop there
+	// costs the user the chain they are on. The record waits for the start that
+	// brings the picked network up.
+	if config.NetworkFromString(o.Network) != config.NetworkECash {
+		return nil
+	}
+	o.mu.RLock()
+	running := o.ecashID
+	o.mu.RUnlock()
+
+	// The record goes in before the pick lands, so a request that failed after
+	// it leaves one for a move that never happened.
+	if running != recorded {
+		o.log.Info().
+			Str("recorded_for", recorded).
+			Str("running", running).
+			Msg("the eCash selection never moved, dropping the owed rewind")
+		return o.Settings.SetPendingRewind(0, "", "")
+	}
+
+	if _, err := o.rewindBelowTheFork(ctx, height); err != nil {
+		if errors.Is(err, errNoLiveCore) {
+			// Still owed. The blocks below the fork are shared either way, so
+			// the chain stays as it is until a Core answers.
+			o.log.Warn().Uint32("rewind_height", height).
+				Msg("no live bitcoin core, so the owed rewind waits")
+			return nil
+		}
+		return fmt.Errorf("rewind to block %d: %w", height, err)
+	}
+	if err := o.Settings.SetPendingRewind(0, "", ""); err != nil {
+		return fmt.Errorf("clear the journalled rewind: %w", err)
 	}
 	return nil
 }

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -309,6 +309,29 @@ func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {
 	require.Equal(t, "alphanet", o.installedECashNetwork())
 }
 
+// A mark an earlier switch left bars a branch that may be the target's own, and
+// only a live Core lifts it. Committing with Core down points this install at a
+// chain Core can never follow, and the same-target retry skips the rewind.
+func TestApplyECashSwitchRefusesOfflineWhenAMarkStaysBarred(t *testing.T) {
+	o := newTestOrchestrator(t)
+	datadir := t.TempDir()
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, datadir)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.Settings.SetRewoundBlockHash(staleMark))
+
+	err := o.ApplyECashSwitch(context.Background(), "alphanet")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), staleMark, "the error has to name the barred block")
+
+	require.Equal(t, "drynet4", o.ecashID, "the old network stays selected")
+	require.Equal(t, "drynet4", o.installedECashNetwork(), "the conf keeps naming it")
+	require.Equal(t, "drynet4", o.Settings.ECashChainID())
+	require.Empty(t, o.Settings.PendingEnforcerWipe(), "a refused switch journals no cleanup")
+	require.Equal(t, staleMark, o.Settings.RewoundBlockHash(), "the mark waits for a live core")
+}
+
 // No published fork height leaves nothing to rewind to, so the switch refuses
 // and the chain stays where it is.
 func TestApplyECashSwitchKeepsTheChainWithNoPublishedForkHeight(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -451,6 +451,65 @@ func TestAdoptECashIDMovesTheInMemoryState(t *testing.T) {
 	require.EqualValues(t, 963648, config.PublishedForkHeight(config.NetworkECash))
 }
 
+// Off eCash the chain is cold and no Core can drop what the retired fork added.
+// Left with no record, those blocks outrank the picked network's and the start
+// that follows serves the chain the user just left.
+func TestAdoptECashIDJournalsTheRewindTheColdPickOwes(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NotEqual(t, string(config.NetworkECash), o.Network)
+
+	o.AdoptECashID("alphanet")
+
+	height, forID, fromID := o.Settings.PendingRewind()
+	require.EqualValues(t, 961631, height, "the last block the two networks share")
+	require.Equal(t, "alphanet", forID)
+	require.Equal(t, "drynet4", fromID, "the blocks above that height are drynet4's")
+}
+
+// Staying on the network this install runs drops nothing, so it may not leave a
+// rewind behind for the next start to make.
+func TestAdoptECashIDOwesNoRewindForTheRunningNetwork(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	o.AdoptECashID("drynet4")
+
+	_, forID, _ := o.Settings.PendingRewind()
+	require.Empty(t, forID)
+}
+
+// A cold pick moves the records, not the chain. A pick that comes back to the
+// network that wrote the blocks owes nothing — and dropping them would bar the
+// user's own chain below the fork for good.
+func TestAdoptECashIDClearsTheRewindOnTheWayBack(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	o.AdoptECashID("alphanet")
+
+	o.AdoptECashID("drynet4")
+
+	_, forID, fromID := o.Settings.PendingRewind()
+	require.Empty(t, forID, "the blocks on disk are the picked network's own")
+	require.Empty(t, fromID)
+}
+
+// The blocks stay with the network that wrote them across every cold pick, so
+// the next one rewinds to what it shares with that network, not with the pick
+// before it.
+func TestAdoptECashIDKeepsTheForkTheBlocksBelongTo(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	o.AdoptECashID("alphanet")
+
+	o.AdoptECashID("alphanet2")
+
+	height, forID, fromID := o.Settings.PendingRewind()
+	require.EqualValues(t, 961631, height, "drynet4 wrote the blocks, so its fork height is the floor")
+	require.Equal(t, "alphanet2", forID)
+	require.Equal(t, "drynet4", fromID)
+}
+
 // attachFakeCore points the orchestrator's Core RPC at a stub and reports the
 // calls it receives. The client is cached behind a key, so seeding both makes
 // CoreStatusClient hand back the stub.
@@ -583,6 +642,86 @@ func TestApplyECashSwitchRewindsAndLandsTheTarget(t *testing.T) {
 	require.Equal(t, "alphanet", o.RunningECashID(ecashCatalog()))
 	require.Equal(t, forkBlock, o.Settings.RewoundBlockHash())
 	require.Nil(t, o.pendingSwap, "a tail that lands leaves nothing pending")
+}
+
+// The journalled drop is what the first live Core owes: it bars the retired
+// fork's first block, records it and clears the journal.
+func TestApplyPendingRewindDropsTheForkTheColdPickLeft(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	require.NoError(t, o.Settings.SetPendingRewind(961631, "alphanet", "drynet4"))
+
+	core := &fakeCore{tips: []int64{979000}, hashes: map[int64]string{979000: tipBlock, 961632: forkBlock}}
+	attachFakeCore(t, o, core)
+	o.process.AdoptProcess(o.configs["bitcoind"], 1)
+
+	require.NoError(t, o.ApplyPendingRewind(context.Background()))
+
+	require.Equal(t, []string{"invalidateblock"}, marks(core))
+	require.Equal(t, []string{forkBlock}, markParams(core), "the first divergent block goes")
+	require.Equal(t, forkBlock, o.Settings.RewoundBlockHash())
+	height, forID, fromID := o.Settings.PendingRewind()
+	require.Zero(t, height)
+	require.Empty(t, forID, "a drop that landed leaves nothing owed")
+	require.Empty(t, fromID)
+}
+
+// A start that brings no Core up cannot make the drop. The blocks below the
+// fork are shared either way, so the record waits rather than being lost.
+func TestApplyPendingRewindKeepsTheRecordWithNoLiveCore(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	require.NoError(t, o.Settings.SetPendingRewind(961631, "alphanet", "drynet4"))
+
+	require.NoError(t, o.ApplyPendingRewind(context.Background()))
+
+	height, forID, _ := o.Settings.PendingRewind()
+	require.EqualValues(t, 961631, height)
+	require.Equal(t, "alphanet", forID, "the next start still owes the drop")
+}
+
+// The Core that answers off eCash follows the network the user is on, so
+// barring a block there costs them that chain. The record waits for the start
+// that brings the picked network up.
+func TestApplyPendingRewindSparesACoreOnAnotherNetwork(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	require.NoError(t, o.Settings.SetPendingRewind(961631, "alphanet", "drynet4"))
+
+	core := &fakeCore{tips: []int64{979000}, hashes: map[int64]string{979000: tipBlock, 961632: forkBlock}}
+	attachFakeCore(t, o, core)
+	o.process.AdoptProcess(o.configs["bitcoind"], 1)
+
+	require.NoError(t, o.ApplyPendingRewind(context.Background()))
+
+	require.Empty(t, core.methods, "no block may go on the network the user is on")
+	_, forID, _ := o.Settings.PendingRewind()
+	require.Equal(t, "alphanet", forID, "the record waits for the network it names")
+}
+
+// A record left by a pick that never landed names a network this install does
+// not run. Making that drop would bar a block on the chain it does.
+func TestApplyPendingRewindDropsARecordForAPickThatNeverLanded(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.Settings.SetPendingRewind(961631, "alphanet", "drynet4"))
+
+	core := &fakeCore{tips: []int64{979000}, hashes: map[int64]string{979000: tipBlock, 961632: forkBlock}}
+	attachFakeCore(t, o, core)
+	o.process.AdoptProcess(o.configs["bitcoind"], 1)
+
+	require.NoError(t, o.ApplyPendingRewind(context.Background()))
+
+	require.Empty(t, core.methods, "the running network's chain stays as it is")
+	_, forID, _ := o.Settings.PendingRewind()
+	require.Empty(t, forID)
 }
 
 // The conf goes before Core stops, so a failure there can still put the drop

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -146,15 +146,16 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 		}
 	} else {
 		// Off eCash no Core answers, so nothing rewinds and the blocks stay.
-		// The network this install runs, not the document's first row: a user on
-		// a retained entry holds that chain.
-		o.mu.RLock()
-		served := o.Catalog
-		o.mu.RUnlock()
-		if !o.ecashChangeHasASharedBlock(o.RunningECashID(served), target) {
+		// The network whose blocks are on disk, not the document's first row: a
+		// user on a retained entry holds that chain.
+		if !o.ecashChangeHasASharedBlock(o.ecashChainOnDisk(), target) {
 			o.restoreECashPick(previousPick)
 			return fmt.Errorf("no fork height says where the two eCash chains part")
 		}
+		// Those blocks are the outgoing network's, and the pick alone leaves
+		// them outranking the confirmed network's. Journalled, so the first Core
+		// that runs on it drops them.
+		o.journalOwedRewind(target)
 	}
 	o.log.Info().
 		Str("current", config.ECashNetworkID()).
@@ -236,6 +237,11 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 	if id == "" {
 		o.log.Warn().Msg("network catalog carries no eCash network, eCash downloads will not resolve")
 	}
+
+	// A pick that reached the settings file and nothing else left the blocks on
+	// the network the record names. Journalled before the record below is moved
+	// onto the pick, because that record is the only thing that still says so.
+	o.journalOwedRewind(id)
 
 	// Logged, not returned: a start moves no chain, and the conf sentinel the
 	// swap writes still names the network this install runs.

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -240,6 +240,42 @@ func TestConfirmWorksFromAnotherNetwork(t *testing.T) {
 	require.Equal(t, string(config.NetworkMainnet), o.Network, "the active network must be left alone")
 }
 
+// The blocks the retired fork added survive that confirm, and with no record
+// they outrank the confirmed network's: the start that follows serves the chain
+// the user just left.
+func TestConfirmFromAnotherNetworkJournalsTheOwedRewind(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+
+	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
+
+	height, forID, fromID := o.Settings.PendingRewind()
+	require.Equal(t, "drynet3", forID, "the drop is owed on the confirmed network")
+	require.Equal(t, "drynet2", fromID, "the blocks above it are drynet2's")
+	require.NotZero(t, height, "the last block the two networks share")
+}
+
+// A pick that reached the settings file and nothing else is adopted by the next
+// start. That start is the last moment anything still knows which network wrote
+// the blocks, because it moves the record onto the pick.
+func TestStartJournalsTheRewindAPinnedPickOwes(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+	_, err := o.Settings.SetECashNetworkID("drynet3")
+	require.NoError(t, err)
+	require.Equal(t, "drynet2", o.Settings.ECashChainID())
+
+	cat := catalogWithECashRows(t, "drynet3", "drynet2")
+	require.Equal(t, "drynet3", o.RunningECashID(cat), "the start adopts the pinned pick")
+	o.adoptCatalog(cat, "drynet3")
+
+	height, forID, fromID := o.Settings.PendingRewind()
+	require.Equal(t, "drynet3", forID)
+	require.Equal(t, "drynet2", fromID)
+	require.NotZero(t, height)
+	require.Equal(t, "drynet3", o.Settings.ECashChainID(), "the record moves onto the pick")
+}
+
 // The user's own bitcoin.conf names the generation, so only they can change it.
 // Reporting success would clear the prompt and strand them on the retired chain.
 func TestConfirmRefusedForAUserManagedConf(t *testing.T) {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -480,6 +480,9 @@ func (o *Orchestrator) getOrCreateMonitor(name string, checker HealthChecker, st
 	defer o.monitorsMu.Unlock()
 
 	if mon, ok := o.monitors[name]; ok {
+		// Endpoints move — a network swap gives bitcoind a new RPC port — so a
+		// cached monitor takes the checker it was handed.
+		mon.ReplaceChecker(checker, startupPatterns)
 		return mon
 	}
 

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -909,6 +909,7 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 
 		o.prepareCoreArgs(&opts)
 		o.prepareEnforcerArgs(&opts)
+		o.prepareSidechainArgs(config, &opts)
 		o.injectSidechainStarter(config, &opts)
 		o.injectHeadlessForForcedBackend(config, &opts)
 
@@ -967,6 +968,43 @@ func (o *Orchestrator) prepareEnforcerArgs(opts *StartOpts) {
 	}
 	opts.EnforcerArgs = o.EnforcerConf.GetCliArgs()
 	o.log.Info().Strs("enforcer_args", opts.EnforcerArgs).Msg("auto-built enforcer args from config")
+}
+
+// prepareSidechainArgs fills opts.TargetArgs from the sidechain's conf. Without
+// it a layer-2 daemon gets no network or port flags at all and boots on its own
+// built-in signet default. Merges per flag rather than bailing out on a
+// non-empty TargetArgs, so an override the caller already placed — electrum's
+// --mainchain-grpc-url — wins on that flag and still gets the rest of the conf.
+func (o *Orchestrator) prepareSidechainArgs(config BinaryConfig, opts *StartOpts) {
+	if config.ChainLayer != 2 || config.IsBitcoinCore {
+		return
+	}
+	scm := o.SidechainConfs[config.Name]
+	if scm == nil || scm.Spec.ConfOnly {
+		return
+	}
+	// The conf's network and ports track the active L1 network.
+	if err := scm.SyncNetworkFromBitcoinConf(); err != nil {
+		o.log.Warn().Err(err).Str("binary", config.Name).Msg("failed to sync sidechain conf from bitcoin conf")
+	}
+	preset := make(map[string]bool, len(opts.TargetArgs))
+	for _, arg := range opts.TargetArgs {
+		preset[cliFlagName(arg)] = true
+	}
+	var fromConf []string
+	for _, arg := range scm.GetCliArgs() {
+		if !preset[cliFlagName(arg)] {
+			fromConf = append(fromConf, arg)
+		}
+	}
+	opts.TargetArgs = append(fromConf, opts.TargetArgs...)
+	o.log.Info().Str("binary", config.Name).Strs("target_args", opts.TargetArgs).Msg("auto-built sidechain args from config")
+}
+
+// cliFlagName is the --flag part of a "--flag=value" or "--flag" argument.
+func cliFlagName(arg string) string {
+	name, _, _ := strings.Cut(arg, "=")
+	return name
 }
 
 // injectSidechainStarter writes the sidechain seed to a temp file and appends
@@ -1283,6 +1321,7 @@ func (o *Orchestrator) RestartDaemon(ctx context.Context, name string, options .
 			ch <- StartupProgress{Stage: "done", Message: fmt.Sprintf("%s started", config.DisplayName), Done: true}
 
 		default:
+			o.prepareSidechainArgs(config, &opts)
 			o.injectSidechainStarter(config, &opts)
 			o.injectHeadlessForForcedBackend(config, &opts)
 			// startTargetOnly emits its own "done" event.

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -919,6 +919,13 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 				return
 			}
 
+			// A pick made from another network could only journal the rewind it
+			// owes. Here, because this is the first Core that can make it, and
+			// it goes before the enforcer validates the retired fork's blocks.
+			if err := o.ApplyPendingRewind(ctx); err != nil {
+				o.log.Error().Err(err).Msg("could not drop the eCash fork the network pick left behind")
+			}
+
 			o.startEnforcerWhenReady(ctx, opts, enforcerPrefetch)
 
 			// Wait for enforcer's gRPC port to actually accept dials before

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -3650,10 +3650,15 @@ func (o *Orchestrator) findConfigByBinaryName(binaryName string) (BinaryConfig, 
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
+	// Exact match, executable name first. A loose match let "thunder-orchard"
+	// resolve to the "thunder" config on whatever order the map handed out.
 	for _, config := range o.configs {
-		if processNameMatches(config.BinaryName, binaryName) || processNameMatches(config.Name, binaryName) {
+		if config.BinaryName == binaryName {
 			return config, true
 		}
+	}
+	if config, ok := o.configs[binaryName]; ok {
+		return config, true
 	}
 	return BinaryConfig{}, false
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1991,6 +1991,14 @@ func (o *Orchestrator) AdoptOrphans(ctx context.Context) error {
 			continue
 		}
 
+		// A prod PID file for a sidechain the resolver would have sent to the
+		// frontend build can only come from a --force-backend start, so the
+		// adopted process keeps that flag.
+		forceBackend := false
+		if !isTestPid && !isGUIPid && config.ChainLayer == 2 && o.process.SidechainVariant != nil {
+			_, forceBackend = o.process.SidechainVariant(config)
+		}
+
 		binPath := BinaryPath(o.DataDir, config.BinaryName)
 		if isGUIPid {
 			config.Name = sidechainGUIProcessName(config.Name)
@@ -2009,7 +2017,7 @@ func (o *Orchestrator) AdoptOrphans(ctx context.Context) error {
 				binPath = CoreBinaryPath(o.DataDir, v, config.BinaryName)
 			}
 		}
-		o.process.AdoptProcessResolved(config, pid, binPath, pidName, false)
+		o.process.AdoptProcessResolved(config, pid, binPath, pidName, forceBackend)
 		o.log.Info().Str("binary", config.Name).Int("pid", pid).Msg("adopted orphaned process")
 	}
 

--- a/sidechain-orchestrator/orchestrator_settings.go
+++ b/sidechain-orchestrator/orchestrator_settings.go
@@ -37,6 +37,13 @@ type OrchestratorSettings struct {
 	// switch left behind. The enforcer keeps one chain per network, not per
 	// fork, so it has to go before the enforcer runs on the new one.
 	PendingEnforcerWipe string `json:"pending_enforcer_wipe,omitempty"`
+	// PendingRewindHeight, PendingRewindFor and PendingRewindFrom are a rewind a
+	// pick made from another network could not run: no Core answers off eCash,
+	// so it waits for the boot that brings one up. From names the network whose
+	// blocks sit above that height.
+	PendingRewindHeight uint32 `json:"pending_rewind_height,omitempty"`
+	PendingRewindFor    string `json:"pending_rewind_for,omitempty"`
+	PendingRewindFrom   string `json:"pending_rewind_from,omitempty"`
 	// ElectrumServerURL overrides the network's default Esplora endpoint for
 	// electrum wallets. Empty means "use the network default".
 	ElectrumServerURL string `json:"electrum_server_url"`
@@ -317,6 +324,35 @@ func (s *SettingsStore) SetPendingEnforcerWipe(id string) error {
 	}
 	next := s.current
 	next.PendingEnforcerWipe = id
+	if err := SaveSettings(s.bitwindowDir, next); err != nil {
+		return err
+	}
+	s.current = next
+	return nil
+}
+
+// PendingRewind returns the height a pick still owes a rewind to, the eCash
+// network it was picked for and the one whose blocks sit above that height. An
+// empty forID means nothing is owed.
+func (s *SettingsStore) PendingRewind() (height uint32, forID, fromID string) {
+	g := s.Get()
+	return g.PendingRewindHeight, g.PendingRewindFor, g.PendingRewindFrom
+}
+
+// SetPendingRewind persists a rewind no live Core could run. An empty forID
+// clears it.
+func (s *SettingsStore) SetPendingRewind(height uint32, forID, fromID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current.PendingRewindHeight == height &&
+		s.current.PendingRewindFor == forID &&
+		s.current.PendingRewindFrom == fromID {
+		return nil
+	}
+	next := s.current
+	next.PendingRewindHeight = height
+	next.PendingRewindFor = forID
+	next.PendingRewindFrom = fromID
 	if err := SaveSettings(s.bitwindowDir, next); err != nil {
 		return err
 	}

--- a/sidechain-orchestrator/orphan_drain_test.go
+++ b/sidechain-orchestrator/orphan_drain_test.go
@@ -18,7 +18,22 @@ import (
 // live process, so the drain has something it must actually signal.
 func startSleeper(t *testing.T) int {
 	t.Helper()
-	cmd := exec.Command("sleep", "300")
+	return startSleeperNamed(t, "sleep")
+}
+
+// startSleeperNamed runs the sleeper from a copy named for the binary it will
+// stand in for, so the name check before a signal recognises it.
+func startSleeperNamed(t *testing.T, name string) int {
+	t.Helper()
+	sleep, err := exec.LookPath("sleep")
+	require.NoError(t, err)
+	body, err := os.ReadFile(sleep)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, body, 0o755))
+
+	cmd := exec.Command(path, "300")
+	cmd.Args[0] = "sleep" // busybox picks its applet from argv[0]
 	require.NoError(t, cmd.Start())
 	pid := cmd.Process.Pid
 	t.Cleanup(func() {
@@ -53,9 +68,9 @@ func waitGone(t *testing.T, pid int, timeout time.Duration) bool {
 // process as a leftover of an earlier run of ours.
 func adoptSleeper(t *testing.T, o *Orchestrator, recordPid bool) int {
 	t.Helper()
-	pid := startSleeper(t)
 	cfg, err := o.getConfig("bitcoind")
 	require.NoError(t, err)
+	pid := startSleeperNamed(t, cfg.BinaryName)
 	if recordPid {
 		require.NoError(t, o.pidManager.WritePidFile(cfg.BinaryName, pid))
 	}
@@ -101,6 +116,44 @@ func TestDrainStopsAnAdoptedOrphanThisInstallOwns(t *testing.T) {
 	drain(t, o)
 
 	require.True(t, waitGone(t, pid, 30*time.Second), "the drain must stop an orphan this install owns")
+}
+
+// An adopted PID came off disk and the OS reuses PID numbers. A stop that
+// trusts the cached number signals whichever stranger now holds it.
+func TestStopRefusesAnAdoptedPidThatIsNoLongerTheBinary(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	cfg, err := o.getConfig("bitcoind")
+	require.NoError(t, err)
+	pid := startSleeper(t) // runs as "sleep", not as bitcoind
+	require.NoError(t, o.pidManager.WritePidFile(cfg.BinaryName, pid))
+	o.process.AdoptProcess(cfg, pid)
+
+	require.Error(t, o.process.Stop(context.Background(), "bitcoind", false))
+	require.True(t, alive(t, pid), "a PID that is not the binary must not be signalled")
+	require.False(t, o.process.IsRunning("bitcoind"), "the registration that named it must go")
+	_, err = o.pidManager.ReadPidFile(cfg.BinaryName)
+	require.Error(t, err, "so must the PID record")
+}
+
+// thunder-orchard is zSide's executable. A substring match let it answer for
+// "thunder", so the zSide daemon filled Thunder's slot and the next stop of
+// Thunder signalled it.
+func TestAdoptOrphansNeverPutsZsideInThundersSlot(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	cfg, err := o.getConfig("zside")
+	require.NoError(t, err)
+	require.Equal(t, "thunder-orchard", cfg.BinaryName)
+	pid := startSleeperNamed(t, cfg.BinaryName)
+	require.NoError(t, o.pidManager.WritePidFile(cfg.BinaryName, pid))
+
+	require.NoError(t, o.AdoptOrphans(context.Background()))
+
+	require.Nil(t, o.process.Get("thunder"), "zSide's PID must never fill Thunder's slot")
+	proc := o.process.Get("zside")
+	require.NotNil(t, proc, "zSide's PID belongs in zSide's slot")
+	require.Equal(t, pid, proc.Pid)
 }
 
 // A binary a different live install owns stays untouched, whatever this run

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -220,6 +220,17 @@ func (pm *ProcessManager) resolvePaths(config BinaryConfig, forceBackend bool) (
 	return binPath, pidName
 }
 
+// pidNameBinary strips the suffix that marks a GUI companion or a frontend
+// build, leaving the executable name the process at that PID reports.
+func pidNameBinary(pidName string) string {
+	for _, suffix := range []string{"-gui", "-test"} {
+		if strings.HasSuffix(pidName, suffix) {
+			return strings.TrimSuffix(pidName, suffix)
+		}
+	}
+	return pidName
+}
+
 // ProcessStartOptions tweaks process.Start behaviour per-call.
 type ProcessStartOptions struct {
 	// ForceBackend skips the SidechainVariant resolver so the prod-download
@@ -584,6 +595,18 @@ func (pm *ProcessManager) Stop(_ context.Context, name string, force bool) error
 		return fmt.Errorf("%s is not running", name)
 	}
 
+	// An adopted PID came off disk, and the OS reuses PID numbers. Re-read the
+	// name before signalling, so a stranger that took the number is dropped
+	// rather than killed.
+	if proc.Adopted {
+		binary := pidNameBinary(proc.PidName)
+		if !pm.pidManager.ValidatePid(proc.Pid, binary) {
+			pm.forget(name, proc)
+			_ = pm.pidManager.DeletePidFile(proc.PidName)
+			return fmt.Errorf("stop %s: pid %d is no longer %s", name, proc.Pid, binary)
+		}
+	}
+
 	if force {
 		if err := forceKillProcess(proc.Pid); err != nil {
 			return fmt.Errorf("force kill %s: %w", name, err)
@@ -842,6 +865,21 @@ func (pm *ProcessManager) Remove(name string) {
 	delete(pm.processes, name)
 }
 
+// forget drops a registration that turned out to name somebody else's process
+// and releases whoever waits on it. A no-op once watchAdopted got there first.
+func (pm *ProcessManager) forget(name string, proc *ManagedProcess) {
+	pm.mu.Lock()
+	won := pm.processes[name] == proc
+	if won {
+		delete(pm.processes, name)
+	}
+	pm.mu.Unlock()
+
+	if won {
+		close(proc.exitCh)
+	}
+}
+
 // Spam filter patterns (ported from Dart isSpam function)
 var spamPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`tower_http`),
@@ -988,13 +1026,20 @@ func (m *PidFileManager) ValidatePid(pid int, binaryName string) bool {
 	return processNameMatches(procName, binaryName)
 }
 
-// processNameMatches compares process names case-insensitively with bidirectional
-// contains check (handles truncated names from ps).
+// commMaxLen is the length Linux truncates a process name to (TASK_COMM_LEN-1).
+const commMaxLen = 15
+
+// processNameMatches compares a name the OS reported against a binary name.
+// macOS reports an executable path, Linux truncates the name to commMaxLen.
+// Anything looser adopts a stranger: "thunder-orchard" answered for "thunder".
 func processNameMatches(procName, binaryName string) bool {
-	procLower := strings.ToLower(procName)
+	procLower := strings.ToLower(filepath.Base(procName))
 	binLower := strings.ToLower(binaryName)
 
-	return strings.Contains(procLower, binLower) || strings.Contains(binLower, procLower)
+	if procLower == binLower {
+		return true
+	}
+	return len(procLower) == commMaxLen && strings.HasPrefix(binLower, procLower)
 }
 
 // ListPidFiles returns all PID files and their PIDs.

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -246,18 +246,25 @@ func TestPidFile_OverwriteKeepsLatest(t *testing.T) {
 	assert.Equal(t, 200, pid)
 }
 
+// A reported name matches its own binary, the path macOS prints for it, and
+// the 15-character name Linux truncates it to — nothing else. A substring
+// match adopted a stranger and then signalled its PID.
 func TestProcessNameMatches(t *testing.T) {
 	tests := []struct {
 		proc, bin string
 		want      bool
 	}{
 		{"bitcoind", "bitcoind", true},
-		{"Bitcoind", "bitcoind", true},   // case insensitive
-		{"bitcoin", "bitcoind", true},    // ps truncation
-		{"bitcoind", "bitcoin", true},    // reverse contains
-		{"unrelated", "bitcoind", false}, // no overlap
+		{"Bitcoind", "bitcoind", true},
+		{"/opt/bin/bitcoind", "bitcoind", true},
+		{"bitcoin", "bitcoind", false},
+		{"bitcoind", "bitcoin", false},
+		{"unrelated", "bitcoind", false},
+		{"thunder-orchard", "thunder", false},
+		{"thunder", "thunder-orchard", false},
 		{"bip300301-enforcer", "bip300301-enforcer", true},
-		{"bip300301", "bip300301-enforcer", true}, // truncated
+		{"bip300301-enfor", "bip300301-enforcer", true},
+		{"bip300301", "bip300301-enforcer", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.proc+"_vs_"+tt.bin, func(t *testing.T) {

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -619,6 +619,7 @@ func (o *Orchestrator) restartResetBinary(ctx context.Context, binary ResetBinar
 	case ResetBinaryBitwindowd:
 		o.startTargetOnly(ctx, cfg, opts, ch, nil)
 	default:
+		o.prepareSidechainArgs(cfg, &opts)
 		o.injectSidechainStarter(cfg, &opts)
 		o.injectHeadlessForForcedBackend(cfg, &opts)
 		o.startTargetOnly(ctx, cfg, opts, ch, nil)

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -234,6 +234,14 @@ func (o *Orchestrator) GatherFilesToDelete(specs []GatherSpec) ([]ResetFileInfo,
 				if dc.BinaryName == "bitwindowd" && o.WalletSvc != nil {
 					add(cat, spec.Binary, o.WalletSvc.MasterWalletPaths())
 				}
+				// bitwindow.db's UTXO metadata and multisig rows carry no wallet
+				// id, so leaving it hands the next wallet the previous one's
+				// labels, freezes and groups. It holds no keys, so DeleteFiles
+				// removes it rather than backing it up; the next boot recreates
+				// it from migrations and re-indexes the chain-derived rows.
+				if dc.BinaryName == "bitwindowd" {
+					add(cat, spec.Binary, config.GetExistingFilesInDir(networkDir, []string{"bitwindow.db"}, o.log))
+				}
 			}
 		}
 	}

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -436,7 +436,7 @@ func (o *Orchestrator) buildResetPlan(specs []GatherSpec) resetPlan {
 
 	restart := make([]resetRestart, 0, len(stop))
 	for _, binary := range resetStartOrder {
-		if !stop[binary] || !o.isResetBinaryRunning(binary) || o.isResetBinaryAdopted(binary) {
+		if !stop[binary] || !o.isResetBinaryRunning(binary) || o.isResetBinaryForeign(binary) {
 			continue
 		}
 		restart = append(restart, resetRestart{
@@ -468,6 +468,12 @@ func (o *Orchestrator) isResetBinaryAdopted(binary ResetBinary) bool {
 	return name != "" && o.process.IsAdopted(name)
 }
 
+// isResetBinaryForeign reports whether an adopted binary belongs to somebody
+// else, so a reset must neither stop nor restart it.
+func (o *Orchestrator) isResetBinaryForeign(binary ResetBinary) bool {
+	return o.isResetBinaryAdopted(binary) && !o.mayStopAdopted(binary.processName())
+}
+
 func (o *Orchestrator) configForResetBinary(binary ResetBinary) (BinaryConfig, bool) {
 	name := binary.processName()
 	if name == "" {
@@ -495,11 +501,11 @@ func (o *Orchestrator) stopResetBinary(ctx context.Context, binary ResetBinary) 
 		return nil
 	}
 
-	if o.process.IsAdopted(name) {
-		o.log.Info().Str("binary", name).Msg("adopted process, skipping reset shutdown")
-		o.process.Remove(name)
-		o.markResetBinaryStopped(name)
-		return nil
+	// A reset wipes the datadir out from under this process, so dropping it from
+	// tracking and deleting anyway is never safe. Stop the orphans this install
+	// owns; refuse the reset for anything else.
+	if o.isResetBinaryForeign(binary) {
+		return fmt.Errorf("%s is running but was not started by this install: stop it before resetting", name)
 	}
 
 	o.setResetBinaryStopping(name, true)

--- a/sidechain-orchestrator/reset_adopted_test.go
+++ b/sidechain-orchestrator/reset_adopted_test.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+package orchestrator
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The bug: a reset skipped every adopted binary, so it wiped the datadir under
+// a daemon that stayed alive, and started no replacement.
+func TestResetPlan_RestartsAnAdoptedOrphanThisInstallOwns(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+	ownThisInstall(t, o)
+	adoptSleeper(t, o, true)
+
+	plan := o.buildResetPlan([]GatherSpec{
+		{Binary: ResetBinaryBitcoind, Categories: []ResetCategory{catData}},
+	})
+
+	require.Equal(t, []ResetBinary{ResetBinaryBitcoind}, resetRestartBinaries(plan))
+}
+
+// The deletion runs the moment this returns, so an orphan this install owns
+// must be dead by then.
+func TestStopResetPlan_StopsAnAdoptedOrphanBeforeTheWipe(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+	ownThisInstall(t, o)
+	pid := adoptSleeper(t, o, true)
+
+	plan := o.buildResetPlan([]GatherSpec{
+		{Binary: ResetBinaryBitcoind, Categories: []ResetCategory{catData}},
+	})
+	require.NoError(t, o.stopResetPlan(context.Background(), plan))
+
+	require.True(t, waitGone(t, pid, 30*time.Second), "the reset must stop an orphan this install owns")
+}
+
+// A daemon this install never started is not ours to stop, and deleting under
+// it would corrupt a live node. The reset refuses instead.
+func TestDeleteFiles_RefusesToWipeUnderAForeignAdoptedProcess(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+	pid := adoptSleeper(t, o, false)
+
+	blocks := filepath.Join(o.BitwindowDir, "signet", "blocks", "blk00000.dat")
+	seedFile(t, blocks)
+
+	_, err := o.DeleteFiles(context.Background(), []string{blocks}, []GatherSpec{
+		{Binary: ResetBinaryBitcoind, Categories: []ResetCategory{catData}},
+	})
+	require.ErrorContains(t, err, "not started by this install")
+
+	require.FileExists(t, blocks, "a refused reset must leave the datadir alone")
+	require.True(t, alive(t, pid), "a daemon this install never started must survive the reset")
+}

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -206,6 +206,81 @@ func TestGather_NeverWipesBundledBinarySoftware(t *testing.T) {
 	assert.NotEmpty(t, files, "bitcoind software should still be gathered")
 }
 
+// seedBitwindowDatabase writes <networkDir>/bitwindow.db and returns its path.
+func seedBitwindowDatabase(t *testing.T, o *Orchestrator) string {
+	t.Helper()
+	dc, ok := config.DirConfigByName("bitwindowd")
+	require.True(t, ok)
+	p := filepath.Join(dc.DatadirNetwork(config.Network(o.Network), ""), "bitwindow.db")
+	seedFile(t, p)
+	return p
+}
+
+// A wallet-only reset has to take bitwindow.db too: its UTXO metadata and
+// multisig rows carry no wallet id, so leaving it hands the next wallet the
+// previous one's data.
+func TestGather_WalletResetTakesBitwindowDatabase(t *testing.T) {
+	redirectHome(t)
+	o := newResetTestOrchestrator(t)
+	dbPath := seedBitwindowDatabase(t, o)
+
+	files, err := o.GatherFilesToDelete([]GatherSpec{
+		{Binary: ResetBinaryBitwindowd, Categories: []ResetCategory{catWallet}},
+	})
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range files {
+		if f.Path == dbPath {
+			found = true
+			assert.Equal(t, catWallet, f.Category)
+		}
+	}
+	assert.True(t, found, "bitwindow.db must be gathered by a wallet-only reset")
+
+	// It is wallet state, not logs or settings: those resets must leave it.
+	for _, cat := range []ResetCategory{catLogs, catSettings} {
+		other, err := o.GatherFilesToDelete([]GatherSpec{
+			{Binary: ResetBinaryBitwindowd, Categories: []ResetCategory{cat}},
+		})
+		require.NoError(t, err)
+		for _, f := range other {
+			assert.NotEqualf(t, dbPath, f.Path, "bitwindow.db must not be gathered by category %v", cat)
+		}
+	}
+}
+
+// Gathering bitwindow.db under catWallet must not reclassify it as a wallet
+// path: a chain-data reset still hard-deletes it, rather than growing a
+// wallet_backups/ copy on every run.
+func TestDeleteFiles_ChainDataResetStillHardDeletesBitwindowDatabase(t *testing.T) {
+	redirectHome(t)
+	o := newResetTestOrchestrator(t)
+	dbPath := seedBitwindowDatabase(t, o)
+
+	gathered, err := o.GatherFilesToDelete([]GatherSpec{
+		{Binary: ResetBinaryBitwindowd, Categories: []ResetCategory{catData}},
+	})
+	require.NoError(t, err)
+	var paths []string
+	for _, f := range gathered {
+		paths = append(paths, f.Path)
+	}
+	require.Contains(t, paths, dbPath)
+
+	assert.False(t, isWalletPath(dbPath, o.allWalletPaths()),
+		"bitwindow.db must not be classified as a wallet path")
+
+	ch, err := o.DeleteFiles(context.Background(), paths)
+	require.NoError(t, err)
+	for evt := range ch {
+		assert.Empty(t, evt.Error)
+	}
+
+	require.NoFileExists(t, dbPath)
+	require.NoDirExists(t, filepath.Join(filepath.Dir(dbPath), "wallet_backups"))
+}
+
 func TestGather_NoSideEffects(t *testing.T) {
 	o := newResetTestOrchestrator(t)
 

--- a/sidechain-orchestrator/restart_daemon_test.go
+++ b/sidechain-orchestrator/restart_daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,6 +116,61 @@ func TestPrepareEnforcerArgs_NoOpWhenAlreadySet(t *testing.T) {
 	opts := StartOpts{EnforcerArgs: []string{"--my=arg"}}
 	o.prepareEnforcerArgs(&opts)
 	require.Equal(t, []string{"--my=arg"}, opts.EnforcerArgs)
+}
+
+// TestPrepareSidechainArgs_CarriesSelectedNetwork is the regression guard for
+// "launching a sidechain on regtest boots it on signet": the daemon gets no
+// network or port flags of its own, so the conf's values have to reach argv.
+func TestPrepareSidechainArgs_CarriesSelectedNetwork(t *testing.T) {
+	config.SetHomeDir(t.TempDir())
+	t.Cleanup(func() { config.SetHomeDir("") })
+
+	o := New(t.TempDir(), string(config.NetworkRegtest), t.TempDir(), AllDefaults(), testLogger(t))
+	cfg, err := o.getConfig("thunder")
+	require.NoError(t, err)
+
+	opts := StartOpts{}
+	o.prepareSidechainArgs(cfg, &opts)
+
+	require.Contains(t, opts.TargetArgs, "--network=regtest")
+	require.Contains(t, opts.TargetArgs, "--rpc-addr=127.0.0.1:16009")
+}
+
+// TestPrepareSidechainArgs_SkipsConfOnlySidechain guards Elements: it takes
+// Core-style -flags and exits on an unknown --option, so none of its conf may
+// reach the command line.
+func TestPrepareSidechainArgs_SkipsConfOnlySidechain(t *testing.T) {
+	config.SetHomeDir(t.TempDir())
+	t.Cleanup(func() { config.SetHomeDir("") })
+
+	o := New(t.TempDir(), string(config.NetworkSignet), t.TempDir(), AllDefaults(), testLogger(t))
+	cfg, err := o.getConfig("liquid-signet")
+	require.NoError(t, err)
+
+	opts := StartOpts{}
+	o.prepareSidechainArgs(cfg, &opts)
+	require.Empty(t, opts.TargetArgs)
+}
+
+// TestPrepareSidechainArgs_MergesWithCallerArgs covers the light-mode order:
+// pointSidechainAtRemoteMainchain has already put --mainchain-grpc-url in
+// TargetArgs, so the helper must keep that flag and still contribute the rest
+// of the conf rather than bail out on a non-empty TargetArgs.
+func TestPrepareSidechainArgs_MergesWithCallerArgs(t *testing.T) {
+	config.SetHomeDir(t.TempDir())
+	t.Cleanup(func() { config.SetHomeDir("") })
+
+	o := New(t.TempDir(), string(config.NetworkRegtest), t.TempDir(), AllDefaults(), testLogger(t))
+	cfg, err := o.getConfig("thunder")
+	require.NoError(t, err)
+
+	opts := StartOpts{TargetArgs: []string{"--mainchain-grpc-url=https://remote.example"}}
+	o.prepareSidechainArgs(cfg, &opts)
+
+	require.Contains(t, opts.TargetArgs, "--mainchain-grpc-url=https://remote.example")
+	require.NotContains(t, opts.TargetArgs, "--mainchain-grpc-url=http://localhost:50051")
+	require.Contains(t, opts.TargetArgs, "--network=regtest")
+	require.Contains(t, opts.TargetArgs, "--rpc-addr=127.0.0.1:16009")
 }
 
 // TestStartEnforcerWhenReady_AlreadyInPM_NoPhantomStart is the symmetric

--- a/sidechain-orchestrator/sidechain/bitassets/handler.go
+++ b/sidechain-orchestrator/sidechain/bitassets/handler.go
@@ -278,7 +278,8 @@ func (h *Handler) ReserveBitAsset(ctx context.Context, req *connect.Request[pb.R
 
 func (h *Handler) TransferBitAsset(ctx context.Context, req *connect.Request[pb.TransferBitAssetRequest]) (*connect.Response[pb.TransferBitAssetResponse], error) {
 	var txid string
-	params := []any{req.Msg.AssetId, req.Msg.Dest, req.Msg.Amount, req.Msg.FeeSats}
+	// transfer_bitasset accepts [dest, asset_id, amount, fee_sats, memo]
+	params := []any{req.Msg.Dest, req.Msg.AssetId, req.Msg.Amount, req.Msg.FeeSats}
 	if err := h.proxy.Client.Call(ctx, "transfer_bitasset", params, &txid); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitassets/handler_test.go
+++ b/sidechain-orchestrator/sidechain/bitassets/handler_test.go
@@ -1,0 +1,70 @@
+package bitassets
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bitassets/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+// rpcCapture is a JSON-RPC request as it went out on the wire.
+type rpcCapture struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+// captureRPC returns an httptest.Server that publishes every request it
+// receives and answers each one with rawResult, plus a Handler proxying to it.
+func captureRPC(t *testing.T, rawResult string) (*Handler, <-chan rpcCapture) {
+	t.Helper()
+
+	requests := make(chan rpcCapture, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcCapture
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requests <- req
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":` + rawResult + `}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	portNum, err := strconv.Atoi(port)
+	require.NoError(t, err)
+
+	return NewHandler(sidechain.NewJSONRPCProxy(host, portNum)), requests
+}
+
+// The backend takes transfer_bitasset(dest, asset_id, amount, fee_sats); sending
+// the first two the other way round transfers the wrong asset to the wrong place.
+func TestTransferBitAssetParamOrder(t *testing.T) {
+	h, requests := captureRPC(t, `"txid-1"`)
+
+	resp, err := h.TransferBitAsset(context.Background(), connect.NewRequest(&pb.TransferBitAssetRequest{
+		AssetId: "asset-1",
+		Dest:    "bNdest",
+		Amount:  500,
+		FeeSats: 7,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "txid-1", resp.Msg.Txid)
+
+	req := <-requests
+	assert.Equal(t, "transfer_bitasset", req.Method)
+	assert.JSONEq(t, `["bNdest","asset-1",500,7]`, string(req.Params))
+}

--- a/sidechain-orchestrator/sidechain/coinshift/handler.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler.go
@@ -2,6 +2,7 @@ package coinshift
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -244,6 +245,21 @@ func (h *Handler) OpenapiSchema(ctx context.Context, req *connect.Request[pb.Ope
 
 // --- Swap methods ---
 
+// swapIDParam turns a hex swap id into the 32-byte array coinshift expects.
+// The bytes are widened to ints because encoding/json marshals []byte as base64.
+func swapIDParam(hexID string) ([]int, error) {
+	b, err := hex.DecodeString(hexID)
+	if err != nil || len(b) != 32 {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("swap_id must be 32 bytes hex, got %q", hexID))
+	}
+	ids := make([]int, len(b))
+	for i, v := range b {
+		ids[i] = int(v)
+	}
+	return ids, nil
+}
+
 func (h *Handler) CreateSwap(ctx context.Context, req *connect.Request[pb.CreateSwapRequest]) (*connect.Response[pb.CreateSwapResponse], error) {
 	var result struct {
 		SwapID string `json:"swap_id"`
@@ -268,8 +284,12 @@ func (h *Handler) CreateSwap(ctx context.Context, req *connect.Request[pb.Create
 }
 
 func (h *Handler) ClaimSwap(ctx context.Context, req *connect.Request[pb.ClaimSwapRequest]) (*connect.Response[pb.ClaimSwapResponse], error) {
+	swapID, err := swapIDParam(req.Msg.SwapId)
+	if err != nil {
+		return nil, err
+	}
 	var txid string
-	params := []any{req.Msg.SwapId, req.Msg.L2ClaimerAddress}
+	params := []any{swapID, req.Msg.L2ClaimerAddress}
 	if err := h.proxy.Client.Call(ctx, "claim_swap", params, &txid); err != nil {
 		return nil, err
 	}
@@ -277,7 +297,11 @@ func (h *Handler) ClaimSwap(ctx context.Context, req *connect.Request[pb.ClaimSw
 }
 
 func (h *Handler) GetSwapStatus(ctx context.Context, req *connect.Request[pb.GetSwapStatusRequest]) (*connect.Response[pb.GetSwapStatusResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_swap_status", []any{req.Msg.SwapId})
+	swapID, err := swapIDParam(req.Msg.SwapId)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_swap_status", []any{swapID})
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +325,11 @@ func (h *Handler) ListSwapsByRecipient(ctx context.Context, req *connect.Request
 }
 
 func (h *Handler) UpdateSwapL1Txid(ctx context.Context, req *connect.Request[pb.UpdateSwapL1TxidRequest]) (*connect.Response[pb.UpdateSwapL1TxidResponse], error) {
-	params := []any{req.Msg.SwapId, req.Msg.L1TxidHex, req.Msg.Confirmations}
+	swapID, err := swapIDParam(req.Msg.SwapId)
+	if err != nil {
+		return nil, err
+	}
+	params := []any{swapID, req.Msg.L1TxidHex, req.Msg.Confirmations}
 	if err := h.proxy.Client.Call(ctx, "update_swap_l1_txid", params, nil); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/coinshift/handler_test.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler_test.go
@@ -1,0 +1,156 @@
+package coinshift
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/coinshift/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+const testSwapIDHex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+
+// captureRPC returns a Handler proxying to a server that answers every method
+// with result, plus an accessor for the params of the most recent call.
+func captureRPC(t *testing.T, result any) (*Handler, func() []any) {
+	t.Helper()
+
+	var (
+		mu     sync.Mutex
+		params []any
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Params []any `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		mu.Lock()
+		params = req.Params
+		mu.Unlock()
+
+		raw, err := json.Marshal(result)
+		if err != nil {
+			t.Errorf("marshal result: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  json.RawMessage(raw),
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	lastParams := func() []any {
+		mu.Lock()
+		defer mu.Unlock()
+		return params
+	}
+	return NewHandler(&sidechain.JSONRPCProxy{Client: rpc.New(host, port)}), lastParams
+}
+
+// assertSwapIDParam checks the param is a 32-element JSON array of the id bytes.
+func assertSwapIDParam(t *testing.T, param any) {
+	t.Helper()
+
+	want, err := hex.DecodeString(testSwapIDHex)
+	require.NoError(t, err)
+
+	elems, ok := param.([]any)
+	require.True(t, ok, "swap_id should be a JSON array, got %T", param)
+	require.Len(t, elems, 32)
+
+	got := make([]byte, len(elems))
+	for i, e := range elems {
+		n, ok := e.(float64)
+		require.True(t, ok, "swap_id element %d should be a number, got %T", i, e)
+		got[i] = byte(n)
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestClaimSwapSendsSwapIDBytes(t *testing.T) {
+	h, lastParams := captureRPC(t, "txid")
+
+	_, err := h.ClaimSwap(context.Background(), connect.NewRequest(&pb.ClaimSwapRequest{
+		SwapId: testSwapIDHex,
+	}))
+	require.NoError(t, err)
+
+	params := lastParams()
+	require.Len(t, params, 2)
+	assertSwapIDParam(t, params[0])
+}
+
+func TestGetSwapStatusSendsSwapIDBytes(t *testing.T) {
+	h, lastParams := captureRPC(t, nil)
+
+	_, err := h.GetSwapStatus(context.Background(), connect.NewRequest(&pb.GetSwapStatusRequest{
+		SwapId: testSwapIDHex,
+	}))
+	require.NoError(t, err)
+
+	params := lastParams()
+	require.Len(t, params, 1)
+	assertSwapIDParam(t, params[0])
+}
+
+func TestUpdateSwapL1TxidSendsSwapIDBytes(t *testing.T) {
+	h, lastParams := captureRPC(t, nil)
+
+	_, err := h.UpdateSwapL1Txid(context.Background(), connect.NewRequest(&pb.UpdateSwapL1TxidRequest{
+		SwapId:        testSwapIDHex,
+		L1TxidHex:     "abcd",
+		Confirmations: 3,
+	}))
+	require.NoError(t, err)
+
+	params := lastParams()
+	require.Len(t, params, 3)
+	assertSwapIDParam(t, params[0])
+}
+
+func TestSwapMethodsRejectInvalidSwapID(t *testing.T) {
+	for _, id := range []string{"", "deadbeef", "zz" + testSwapIDHex[2:]} {
+		h, _ := captureRPC(t, nil)
+		ctx := context.Background()
+
+		_, err := h.ClaimSwap(ctx, connect.NewRequest(&pb.ClaimSwapRequest{SwapId: id}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+		_, err = h.GetSwapStatus(ctx, connect.NewRequest(&pb.GetSwapStatusRequest{SwapId: id}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+		_, err = h.UpdateSwapL1Txid(ctx, connect.NewRequest(&pb.UpdateSwapL1TxidRequest{SwapId: id}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	}
+}

--- a/sidechain-orchestrator/sidechain/truthcoin/handler.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler.go
@@ -282,23 +282,34 @@ func (h *Handler) CalculateInitialLiquidity(ctx context.Context, req *connect.Re
 }
 
 func (h *Handler) MarketCreate(ctx context.Context, req *connect.Request[pb.MarketCreateRequest]) (*connect.Response[pb.MarketCreateResponse], error) {
-	var txid string
-	params := []any{
-		req.Msg.Title,
-		req.Msg.Description,
-		req.Msg.Dimensions,
-		req.Msg.FeeSats,
-		req.Msg.Beta,
-		req.Msg.InitialLiquidity,
-		req.Msg.TradingFee,
-		req.Msg.Tags,
-		req.Msg.CategoryTxids,
-		req.Msg.ResidualNames,
+	// market_create takes a single request object; dimensions is an array of
+	// DimensionInput carried over the wire as JSON.
+	var dimensions []any
+	if err := json.Unmarshal([]byte(req.Msg.Dimensions), &dimensions); err != nil {
+		return nil, fmt.Errorf("unmarshal dimensions: %w", err)
 	}
-	if err := h.proxy.Client.Call(ctx, "market_create", params, &txid); err != nil {
+	request := map[string]any{
+		"title":       req.Msg.Title,
+		"description": req.Msg.Description,
+		"dimensions":  dimensions,
+		"tx_fee_sats": req.Msg.FeeSats,
+	}
+	if req.Msg.Beta != nil {
+		request["beta"] = *req.Msg.Beta
+	}
+	if req.Msg.TradingFee != nil {
+		request["trading_fee"] = *req.Msg.TradingFee
+	}
+	if req.Msg.InitialLiquidity != nil {
+		request["initial_liquidity"] = *req.Msg.InitialLiquidity
+	}
+	var result struct {
+		Txid string `json:"txid"`
+	}
+	if err := h.proxy.Client.Call(ctx, "market_create", []any{request}, &result); err != nil {
 		return nil, err
 	}
-	return connect.NewResponse(&pb.MarketCreateResponse{Txid: txid}), nil
+	return connect.NewResponse(&pb.MarketCreateResponse{Txid: result.Txid}), nil
 }
 
 func (h *Handler) MarketList(ctx context.Context, req *connect.Request[pb.MarketListRequest]) (*connect.Response[pb.MarketListResponse], error) {
@@ -318,15 +329,19 @@ func (h *Handler) MarketGet(ctx context.Context, req *connect.Request[pb.MarketG
 }
 
 func (h *Handler) MarketBuy(ctx context.Context, req *connect.Request[pb.MarketBuyRequest]) (*connect.Response[pb.MarketBuyResponse], error) {
-	params := []any{
-		req.Msg.MarketId,
-		req.Msg.OutcomeIndex,
-		req.Msg.SharesAmount,
-		req.Msg.DryRun,
-		req.Msg.FeeSats,
-		req.Msg.MaxCost,
+	// market_buy takes a single request object with integer shares.
+	request := map[string]any{
+		"market_id":     req.Msg.MarketId,
+		"outcome_index": req.Msg.OutcomeIndex,
+		"shares_amount": int64(req.Msg.SharesAmount),
 	}
-	raw, err := h.proxy.Client.CallRaw(ctx, "market_buy", params)
+	if req.Msg.DryRun != nil {
+		request["dry_run"] = *req.Msg.DryRun
+	}
+	if req.Msg.MaxCost != nil {
+		request["max_cost"] = *req.Msg.MaxCost
+	}
+	raw, err := h.proxy.Client.CallRaw(ctx, "market_buy", []any{request})
 	if err != nil {
 		return nil, err
 	}
@@ -334,16 +349,20 @@ func (h *Handler) MarketBuy(ctx context.Context, req *connect.Request[pb.MarketB
 }
 
 func (h *Handler) MarketSell(ctx context.Context, req *connect.Request[pb.MarketSellRequest]) (*connect.Response[pb.MarketSellResponse], error) {
-	params := []any{
-		req.Msg.MarketId,
-		req.Msg.OutcomeIndex,
-		req.Msg.SharesAmount,
-		req.Msg.SellerAddress,
-		req.Msg.DryRun,
-		req.Msg.FeeSats,
-		req.Msg.MinProceeds,
+	// market_sell takes a single request object.
+	request := map[string]any{
+		"market_id":      req.Msg.MarketId,
+		"outcome_index":  req.Msg.OutcomeIndex,
+		"shares_amount":  req.Msg.SharesAmount,
+		"seller_address": req.Msg.SellerAddress,
 	}
-	raw, err := h.proxy.Client.CallRaw(ctx, "market_sell", params)
+	if req.Msg.DryRun != nil {
+		request["dry_run"] = *req.Msg.DryRun
+	}
+	if req.Msg.MinProceeds != nil {
+		request["min_proceeds"] = *req.Msg.MinProceeds
+	}
+	raw, err := h.proxy.Client.CallRaw(ctx, "market_sell", []any{request})
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/truthcoin/handler_test.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler_test.go
@@ -1,0 +1,141 @@
+package truthcoin
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/truthcoin/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+// capturingRPC returns a Handler wired to a JSON-RPC server that replies with a
+// fixed result and records the params of every request it receives.
+func capturingRPC(t *testing.T, result string) (*Handler, *[]json.RawMessage) {
+	t.Helper()
+
+	var params []json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Params json.RawMessage `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		params = append(params, req.Params)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":` + result + `}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	portNum, err := strconv.Atoi(port)
+	require.NoError(t, err)
+
+	return NewHandler(&sidechain.JSONRPCProxy{Client: rpc.New(host, portNum)}), &params
+}
+
+func TestMarketCreateSendsRequestObject(t *testing.T) {
+	h, params := capturingRPC(t, `{"txid":"txid123","market_id":"market1","claimed_decisions":[]}`)
+
+	beta := 7.0
+	tradingFee := 0.005
+	resp, err := h.MarketCreate(context.Background(), connect.NewRequest(&pb.MarketCreateRequest{
+		Title:       "Will it rain?",
+		Description: "weather market",
+		Dimensions:  `[{"type":"existing","id":"deadbeef"}]`,
+		FeeSats:     1000,
+		Beta:        &beta,
+		TradingFee:  &tradingFee,
+		Tags:        []string{"weather"},
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "txid123", resp.Msg.Txid)
+
+	require.Len(t, *params, 1)
+	assert.JSONEq(t, `[{
+		"title": "Will it rain?",
+		"description": "weather market",
+		"dimensions": [{"type":"existing","id":"deadbeef"}],
+		"tx_fee_sats": 1000,
+		"beta": 7.0,
+		"trading_fee": 0.005
+	}]`, string((*params)[0]))
+}
+
+func TestMarketCreateRejectsNonJSONDimensions(t *testing.T) {
+	h, _ := capturingRPC(t, `{"txid":"txid123","market_id":"market1","claimed_decisions":[]}`)
+
+	_, err := h.MarketCreate(context.Background(), connect.NewRequest(&pb.MarketCreateRequest{
+		Title:       "Will it rain?",
+		Description: "weather market",
+		Dimensions:  "[deadbeef]",
+		FeeSats:     1000,
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal dimensions")
+}
+
+func TestMarketBuySendsRequestObject(t *testing.T) {
+	h, params := capturingRPC(t, `{"cost_sats":100,"trading_fee_sats":1,"new_price":0.6}`)
+
+	dryRun := true
+	feeSats := int64(1000)
+	maxCost := int64(5000)
+	// A fractional share count must be coerced to the integer the RPC expects.
+	_, err := h.MarketBuy(context.Background(), connect.NewRequest(&pb.MarketBuyRequest{
+		MarketId:     "market1",
+		OutcomeIndex: 2,
+		SharesAmount: 7.5,
+		DryRun:       &dryRun,
+		FeeSats:      &feeSats,
+		MaxCost:      &maxCost,
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, *params, 1)
+	assert.JSONEq(t, `[{
+		"market_id": "market1",
+		"outcome_index": 2,
+		"shares_amount": 7,
+		"dry_run": true,
+		"max_cost": 5000
+	}]`, string((*params)[0]))
+}
+
+func TestMarketSellSendsRequestObject(t *testing.T) {
+	h, params := capturingRPC(t, `{"proceeds_sats":100,"trading_fee_sats":1,"net_proceeds_sats":99,"new_price":0.4}`)
+
+	dryRun := false
+	feeSats := int64(1000)
+	minProceeds := int64(50)
+	_, err := h.MarketSell(context.Background(), connect.NewRequest(&pb.MarketSellRequest{
+		MarketId:      "market1",
+		OutcomeIndex:  2,
+		SharesAmount:  7,
+		SellerAddress: "tNaddr",
+		DryRun:        &dryRun,
+		FeeSats:       &feeSats,
+		MinProceeds:   &minProceeds,
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, *params, 1)
+	assert.JSONEq(t, `[{
+		"market_id": "market1",
+		"outcome_index": 2,
+		"shares_amount": 7,
+		"seller_address": "tNaddr",
+		"dry_run": false,
+		"min_proceeds": 50
+	}]`, string((*params)[0]))
+}

--- a/sidechain-orchestrator/sidechain_variant_test.go
+++ b/sidechain-orchestrator/sidechain_variant_test.go
@@ -353,6 +353,10 @@ func TestOrchestrator_ForceBackend_AdoptsProdPidWhenTestSidechainsEnabled(t *tes
 	require.NoError(t, o.AdoptOrphans(context.Background()))
 	require.True(t, o.process.IsRunning(cfg.Name), "prod PID should be adopted as force-backend fallback while test sidechains are enabled")
 
+	// RestartDaemon and buildResetPlan read the flag back, so losing it here
+	// would restart the sidechain as its GUI companion.
+	assert.True(t, o.process.ForceBackendFor(cfg.Name), "adoption must keep the ForceBackend flag of a prod PID file")
+
 	// The path fields answer the request, so ask the way the backend was started.
 	status := o.StatusWithOptions(cfg.Name, DownloadOptions{ForceBackend: true})
 	assert.True(t, status.Running)

--- a/sidechain-orchestrator/start_with_l1_electrum_test.go
+++ b/sidechain-orchestrator/start_with_l1_electrum_test.go
@@ -2,6 +2,9 @@ package orchestrator
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -72,6 +75,44 @@ func TestPointSidechainAtRemoteMainchainFailsWithoutRemote(t *testing.T) {
 	require.False(t, o.pointSidechainAtRemoteMainchain(cfg, &opts, ch))
 	require.Empty(t, opts.TargetArgs)
 	require.Error(t, (<-ch).Error)
+}
+
+// Light mode fills --mainchain-grpc-url before the conf-derived args are
+// built, and the daemon has no network flag of its own — so the spawned argv
+// has to carry both the remote mainchain and the selected network, or the
+// sidechain silently boots on its clap default of signet.
+func TestStartWithL1LightModeSidechainArgvCarriesNetwork(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a shell script as the fake binary")
+	}
+
+	config.SetHomeDir(t.TempDir())
+	t.Cleanup(func() { config.SetHomeDir("") })
+
+	dataDir := t.TempDir()
+	o := New(dataDir, string(config.NetworkSignet), t.TempDir(), AllDefaults(), testLogger(t))
+	require.NoError(t, WriteNodeMode(o.BitwindowDir, NodeModeLight))
+
+	// A binary on disk keeps the boot off the network. It outlives the spawn
+	// long enough for the exit to be the thing that ends the connection wait.
+	binDir := BinDir(dataDir)
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "thunder"), []byte("#!/bin/sh\nsleep 1\n"), 0o755))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// ForceBackend: the daemon takes the argv, not the sidechain's Flutter GUI.
+	ch, err := o.StartWithL1(ctx, "thunder", StartOpts{ForceBackend: true})
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	proc := o.process.LatestRun("thunder")
+	require.NotNil(t, proc)
+	require.Contains(t, proc.Cmd.Args, "--network=signet")
+	require.Contains(t, proc.Cmd.Args, "--mainchain-grpc-url=https://orchestrator.signet.drivechain.info")
+	require.NotContains(t, proc.Cmd.Args, "--mainchain-grpc-url=http://localhost:50051")
 }
 
 // zmq-style sidechains carry no mainchain-grpc-url and can't reach a remote

--- a/sidechain_core/lib/models/enforcer_config_options.dart
+++ b/sidechain_core/lib/models/enforcer_config_options.dart
@@ -180,14 +180,6 @@ class EnforcerConfigOptions {
       defaultValue: '127.0.0.1:8122',
     ),
     EnforcerConfigOption(
-      key: 'serve-json-rpc-addr',
-      category: 'Server',
-      description: 'JSON-RPC Address',
-      tooltip: 'Address to serve other JSON-RPC methods.',
-      inputType: EnforcerConfigInputType.text,
-      defaultValue: '127.0.0.1:8123',
-    ),
-    EnforcerConfigOption(
       key: 'serve-grpc-addr',
       category: 'Server',
       description: 'gRPC Address',
@@ -199,15 +191,6 @@ class EnforcerConfigOptions {
     // ===================
     // Wallet Options
     // ===================
-    EnforcerConfigOption(
-      key: 'wallet-full-scan',
-      category: 'Wallet',
-      description: 'Full Scan on Startup',
-      tooltip:
-          'If true, the wallet will perform a full scan of the blockchain on startup, before proceeding with normal operations.',
-      inputType: EnforcerConfigInputType.boolean,
-      defaultValue: false,
-    ),
     EnforcerConfigOption(
       key: 'wallet-auto-create',
       category: 'Wallet',
@@ -300,13 +283,6 @@ class EnforcerConfigOptions {
       tooltip: 'Path to the Bitcoin Core bitcoin-cli binary.',
       inputType: EnforcerConfigInputType.path,
       defaultValue: 'bitcoin-cli',
-    ),
-    EnforcerConfigOption(
-      key: 'signet-miner-coinbase-recipient',
-      category: 'Signet Miner',
-      description: 'Coinbase Recipient',
-      tooltip: 'Address for block reward payment.',
-      inputType: EnforcerConfigInputType.text,
     ),
 
     // ===================

--- a/truthcoin/lib/pages/market_creation_page.dart
+++ b/truthcoin/lib/pages/market_creation_page.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
@@ -191,7 +193,7 @@ class _DimensionsStep extends StatelessWidget {
             hintText: 'e.g., 004008',
           ),
         ] else if (model.marketType == MarketType.categorical) ...[
-          SailText.secondary13('Enter slot IDs for categorical outcomes.'),
+          SailText.secondary13('Enter one decision slot ID per dimension.'),
           const SizedBox(height: 8),
           SailText.secondary13('Slot IDs (comma-separated)'),
           SailTextField(
@@ -199,12 +201,12 @@ class _DimensionsStep extends StatelessWidget {
             hintText: 'e.g., 004008,004009,004010',
           ),
         ] else ...[
-          SailText.secondary13('Enter custom dimension specification using bracket notation.'),
+          SailText.secondary13('Enter decision slot IDs, or paste DimensionInput JSON.'),
           const SizedBox(height: 8),
           SailText.secondary13('Dimensions'),
           SailTextField(
             controller: model.dimensionsController,
-            hintText: 'e.g., [004008] or [[004008,004009]]',
+            hintText: 'e.g., 004008,004009 or [{"type":"existing","id":"004008"}]',
           ),
           const SizedBox(height: 8),
           Container(
@@ -217,9 +219,9 @@ class _DimensionsStep extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SailText.secondary12('Dimension Syntax:', bold: true),
-                SailText.secondary12('[slot_id] - Binary outcome from single slot'),
-                SailText.secondary12('[s1,s2,s3] - Combined binary slots'),
-                SailText.secondary12('[[s1,s2,s3]] - Categorical from related slots'),
+                SailText.secondary12('slot_id - One dimension per claimed decision'),
+                SailText.secondary12('{"type":"existing","id":"s1"} - Reference a claimed decision'),
+                SailText.secondary12('{"type":"new",...} - Claim a decision with the market'),
               ],
             ),
           ),
@@ -600,6 +602,26 @@ class MarketCreationViewModel extends BaseViewModel {
     }
   }
 
+  /// Dimensions as the `DimensionInput` JSON array market_create takes. Every
+  /// decision ID becomes an `existing` reference; already-formed JSON passes
+  /// through so custom mode can claim new decisions.
+  String get dimensionInputs {
+    final input = dimensionsController.text.trim();
+    if (input.isEmpty) return '[]';
+
+    try {
+      final decoded = jsonDecode(input);
+      if (decoded is List && decoded.every((d) => d is Map)) return input;
+    } on FormatException {
+      // Not JSON: read the input as decision IDs.
+    }
+
+    final ids = input.split(RegExp(r'[\s,\[\]]+')).where((id) => id.isNotEmpty);
+    return jsonEncode([
+      for (final id in ids) {'type': 'existing', 'id': id},
+    ]);
+  }
+
   bool get canContinue {
     switch (currentStep) {
       case 0:
@@ -672,7 +694,7 @@ class MarketCreationViewModel extends BaseViewModel {
     final txid = await _marketProvider.createMarket(
       title: titleController.text.trim(),
       description: descriptionController.text.trim(),
-      dimensions: effectiveDimensions,
+      dimensions: dimensionInputs,
       feeSats: 1000,
       beta: liquidityMethod == LiquidityMethod.beta ? double.tryParse(betaController.text) : null,
       initialLiquidity: liquidityMethod == LiquidityMethod.initialLiquidity

--- a/truthcoin/test/pages/market_creation_page_test.dart
+++ b/truthcoin/test/pages/market_creation_page_test.dart
@@ -78,4 +78,39 @@ void main() {
       expect(find.textContaining('Back'), findsWidgets);
     });
   });
+
+  group('MarketCreationViewModel.dimensionInputs', () {
+    const twoExisting = '[{"type":"existing","id":"004008"},{"type":"existing","id":"004009"}]';
+
+    test('a slot ID becomes an existing DimensionInput', () {
+      final model = MarketCreationViewModel()..dimensionsController.text = '004008';
+
+      expect(model.dimensionInputs, '[{"type":"existing","id":"004008"}]');
+    });
+
+    test('comma-separated slot IDs become one DimensionInput each', () {
+      final model = MarketCreationViewModel()
+        ..setMarketType(MarketType.categorical)
+        ..dimensionsController.text = '004008, 004009';
+
+      expect(model.dimensionInputs, twoExisting);
+    });
+
+    test('bracket notation is flattened to existing references', () {
+      final model = MarketCreationViewModel()
+        ..setMarketType(MarketType.custom)
+        ..dimensionsController.text = '[[004008,004009]]';
+
+      expect(model.dimensionInputs, twoExisting);
+    });
+
+    test('DimensionInput JSON passes through', () {
+      const dimensions = '[{"type":"new","period_index":3,"decision_type":"binary","header":"Rain?"}]';
+      final model = MarketCreationViewModel()
+        ..setMarketType(MarketType.custom)
+        ..dimensionsController.text = dimensions;
+
+      expect(model.dimensionInputs, dimensions);
+    });
+  });
 }


### PR DESCRIPTION
A set of **15 independent fixes** to the BitWindow orchestrator core & sidechains, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`39 files changed, 1929 insertions(+), 115 deletions(-)`).

## Fixes (oldest first)

- **`4a405c208`** CoinShift typed Claim, Status, and Update send an undecodable SwapId
- **`b6e47541e`** Truthcoin typed market create, buy, and sell calls fail at the JSON-RPC boundary
- **`fce3b36f9`** Network rewrite drops all but final Bitcoin Core peer
- **`e7de9eb53`** Sidechain launch ignores selected network and defaults to Signet
- **`294d5b5f1`** no-Core eCash reverse switch commits onto its still-barred target branch
- **`81b3d9c36`** cross-network eCash adoption skips the required Core rewind
- **`b2e72cb95`** BitWindow ships a stale enforcer option that prevents startup
- **`8f249f3d9`** Orchestrator shared CoreStatusClient can misroute concurrent wallet RPCs
- **`47ae0cfd5`** BitWindow wallet-only reset leaves `bitwindow.db` (unscoped SQLite tables) byte-intact, so a post-reset wallet reads prior-wallet metadata
- **`f43981f05`** drivechain-frontends `AdoptOrphans` loses ForceBackend flag for re-adopted sidechain prod PID files
- **`5b0480dc5`** sidechain-orchestrator `AdoptOrphans` adopts unrelated process via bidirectional-substring `processNameMatches`, then signals wrong PID
- **`2079d1119`** drivechain-frontends/sidechain-orchestrator — Reset on adopted binary wipes datadir while OS process stays alive and no restart is scheduled
- **`b62d8a037`** Network swap reuses the old Bitcoin Core health checker and stalls L1 restart
- **`f9758655a`** SetElectrumServer persist failure leaves engine on new endpoint with no rollback
- **`6c81dfabb`** BitAssets typed transfer swaps destination and asset ID

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.