### PR TITLE
BitWindow orchestrator core & sidechains (2 of 2): 16 fixes from a security review

### DIFF
--- a/sidechain-orchestrator/api/multisiglounge_handler.go
+++ b/sidechain-orchestrator/api/multisiglounge_handler.go
@@ -532,23 +532,44 @@ func watchRangeEnd(next int) int {
 	return ((next+multisigWatchRangeLookahead)/multisigWatchRangeChunk+1)*multisigWatchRangeChunk - 1
 }
 
-// watchDescriptorRange reports the imported range end covering both of the
-// wallet's active descriptors (-1 when either is missing) and the highest next
-// index Core will hand out from them.
-func (h *MultisigLoungeHandler) watchDescriptorRange(ctx context.Context, name string) (int, int, error) {
+// watchDescriptorState is what the watch wallet currently tracks: the imported
+// range end covering both active descriptors (-1 when either is missing), the
+// highest next index Core will hand out, and the descriptors themselves.
+type watchDescriptorState struct {
+	end     int
+	next    int
+	receive string
+	change  string
+}
+
+// normalizeDescriptor puts a descriptor in a comparable form: checksum dropped,
+// lower-cased, hardened steps written "h". Core may echo a descriptor in another
+// spelling than it was imported with, and a raw compare would then re-import it.
+func normalizeDescriptor(desc string) string {
+	if i := strings.LastIndex(desc, "#"); i >= 0 {
+		desc = desc[:i]
+	}
+	return strings.ReplaceAll(strings.ToLower(desc), "'", "h")
+}
+
+// watchDescriptorRange reports the wallet's active descriptor state, with the
+// descriptors normalized for comparison against freshly built ones.
+func (h *MultisigLoungeHandler) watchDescriptorRange(ctx context.Context, name string) (watchDescriptorState, error) {
 	var res struct {
 		Descriptors []struct {
-			Active   bool  `json:"active"`
-			Internal bool  `json:"internal"`
-			Range    []int `json:"range"`
-			Next     int   `json:"next"`
+			Desc     string `json:"desc"`
+			Active   bool   `json:"active"`
+			Internal bool   `json:"internal"`
+			Range    []int  `json:"range"`
+			Next     int    `json:"next"`
 		} `json:"descriptors"`
 	}
+	state := watchDescriptorState{end: -1}
 	if err := h.coreCallWallet(ctx, name, "listdescriptors", nil, &res); err != nil {
-		return 0, 0, fmt.Errorf("listdescriptors: %w", err)
+		return state, fmt.Errorf("listdescriptors: %w", err)
 	}
 
-	end, next := -1, 0
+	end := -1
 	var haveReceive, haveChange bool
 	for _, d := range res.Descriptors {
 		if !d.Active || len(d.Range) != 2 {
@@ -556,27 +577,29 @@ func (h *MultisigLoungeHandler) watchDescriptorRange(ctx context.Context, name s
 		}
 		if d.Internal {
 			haveChange = true
+			state.change = normalizeDescriptor(d.Desc)
 		} else {
 			haveReceive = true
+			state.receive = normalizeDescriptor(d.Desc)
 		}
 		if end < 0 || d.Range[1] < end {
 			end = d.Range[1]
 		}
-		if d.Next > next {
-			next = d.Next
+		if d.Next > state.next {
+			state.next = d.Next
 		}
 	}
-	if !haveReceive || !haveChange {
-		return -1, next, nil
+	if haveReceive && haveChange {
+		state.end = end
 	}
-	return end, next, nil
+	return state, nil
 }
 
 // ensureWatchWallet makes sure the group's watch-only descriptor wallet exists,
 // has the Phase-1 receive/change descriptors imported, and that their range
 // still covers the addresses the wallet is about to hand out. Idempotent: an
 // already-existing wallet is loaded, not recreated, and the descriptors are only
-// re-imported when the imported range falls short.
+// re-imported when the imported range falls short or the policy changed.
 func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.GroupData) (string, error) {
 	name := watchWalletName(g)
 
@@ -612,23 +635,32 @@ func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.Gro
 
 	// The imported range is a hard cap: an address past its end is derivable but
 	// invisible to the wallet, so keep it ahead of the next index Core hands out.
-	haveEnd, next, err := h.watchDescriptorRange(ctx, name)
+	state, err := h.watchDescriptorRange(ctx, name)
 	if err != nil {
 		return "", err
 	}
-	wantEnd := watchRangeEnd(next)
-	if haveEnd >= wantEnd {
-		return name, nil
-	}
+	wantEnd := watchRangeEnd(state.next)
 
 	receive, change, err := wallet.BuildMultisigLoungeDescriptors(groupDataToLoungeGroup(g))
 	if err != nil {
 		return "", fmt.Errorf("build descriptors: %w", err)
 	}
 
+	// An edited group keeps its id, so the wallet is reused: what it tracks can be
+	// a retired policy, which must be replaced rather than served.
+	samePolicy := state.receive == normalizeDescriptor(receive) && state.change == normalizeDescriptor(change)
+	if state.end >= wantEnd && samePolicy {
+		return name, nil
+	}
+
 	// The widened indices were never handed out, so they carry no history and
 	// need no rescan. Keep "now", as the first import always used.
 	var timestamp interface{} = "now"
+	if state.end >= 0 && !samePolicy {
+		// A new policy's addresses can already hold deposits, and no deposit can
+		// predate the group; 0 (unset creation time) rescans from genesis.
+		timestamp = g.GetCreated() / 1000
+	}
 
 	descs := []map[string]interface{}{
 		{"desc": receive, "active": true, "internal": false, "timestamp": timestamp, "range": []int{0, wantEnd}},

--- a/sidechain-orchestrator/api/multisiglounge_handler.go
+++ b/sidechain-orchestrator/api/multisiglounge_handler.go
@@ -335,6 +335,40 @@ func groupDataToLoungeGroup(g *pb.GroupData) wallet.MultisigLoungeGroup {
 	}
 }
 
+// groupScriptType reads the group's multisig script type ("wsh", "sh-wsh",
+// "sh", or "tr") back out of its declared receive descriptor, so every
+// descriptor the orchestrator rebuilds matches the one the group published. A
+// legacy group that declares no descriptor gets "", the native-P2WSH default.
+func groupScriptType(g *pb.GroupData) string {
+	desc := g.GetDescriptorReceive()
+	if desc == "" {
+		return ""
+	}
+	_, _, scriptType, _, err := wallet.ParseMultisigDescriptor(desc)
+	if err != nil {
+		return ""
+	}
+	return scriptType
+}
+
+// multisigChangeType maps a group's multisig script type to the Core
+// walletcreatefundedpsbt change_type, so change pays an address the watch
+// wallet's own descriptors cover. Empty when the group declares no type.
+func multisigChangeType(scriptType string) string {
+	switch scriptType {
+	case "sh":
+		return "legacy"
+	case "sh-wsh":
+		return "p2sh-segwit"
+	case "wsh":
+		return "bech32"
+	case "tr":
+		return "bech32m"
+	default:
+		return ""
+	}
+}
+
 // coreCall invokes a bitcoind JSON-RPC method with positional params, wallet-less
 // (matching the Dart multisig path), and unmarshals the result into out.
 func (h *MultisigLoungeHandler) coreCall(ctx context.Context, method string, params []interface{}, out interface{}) error {
@@ -415,7 +449,7 @@ func (h *MultisigLoungeHandler) SignTransaction(
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet owns none of the group's keys; cannot sign"))
 	}
 
-	receiveDesc, changeDesc, err := wallet.BuildMultisigSigningDescriptors(loungeGroup, signWithXprv)
+	receiveDesc, changeDesc, err := wallet.BuildMultisigSigningDescriptorsTyped(loungeGroup, signWithXprv, groupScriptType(group))
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("build signing descriptors: %w", err))
 	}
@@ -641,7 +675,7 @@ func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.Gro
 	}
 	wantEnd := watchRangeEnd(state.next)
 
-	receive, change, err := wallet.BuildMultisigLoungeDescriptors(groupDataToLoungeGroup(g))
+	receive, change, err := wallet.BuildMultisigLoungeDescriptorsTyped(groupDataToLoungeGroup(g), groupScriptType(g))
 	if err != nil {
 		return "", fmt.Errorf("build descriptors: %w", err)
 	}
@@ -900,6 +934,11 @@ func (h *MultisigLoungeHandler) CreateSpendPsbt(
 	options := map[string]interface{}{
 		"includeWatching": true,
 		"changePosition":  1,
+	}
+	// The watch wallet holds only the group's own change descriptor, so Core must
+	// be told which output type that is or it cannot produce a change address.
+	if ct := multisigChangeType(groupScriptType(group)); ct != "" {
+		options["change_type"] = ct
 	}
 	if rate := req.Msg.GetFeeRateSatVb(); rate > 0 {
 		options["fee_rate"] = rate

--- a/sidechain-orchestrator/api/multisiglounge_sync_test.go
+++ b/sidechain-orchestrator/api/multisiglounge_sync_test.go
@@ -231,6 +231,49 @@ func TestSyncGroupBalanceE2E(t *testing.T) {
 	require.Equal(t, msAddr, resp.Msg.Utxos[0].Address)
 }
 
+// TestSyncGroupPolicyChangeReimports proves a same-id policy edit (2-of-3 to
+// 3-of-3) re-imports the watch wallet's descriptors instead of silently serving
+// the retired policy: a deposit made to the new policy before the re-import —
+// so only a rescan can find it — must show up in SyncGroup.
+func TestSyncGroupPolicyChangeReimports(t *testing.T) {
+	rt := newLoungeRegtest(t)
+	h := newSyncHandler(rt)
+	group := loungeSyncTestGroup(t)
+	ctx := context.Background()
+
+	// First sync imports the 2-of-3 descriptors with a range that stays ample.
+	_, err := h.SyncGroup(ctx, connect.NewRequest(&pb.SyncGroupRequest{Group: group}))
+	require.NoError(t, err)
+
+	rt.rpcInto(t, "", "createwallet", `["fund"]`, nil)
+	var fundAddr string
+	rt.rpcInto(t, "fund", "getnewaddress", "", &fundAddr)
+	rt.rpcInto(t, "", "generatetoaddress", fmt.Sprintf(`[101,%q]`, fundAddr), nil)
+
+	// Same id, same keys, new threshold: what editing a group produces.
+	group.M = 3
+	receive, _, err := wallet.BuildMultisigLoungeDescriptors(groupDataToLoungeGroup(group))
+	require.NoError(t, err)
+	var addrs []string
+	rt.rpcInto(t, "", "deriveaddresses", fmt.Sprintf(`[%q,[0,0]]`, receive), &addrs)
+	require.Len(t, addrs, 1)
+
+	rt.rpcInto(t, "fund", "sendtoaddress", fmt.Sprintf(`[%q,"1.0"]`, addrs[0]), nil)
+	rt.rpcInto(t, "", "generatetoaddress", fmt.Sprintf(`[1,%q]`, fundAddr), nil)
+
+	resp, err := h.SyncGroup(ctx, connect.NewRequest(&pb.SyncGroupRequest{Group: group}))
+	require.NoError(t, err)
+	require.Equal(t, int64(100_000_000), resp.Msg.ConfirmedSats, "the 3-of-3 deposit must be visible")
+	require.Len(t, resp.Msg.Utxos, 1)
+	require.Equal(t, addrs[0], resp.Msg.Utxos[0].Address)
+
+	// The wallet now tracks the new policy, and reports it in the spelling the
+	// next sync compares against — so it does not re-import (and rescan) again.
+	state, err := h.watchDescriptorRange(ctx, watchWalletName(group))
+	require.NoError(t, err)
+	require.Equal(t, normalizeDescriptor(receive), state.receive)
+}
+
 func TestRestoreHistoryE2E(t *testing.T) {
 	rt := newLoungeRegtest(t)
 	h := newSyncHandler(rt)

--- a/sidechain-orchestrator/api/multisiglounge_sync_test.go
+++ b/sidechain-orchestrator/api/multisiglounge_sync_test.go
@@ -557,3 +557,69 @@ func TestCreateSpendPsbtE2E(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cab.Msg.Txid, 64, "the CreateSpendPsbt output must sign+combine+broadcast end to end")
 }
+
+// TestGroupScriptType pins the script type read back out of a group's declared
+// receive descriptor; a group that declares none stays on the wsh default.
+func TestGroupScriptType(t *testing.T) {
+	base := loungeSyncTestGroup(t)
+	for _, scriptType := range []string{"wsh", "sh-wsh", "sh", "tr"} {
+		t.Run(scriptType, func(t *testing.T) {
+			receive, _, err := wallet.BuildMultisigLoungeDescriptorsTyped(groupDataToLoungeGroup(base), scriptType)
+			require.NoError(t, err)
+			require.Equal(t, scriptType, groupScriptType(&pb.GroupData{DescriptorReceive: receive}))
+		})
+	}
+	require.Equal(t, "", groupScriptType(&pb.GroupData{}), "a legacy group declares no descriptor")
+	require.Equal(t, "", groupScriptType(&pb.GroupData{DescriptorReceive: "not a descriptor"}))
+}
+
+// TestWatchWalletUsesDeclaredScriptType pins the non-wsh path: a group whose
+// declared descriptors are sh(wsh(sortedmulti)) must import THOSE descriptors
+// into its watch wallet, and fund its change from the same script type.
+func TestWatchWalletUsesDeclaredScriptType(t *testing.T) {
+	group := loungeSyncTestGroup(t)
+	receive, change, err := wallet.BuildMultisigLoungeDescriptorsTyped(groupDataToLoungeGroup(group), "sh-wsh")
+	require.NoError(t, err)
+	group.DescriptorReceive = receive
+	group.DescriptorChange = change
+
+	var imported []map[string]interface{}
+	var fundOptions map[string]interface{}
+	unmarshalParam := func(paramsJSON string, i int, out interface{}) {
+		var params []json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(paramsJSON), &params))
+		require.NoError(t, json.Unmarshal(params[i], out))
+	}
+
+	h := NewMultisigLoungeHandler()
+	h.SetCoreCaller(func(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
+		switch method {
+		case "listwallets":
+			return json.RawMessage(`[]`), nil
+		case "loadwallet":
+			return nil, fmt.Errorf("wallet not found")
+		case "createwallet":
+			return json.RawMessage(`{}`), nil
+		case "listdescriptors":
+			return json.RawMessage(`{"descriptors":[]}`), nil
+		case "importdescriptors":
+			unmarshalParam(paramsJSON, 0, &imported)
+			return json.RawMessage(`[{"success":true},{"success":true}]`), nil
+		case "walletcreatefundedpsbt":
+			unmarshalParam(paramsJSON, 3, &fundOptions)
+			return json.RawMessage(`{"psbt":"cHNidP8BAAA=","fee":0.0001}`), nil
+		}
+		return nil, fmt.Errorf("unexpected method %s", method)
+	})
+
+	_, err = h.CreateSpendPsbt(context.Background(), connect.NewRequest(&pb.CreateSpendPsbtRequest{
+		Group:        group,
+		Destinations: []*pb.SpendDestination{{Address: "bcrt1qdest", Sats: 50_000}},
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, imported, 2)
+	require.Equal(t, receive, imported[0]["desc"], "the watch wallet must import the group's declared receive descriptor")
+	require.Equal(t, change, imported[1]["desc"], "the watch wallet must import the group's declared change descriptor")
+	require.Equal(t, "p2sh-segwit", fundOptions["change_type"], "change must pay the group's own script type")
+}

--- a/sidechain-orchestrator/api/multisiglounge_sync_test.go
+++ b/sidechain-orchestrator/api/multisiglounge_sync_test.go
@@ -384,6 +384,19 @@ func TestRestoreHistoryNetsRowsPerTxid(t *testing.T) {
 		{"spend with change to a group address", spendRows, false, 50_000_000, "payee"},
 		{"deposit", depositRows, true, 100_000_000, "grp"},
 	}
+
+	// ensureWatchWallet now always rebuilds the group's descriptors to detect a
+	// same-id policy change, so RestoreHistory needs a group that carries a real
+	// policy; the row-netting under test does not depend on it. listdescriptors
+	// reports the group's own current descriptors so the watch wallet reads as
+	// already up to date and restore proceeds straight to reading history.
+	group := loungeSyncTestGroup(t)
+	group.Id = "restore"
+	group.WatchWalletName = "ms_test"
+	recvDesc, changeDesc, err := wallet.BuildMultisigLoungeDescriptorsTyped(
+		groupDataToLoungeGroup(group), groupScriptType(group))
+	require.NoError(t, err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewMultisigLoungeHandler()
@@ -400,17 +413,18 @@ func TestRestoreHistoryNetsRowsPerTxid(t *testing.T) {
 				case "getrawtransaction":
 					return json.RawMessage(raw), nil
 				case "listdescriptors":
-					// The watch wallet already covers the indices it hands out.
-					return json.RawMessage(`{"descriptors":[
-						{"desc":"wsh(x)","active":true,"internal":false,"range":[0,999],"next":0},
-						{"desc":"wsh(y)","active":true,"internal":true,"range":[0,999],"next":0}
-					]}`), nil
+					// The watch wallet already tracks the group's current
+					// descriptors and covers the indices it hands out.
+					return json.RawMessage(fmt.Sprintf(`{"descriptors":[
+						{"desc":%q,"active":true,"internal":false,"range":[0,999],"next":0},
+						{"desc":%q,"active":true,"internal":true,"range":[0,999],"next":0}
+					]}`, recvDesc, changeDesc)), nil
 				}
 				return nil, fmt.Errorf("unexpected method %s", method)
 			})
 
 			resp, err := h.RestoreHistory(context.Background(), connect.NewRequest(&pb.RestoreHistoryRequest{
-				Group: &pb.GroupData{Id: "restore", WatchWalletName: "ms_test"},
+				Group: group,
 			}))
 			require.NoError(t, err)
 			require.Len(t, resp.Msg.Transactions, 1)

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -663,7 +663,7 @@ func (h *Handler) fetchSidechainBalance(ctx context.Context, binary pb.BinaryTyp
 		if err != nil {
 			return 0, 0, err
 		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
+		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats(), resp.AvailableSats())
 		return confirmed, pending, nil
 	case pb.BinaryType_BINARY_TYPE_BITNAMES:
 		resp, err := bitnames.NewClient("localhost", port).Balance(ctx)

--- a/sidechain-orchestrator/api/sidechain_balance_test.go
+++ b/sidechain-orchestrator/api/sidechain_balance_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+)
+
+// TestFetchSidechainBalanceZSide feeds the exact balance JSON a zside node
+// emits and checks it is not silently read as zero.
+func TestFetchSidechainBalanceZSide(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{
+			"total_shielded_sats": 60000,
+			"total_transparent_sats": 40000,
+			"available_shielded_sats": 50000,
+			"available_transparent_sats": 30000
+		}}`))
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	confirmed, pending, err := (&Handler{}).fetchSidechainBalance(
+		context.Background(), pb.BinaryType_BINARY_TYPE_ZSIDE, port,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(80_000), confirmed)
+	assert.Equal(t, int64(20_000), pending)
+}

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -502,7 +502,7 @@ func run(cctx *cli.Context) error {
 	bmmStore := bmmstate.NewStore(walletSvc.NetworkDir(), 0)
 	bmmEngine := engines.NewBmmEngine(log, bmmHandler, orch, bmmStore)
 	bmmHandler.SetEngine(bmmEngine)
-	walletEngine.OnNetworkReset(func(dir string) { bmmStore.Rebind(dir) })
+	walletEngine.OnNetworkReset(bmmEngine.ResetForNetwork)
 	go func() {
 		if err := bmmEngine.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			log.Error().Err(err).Msg("bmm engine exited")

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -538,22 +539,32 @@ func (m *BitcoinConfManager) applyMainSectionDefaults(n Network) {
 	if m.Config == nil {
 		return
 	}
-	// Keys that identify a specific chain=main network (forknet vs eCash vs
-	// real mainnet). Strip them first so a swap never leaves a sibling's port
-	// or peer behind — forknet and eCash use different ports, and only
-	// eCash sets addnode/uacomment.
-	mainVariantKeys := []string{
-		"port", "rpcport", "rpcbind", "rpcallowip", "addnode", "uacomment",
-		"assumevalid", "minimumchainwork", "listenonion", "drivechain", "fallbackfee",
-	}
-	for _, k := range mainVariantKeys {
-		m.Config.RemoveSetting(k, "main")
+	// Strip the keys we wrote ourselves first, so a swap never leaves a
+	// sibling's port or peer behind — forknet and eCash use different ports,
+	// and only eCash sets addnode/uacomment. A value the operator set by hand
+	// is theirs: deleting a custom port= moves their node, and deleting a
+	// custom rpcport= can stop Core from starting at all.
+	for k, ourValues := range m.injectedMainValues() {
+		if slices.Contains(ourValues, m.Config.GetSetting(k, "main")) {
+			m.Config.RemoveSetting(k, "main")
+		}
 	}
 
-	var defaults []struct{ k, v string }
+	for _, kv := range m.mainSectionDefaults(n) {
+		// An unpublished peer must not become `addnode=`, which bitcoind rejects.
+		if kv.v == "" {
+			continue
+		}
+		m.Config.SetSetting(kv.k, kv.v, "main")
+	}
+}
+
+// mainSectionDefaults is the [main] block n wants. Networks that don't read
+// [main] get none.
+func (m *BitcoinConfManager) mainSectionDefaults(n Network) []struct{ k, v string } {
 	switch n {
 	case NetworkForknet:
-		defaults = []struct{ k, v string }{
+		return []struct{ k, v string }{
 			{"port", "8300"},
 			{"rpcport", "18301"},
 			{"assumevalid", "0000000000000000000000000000000000000000000000000000000000000000"},
@@ -563,7 +574,7 @@ func (m *BitcoinConfManager) applyMainSectionDefaults(n Network) {
 			{"fallbackfee", "0.00021"},
 		}
 	case NetworkECash:
-		defaults = []struct{ k, v string }{
+		return []struct{ k, v string }{
 			{"port", "8301"},
 			{"rpcport", "18302"},
 			{"addnode", m.ECashPeer()},
@@ -575,13 +586,26 @@ func (m *BitcoinConfManager) applyMainSectionDefaults(n Network) {
 			{"fallbackfee", "0.00021"},
 		}
 	}
-	for _, kv := range defaults {
-		// An unpublished peer must not become `addnode=`, which bitcoind rejects.
-		if kv.v == "" {
-			continue
+	return nil
+}
+
+// injectedMainValues maps each [main] key BitWindow writes to the values it
+// writes there. Anything else under [main] is the operator's own.
+func (m *BitcoinConfManager) injectedMainValues() map[string][]string {
+	out := map[string][]string{}
+	for _, n := range []Network{NetworkForknet, NetworkECash} {
+		for _, kv := range m.mainSectionDefaults(n) {
+			out[kv.k] = append(out[kv.k], kv.v)
 		}
-		m.Config.SetSetting(kv.k, kv.v, "main")
 	}
+	// The eCash id and its seed come from the catalog, so what's on disk can
+	// be older than what mainSectionDefaults builds now. A uacomment naming an
+	// eCash network marks the block as ours, stale values included.
+	if uacomment := m.Config.GetSetting("uacomment", "main"); IsECashUAComment(uacomment) {
+		out["uacomment"] = append(out["uacomment"], uacomment)
+		out["addnode"] = append(out["addnode"], m.Config.GetSetting("addnode", "main"))
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -925,9 +925,70 @@ func TestApplyMainSectionDefaultsECashThenMainnet(t *testing.T) {
 	require.Equal(t, "", m.Config.GetSetting("uacomment", "main"))
 }
 
+// A [main] value the operator set by hand is not ours to delete: it survives
+// a mainnet → signet → mainnet round trip.
+func TestApplyMainSectionDefaultsKeepsUserMainnetPorts(t *testing.T) {
+	m := &BitcoinConfManager{Config: NewBitcoinConfig(), ECashID: "alphanet", log: zerolog.Nop()}
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("port", "28333", "main")
+	m.Config.SetSetting("rpcport", "28332", "main")
+	m.Config.SetSetting("addnode", "mypeer:1234", "main")
+	m.Config.SetSetting("rpcbind", "127.0.0.1", "main")
+
+	m.applyMainSectionDefaults(NetworkSignet)
+	m.applyMainSectionDefaults(NetworkMainnet)
+
+	require.Equal(t, "28333", m.Config.GetSetting("port", "main"))
+	require.Equal(t, "28332", m.Config.GetSetting("rpcport", "main"))
+	require.Equal(t, "mypeer:1234", m.Config.GetSetting("addnode", "main"))
+	require.Equal(t, "127.0.0.1", m.Config.GetSetting("rpcbind", "main"))
+}
+
+// Forknet → mainnet still strips everything forknet injected, while leaving
+// the operator's own addnode alone.
+func TestApplyMainSectionDefaultsForknetThenMainnet(t *testing.T) {
+	m := &BitcoinConfManager{Config: NewBitcoinConfig(), ECashID: "alphanet", log: zerolog.Nop()}
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("addnode", "mypeer:1234", "main")
+
+	m.applyMainSectionDefaults(NetworkForknet)
+	require.Equal(t, "8300", m.Config.GetSetting("port", "main"))
+
+	m.applyMainSectionDefaults(NetworkMainnet)
+	require.Equal(t, "", m.Config.GetSetting("port", "main"))
+	require.Equal(t, "", m.Config.GetSetting("rpcport", "main"))
+	require.Equal(t, "", m.Config.GetSetting("drivechain", "main"))
+	require.Equal(t, "", m.Config.GetSetting("fallbackfee", "main"))
+	require.Equal(t, "mypeer:1234", m.Config.GetSetting("addnode", "main"))
+}
+
 // ---------------------------------------------------------------------------
 // UpdateNetwork
 // ---------------------------------------------------------------------------
+
+// The round trip goes through the file too: a swap away and back must not
+// rewrite the master conf without the operator's ports.
+func TestUpdateNetworkRoundTripKeepsUserMainnetPorts(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := newTestManager(tmpDir)
+	m.Network = NetworkMainnet
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("port", "28333", "main")
+	m.Config.SetSetting("rpcport", "28332", "main")
+
+	masterPath := m.getBitWindowConfigPath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(masterPath), 0755))
+	require.NoError(t, os.WriteFile(masterPath, []byte(m.Config.Serialize()), 0644))
+
+	require.NoError(t, m.UpdateNetwork(NetworkSignet))
+	require.NoError(t, m.UpdateNetwork(NetworkMainnet))
+
+	data, err := os.ReadFile(masterPath)
+	require.NoError(t, err)
+	saved := ParseBitcoinConfig(string(data))
+	require.Equal(t, "28333", saved.GetSetting("port", "main"))
+	require.Equal(t, "28332", saved.GetSetting("rpcport", "main"))
+}
 
 func TestUpdateNetworkCallsCallback(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -253,10 +253,18 @@ func SplitCheckEsploraURLs() []string {
 	return []string{"https://mempool.space/api", "https://blockstream.info/api"}
 }
 
-// IsEcashFork reports whether the network is a fork of BTC mainnet, so its
-// pre-fork outpoints also exist on BTC.
+// IsEcashFork reports whether the network runs the eCash fork flow (claims,
+// split UI).
 func IsEcashFork(n Network) bool {
 	return n == NetworkForknet || n == NetworkECash
+}
+
+// SharesBitcoinHistory reports whether the network forked off BTC mainnet, so
+// its pre-fork outpoints also exist on BTC. Forknet is excluded: it is a
+// fresh-genesis rehearsal chain that only reuses mainnet params, so none of its
+// outpoints can ever exist on Bitcoin.
+func SharesBitcoinHistory(n Network) bool {
+	return n == NetworkECash
 }
 
 // WalletChainSourceURLsForNetwork returns the endpoints the electrum wallet

--- a/sidechain-orchestrator/config/network_table_test.go
+++ b/sidechain-orchestrator/config/network_table_test.go
@@ -55,6 +55,34 @@ func TestChainMainNetworksHaveDistinctDatadirGroups(t *testing.T) {
 	}
 }
 
+// Forknet runs the eCash fork flow but has its own genesis, so it shares no
+// outpoint with Bitcoin. Collapsing the two predicates sends its txids to the
+// public BTC explorers.
+func TestSharesBitcoinHistory(t *testing.T) {
+	cases := []struct {
+		n      Network
+		fork   bool
+		shares bool
+	}{
+		{NetworkMainnet, false, false},
+		{NetworkForknet, true, false},
+		{NetworkECash, true, true},
+		{NetworkSignet, false, false},
+		{NetworkTestnet, false, false},
+		{NetworkRegtest, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.n), func(t *testing.T) {
+			if got := IsEcashFork(tc.n); got != tc.fork {
+				t.Errorf("IsEcashFork = %v, want %v", got, tc.fork)
+			}
+			if got := SharesBitcoinHistory(tc.n); got != tc.shares {
+				t.Errorf("SharesBitcoinHistory = %v, want %v", got, tc.shares)
+			}
+		})
+	}
+}
+
 // Launch scripts and ORCHESTRATOR_NETWORK still carry the name the slot went
 // out with. Falling through to signet would boot a network nobody asked for.
 func TestLookupNetworkAcceptsTheLegacyECashName(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -308,6 +308,9 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		// The enforcer chain goes on every switch. Journalled because past the
 		// commit below a retry reads FromID == ToID and skips this call.
 		if err := o.Settings.SetPendingEnforcerWipe(toID); err != nil {
+			// Core still answers, so the drop goes back. Left barred, the
+			// branch on disk is one Core can no longer follow.
+			o.restoreRewind(ctx, dropped)
 			o.restartAfterAbort(ctx, restartL1, stoppedL2)
 			return fmt.Errorf("journal the enforcer cleanup for %s: %w", toID, err)
 		}

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -435,7 +435,7 @@ func (o *Orchestrator) rewindBelowTheFork(ctx context.Context, height uint32) (s
 	if o.Settings != nil {
 		previous = o.Settings.RewoundBlockHash()
 	}
-	hash, err := dropForkAbove(ctx, client, height, previous)
+	hash, err := resolveForkAbove(ctx, client, height, previous)
 	if err != nil {
 		return "", err
 	}
@@ -444,12 +444,15 @@ func (o *Orchestrator) rewindBelowTheFork(ctx context.Context, height uint32) (s
 	// meant to leave.
 	o.clearedMark = previous
 
-	// A drop nobody recorded cannot be taken back, and the next switch would bar
-	// this branch too — leaving Core under the fork with neither to follow. It
-	// runs for an empty hash too, which records that nothing is barred.
+	// The record goes in before the bar, never after. A drop nobody recorded
+	// cannot be taken back, and the next switch would bar this branch too —
+	// leaving Core under the fork with neither to follow. A record whose bar
+	// never lands costs nothing: clearMark tolerates a block Core does not hold
+	// and reconsiderblock on a live block is a no-op. It runs for an empty hash
+	// too, which records that nothing is barred.
 	if o.Settings != nil {
 		if err := o.Settings.CommitRewind(hash); err != nil {
-			o.restoreRewind(ctx, hash)
+			o.restoreRewind(ctx, "")
 			return "", fmt.Errorf("record the dropped block %s: %w", hash, err)
 		}
 	}
@@ -457,6 +460,12 @@ func (o *Orchestrator) rewindBelowTheFork(ctx context.Context, height uint32) (s
 		o.log.Info().Uint32("height", height).
 			Msg("the chain sits below the fork, so nothing had to be dropped")
 		return "", nil
+	}
+	if _, err := client.call(ctx, "invalidateblock", hash); err != nil {
+		// The call may have landed and only the answer been lost, so the rollback
+		// names the block: reconsidering one Core never barred is a no-op.
+		o.restoreRewind(ctx, hash)
+		return "", fmt.Errorf("drop block %s: %w", hash, err)
 	}
 	o.log.Info().Str("block", hash).Uint32("height", height+1).
 		Msg("dropped the retired eCash chain from this block up")
@@ -496,18 +505,23 @@ func (o *Orchestrator) restoreRewind(ctx context.Context, hash string) {
 	}
 }
 
-// dropForkAbove bars the retired fork from height+1 up and returns the block it
-// barred. previousMark is the block an earlier switch barred, or empty.
+// resolveForkAbove names the block the drop has to bar — the first one above
+// height — and lifts the mark an earlier switch left. previousMark is the block
+// that switch barred, or empty. An empty result means the chain sits below the
+// fork and nothing has to go.
+//
+// The bar itself is the caller's, so the record of what is about to go can land
+// before the call that cannot be taken back.
 //
 // It reads the outgoing block before clearing previousMark. reconsiderblock
 // revalidates the branch it clears, and a branch with more work becomes the
 // active chain — a read after it would name the incoming fork and bar the very
 // chain this switch moves to.
 //
-// It bars height+1, not height. invalidateblock bars the block AND every
+// It names height+1, not height. invalidateblock bars the block AND every
 // descendant, so barring the last shared block would bar the incoming chain too
 // and Core could never move past it.
-func dropForkAbove(ctx context.Context, client *CoreStatusClient, height uint32, previousMark string) (string, error) {
+func resolveForkAbove(ctx context.Context, client *CoreStatusClient, height uint32, previousMark string) (string, error) {
 	// A node still below the fork holds no block either network disagrees on, so
 	// there is nothing to drop and the switch goes on. Asking for the block
 	// anyway fails the switch until the chain catches up.
@@ -538,10 +552,6 @@ func dropForkAbove(ctx context.Context, client *CoreStatusClient, height uint32,
 	// the network it dropped would park forever. Clear it before the new one.
 	if err := clearMark(ctx, client, previousMark); err != nil {
 		return "", err
-	}
-
-	if _, err := client.call(ctx, "invalidateblock", hash); err != nil {
-		return "", fmt.Errorf("drop block %s: %w", hash, err)
 	}
 	return hash, nil
 }

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -203,7 +203,7 @@ func (o *Orchestrator) recordECashSwitch(fromID, toID string) error {
 	if o.WalletSvc != nil {
 		o.WalletSvc.ClearNetworkScans(string(config.NetworkECash))
 	}
-	if err := o.ApplyPendingEnforcerWipe(); err != nil {
+	if err := o.applyPendingEnforcerWipeLocked(); err != nil {
 		return err
 	}
 	o.clearNetworkSwapCaches()
@@ -365,10 +365,24 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	return o.finishECashSwitch(plan.FromID, toID, restartL1)
 }
 
-// applyPendingEnforcerWipe clears the enforcer chain a switch journalled, and
+// ApplyPendingEnforcerWipe clears the enforcer chain a switch journalled, and
 // keeps the record until it is gone. The enforcer keeps one validator chain per
 // network, not per fork, so a leftover serves the retired generation.
+//
+// The lock makes the record the in-flight switch's own. That switch writes it
+// before it commits its selection, so a caller that reads in between — an
+// enforcer restart, say — finds running != recorded and drops a cleanup the
+// switch still owes.
 func (o *Orchestrator) ApplyPendingEnforcerWipe() error {
+	o.swapNetworkMu.Lock()
+	defer o.swapNetworkMu.Unlock()
+	return o.applyPendingEnforcerWipeLocked()
+}
+
+// applyPendingEnforcerWipeLocked is ApplyPendingEnforcerWipe's body.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) applyPendingEnforcerWipeLocked() error {
 	if o.Settings == nil {
 		return nil
 	}

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -589,6 +591,62 @@ func TestApplyECashSwitchTakesTheRewindBackWhenTheConfWillNotWrite(t *testing.T)
 		"a conf that will not write must leave the chain as it was")
 	require.Empty(t, o.Settings.RewoundBlockHash())
 	require.Equal(t, "drynet4", o.ecashID)
+}
+
+// blockOnLog breaks the world once, the first time a log line starts with
+// prefix. It is the only seam a test has between two steps of one call.
+type blockOnLog struct {
+	prefix string
+	block  func()
+	fired  bool
+}
+
+func (h *blockOnLog) Run(_ *zerolog.Event, _ zerolog.Level, msg string) {
+	if h.fired || !strings.HasPrefix(msg, h.prefix) {
+		return
+	}
+	h.fired = true
+	h.block()
+}
+
+// The enforcer cleanup is journalled after the rewind is recorded, so a fault
+// that only shows up there aborts with the retired branch still barred. Core
+// then follows neither chain: the branch on disk is invalidated and the
+// incoming fork was never fetched.
+func TestApplyECashSwitchTakesTheRewindBackWhenTheJournalWillNotWrite(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	core := &fakeCore{tips: []int64{979000}, hashes: map[int64]string{979000: tipBlock, 961632: forkBlock}}
+	attachFakeCore(t, o, core)
+	o.process.AdoptProcess(o.configs["bitcoind"], 1)
+	o.stopBinary = func(_ context.Context, name string, _ bool, _ ...StopOptions) error {
+		o.process.Remove(name)
+		return nil
+	}
+
+	// A file where the settings directory belongs, so every write refuses. It
+	// goes in on the line the rewind logs once it has recorded its drop, the
+	// only seam between that record and the journal write below it.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o644))
+	hook := &blockOnLog{
+		prefix: "dropped the retired eCash chain",
+		block:  func() { o.Settings.bitwindowDir = blocked },
+	}
+	o.log = o.log.Hook(hook)
+
+	err := o.ApplyECashSwitch(context.Background(), "alphanet")
+	require.Error(t, err)
+
+	require.True(t, hook.fired, "the rewind has to land before the journal write refuses")
+	require.Equal(t, []string{"invalidateblock", "reconsiderblock"}, marks(core),
+		"a journal that will not write must leave the chain as it was")
+	require.Equal(t, []string{forkBlock, forkBlock}, markParams(core))
+	require.Equal(t, "drynet4", o.ecashID, "the old network stays selected")
+	require.Equal(t, "drynet4", o.installedECashNetwork(), "the conf keeps naming the old network")
 }
 
 // Barring the outgoing branch while the incoming one is still barred parks Core

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -367,35 +367,35 @@ const (
 
 // invalidateblock bars the block and every descendant. Barring the last shared
 // block would bar the incoming chain too, and Core could never move past it.
-func TestDropForkAboveBarsTheFirstDivergentBlock(t *testing.T) {
+func TestResolveForkAboveNamesTheFirstDivergentBlock(t *testing.T) {
 	core := &fakeCore{
 		tips:   []int64{979000},
 		hashes: map[int64]string{979000: tipBlock, 961631: sharedBlock, 961632: forkBlock},
 	}
 
-	got, err := dropForkAbove(context.Background(), core.start(t), 961631, "")
+	got, err := resolveForkAbove(context.Background(), core.start(t), 961631, "")
 	require.NoError(t, err)
 	require.Equal(t, forkBlock, got, "the block above the fork is the one that goes")
-	require.Equal(t, []string{"invalidateblock"}, marks(core))
-	require.Equal(t, forkBlock, markParams(core)[0], "the shared block must survive")
+	require.NotEqual(t, sharedBlock, got, "the shared block must survive")
+	require.Empty(t, marks(core), "the bar waits for the caller to record the block")
 }
 
 // reconsiderblock revalidates the branch it clears, and a branch with more work
 // becomes the active chain. A read after it would name the incoming fork and
 // bar the very chain this switch moves to.
-func TestDropForkAboveReadsTheBlockBeforeClearingTheOldMark(t *testing.T) {
+func TestResolveForkAboveReadsTheBlockBeforeClearingTheOldMark(t *testing.T) {
 	core := &fakeCore{
 		tips:   []int64{979000},
 		hashes: map[int64]string{979000: tipBlock, 961632: forkBlock},
 	}
 
-	got, err := dropForkAbove(context.Background(), core.start(t), 961631, staleMark)
+	got, err := resolveForkAbove(context.Background(), core.start(t), 961631, staleMark)
 	require.NoError(t, err)
 	require.Equal(t, forkBlock, got)
 	require.Less(t, lastIndexOf(core.methods, "getblockhash"), indexOf(core.methods, "reconsiderblock"),
 		"the read has to come first")
-	require.Equal(t, []string{"reconsiderblock", "invalidateblock"}, marks(core))
-	require.Equal(t, []string{staleMark, forkBlock}, markParams(core))
+	require.Equal(t, []string{"reconsiderblock"}, marks(core))
+	require.Equal(t, []string{staleMark}, markParams(core))
 }
 
 // The chains part at no published height, so the blocks on disk belong to a
@@ -564,6 +564,30 @@ func TestApplyECashSwitchRewindsAndLandsTheTarget(t *testing.T) {
 	require.Nil(t, o.pendingSwap, "a tail that lands leaves nothing pending")
 }
 
+// The record goes in before the bar, so a kill between the two can only leave a
+// record whose bar never landed — which clears as a no-op. The other order
+// leaves a bar no record names, and the next switch bars its own branch too,
+// parking Core under the fork with neither to follow.
+func TestRewindBelowTheForkRecordsTheDropBeforeItBars(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	core := &fakeCore{tips: []int64{979000}, hashes: map[int64]string{979000: tipBlock, 961632: forkBlock}}
+	attachFakeCore(t, o, core)
+	o.process.AdoptProcess(o.configs["bitcoind"], 1)
+	// A file where the settings directory belongs, so the record cannot land.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o644))
+	o.Settings.bitwindowDir = blocked
+
+	_, err := o.rewindBelowTheFork(context.Background(), 961631)
+
+	require.Error(t, err)
+	require.Empty(t, marks(core), "no block may be barred until the record is on disk")
+}
+
 // The conf goes before Core stops, so a failure there can still put the drop
 // back. Once Core is down nothing can, and the retry would clear the chain the
 // rewind saved.
@@ -652,32 +676,30 @@ func TestApplyECashSwitchTakesTheRewindBackWhenTheJournalWillNotWrite(t *testing
 // Barring the outgoing branch while the incoming one is still barred parks Core
 // under the fork with no chain to follow. A failure to clear the old mark has
 // to stop the switch.
-func TestDropForkAboveStopsWhenTheOldMarkWillNotClear(t *testing.T) {
+func TestResolveForkAboveStopsWhenTheOldMarkWillNotClear(t *testing.T) {
 	core := &fakeCore{
 		tips:         []int64{979000},
 		hashes:       map[int64]string{979000: tipBlock, 961632: forkBlock},
 		reconsiderNo: true,
 	}
 
-	_, err := dropForkAbove(context.Background(), core.start(t), 961631, staleMark)
-	require.Error(t, err)
-	require.NotContains(t, core.methods, "invalidateblock",
+	_, err := resolveForkAbove(context.Background(), core.start(t), 961631, staleMark)
+	require.Error(t, err,
 		"nothing may be barred while the target branch is still barred")
 }
 
 // A hash from an earlier switch names a chain a wiped datadir no longer holds.
 // Core reports that as block-not-found, which must not stop the switch.
-func TestDropForkAboveIgnoresAnUnknownOldMark(t *testing.T) {
+func TestResolveForkAboveIgnoresAnUnknownOldMark(t *testing.T) {
 	core := &fakeCore{
 		tips:              []int64{979000},
 		hashes:            map[int64]string{979000: tipBlock, 961632: forkBlock},
 		reconsiderUnknown: true,
 	}
 
-	got, err := dropForkAbove(context.Background(), core.start(t), 961631, staleMark)
+	got, err := resolveForkAbove(context.Background(), core.start(t), 961631, staleMark)
 	require.NoError(t, err)
-	require.Equal(t, forkBlock, got)
-	require.Contains(t, core.methods, "invalidateblock")
+	require.Equal(t, forkBlock, got, "the switch goes on and the block still has to go")
 }
 
 // marks lists the calls that change what Core follows, dropping the reads that
@@ -724,13 +746,13 @@ func lastIndexOf(list []string, want string) int {
 
 // A node still syncing below the fork holds no block either network disagrees
 // on. Asking for one fails the switch until the chain catches up.
-func TestDropForkAboveSkipsAChainBelowTheFork(t *testing.T) {
+func TestResolveForkAboveSkipsAChainBelowTheFork(t *testing.T) {
 	core := &fakeCore{
 		tips:   []int64{900000},
 		hashes: map[int64]string{900000: tipBlock},
 	}
 
-	got, err := dropForkAbove(context.Background(), core.start(t), 961631, "")
+	got, err := resolveForkAbove(context.Background(), core.start(t), 961631, "")
 	require.NoError(t, err)
 	require.Empty(t, got, "nothing was dropped, so nothing is named")
 	require.Empty(t, marks(core), "a chain below the fork needs no mark")
@@ -738,13 +760,13 @@ func TestDropForkAboveSkipsAChainBelowTheFork(t *testing.T) {
 
 // A move back to a fork an earlier switch barred has to lift that bar even when
 // the chain sits below the fork. Leaving it parks Core there for good.
-func TestDropForkAboveClearsTheOldMarkBelowTheFork(t *testing.T) {
+func TestResolveForkAboveClearsTheOldMarkBelowTheFork(t *testing.T) {
 	core := &fakeCore{
 		tips:   []int64{900000},
 		hashes: map[int64]string{900000: tipBlock},
 	}
 
-	got, err := dropForkAbove(context.Background(), core.start(t), 961631, staleMark)
+	got, err := resolveForkAbove(context.Background(), core.start(t), 961631, staleMark)
 	require.NoError(t, err)
 	require.Empty(t, got, "nothing was dropped, so nothing is named")
 	require.Equal(t, []string{"reconsiderblock"}, marks(core), "the old bar still has to lift")

--- a/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
+++ b/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
@@ -175,6 +176,42 @@ func TestAnEnforcerCleanupForAnAbortedSwitchIsDropped(t *testing.T) {
 	require.DirExists(t, chain, "the running generation's validator chain must survive")
 	require.Empty(t, o.Settings.PendingEnforcerWipe(),
 		"a cleanup for a network we never moved to must go")
+}
+
+// A switch in flight is not an aborted one. An enforcer restart that lands
+// between the record and the commit would read it as aborted and drop a cleanup
+// that is still owed, leaving the retired generation's chain in place.
+func TestAnEnforcerCleanupWaitsForTheSwitchThatJournalledIt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+
+	chain := filepath.Join(config.EnforcerDirs.RootDir(), "validator", "bitcoin")
+	require.NoError(t, os.MkdirAll(chain, 0o755))
+
+	// A switch to alphanet in flight: its record is written and the selection
+	// still names the fork this install is leaving.
+	o.swapNetworkMu.Lock()
+	done := make(chan error, 1)
+	go func() { done <- o.ApplyPendingEnforcerWipe() }()
+	select {
+	case <-done:
+		t.Fatal("a restart must not consume the record of a switch in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The switch commits, so the cleanup now names the generation that runs.
+	o.mu.Lock()
+	o.ecashID = "alphanet"
+	o.mu.Unlock()
+	o.swapNetworkMu.Unlock()
+
+	require.NoError(t, <-done)
+	require.NoDirExists(t, chain, "the retired generation's validator chain must go")
+	require.Empty(t, o.Settings.PendingEnforcerWipe(), "cleanup that ran clears its journal")
 }
 
 // A pick made from another network reaches eCash through SwapNetwork, not

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -141,6 +141,20 @@ func (e *BmmEngine) Stop(sidechain pb.BinaryType) {
 	e.notify()
 }
 
+// ResetForNetwork drops automation and per-chain round state, and repoints the
+// store, so a network swap cannot leave the engine bidding on a chain the user
+// never armed it for.
+func (e *BmmEngine) ResetForNetwork(networkDir string) {
+	e.store.Rebind(networkDir)
+	e.mu.Lock()
+	e.targets = make(map[pb.BinaryType]bmmTarget)
+	e.current = make(map[pb.BinaryType]*bmmstate.Round)
+	e.unconnected = make(map[pb.BinaryType][]*bmmstate.Round)
+	e.mu.Unlock()
+	e.log.Info().Msg("bmm automation cleared for network swap")
+	e.notify()
+}
+
 // Running reports whether the engine bids for sidechain, with the wallet it
 // spends from and its bid bounds.
 func (e *BmmEngine) Running(sidechain pb.BinaryType) (bool, string, int64, int64) {

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -187,7 +187,23 @@ func cloneRound(r *bmmstate.Round) bmmstate.Round {
 
 // History returns a sidechain's settled rounds, newest first.
 func (e *BmmEngine) History(sidechain pb.BinaryType) ([]bmmstate.Round, error) {
-	return e.store.List(int32(sidechain))
+	rounds, err := e.store.List(int32(sidechain))
+	if err != nil {
+		return nil, err
+	}
+	// The round in play is on disk as well, so a restart can resume its bid, but
+	// it belongs in Current rather than in history.
+	current := e.Current(sidechain)
+	if current == nil {
+		return rounds, nil
+	}
+	out := rounds[:0]
+	for _, r := range rounds {
+		if r.PrevMainHash != current.PrevMainHash {
+			out = append(out, r)
+		}
+	}
+	return out, nil
 }
 
 // Round returns one round by its mainchain tip, current or settled.
@@ -389,6 +405,13 @@ func (e *BmmEngine) markTip(sidechain pb.BinaryType, tip string) bool {
 func (e *BmmEngine) openRound(
 	ctx context.Context, sidechain pb.BinaryType, tip string, height int32, target bmmTarget,
 ) {
+	// A round resumed from disk already holds a live bid for this tip; opening a
+	// second one would bid against it and overwrite it.
+	if e.adoptOpenRound(sidechain, tip) {
+		e.notify()
+		return
+	}
+
 	round := &bmmstate.Round{
 		Sidechain:      int32(sidechain),
 		PrevMainHash:   tip,
@@ -406,11 +429,44 @@ func (e *BmmEngine) openRound(
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
 			e.log.Info().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid refused, retrying next tick")
 			e.retryTip(sidechain, tip)
-		} else {
-			e.log.Warn().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid failed")
+			e.notify()
+			return
 		}
+		e.log.Warn().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid failed")
 	}
-	e.notify()
+	e.saveOpen(round)
+}
+
+// adoptOpenRound takes a round resumed from disk back as the round in play, so a
+// restart mid-round carries on the bid it already broadcast.
+func (e *BmmEngine) adoptOpenRound(sidechain pb.BinaryType, tip string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	pending := e.unconnected[sidechain]
+	for i, round := range pending {
+		if round.PrevMainHash != tip || liveBid(round) == nil {
+			continue
+		}
+		e.unconnected[sidechain] = append(pending[:i:i], pending[i+1:]...)
+		e.current[sidechain] = round
+		return true
+	}
+	return false
+}
+
+// saveOpen records a round still in play, so a restart can resume a bid already
+// broadcast. The engine keeps mutating it, so it is copied under the lock.
+func (e *BmmEngine) saveOpen(round *bmmstate.Round) {
+	e.mu.Lock()
+	snapshot := cloneRound(round)
+	e.mu.Unlock()
+	// A round that never got a bid out has nothing to resume, and writing it
+	// down would leave it open on disk for good.
+	if liveBid(&snapshot) == nil {
+		return
+	}
+	e.save(&snapshot)
 }
 
 // retryTip unwinds a round whose opening bid was refused on a precondition, so
@@ -442,7 +498,7 @@ func (e *BmmEngine) snapshotOthers(ctx context.Context, sidechain pb.BinaryType,
 		return nil
 	}
 
-	ours := e.ourTxids(sidechain)
+	ours := e.ourTxids(sidechain, tip)
 	out := make([]bmmstate.Bid, 0, len(resp.Msg.Bids))
 	for _, b := range resp.Msg.Bids {
 		if ours[b.Txid] {
@@ -463,11 +519,19 @@ func (e *BmmEngine) snapshotOthers(ctx context.Context, sidechain pb.BinaryType,
 	return out
 }
 
-func (e *BmmEngine) ourTxids(sidechain pb.BinaryType) map[string]bool {
+func (e *BmmEngine) ourTxids(sidechain pb.BinaryType, tip string) map[string]bool {
+	out := make(map[string]bool)
+	// An M8 broadcast before a restart is still in the mempool, and raising
+	// against our own bid would spend for nothing.
+	if stored, err := e.store.Get(int32(sidechain), tip); err == nil && stored != nil {
+		for _, b := range stored.OurBids {
+			out[b.Txid] = true
+		}
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	out := make(map[string]bool)
 	if round, ok := e.current[sidechain]; ok {
 		for _, b := range round.OurBids {
 			out[b.Txid] = true
@@ -589,7 +653,7 @@ func (e *BmmEngine) maybeRaise(ctx context.Context, sidechain pb.BinaryType, tar
 		e.log.Warn().Err(err).Stringer("sidechain", sidechain).
 			Int64("to_sats", next).Msg("raising bmm bid failed, keeping the live bid")
 	}
-	e.notify()
+	e.saveOpen(round)
 }
 
 func liveBid(round *bmmstate.Round) *bmmstate.Bid {
@@ -741,6 +805,12 @@ func (e *BmmEngine) retryConnects(ctx context.Context, sidechain pb.BinaryType, 
 
 	var stillPending []*bmmstate.Round
 	for _, round := range pending {
+		// A round resumed on the tip it bid on is undecided rather than overdue:
+		// the block that decides it is not mined yet, so waiting costs nothing.
+		if round.Result == ResultOpen && round.PrevMainHash == tip {
+			stillPending = append(stillPending, round)
+			continue
+		}
 		if e.retryRound(ctx, sidechain, round, tip, tipHeight) {
 			continue
 		}

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -154,6 +154,27 @@ func TestBmmEngineIdleUntilStarted(t *testing.T) {
 	assert.False(t, running)
 }
 
+// A network swap disarms automation: bidding on the incoming chain was never
+// asked for, and its money is not the money the user armed.
+func TestBmmEngineResetForNetworkDisarms(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, 20_000))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids)
+
+	engine.ResetForNetwork(t.TempDir())
+
+	tip.set("block-2")
+	engine.tick(ctx)
+
+	assert.Equal(t, 1, backend.bids, "no bid on a chain the user never armed")
+	running, _, _, _ := engine.Running(testSidechain)
+	assert.False(t, running)
+	assert.Nil(t, engine.Current(testSidechain))
+}
+
 // Only a new tip opens a round, so a repeated tip must not bid again.
 func TestBmmEngineOpensOneRoundPerTip(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -584,6 +584,88 @@ func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 	assert.Greater(t, backend.connects, before, "the won block is retried after a restart")
 }
 
+// The opening bid is broadcast the moment the round opens, so a restart before
+// anything settles it must resume the block it may have won.
+func TestBmmEngineResumesAnOpenRoundAfterRestart(t *testing.T) {
+	engine, backend, tip, store := newEngine(t)
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, 10_000))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids)
+
+	// The engine dies with the round still open.
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, store)
+	restarted.resumeUnconnected()
+
+	backend.commitment = "critical"
+	backend.connected = true
+	tip.set("block-2")
+	before := backend.connects
+	restarted.retryConnects(ctx, testSidechain, tip.hash, tip.height)
+
+	assert.Greater(t, backend.connects, before, "the open round's bid is connected after a restart")
+	history := mustHistory(t, restarted)
+	require.NotEmpty(t, history)
+	assert.Equal(t, ResultWon, history[0].Result)
+}
+
+// A restarted engine still has an M8 of its own in the mempool, so it must carry
+// that round on rather than open a second one and bid against itself.
+func TestBmmEngineCarriesOnAResumedOpenRound(t *testing.T) {
+	engine, backend, tip, store := newEngine(t)
+	backend.feesSats = 50_000
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, 30_000))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids)
+
+	backend.others = []*bmmpb.Bid{
+		{Txid: "txid-1", CriticalHash: "critical", BidSats: 10_000, PrevMainHash: "block-1"},
+	}
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, store)
+	restarted.resumeUnconnected()
+	require.NoError(t, restarted.Start(testSidechain, "", 10_000, 30_000))
+	restarted.tick(ctx)
+
+	assert.Equal(t, 1, backend.bids, "the resumed round is not bid on again")
+	current := restarted.Current(testSidechain)
+	require.NotNil(t, current)
+	require.Len(t, current.OurBids, 1)
+	assert.Equal(t, "txid-1", current.OurBids[0].Txid, "the round in play is the one from disk")
+
+	restarted.tick(ctx)
+	assert.Equal(t, 1, backend.bids, "our own outstanding bid is not competition to raise against")
+	assert.Empty(t, restarted.Current(testSidechain).OtherBids)
+}
+
+// A resumed round bids on the tip that is still current, so the block deciding
+// it is not mined yet. Waiting for it must not burn the retries that keep the
+// paid bid alive.
+func TestBmmEngineWaitsForTheBlockThatDecidesAResumedRound(t *testing.T) {
+	engine, backend, tip, store := newEngine(t)
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, 10_000))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids)
+
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, store)
+	restarted.resumeUnconnected()
+	for range bmmConnectAttempts + 1 {
+		restarted.retryConnects(ctx, testSidechain, tip.hash, tip.height)
+	}
+
+	backend.commitment = "critical"
+	backend.connected = true
+	tip.set("block-2")
+	before := backend.connects
+	restarted.retryConnects(ctx, testSidechain, tip.hash, tip.height)
+
+	assert.Greater(t, backend.connects, before, "the bid still connects once the tip moves")
+}
+
 func TestBmmEngineRecordsBlockHeights(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	require.NoError(t, engine.Start(testSidechain, "", 10_000, 10_000))

--- a/sidechain-orchestrator/engines/split_engine.go
+++ b/sidechain-orchestrator/engines/split_engine.go
@@ -106,7 +106,7 @@ func (e *SplitEngine) Run(ctx context.Context) error {
 }
 
 func (e *SplitEngine) tick(ctx context.Context) {
-	if !config.IsEcashFork(config.NetworkFromString(e.network())) {
+	if !config.SharesBitcoinHistory(config.NetworkFromString(e.network())) {
 		return
 	}
 	st, err := e.fork.ForkState(ctx)

--- a/sidechain-orchestrator/engines/split_engine_test.go
+++ b/sidechain-orchestrator/engines/split_engine_test.go
@@ -142,6 +142,19 @@ func TestSplitEngineSkipsNonEcashNetwork(t *testing.T) {
 	require.Empty(t, store.statuses)
 }
 
+// Forknet has its own genesis, so no coin of its can exist on Bitcoin. Asking
+// mempool.space about one leaks the txid and answers 404 forever.
+func TestSplitEngineSkipsForknet(t *testing.T) {
+	btc := newFakeOutspend()
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "forknet")
+
+	e.tick(context.Background())
+
+	require.Empty(t, btc.calls)
+	require.Empty(t, store.statuses)
+}
+
 func TestSplitEngineSkipsSimulatedFork(t *testing.T) {
 	btc := newFakeOutspend()
 	store := &fakeSplitStore{statuses: map[string]bool{}}

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -438,7 +438,14 @@ func (o *Orchestrator) SelectECashNetwork(id string) error {
 	// blocks; Core's own block store is never touched. Off eCash the directory
 	// belongs to the running network, so the work waits for the swap back.
 	if err := o.Settings.SetPendingEnforcerWipe(id); err != nil {
-		o.log.Warn().Err(err).Msg("could not record the enforcer cleanup")
+		// Put the pick back: a durable pick with no cleanup record boots the new
+		// generation on the retired generation's validator chain, and the
+		// previous == id guard above keeps a retry from ever writing it.
+		if _, rbErr := o.Settings.SetECashNetworkID(previous); rbErr != nil {
+			o.log.Error().Err(rbErr).Str("previous", previous).
+				Msg("could not put the eCash network pick back")
+		}
+		return fmt.Errorf("record the enforcer cleanup for %s: %w", id, err)
 	}
 	return nil
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -918,7 +918,9 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 				return
 			}
 
-			o.startEnforcerWhenReady(ctx, opts, enforcerPrefetch)
+			// The boot goes on to the target either way: an enforcer that did
+			// not start already surfaces on its own card, and on the wait below.
+			_ = o.startEnforcerWhenReady(ctx, opts, enforcerPrefetch)
 
 			// Wait for enforcer's gRPC port to actually accept dials before
 			// launching the sidechain target. startEnforcerWhenReady returns
@@ -1279,7 +1281,10 @@ func (o *Orchestrator) RestartDaemon(ctx context.Context, name string, options .
 
 		case "enforcer":
 			o.prepareEnforcerArgs(&opts)
-			o.startEnforcerWhenReady(ctx, opts, nil)
+			if err := o.startEnforcerWhenReady(ctx, opts, nil); err != nil {
+				ch <- StartupProgress{Error: err}
+				return
+			}
 			ch <- StartupProgress{Stage: "done", Message: fmt.Sprintf("%s started", config.DisplayName), Done: true}
 
 		default:
@@ -1301,7 +1306,9 @@ func (o *Orchestrator) exitedFunc(name string) func() (int, bool) {
 // startEnforcerWhenReady waits for wallet + IBD completion, then starts the enforcer.
 // If prefetched is non-nil, the enforcer binary is already being downloaded
 // in parallel and we wait on its completion instead of starting a new download.
-func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpts, prefetched <-chan error) {
+// It returns the reason it gave up, so a caller that already deleted state on
+// the promise of a restart is not told the enforcer came back.
+func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpts, prefetched <-chan error) error {
 	// A switch that could not finish its enforcer cleanup journalled it. Here,
 	// because a leftover validator chain serves the retired generation.
 	if err := o.ApplyPendingEnforcerWipe(); err != nil {
@@ -1309,7 +1316,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		mon := o.getOrCreateMonitor("enforcer", NewHealthChecker(o.configs["enforcer"]), enforcerStartupPatterns)
 		mon.SetConnectionError(err.Error())
 		mon.SetInitializing(false)
-		return
+		return fmt.Errorf("clear the enforcer chain a switch left behind: %w", err)
 	}
 
 	// 1. Wait for wallet to exist — enforcer needs the L1 seed.
@@ -1319,7 +1326,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		for !o.WalletSvc.HasWallet() {
 			select {
 			case <-ctx.Done():
-				return
+				return ctx.Err()
 			case <-sub:
 			}
 		}
@@ -1358,7 +1365,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 			}
 			select {
 			case <-ctx.Done():
-				return
+				return ctx.Err()
 			case <-time.After(5 * time.Second):
 			}
 		}
@@ -1380,7 +1387,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 			pid := o.discoverPid(enforcerCfg)
 			o.process.AdoptProcess(enforcerCfg, pid)
 		}
-		return
+		return nil
 	}
 
 	// The enforcer runs with no wallet, so it takes no seed. Every arg a
@@ -1403,7 +1410,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 			o.log.Error().Err(err).Msg("refusing to start the enforcer with no coinbase recipient")
 			enforcerMon.SetConnectionError(fmt.Sprintf("cannot start the enforcer without a payout address: %v", err))
 			enforcerMon.SetInitializing(false)
-			return
+			return fmt.Errorf("cannot start the enforcer without a payout address: %w", err)
 		}
 		opts.EnforcerArgs = append(opts.EnforcerArgs, fmt.Sprintf("--coinbase-recipient=%s", recipient))
 		o.log.Info().Str("address", recipient).Msg("the block reward pays to the starter wallet")
@@ -1425,7 +1432,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 			enforcerMon.SetConnectionError(err.Error())
 			enforcerMon.SetInitializing(false)
 			o.log.Error().Err(err).Str("zmq_addr", zmqAddr).Msg("refusing to start enforcer: bitcoind ZMQ socket unreachable")
-			return
+			return err
 		}
 	}
 
@@ -1443,20 +1450,20 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		if err := <-prefetched; err != nil {
 			enforcerMon.SetInitializing(false)
 			o.log.Error().Err(err).Msg("enforcer prefetch download failed")
-			return
+			return fmt.Errorf("download the enforcer: %w", err)
 		}
 	} else {
 		downloadCh, err := o.download.Download(ctx, enforcerCfg, o.Network, false)
 		if err != nil {
 			enforcerMon.SetInitializing(false)
 			o.log.Error().Err(err).Msg("failed to download enforcer")
-			return
+			return fmt.Errorf("download the enforcer: %w", err)
 		}
 		for progress := range downloadCh {
 			if progress.Error != nil {
 				enforcerMon.SetInitializing(false)
 				o.log.Error().Err(progress.Error).Msg("enforcer download error")
-				return
+				return fmt.Errorf("download the enforcer: %w", progress.Error)
 			}
 		}
 	}
@@ -1472,10 +1479,10 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		if err := waitForConnectedOrExit(ctx, enforcerMon, o.process.Get("enforcer")); err != nil {
 			enforcerMon.SetInitializing(false)
 			o.log.Error().Err(err).Msg("failed to wait for enforcer")
-			return
+			return fmt.Errorf("wait for the enforcer: %w", err)
 		}
 		o.log.Info().Msg("enforcer connection recovered")
-		return
+		return nil
 	}
 
 	// Log the literal argv at the actual spawn site: the auto-built-args log in
@@ -1487,10 +1494,11 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 	if _, err := o.process.Start(ctx, enforcerCfg, opts.EnforcerArgs, enforcerEnv()); err != nil {
 		enforcerMon.SetInitializing(false)
 		o.log.Error().Err(err).Msg("failed to start enforcer")
-		return
+		return fmt.Errorf("start the enforcer: %w", err)
 	}
 
 	o.log.Info().Msg("enforcer started")
+	return nil
 }
 
 // enforcerEnv returns the environment overlay applied when launching the

--- a/sidechain-orchestrator/orchestrator_settings.go
+++ b/sidechain-orchestrator/orchestrator_settings.go
@@ -344,7 +344,8 @@ func (s *SettingsStore) SetRewoundBlockHash(hash string) error {
 	return nil
 }
 
-// CommitRewind records the block a drop barred, so a later switch can lift it.
+// CommitRewind records the block a drop is about to bar, so a later switch can
+// lift it. It runs before the bar: a bar no record names can never be lifted.
 func (s *SettingsStore) CommitRewind(hash string) error {
 	return s.SetRewoundBlockHash(hash)
 }

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -575,6 +575,10 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	return cmd.Process.Pid, nil
 }
 
+// forceKillReapTimeout bounds the wait for a force-killed process to be
+// reaped, so a Stop that returns nil means the slot is free to start again.
+const forceKillReapTimeout = 5 * time.Second
+
 func (pm *ProcessManager) Stop(_ context.Context, name string, force bool) error {
 	pm.mu.Lock()
 	proc, exists := pm.processes[name]
@@ -585,10 +589,7 @@ func (pm *ProcessManager) Stop(_ context.Context, name string, force bool) error
 	}
 
 	if force {
-		if err := forceKillProcess(proc.Pid); err != nil {
-			return fmt.Errorf("force kill %s: %w", name, err)
-		}
-		return nil
+		return pm.forceKill(name, proc)
 	}
 
 	if err := killProcess(proc.Pid); err != nil {
@@ -603,7 +604,22 @@ func (pm *ProcessManager) Stop(_ context.Context, name string, force bool) error
 			Str("binary", name).
 			Dur("timeout", gracefulKillTimeout).
 			Msg("graceful shutdown timed out, force killing")
-		return forceKillProcess(proc.Pid)
+		return pm.forceKill(name, proc)
+	}
+}
+
+// forceKill kills the process and waits for the reaper to free its slot.
+// Returning before that lets an immediate restart hit "already running".
+func (pm *ProcessManager) forceKill(name string, proc *ManagedProcess) error {
+	if err := forceKillProcess(proc.Pid); err != nil {
+		return fmt.Errorf("force kill %s: %w", name, err)
+	}
+
+	select {
+	case <-proc.exitCh:
+		return nil
+	case <-time.After(forceKillReapTimeout):
+		return fmt.Errorf("%s did not exit after the force kill", name)
 	}
 }
 

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -30,6 +30,23 @@ func TestProcessManager_StartAndStop(t *testing.T) {
 	assert.False(t, pm.IsRunning("sleep-test"))
 }
 
+// A force stop only counts as done once the slot is free — a restart starts
+// the binary again the moment Stop returns.
+func TestProcessManager_ForceStopFreesSlot(t *testing.T) {
+	pm, dir := newTestProcessManager(t)
+	symlinkSystemBinary(t, dir, "sleep")
+
+	config := BinaryConfig{Name: "sleep-test", BinaryName: "sleep"}
+	_, err := pm.Start(context.Background(), config, []string{"30"}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, pm.Stop(context.Background(), "sleep-test", true))
+	assert.False(t, pm.IsRunning("sleep-test"))
+
+	_, err = pm.Start(context.Background(), config, []string{"30"}, nil)
+	require.NoError(t, err, "a force stop must free the slot for an immediate restart")
+}
+
 func TestProcessManager_ConcurrentStartSpawnsOnce(t *testing.T) {
 	pm, dir := newTestProcessManager(t)
 	symlinkSystemBinary(t, dir, "sleep")

--- a/sidechain-orchestrator/reject_block.go
+++ b/sidechain-orchestrator/reject_block.go
@@ -185,7 +185,7 @@ func (o *Orchestrator) reconcileEnforcer(ctx context.Context, client *CoreStatus
 		}
 	}
 
-	if err := o.rebuildEnforcerChain(ctx); err != nil {
+	if err := o.rebuildEnforcerChain(ctx, wait); err != nil {
 		return enforcerReconciliation{Checked: true, Height: height, Err: err.Error()}
 	}
 	return enforcerReconciliation{Checked: true, Height: height, Rebuilt: true}
@@ -310,8 +310,9 @@ func (o *Orchestrator) awaitEnforcerRollback(ctx context.Context, client *CoreSt
 
 // rebuildEnforcerChain deletes the enforcer's validator chain and starts it
 // again. It re-reads every block from the local Core, so this costs no network
-// download.
-func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context) error {
+// download. It returns only once the restart is over: the chain is already
+// gone, so a rebuild reported over a stopped enforcer hides a wiped one.
+func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context, wait time.Duration) error {
 	if err := o.stopForNetworkSwap(ctx, "enforcer"); err != nil {
 		return fmt.Errorf("stop the enforcer: %w", err)
 	}
@@ -329,14 +330,45 @@ func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("start the enforcer: %w", err)
 	}
-	go func() {
-		for p := range bootCh {
-			if p.Error != nil {
-				o.log.Error().Err(p.Error).Msg("enforcer restart after the reject failed")
-			}
-		}
-	}()
+	if err := o.awaitEnforcerBoot(bootCh, wait); err != nil {
+		o.log.Error().Err(err).Msg("enforcer restart after the reject failed")
+		return fmt.Errorf("the enforcer chain was cleared but the enforcer did not come back: %w", err)
+	}
 	return nil
+}
+
+// awaitEnforcerBoot waits for a restart to finish and reports what it left
+// behind. A boot stream that ends without an error says the start path ran, so
+// a live process is the only trustworthy evidence that the restart took.
+func (o *Orchestrator) awaitEnforcerBoot(bootCh <-chan StartupProgress, wait time.Duration) error {
+	if err := drainEnforcerBoot(bootCh, wait); err != nil {
+		return err
+	}
+	if !o.enforcerReachable() {
+		return fmt.Errorf("the enforcer is not running")
+	}
+	return nil
+}
+
+// drainEnforcerBoot reads a boot stream to its end and returns the first
+// failure it carries. A stream that neither fails nor ends within wait is a
+// failure of its own: the caller holds the reject lock while it waits.
+func drainEnforcerBoot(bootCh <-chan StartupProgress, wait time.Duration) error {
+	timeout := time.NewTimer(wait)
+	defer timeout.Stop()
+	for {
+		select {
+		case p, ok := <-bootCh:
+			if !ok {
+				return nil
+			}
+			if p.Error != nil {
+				return p.Error
+			}
+		case <-timeout.C:
+			return fmt.Errorf("the restart did not finish within %s", wait)
+		}
+	}
 }
 
 // normalizeBlockHash puts a hash in the form Core answers with. Core takes

--- a/sidechain-orchestrator/reject_block_test.go
+++ b/sidechain-orchestrator/reject_block_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeCore answers the RPCs a reject makes. tips is read one entry per
@@ -302,5 +303,66 @@ func TestAcceptBlockRefusesAnEmptyHash(t *testing.T) {
 	}
 	if len(core.methods) != 0 {
 		t.Errorf("rpc calls = %v, want none for a blank hash", core.methods)
+	}
+}
+
+// A boot stream that ends without an error says the start path ran, not that
+// the enforcer came back. Reporting a rebuild there leaves the user with an
+// enforcer that is both stopped and wiped, and no error to say so.
+func TestAwaitEnforcerBootReportsADaemonThatNeverCameBack(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	bootCh := make(chan StartupProgress, 1)
+	bootCh <- StartupProgress{Stage: "done", Message: "enforcer started", Done: true}
+	close(bootCh)
+
+	err := o.awaitEnforcerBoot(bootCh, time.Second)
+	if err == nil {
+		t.Fatal("awaitEnforcerBoot reported a restart while the enforcer sat stopped")
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("err = %v, want the stopped enforcer named", err)
+	}
+}
+
+func TestAwaitEnforcerBootAcceptsALiveEnforcer(t *testing.T) {
+	o := newTestOrchestrator(t)
+	enforcerCfg, err := o.getConfig("enforcer")
+	if err != nil {
+		t.Fatalf("getConfig: %v", err)
+	}
+	o.process.AdoptProcess(enforcerCfg, 1234)
+
+	bootCh := make(chan StartupProgress, 1)
+	bootCh <- StartupProgress{Stage: "done", Done: true}
+	close(bootCh)
+
+	if err := o.awaitEnforcerBoot(bootCh, time.Second); err != nil {
+		t.Fatalf("awaitEnforcerBoot: %v", err)
+	}
+}
+
+func TestAwaitEnforcerBootReturnsTheBootFailure(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	bootCh := make(chan StartupProgress, 1)
+	bootCh <- StartupProgress{Error: fmt.Errorf("cannot start the enforcer without a payout address")}
+	close(bootCh)
+
+	err := o.awaitEnforcerBoot(bootCh, time.Second)
+	if err == nil {
+		t.Fatal("awaitEnforcerBoot swallowed the boot failure")
+	}
+	if !strings.Contains(err.Error(), "payout address") {
+		t.Errorf("err = %v, want the boot failure", err)
+	}
+}
+
+// A restart that never finishes must not hold the reject lock for good.
+func TestAwaitEnforcerBootGivesUpOnAStalledRestart(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	if err := o.awaitEnforcerBoot(make(chan StartupProgress), 20*time.Millisecond); err == nil {
+		t.Fatal("awaitEnforcerBoot waited out a restart that never finished")
 	}
 }

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -613,9 +613,10 @@ func (o *Orchestrator) restartResetBinary(ctx context.Context, binary ResetBinar
 		}
 	case ResetBinaryEnforcer:
 		o.prepareEnforcerArgs(&opts)
-		o.startEnforcerWhenReady(ctx, opts, nil)
-		mon := o.getOrCreateMonitor("enforcer", NewHealthChecker(cfg), enforcerStartupPatterns)
-		startErr = waitForConnectedOrExit(ctx, mon, o.process.Get("enforcer"))
+		if startErr = o.startEnforcerWhenReady(ctx, opts, nil); startErr == nil {
+			mon := o.getOrCreateMonitor("enforcer", NewHealthChecker(cfg), enforcerStartupPatterns)
+			startErr = waitForConnectedOrExit(ctx, mon, o.process.Get("enforcer"))
+		}
 	case ResetBinaryBitwindowd:
 		o.startTargetOnly(ctx, cfg, opts, ch, nil)
 	default:

--- a/sidechain-orchestrator/reset_to_block.go
+++ b/sidechain-orchestrator/reset_to_block.go
@@ -293,7 +293,6 @@ func resetCoreToBlock(
 	// reconsiderblock returns, so that one call is the whole replay. A poll on
 	// the side is the only way to report how far it got.
 	replay := make(chan error, 1)
-	reconsidered = true
 	go func() {
 		_, err := client.call(ctx, "reconsiderblock", base.TargetHash)
 		replay <- err
@@ -308,6 +307,9 @@ func resetCoreToBlock(
 	if err := awaitResetReplay(ctx, client, base, parked, replay, emit); err != nil {
 		return fail(ResetPhaseSyncForward, err)
 	}
+	// A reconsiderblock that never reached Core leaves the mark in force, so
+	// only a call Core answered retires the retry.
+	reconsidered = true
 
 	final, _, err := coreTip(ctx, client)
 	if err != nil {

--- a/sidechain-orchestrator/reset_to_block_test.go
+++ b/sidechain-orchestrator/reset_to_block_test.go
@@ -216,6 +216,30 @@ func TestResetCoreToBlockClearsTheMarkWhenTheTipReadFails(t *testing.T) {
 	}
 }
 
+// A reconsiderblock that never reached Core left the target invalid, so the
+// failed replay must still take the drop back.
+func TestResetCoreToBlockClearsTheMarkWhenTheReplayFails(t *testing.T) {
+	resetSyncPollInterval = time.Millisecond
+	t.Cleanup(func() { resetSyncPollInterval = time.Second })
+
+	core := &fakeCore{
+		tips:         []int64{978999},
+		hashes:       map[int64]string{978999: parent},
+		headers:      map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+		reconsiderNo: true,
+	}
+
+	base := ResetProgress{TargetHeight: 979000, TargetHash: target979000, TipHeight: 979472, BlocksTotal: 473}
+	if _, err := resetCoreToBlock(context.Background(), core.start(t), base, func(ResetProgress) {}); err == nil {
+		t.Fatal("resetCoreToBlock reported no error after a failed replay")
+	}
+
+	calls := strings.Join(core.methods, ",")
+	if got := strings.Count(calls, "reconsiderblock"); got != 2 {
+		t.Errorf("reconsiderblock calls = %d in %s, want a retry after the failed replay", got, calls)
+	}
+}
+
 // Progress is a snapshot, so a slow reader may miss ticks. The terminal
 // message carries the outcome, so a full buffer must not drop it.
 func TestResetEmitKeepsTheTerminalMessage(t *testing.T) {

--- a/sidechain-orchestrator/restart_daemon_test.go
+++ b/sidechain-orchestrator/restart_daemon_test.go
@@ -153,7 +153,7 @@ func TestStartEnforcerWhenReady_AlreadyInPM_NoPhantomStart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	o.startEnforcerWhenReady(ctx, StartOpts{}, nil)
+	_ = o.startEnforcerWhenReady(ctx, StartOpts{}, nil)
 
 	// Adopted PID survives — the guard never spawned a new process and
 	// never tried to mutate pm.processes.

--- a/sidechain-orchestrator/sidechain/bitassets/client.go
+++ b/sidechain-orchestrator/sidechain/bitassets/client.go
@@ -110,9 +110,10 @@ func unmarshal[T any](c *Client, ctx context.Context, method string, params inte
 // Wallet / Balance
 // ---------------------------------------------------------------------------
 
-// Balance returns the node wallet balance.
+// Balance returns the node wallet balance. BitAssets names the RPC
+// "bitcoin_balance" rather than "balance".
 func (c *Client) Balance(ctx context.Context) (*BalanceResponse, error) {
-	r, err := unmarshal[BalanceResponse](c, ctx, "balance", nil)
+	r, err := unmarshal[BalanceResponse](c, ctx, "bitcoin_balance", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitassets/client_test.go
+++ b/sidechain-orchestrator/sidechain/bitassets/client_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +43,7 @@ func clientFromServer(srv *httptest.Server) *Client {
 
 func TestBalance(t *testing.T) {
 	srv := fakeRPC(t, map[string]interface{}{
-		"balance": BalanceResponse{TotalSats: 100_000, AvailableSats: 80_000},
+		"bitcoin_balance": BalanceResponse{TotalSats: 100_000, AvailableSats: 80_000},
 	})
 	defer srv.Close()
 
@@ -100,6 +102,72 @@ func TestRPCError(t *testing.T) {
 	_, err := c.GetBlockCount(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not ready")
+}
+
+// TestClientMethodsInSchema drives every Client method against a recording
+// server and asserts each wire method is a path in the schema snapshot.
+func TestClientMethodsInSchema(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		mu.Lock()
+		methods = append(methods, req.Method)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":null}`))
+	}))
+	defer srv.Close()
+
+	c := clientFromServer(srv)
+	ctx := context.Background()
+	calls := []func(){
+		func() { _, _ = c.Balance(ctx) },
+		func() { _, _ = c.GetNewAddress(ctx) },
+		func() { _, _ = c.GetWalletAddresses(ctx) },
+		func() { _, _ = c.GetWalletUTXOs(ctx) },
+		func() { _, _ = c.ListUTXOs(ctx) },
+		func() { _, _ = c.MyUTXOs(ctx) },
+		func() { _, _ = c.Transfer(ctx, "addr", 1, 2, nil) },
+		func() { _, _ = c.CreateDeposit(ctx, "addr", 1, 2) },
+		func() { _, _ = c.Withdraw(ctx, "addr", 1, 2, 3) },
+		func() { _, _ = c.SidechainWealthSats(ctx) },
+		func() { _, _ = c.GetBlockCount(ctx) },
+		func() { _, _ = c.GetBlock(ctx, "hash") },
+		func() { _, _ = c.GetBMMInclusions(ctx, "hash") },
+		func() { _, _ = c.GetBestMainchainBlockHash(ctx) },
+		func() { _, _ = c.GetBestSidechainBlockHash(ctx) },
+		func() { _, _ = c.LatestFailedWithdrawalBundleHeight(ctx) },
+		func() { _, _ = c.PendingWithdrawalBundle(ctx) },
+		func() { _ = c.ConnectPeer(ctx, "1.2.3.4:8333") },
+		func() { _, _ = c.ListPeers(ctx) },
+		func() { _, _ = c.GenerateMnemonic(ctx) },
+		func() { _ = c.SetSeedFromMnemonic(ctx, "mnemonic") },
+		func() { _, _ = c.Mine(ctx, 1) },
+		func() { _, _ = c.OpenAPISchema(ctx) },
+		func() { _ = c.Stop(ctx) },
+	}
+	for _, call := range calls {
+		call()
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, methods, len(calls))
+
+	raw, err := os.ReadFile("testdata/openapi_schema.json")
+	require.NoError(t, err)
+	var schema struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &schema))
+
+	for _, method := range methods {
+		assert.Contains(t, schema.Paths, method, "method not exposed by the bitassets node")
+	}
 }
 
 func TestNullableResults(t *testing.T) {

--- a/sidechain-orchestrator/sidechain/bitassets/types.go
+++ b/sidechain-orchestrator/sidechain/bitassets/types.go
@@ -1,7 +1,7 @@
 // Package bitassets provides a JSON-RPC client for the Bitassets sidechain.
 package bitassets
 
-// BalanceResponse is the reply from the "balance" RPC.
+// BalanceResponse is the reply from the "bitcoin_balance" RPC.
 type BalanceResponse struct {
 	TotalSats     int64 `json:"total_sats"`
 	AvailableSats int64 `json:"available_sats"`

--- a/sidechain-orchestrator/sidechain/truthcoin/handler.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler.go
@@ -3,6 +3,7 @@ package truthcoin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -255,7 +256,7 @@ func (h *Handler) GetWalletAddresses(ctx context.Context, req *connect.Request[p
 }
 
 func (h *Handler) MyUtxos(ctx context.Context, req *connect.Request[pb.MyUtxosRequest]) (*connect.Response[pb.MyUtxosResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "my_utxos", nil)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_wallet_utxos", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -360,9 +361,21 @@ func (h *Handler) MarketPositions(ctx context.Context, req *connect.Request[pb.M
 }
 
 // --- Slots ---
+// The node exposes slots as "decision" methods.
+
+// claimDecisions issues a decision_claim for one batch of decisions.
+func (h *Handler) claimDecisions(ctx context.Context, claim map[string]any) (string, error) {
+	var result struct {
+		Txid string `json:"txid"`
+	}
+	if err := h.proxy.Client.Call(ctx, "decision_claim", []any{claim}, &result); err != nil {
+		return "", err
+	}
+	return result.Txid, nil
+}
 
 func (h *Handler) SlotStatus(ctx context.Context, req *connect.Request[pb.SlotStatusRequest]) (*connect.Response[pb.SlotStatusResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "slot_status", nil)
+	raw, err := h.proxy.Client.CallRaw(ctx, "decision_status", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -370,8 +383,14 @@ func (h *Handler) SlotStatus(ctx context.Context, req *connect.Request[pb.SlotSt
 }
 
 func (h *Handler) SlotList(ctx context.Context, req *connect.Request[pb.SlotListRequest]) (*connect.Response[pb.SlotListResponse], error) {
-	params := []any{req.Msg.Period, req.Msg.Status}
-	raw, err := h.proxy.Client.CallRaw(ctx, "slot_list", params)
+	filter := map[string]any{}
+	if req.Msg.Period != nil {
+		filter["period"] = req.Msg.GetPeriod()
+	}
+	if req.Msg.Status != nil {
+		filter["status"] = req.Msg.GetStatus()
+	}
+	raw, err := h.proxy.Client.CallRaw(ctx, "decision_list", []any{filter})
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +398,7 @@ func (h *Handler) SlotList(ctx context.Context, req *connect.Request[pb.SlotList
 }
 
 func (h *Handler) SlotGet(ctx context.Context, req *connect.Request[pb.SlotGetRequest]) (*connect.Response[pb.SlotGetResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "slot_get", req.Msg.SlotId)
+	raw, err := h.proxy.Client.CallRaw(ctx, "decision_get", []any{req.Msg.SlotId})
 	if err != nil {
 		return nil, err
 	}
@@ -387,33 +406,43 @@ func (h *Handler) SlotGet(ctx context.Context, req *connect.Request[pb.SlotGetRe
 }
 
 func (h *Handler) SlotClaim(ctx context.Context, req *connect.Request[pb.SlotClaimRequest]) (*connect.Response[pb.SlotClaimResponse], error) {
-	var txid string
-	params := []any{
-		req.Msg.FeeSats,
-		req.Msg.PeriodIndex,
-		req.Msg.SlotIndex,
-		req.Msg.Question,
-		req.Msg.IsStandard,
-		req.Msg.IsScaled,
-		req.Msg.Min,
-		req.Msg.Max,
+	claim := map[string]any{
+		"decision_type": "binary",
+		"decisions": []any{map[string]any{
+			"period_index": req.Msg.PeriodIndex,
+			"header":       req.Msg.Question,
+		}},
+		"tx_fee_sats": req.Msg.FeeSats,
 	}
-	if err := h.proxy.Client.Call(ctx, "slot_claim", params, &txid); err != nil {
+	if req.Msg.GetIsScaled() {
+		claim["decision_type"] = "scaled"
+		if req.Msg.Min != nil {
+			claim["min"] = req.Msg.GetMin()
+		}
+		if req.Msg.Max != nil {
+			claim["max"] = req.Msg.GetMax()
+		}
+	}
+	txid, err := h.claimDecisions(ctx, claim)
+	if err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SlotClaimResponse{Txid: txid}), nil
 }
 
 func (h *Handler) SlotClaimCategory(ctx context.Context, req *connect.Request[pb.SlotClaimCategoryRequest]) (*connect.Response[pb.SlotClaimCategoryResponse], error) {
-	var slots any
+	decisions := []any{}
 	if req.Msg.SlotsJson != "" {
-		if err := json.Unmarshal([]byte(req.Msg.SlotsJson), &slots); err != nil {
+		if err := json.Unmarshal([]byte(req.Msg.SlotsJson), &decisions); err != nil {
 			return nil, fmt.Errorf("unmarshal slots: %w", err)
 		}
 	}
-	var txid string
-	params := []any{slots, req.Msg.IsStandard, req.Msg.FeeSats}
-	if err := h.proxy.Client.Call(ctx, "slot_claim_category", params, &txid); err != nil {
+	txid, err := h.claimDecisions(ctx, map[string]any{
+		"decision_type": "category",
+		"decisions":     decisions,
+		"tx_fee_sats":   req.Msg.FeeSats,
+	})
+	if err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SlotClaimCategoryResponse{Txid: txid}), nil
@@ -422,12 +451,8 @@ func (h *Handler) SlotClaimCategory(ctx context.Context, req *connect.Request[pb
 // --- Voting ---
 
 func (h *Handler) VoteRegister(ctx context.Context, req *connect.Request[pb.VoteRegisterRequest]) (*connect.Response[pb.VoteRegisterResponse], error) {
-	var txid string
-	params := []any{req.Msg.FeeSats, req.Msg.ReputationBondSats}
-	if err := h.proxy.Client.Call(ctx, "vote_register", params, &txid); err != nil {
-		return nil, err
-	}
-	return connect.NewResponse(&pb.VoteRegisterResponse{Txid: txid}), nil
+	return nil, connect.NewError(connect.CodeUnimplemented,
+		errors.New("truthcoin has no voter registration RPC: voting identity is derived from the wallet automatically"))
 }
 
 func (h *Handler) VoteVoter(ctx context.Context, req *connect.Request[pb.VoteVoterRequest]) (*connect.Response[pb.VoteVoterResponse], error) {
@@ -483,7 +508,7 @@ func (h *Handler) VotePeriod(ctx context.Context, req *connect.Request[pb.VotePe
 func (h *Handler) VotecoinTransfer(ctx context.Context, req *connect.Request[pb.VotecoinTransferRequest]) (*connect.Response[pb.VotecoinTransferResponse], error) {
 	var txid string
 	params := []any{req.Msg.Dest, req.Msg.Amount, req.Msg.FeeSats, req.Msg.Memo}
-	if err := h.proxy.Client.Call(ctx, "votecoin_transfer", params, &txid); err != nil {
+	if err := h.proxy.Client.Call(ctx, "transfer_votecoin", params, &txid); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.VotecoinTransferResponse{Txid: txid}), nil

--- a/sidechain-orchestrator/sidechain/truthcoin/handler_test.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler_test.go
@@ -1,0 +1,203 @@
+package truthcoin
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/truthcoin/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+// schemaMethods returns the JSON-RPC method names the node exposes, taken from
+// the OpenAPI snapshot.
+func schemaMethods(t *testing.T) map[string]json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/openapi_schema.json")
+	require.NoError(t, err)
+
+	var schema struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &schema))
+	require.NotEmpty(t, schema.Paths)
+	return schema.Paths
+}
+
+type nodeCall struct {
+	method string
+	params json.RawMessage
+}
+
+// nodeRecorder collects the JSON-RPC calls a Handler makes.
+type nodeRecorder struct {
+	mu    sync.Mutex
+	calls []nodeCall
+}
+
+func (n *nodeRecorder) add(call nodeCall) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, call)
+}
+
+func (n *nodeRecorder) all() []nodeCall {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]nodeCall(nil), n.calls...)
+}
+
+// fakeNode returns a Handler talking to a node that records every call and
+// always answers with a null result.
+func fakeNode(t *testing.T) (*Handler, *nodeRecorder) {
+	t.Helper()
+	rec := &nodeRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		rec.add(nodeCall{method: req.Method, params: req.Params})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return NewHandler(sidechain.NewJSONRPCProxy(host, port)), rec
+}
+
+// callHandlerMethod invokes exported Handler method i with a zero request.
+func callHandlerMethod(h *Handler, i int) error {
+	reqType := reflect.TypeOf(h).Method(i).Type.In(2).Elem()
+	req := reflect.New(reqType)
+	msg := req.Elem().FieldByName("Msg")
+	msg.Set(reflect.New(msg.Type().Elem()))
+
+	out := reflect.ValueOf(h).Method(i).Call([]reflect.Value{
+		reflect.ValueOf(context.Background()), req,
+	})
+	err, _ := out[1].Interface().(error)
+	return err
+}
+
+// TestHandlerMethodsExistOnNode drives every Handler method and fails on any
+// JSON-RPC method name the node's schema does not have.
+func TestHandlerMethodsExistOnNode(t *testing.T) {
+	methods := schemaMethods(t)
+
+	// CallRaw forwards a caller-supplied method name; VoteRegister has no
+	// backing RPC and is covered by TestVoteRegisterUnimplemented.
+	skip := map[string]bool{"CallRaw": true, "VoteRegister": true}
+
+	ht := reflect.TypeOf(&Handler{})
+	for i := 0; i < ht.NumMethod(); i++ {
+		name := ht.Method(i).Name
+		if skip[name] {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			h, rec := fakeNode(t)
+			require.NoError(t, callHandlerMethod(h, i))
+
+			calls := rec.all()
+			require.NotEmpty(t, calls, "%s issued no JSON-RPC call", name)
+			for _, call := range calls {
+				assert.Contains(t, methods, call.method, "%s calls a method the node does not expose", name)
+			}
+		})
+	}
+}
+
+func TestSlotClaimSendsDecisionClaim(t *testing.T) {
+	h, rec := fakeNode(t)
+
+	scaled := true
+	lo, hi := int32(0), int32(100)
+	_, err := h.SlotClaim(context.Background(), connect.NewRequest(&pb.SlotClaimRequest{
+		FeeSats:     1000,
+		PeriodIndex: 3,
+		SlotIndex:   7,
+		Question:    "will it rain?",
+		IsStandard:  true,
+		IsScaled:    &scaled,
+		Min:         &lo,
+		Max:         &hi,
+	}))
+	require.NoError(t, err)
+
+	calls := rec.all()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "decision_claim", calls[0].method)
+	assert.JSONEq(t, `[{
+		"decision_type": "scaled",
+		"decisions": [{"period_index": 3, "header": "will it rain?"}],
+		"tx_fee_sats": 1000,
+		"min": 0,
+		"max": 100
+	}]`, string(calls[0].params))
+}
+
+func TestSlotClaimCategorySendsDecisionClaim(t *testing.T) {
+	h, rec := fakeNode(t)
+
+	_, err := h.SlotClaimCategory(context.Background(), connect.NewRequest(&pb.SlotClaimCategoryRequest{
+		SlotsJson:  `[{"period_index":1,"header":"who wins?"}]`,
+		IsStandard: true,
+		FeeSats:    500,
+	}))
+	require.NoError(t, err)
+
+	calls := rec.all()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "decision_claim", calls[0].method)
+	assert.JSONEq(t, `[{
+		"decision_type": "category",
+		"decisions": [{"period_index": 1, "header": "who wins?"}],
+		"tx_fee_sats": 500
+	}]`, string(calls[0].params))
+}
+
+func TestSlotListSendsDecisionFilter(t *testing.T) {
+	h, rec := fakeNode(t)
+
+	period := int32(4)
+	status := "Voting"
+	_, err := h.SlotList(context.Background(), connect.NewRequest(&pb.SlotListRequest{
+		Period: &period,
+		Status: &status,
+	}))
+	require.NoError(t, err)
+
+	calls := rec.all()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "decision_list", calls[0].method)
+	assert.JSONEq(t, `[{"period": 4, "status": "Voting"}]`, string(calls[0].params))
+}
+
+func TestVoteRegisterUnimplemented(t *testing.T) {
+	h, rec := fakeNode(t)
+
+	_, err := h.VoteRegister(context.Background(), connect.NewRequest(&pb.VoteRegisterRequest{FeeSats: 1000}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnimplemented, connect.CodeOf(err))
+	assert.Empty(t, rec.all())
+}

--- a/sidechain-orchestrator/sidechain/zside/client_test.go
+++ b/sidechain-orchestrator/sidechain/zside/client_test.go
@@ -40,16 +40,26 @@ func clientFromServer(srv *httptest.Server) *Client {
 }
 
 func TestBalance(t *testing.T) {
+	// The exact keys the zside node emits.
 	srv := fakeRPC(t, map[string]interface{}{
-		"balance": BalanceResponse{TotalSats: 100_000, AvailableSats: 80_000},
+		"balance": map[string]int64{
+			"total_shielded_sats":        60_000,
+			"total_transparent_sats":     40_000,
+			"available_shielded_sats":    50_000,
+			"available_transparent_sats": 30_000,
+		},
 	})
 	defer srv.Close()
 
 	c := clientFromServer(srv)
 	bal, err := c.Balance(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, int64(100_000), bal.TotalSats)
-	assert.Equal(t, int64(80_000), bal.AvailableSats)
+	assert.Equal(t, int64(60_000), bal.TotalShieldedSats)
+	assert.Equal(t, int64(40_000), bal.TotalTransparentSats)
+	assert.Equal(t, int64(50_000), bal.AvailableShieldedSats)
+	assert.Equal(t, int64(30_000), bal.AvailableTransparentSats)
+	assert.Equal(t, int64(100_000), bal.TotalSats())
+	assert.Equal(t, int64(80_000), bal.AvailableSats())
 }
 
 func TestGetBlockCount(t *testing.T) {

--- a/sidechain-orchestrator/sidechain/zside/types.go
+++ b/sidechain-orchestrator/sidechain/zside/types.go
@@ -1,10 +1,23 @@
 // Package zside provides a JSON-RPC client for the Zside sidechain.
 package zside
 
-// BalanceResponse is the reply from the "balance" RPC.
+// BalanceResponse is the reply from the "balance" RPC. ZSide splits the wallet
+// into a shielded and a transparent pool.
 type BalanceResponse struct {
-	TotalSats     int64 `json:"total_sats"`
-	AvailableSats int64 `json:"available_sats"`
+	TotalShieldedSats        int64 `json:"total_shielded_sats"`
+	TotalTransparentSats     int64 `json:"total_transparent_sats"`
+	AvailableShieldedSats    int64 `json:"available_shielded_sats"`
+	AvailableTransparentSats int64 `json:"available_transparent_sats"`
+}
+
+// TotalSats is the total balance across both pools.
+func (b BalanceResponse) TotalSats() int64 {
+	return b.TotalShieldedSats + b.TotalTransparentSats
+}
+
+// AvailableSats is the available balance across both pools.
+func (b BalanceResponse) AvailableSats() int64 {
+	return b.AvailableShieldedSats + b.AvailableTransparentSats
 }
 
 // PeerInfo describes a connected peer.

--- a/truthcoin/lib/pages/voting_dashboard_page.dart
+++ b/truthcoin/lib/pages/voting_dashboard_page.dart
@@ -84,11 +84,9 @@ class _VoterStatusCard extends StatelessWidget {
           ? SailColumn(
               spacing: SailStyleValues.padding12,
               children: [
-                SailText.secondary15('Not registered as a voter'),
-                const SizedBox(height: 8),
-                SailButton(
-                  label: 'Register as Voter',
-                  onPressed: () async => model.showRegisterDialog(context),
+                SailText.secondary15('No voting history yet'),
+                SailText.secondary13(
+                  'Voting identity is derived from your wallet. Hold Votecoin and cast a vote to appear here.',
                 ),
               ],
             )
@@ -573,103 +571,9 @@ class VotingDashboardViewModel extends BaseViewModel {
     }
   }
 
-  Future<void> showRegisterDialog(BuildContext context) async {
-    final result = await showThemedDialog<bool>(
-      context: context,
-      builder: (context) => _RegisterVoterDialog(
-        votingProvider: _votingProvider,
-      ),
-    );
-
-    if (result == true) {
-      await loadData();
-    }
-  }
-
   @override
   void dispose() {
     _votingProvider.removeListener(_onProviderChange);
-    super.dispose();
-  }
-}
-
-class _RegisterVoterDialog extends StatefulWidget {
-  final VotingProvider votingProvider;
-
-  const _RegisterVoterDialog({required this.votingProvider});
-
-  @override
-  State<_RegisterVoterDialog> createState() => _RegisterVoterDialogState();
-}
-
-class _RegisterVoterDialogState extends State<_RegisterVoterDialog> {
-  final TextEditingController bondController = TextEditingController();
-  bool isLoading = false;
-  String? error;
-
-  @override
-  Widget build(BuildContext context) {
-    return SailDialog(
-      title: 'Register as Voter',
-      maxWidth: 460,
-      error: error,
-      actions: [
-        SailButton(
-          label: 'Cancel',
-          variant: ButtonVariant.ghost,
-          onPressed: () async => Navigator.of(context).pop(false),
-        ),
-        SailButton(
-          label: 'Register',
-          loading: isLoading,
-          onPressed: () async => _register(),
-        ),
-      ],
-      child: SailColumn(
-        spacing: SailStyleValues.padding08,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SailText.secondary13(
-            'Register to participate in the oracle voting system. '
-            'You can optionally provide a reputation bond to increase your initial reputation.',
-          ),
-          const SizedBox(height: 8),
-          SailText.secondary12('Reputation Bond (optional, in sats)'),
-          const SizedBox(height: 4),
-          SailTextField(
-            controller: bondController,
-            hintText: 'e.g., 10000',
-            textFieldType: TextFieldType.number,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _register() async {
-    setState(() {
-      isLoading = true;
-      error = null;
-    });
-
-    final bondSats = int.tryParse(bondController.text);
-    final txid = await widget.votingProvider.registerAsVoter(
-      bondSats: bondSats,
-      feeSats: 1000,
-    );
-
-    setState(() => isLoading = false);
-
-    if (txid != null && mounted) {
-      Navigator.of(context).pop(true);
-    } else {
-      setState(() => error = widget.votingProvider.error ?? 'Registration failed');
-    }
-  }
-
-  @override
-  void dispose() {
-    bondController.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
A set of **16 independent fixes** to the BitWindow orchestrator core & sidechains, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`35 files changed, 1356 insertions(+), 266 deletions(-)`).

## Fixes (oldest first)

- **`1c8d9f300`** Network round trip deletes custom mainnet ports and can prevent Core restart
- **`8984f5789`** Truthcoin frontend sends voting transactions to absent backend RPC methods
- **`0025fdd9b`** BitAssets CLI balance calls wrong JSON-RPC method
- **`32bb82d7f`** drivechain-frontends/sidechain-orchestrator — RejectBlock reports rebuild success after seed failure leaves enforcer stopped and wiped
- **`0bf8dda41`** BMM engine automated bidding survives network swap
- **`106511a99`** multisig watch wallet retains stale descriptors after same-ID policy change
- **`58d259f03`** Reset reconsider transport failure persistently strands Core below the target
- **`27d0c7aba`** BMM open rounds are not persisted, so restart can forfeit a mined bid
- **`0f8b1205a`** eCash journal-failure abort leaves the retained branch invalidated
- **`47d366739`** faulted cold-pick eCash journal save is swallowed — new generation's enforcer inherits retired generation's validator chain
- **`b34246f6b`** eCash rewind crash window strands the dropped network
- **`30d0a74c1`** concurrent enforcer restart consumes an in-flight eCash switch's wipe journal
- **`c3765db3d`** drivechain-frontends force-stop success leaves stale process slot that rejects immediate restart
- **`4786f24ad`** zSide CLI balance silently reports zero for nonzero wallet
- **`ede06cec2`** forknet eCash split engine poisons every forknet outpoint as non-splittable via BTC-mainnet esplora 404s
- **`086abf975`** non-WSH multisig lounge groups import the wrong watch descriptors

## Reconciliation

One commit reconciles fixes that each pass alone but interact when combined (kept every fix; the change is minimal and additive):

- `80330bfb1` reconcile orch-core-2 — give the restore-history test a real group

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.