### PR TITLE
BitWindow orchestrator wallet: 15 fixes from a security review

### DIFF
--- a/sidechain-orchestrator/api/deposit.go
+++ b/sidechain-orchestrator/api/deposit.go
@@ -67,6 +67,9 @@ func (h *WalletHandler) CreateDeposit(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	// Read the network before the broadcast: a swap racing it would file the
+	// record under the chain we swapped to.
+	network := h.svc.Network()
 	send, err := h.SendTransaction(ctx, connect.NewRequest(&wpb.SendTransactionRequest{
 		WalletId:       req.Msg.WalletId,
 		RawOutputs:     []*wpb.RawOutput{{ValueSats: treasurySats, ScriptHex: treasuryHex}},
@@ -81,6 +84,7 @@ func (h *WalletHandler) CreateDeposit(
 	// An M5 is an ordinary transaction on the wire, so nothing later can tell
 	// it apart from a normal send. Record it while we still know.
 	if err := h.svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+		Network:     network,
 		Txid:        send.Msg.Txid,
 		WalletID:    walletID,
 		Slot:        uint32(slot),

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -321,8 +321,19 @@ func (h *WalletHandler) UpdateWalletMetadata(ctx context.Context, req *connect.R
 }
 
 func (h *WalletHandler) DeleteWallet(ctx context.Context, req *connect.Request[pb.DeleteWalletRequest]) (*connect.Response[pb.DeleteWalletResponse], error) {
+	// Read the type before the delete: afterwards the wallet is gone.
+	w := h.svc.GetWalletByID(req.Msg.WalletId)
+	usesCore := w != nil && w.WalletType == wallet.WalletTypeBitcoinCore
+
 	if err := h.svc.DeleteWallet(req.Msg.WalletId); err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	// The wallet is out of wallet.json, but Core still holds it loaded and
+	// serving keys. A failed unload only leaves that stale Core wallet behind.
+	if usesCore && h.engine != nil {
+		if err := h.engine.ForgetWallet(ctx, req.Msg.WalletId); err != nil {
+			h.svc.Log().Warn().Err(err).Str("wallet_id", req.Msg.WalletId).Msg("could not unload deleted wallet from core")
+		}
 	}
 	return connect.NewResponse(&pb.DeleteWalletResponse{}), nil
 }

--- a/sidechain-orchestrator/wallet/backend.go
+++ b/sidechain-orchestrator/wallet/backend.go
@@ -72,6 +72,14 @@ type Bip47Backend interface {
 	EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error
 }
 
+// ForgetBackend is a Backend holding per-wallet state of its own — Core keeps
+// the wallet loaded and serving keys — that a delete has to drop.
+type ForgetBackend interface {
+	Backend
+	// Forget releases the backend state walletID held. Idempotent.
+	Forget(ctx context.Context, walletID string) error
+}
+
 // DepositBackend is a backend that builds the BIP300 M5 itself, so the caller
 // hands it the slot and the destination instead of a raw treasury output.
 type DepositBackend interface {

--- a/sidechain-orchestrator/wallet/bip47/derive.go
+++ b/sidechain-orchestrator/wallet/bip47/derive.go
@@ -11,8 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
-// AddressType selects between P2PKH (BIP47 v1 default) and P2WPKH (segwit
-// feature, recipient code byte 79 == 0x01).
+// AddressType selects between P2PKH (BIP47 v1 default) and P2WPKH.
 type AddressType int
 
 const (

--- a/sidechain-orchestrator/wallet/bip47/paymentcode.go
+++ b/sidechain-orchestrator/wallet/bip47/paymentcode.go
@@ -56,6 +56,17 @@ func parseFromCheckDecoded(b []byte) (*PaymentCode, error) {
 	if pc.SignByte != 0x02 && pc.SignByte != 0x03 {
 		return nil, fmt.Errorf("invalid sign byte 0x%02x", pc.SignByte)
 	}
+	// v1 fixes the features byte and bytes 67-79 at zero. Accepting anything
+	// else would let one key pair have several encodings, each deriving the
+	// same addresses off its own send-index counter.
+	if pc.Features != 0x00 {
+		return nil, fmt.Errorf("unsupported features byte 0x%02x", pc.Features)
+	}
+	for i, v := range pc.Reserved {
+		if v != 0x00 {
+			return nil, fmt.Errorf("reserved byte %d must be zero, got 0x%02x", 67+i, v)
+		}
+	}
 	if _, err := pc.PubKey(); err != nil {
 		return nil, fmt.Errorf("invalid pubkey: %w", err)
 	}

--- a/sidechain-orchestrator/wallet/bip47/paymentcode.go
+++ b/sidechain-orchestrator/wallet/bip47/paymentcode.go
@@ -95,6 +95,15 @@ func (pc *PaymentCode) PubKey() (*btcec.PublicKey, error) {
 	return btcec.ParsePubKey(cp[:])
 }
 
+// AddressType reports the address form the code asks to be paid at: byte 79
+// (Reserved[12]) == 0x01 is the segwit feature, anything else the v1 default.
+func (pc *PaymentCode) AddressType() AddressType {
+	if pc.Reserved[12] == 0x01 {
+		return AddressP2WPKH
+	}
+	return AddressP2PKH
+}
+
 // AsExtendedPubKey wraps the payment-code pubkey + chaincode for non-hardened
 // child derivation. Version bytes are placeholder — they only affect xpub
 // serialization, not derivation output.

--- a/sidechain-orchestrator/wallet/bip47/paymentcode_test.go
+++ b/sidechain-orchestrator/wallet/bip47/paymentcode_test.go
@@ -62,6 +62,32 @@ func TestPaymentCode_RejectsWrongVersionByte(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestPaymentCode_RejectsNonCanonicalEncodings pins that a second encoding of
+// the same key material — features byte set, or any reserved byte non-zero —
+// does not parse. Such a code derives exactly the same addresses as the
+// canonical one, so accepting it splits the send-index state and reuses them.
+func TestPaymentCode_RejectsNonCanonicalEncodings(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*PaymentCode)
+	}{
+		{"features byte set", func(pc *PaymentCode) { pc.Features = 0x01 }},
+		{"first reserved byte set", func(pc *PaymentCode) { pc.Reserved[0] = 0x01 }},
+		{"last reserved byte set", func(pc *PaymentCode) { pc.Reserved[12] = 0x01 }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pc, err := ParsePaymentCode(bobPaymentCode)
+			require.NoError(t, err)
+			tt.mutate(pc)
+
+			alias := pc.Base58()
+			require.NotEqual(t, bobPaymentCode, alias)
+			_, err = ParsePaymentCode(alias)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestNotificationAddress_AliceMainnet(t *testing.T) {
 	pc, err := ParsePaymentCode(alicePaymentCode)
 	require.NoError(t, err)

--- a/sidechain-orchestrator/wallet/bip47send/bip47send.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send.go
@@ -275,7 +275,7 @@ func SubstituteBip47Destination(
 		return nil, fmt.Errorf("reserve next index: %w", err)
 	}
 
-	derived, err := bip47.DerivePaymentAddress(senderSeedHex, recipient, idx, net)
+	derived, err := bip47.DerivePaymentAddressTyped(senderSeedHex, recipient, idx, net, recipient.AddressType())
 	if err != nil {
 		return nil, fmt.Errorf("derive payment address: %w", err)
 	}

--- a/sidechain-orchestrator/wallet/bip47send/bip47send.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send.go
@@ -209,8 +209,8 @@ type SubstituteResult struct {
 	// by a derived per-payment address. Identity to the input when no BIP47
 	// code is present.
 	Destinations map[string]int64
-	// RecipientCode is the BIP47 code of the recipient, or "" when no BIP47
-	// destination was found.
+	// RecipientCode is the recipient's canonical BIP47 code, or "" when no
+	// BIP47 destination was found.
 	RecipientCode string
 	// Recipient is the parsed payment code, nil when no BIP47 destination.
 	Recipient *bip47.PaymentCode
@@ -270,7 +270,11 @@ func SubstituteBip47Destination(
 		return nil, ErrSelfSend
 	}
 
-	idx, err := reserver.ReserveNextIndex(walletID, bip47Addr)
+	// Key persistent state on the code's canonical encoding, not on whatever
+	// string the caller passed, so one recipient always gets one counter.
+	recipientCode := recipient.Base58()
+
+	idx, err := reserver.ReserveNextIndex(walletID, recipientCode)
 	if err != nil {
 		return nil, fmt.Errorf("reserve next index: %w", err)
 	}
@@ -282,7 +286,7 @@ func SubstituteBip47Destination(
 
 	return &SubstituteResult{
 		Destinations:  map[string]int64{derived.EncodeAddress(): bip47Sats},
-		RecipientCode: bip47Addr,
+		RecipientCode: recipientCode,
 		Recipient:     recipient,
 		Index:         idx,
 		IsBip47:       true,

--- a/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
@@ -176,6 +176,31 @@ func TestSubstituteBip47Destination_AlignsWithVectors(t *testing.T) {
 	}
 }
 
+// A recipient code carrying the segwit feature byte must be paid at P2WPKH,
+// not silently at the P2PKH address it can't watch for.
+func TestSubstituteBip47Destination_HonoursSegwitFeatureByte(t *testing.T) {
+	recipient, err := bip47.ParsePaymentCode(bobPM)
+	require.NoError(t, err)
+	recipient.Reserved[12] = 0x01
+	segwitPM := recipient.Base58()
+
+	reserver := &fakeReserver{}
+	dest := map[string]int64{segwitPM: 100_000}
+
+	r, err := SubstituteBip47Destination(aliceSeedHex, "w1", dest, &chaincfg.MainNetParams, reserver)
+	require.NoError(t, err)
+	require.True(t, r.IsBip47)
+	require.Len(t, r.Destinations, 1)
+
+	want, err := bip47.DerivePaymentAddressTyped(aliceSeedHex, recipient, 0, &chaincfg.MainNetParams, bip47.AddressP2WPKH)
+	require.NoError(t, err)
+
+	for addr := range r.Destinations {
+		assert.Equal(t, want.EncodeAddress(), addr)
+		assert.NotEqual(t, aliceToBobAddresses[0], addr)
+	}
+}
+
 func TestSubstituteBip47Destination_PassthroughForNonBip47(t *testing.T) {
 	reserver := &fakeReserver{}
 	dest := map[string]int64{

--- a/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
@@ -176,29 +176,25 @@ func TestSubstituteBip47Destination_AlignsWithVectors(t *testing.T) {
 	}
 }
 
-// A recipient code carrying the segwit feature byte must be paid at P2WPKH,
-// not silently at the P2PKH address it can't watch for.
-func TestSubstituteBip47Destination_HonoursSegwitFeatureByte(t *testing.T) {
-	recipient, err := bip47.ParsePaymentCode(bobPM)
+// TestSubstituteBip47Destination_ReservedByteAliasGetsNoCounter pins that a
+// re-encoding of Bob's code with a reserved byte set never opens a second
+// send-index row: it derives the same addresses as the canonical code, so its
+// own counter would hand out addresses already paid to.
+func TestSubstituteBip47Destination_ReservedByteAliasGetsNoCounter(t *testing.T) {
+	bob, err := bip47.ParsePaymentCode(bobPM)
 	require.NoError(t, err)
-	recipient.Reserved[12] = 0x01
-	segwitPM := recipient.Base58()
+	bob.Reserved[12] = 0x01
+	alias := bob.Base58()
 
 	reserver := &fakeReserver{}
-	dest := map[string]int64{segwitPM: 100_000}
-
-	r, err := SubstituteBip47Destination(aliceSeedHex, "w1", dest, &chaincfg.MainNetParams, reserver)
+	r, err := SubstituteBip47Destination(aliceSeedHex, "w1", map[string]int64{bobPM: 100_000}, &chaincfg.MainNetParams, reserver)
 	require.NoError(t, err)
 	require.True(t, r.IsBip47)
-	require.Len(t, r.Destinations, 1)
 
-	want, err := bip47.DerivePaymentAddressTyped(aliceSeedHex, recipient, 0, &chaincfg.MainNetParams, bip47.AddressP2WPKH)
+	r2, err := SubstituteBip47Destination(aliceSeedHex, "w1", map[string]int64{alias: 100_000}, &chaincfg.MainNetParams, reserver)
 	require.NoError(t, err)
-
-	for addr := range r.Destinations {
-		assert.Equal(t, want.EncodeAddress(), addr)
-		assert.NotEqual(t, aliceToBobAddresses[0], addr)
-	}
+	assert.False(t, r2.IsBip47, "a non-canonical encoding must not read as a payment code")
+	assert.Len(t, reserver.counters, 1, "the alias must not get a counter of its own")
 }
 
 func TestSubstituteBip47Destination_PassthroughForNonBip47(t *testing.T) {

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -61,8 +63,9 @@ type CoreBackend struct {
 }
 
 var (
-	_ Backend      = (*CoreBackend)(nil)
-	_ Bip47Backend = (*CoreBackend)(nil)
+	_ Backend       = (*CoreBackend)(nil)
+	_ Bip47Backend  = (*CoreBackend)(nil)
+	_ ForgetBackend = (*CoreBackend)(nil)
 )
 
 // NewCoreBackend creates the Bitcoin Core wallet backend.
@@ -164,6 +167,70 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 	p.loadingErr = nil
 	p.coreWallets[walletID] = walletName
 	return walletName, nil
+}
+
+// Forget drops a deleted wallet's Core state: the cached name goes, Core
+// unloads the wallet, and its directory moves under
+// <coreDataDir>/wallet_backups/. Leaving the directory in place would make a
+// later wallet of the same name reuse it — createAndImport falls back to
+// loadwallet on "already exists" — so the deleted wallet's descriptors, keys
+// included, would serve the new wallet. Backed up rather than removed: the
+// keys are not reconstructible.
+func (p *CoreBackend) Forget(ctx context.Context, walletID string) error {
+	p.mu.Lock()
+	name, cached := p.coreWallets[walletID]
+	delete(p.coreWallets, walletID)
+	delete(p.bip47NotifRetry, walletID)
+	p.mu.Unlock()
+
+	if !cached {
+		// Core can still hold the wallet from an earlier run of this process.
+		if len(walletID) < 8 {
+			return nil
+		}
+		name = fmt.Sprintf("wallet_%s", walletID[:8])
+	}
+
+	// A wallet Core never loaded has nothing to unload, but its directory is
+	// still there to move. Any other failure leaves the wallet open in Core,
+	// where renaming its directory out from under it would corrupt it.
+	if err := p.rpc.UnloadWallet(ctx, name); err != nil && !strings.Contains(err.Error(), "not loaded") {
+		return fmt.Errorf("unload wallet: %w", err)
+	}
+
+	if dir := p.coreWalletDir(name); dir != "" {
+		backupRoot := filepath.Join(p.svc.CoreDataDir, "wallet_backups", time.Now().UTC().Format("20060102-150405"))
+		if _, err := p.svc.moveToBackupRoot(dir, backupRoot); err != nil {
+			return fmt.Errorf("back up wallet dir: %w", err)
+		}
+	}
+
+	p.log.Info().Str("wallet", name).Msg("unloaded deleted Bitcoin Core wallet")
+	return nil
+}
+
+// coreWalletDir locates a Core wallet's directory under the Core datadir:
+// Core keeps wallets in <datadir>/[<chain>/]wallets/<name>, older nodes flat
+// alongside. Empty when no directory of that name is there.
+func (p *CoreBackend) coreWalletDir(name string) string {
+	if p.svc.CoreDataDir == "" {
+		return ""
+	}
+	var chain string
+	if net := p.net(); net != nil && net.Name != chaincfg.MainNetParams.Name {
+		chain = net.Name
+	}
+	for _, dir := range []string{
+		filepath.Join(p.svc.CoreDataDir, chain, "wallets", name),
+		filepath.Join(p.svc.CoreDataDir, chain, name),
+		filepath.Join(p.svc.CoreDataDir, "wallets", name),
+		filepath.Join(p.svc.CoreDataDir, name),
+	} {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return ""
 }
 
 // EnsureAll syncs all bitcoinCore wallets (full and watch-only) to Bitcoin Core.

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -1085,13 +1085,14 @@ func (p *CoreBackend) CreateCpfp(ctx context.Context, walletID string, req CpfpR
 			fmt.Errorf("target rate %d sat/vB does not exceed parent rate %d sat/vB", req.TargetRate, parentFee/parentVsize))
 	}
 
-	// Size the child for the wallet's own script kind: a taproot (BIP86) wallet
-	// imports only tr() descriptors, so its child is P2TR — using native-segwit
-	// sizing mis-estimates the fee. Default wallets resolve to native segwit.
+	// The child's output takes the wallet's own kind (a tr()-only wallet's child
+	// is P2TR); its input is sized from the parent's own script, which for a
+	// BIP47 payment window is a pkh() import twice as wide as the wallet's.
 	childKind := p.walletScriptKind(walletID)
+	parentKind := addressKind(parent.Address, p.net())
 
 	parentValueSats := int64(math.Round(parent.Amount * 1e8))
-	childVsize := int64(11 + inputVsize(childKind) + outputVsizeForKind(childKind))
+	childVsize := int64(11 + inputVsize(parentKind) + outputVsizeForKind(childKind))
 	_, outputSats, err := cpfpChildPlan(req.TargetRate, parentVsize, parentFee, childVsize, parentValueSats)
 	if err != nil {
 		return "", connect.NewError(connect.CodeInvalidArgument, err)

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -1352,12 +1352,14 @@ func (p *CoreBackend) createWatchOnlyWallet(ctx context.Context, walletName stri
 				return fmt.Errorf("add checksum: %w", err)
 			}
 		}
-		descriptors = append(descriptors, ImportDescriptor{
-			Desc:      desc,
-			Active:    true,
-			Timestamp: "now",
-			Range:     []int{0, 1000},
-		})
+		// Core rejects a range on an un-ranged descriptor, and only a ranged
+		// descriptor may be active, so a fixed one imports as neither.
+		imp := ImportDescriptor{Desc: desc, Timestamp: "now"}
+		if strings.Contains(desc, "*") {
+			imp.Active = true
+			imp.Range = []int{0, 1000}
+		}
+		descriptors = append(descriptors, imp)
 	} else if watchOnly.Xpub != "" {
 		descriptors = append(descriptors,
 			ImportDescriptor{

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -103,8 +103,13 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 
 	// Check cache
 	if name, ok := p.coreWallets[walletID]; ok {
-		p.retryBip47NotificationDescriptor(ctx, walletID, name)
-		return name, nil
+		if p.coreWalletLoaded(ctx, name) {
+			p.retryBip47NotificationDescriptor(ctx, walletID, name)
+			return name, nil
+		}
+		// bitcoind restarted and dropped the wallet; re-create it below, which
+		// falls through to loadwallet for one that is only unloaded.
+		delete(p.coreWallets, walletID)
 	}
 
 	// Short-circuit while a recent attempt is still in the bitcoind-warming-up
@@ -252,16 +257,20 @@ func (p *CoreBackend) EnsureAll(ctx context.Context) (int, error) {
 	return synced, nil
 }
 
+// coreWalletLoaded reports whether Core still holds the wallet. A bitcoind
+// restart unloads it, so a cached name is no proof. A failing listwallets
+// answers "loaded", so an unreachable node doesn't cost the cache entry.
+// Caller holds p.mu.
+func (p *CoreBackend) coreWalletLoaded(ctx context.Context, name string) bool {
+	loaded, err := p.rpc.ListWallets(ctx)
+	if err != nil {
+		return true
+	}
+	return lo.Contains(loaded, name)
+}
+
 // walletName returns the Core wallet name for a wallet ID, ensuring it exists.
 func (p *CoreBackend) walletName(ctx context.Context, walletID string) (string, error) {
-	p.mu.Lock()
-	if name, ok := p.coreWallets[walletID]; ok {
-		p.retryBip47NotificationDescriptor(ctx, walletID, name)
-		p.mu.Unlock()
-		return name, nil
-	}
-	p.mu.Unlock()
-
 	return p.Ensure(ctx, walletID)
 }
 

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -231,6 +233,128 @@ func TestCoreBackendEnsureTransientBackoff(t *testing.T) {
 	_, err = backend.Ensure(ctx, coreID)
 	require.ErrorContains(t, err, "Verifying blocks")
 	assert.Len(t, fake.callsFor("listwallets"), 1)
+}
+
+// A deleted wallet's Core wallet must not stay loaded: it keeps serving keys
+// the user deleted, and a same-prefix successor would reuse its descriptors.
+func TestCoreBackendForgetUnloadsWallet(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("unloadwallet", func(bitcoindCall) (any, string) { return map[string]any{}, "" })
+	ctx := context.Background()
+
+	name, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+
+	require.NoError(t, backend.Forget(ctx, coreID))
+	unloads := fake.callsFor("unloadwallet")
+	require.Len(t, unloads, 1)
+	assert.Equal(t, name, mustString(t, unloads[0].Params[0]))
+
+	// The cached name is gone with it, so the next Ensure provisions from
+	// scratch instead of handing back a wallet Core no longer has.
+	creates := len(fake.callsFor("createwallet"))
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Len(t, fake.callsFor("createwallet"), creates+1)
+}
+
+// Unloading alone isn't enough: the wallet's directory has to move aside too.
+// Core refuses to create a wallet over an existing directory, and
+// createAndImport's fallback would load the deleted wallet and import a
+// same-named successor's descriptors into it.
+func TestCoreBackendForgetBacksUpWalletDir(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	coreDir := t.TempDir()
+	backend.svc.CoreDataDir = coreDir
+	walletsDir := filepath.Join(coreDir, "regtest", "wallets")
+
+	fake.stubEnsureFlow()
+	// bitcoind creates the wallet's directory, and refuses a name whose
+	// directory is already there.
+	fake.handle("createwallet", func(c bitcoindCall) (any, string) {
+		var name string
+		if err := json.Unmarshal(c.Params[0], &name); err != nil {
+			return nil, err.Error()
+		}
+		dir := filepath.Join(walletsDir, name)
+		if _, err := os.Stat(dir); err == nil {
+			return nil, "Failed to create database path '" + dir + "'. Database already exists."
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, err.Error()
+		}
+		if err := os.WriteFile(filepath.Join(dir, "wallet.dat"), []byte(name), 0o600); err != nil {
+			return nil, err.Error()
+		}
+		return map[string]any{}, ""
+	})
+	fake.handle("loadwallet", func(bitcoindCall) (any, string) { return map[string]any{}, "" })
+	fake.handle("unloadwallet", func(bitcoindCall) (any, string) { return map[string]any{}, "" })
+	ctx := context.Background()
+
+	name, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.DirExists(t, filepath.Join(walletsDir, name))
+
+	require.NoError(t, backend.Forget(ctx, coreID))
+	assert.NoDirExists(t, filepath.Join(walletsDir, name))
+	backup := findBackup(t, filepath.Join(coreDir, "wallet_backups"), name)
+	require.NotEmpty(t, backup, "wallet dir moved to backup, never removed")
+	assert.FileExists(t, filepath.Join(backup, "wallet.dat"))
+
+	// A same-named successor now gets a Core wallet of its own: createwallet
+	// succeeds and imports into it, and Core is never asked to load the
+	// deleted wallet's file.
+	imports := len(fake.callsFor("importdescriptors"))
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Len(t, fake.callsFor("createwallet"), 2)
+	assert.Empty(t, fake.callsFor("loadwallet"))
+	assert.Greater(t, len(fake.callsFor("importdescriptors")), imports)
+}
+
+// Core rejects unloadwallet for a wallet it never loaded — one left behind by
+// an earlier run. That's not a failure for the delete path, and the wallet's
+// directory still has to move aside.
+func TestCoreBackendForgetIgnoresUnloadedWallet(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	coreDir := t.TempDir()
+	backend.svc.CoreDataDir = coreDir
+	name := "wallet_" + coreID[:8]
+	dir := filepath.Join(coreDir, "regtest", "wallets", name)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	fake.handle("unloadwallet", func(bitcoindCall) (any, string) {
+		return nil, "Requested wallet does not exist or is not loaded"
+	})
+
+	require.NoError(t, backend.Forget(context.Background(), coreID))
+	require.Len(t, fake.callsFor("unloadwallet"), 1)
+	assert.NoDirExists(t, dir)
+	assert.NotEmpty(t, findBackup(t, filepath.Join(coreDir, "wallet_backups"), name))
+}
+
+// The delete path reaches Core through the engine, which can no longer resolve
+// the wallet's type — the wallet is already out of wallet.json.
+func TestWalletEngineForgetWalletAfterDelete(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("unloadwallet", func(bitcoindCall) (any, string) { return map[string]any{}, "" })
+	ctx := context.Background()
+
+	svc := backend.svc
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	router := NewBackendRouter(svc, backend, nil)
+	engine := NewWalletEngine(svc, router, StaticParams(&chaincfg.RegressionNetParams), log)
+
+	name, err := engine.Backend().Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.NoError(t, svc.DeleteWallet(coreID))
+
+	require.NoError(t, engine.ForgetWallet(ctx, coreID))
+	unloads := fake.callsFor("unloadwallet")
+	require.Len(t, unloads, 1)
+	assert.Equal(t, name, mustString(t, unloads[0].Params[0]))
 }
 
 // A failed BIP47 notification import doesn't break wallet loading, but the

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -1482,6 +1482,43 @@ func TestCoreBackendImportsEveryKindTheWalletAdvertises(t *testing.T) {
 	assert.Contains(t, singleSig[2].Desc, "wpkh([")
 }
 
+// Core rejects a range on an un-ranged descriptor and refuses to make one
+// active, so a fixed watch-only descriptor must be imported with neither.
+func TestCoreBackendWatchOnlyRangeFollowsTheDescriptor(t *testing.T) {
+	const xpub = "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
+	tests := []struct {
+		name       string
+		descriptor string
+		wantActive bool
+		wantRange  []int
+	}{
+		{"fixed", "addr(" + p2wpkhAddr(t, fixedKey(0x42), &chaincfg.RegressionNetParams) + ")", false, nil},
+		{"ranged", "wpkh(" + xpub + "/0/*)", true, []int{0, 1000}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(t)
+			require.NoError(t, svc.CreateWatchOnlyWallet("Watch", tt.descriptor, `{"background_svg":""}`))
+
+			fake := newFakeBitcoind(t)
+			fake.stubEnsureFlow()
+			backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+
+			_, err := backend.Ensure(context.Background(), svc.ActiveWalletID())
+			require.NoError(t, err)
+
+			imports := fake.callsFor("importdescriptors")
+			require.Len(t, imports, 1, "watch-only wallets import no bip47 notification key")
+			var descs []ImportDescriptor
+			require.NoError(t, json.Unmarshal(imports[0].Params[0], &descs))
+			require.Len(t, descs, 1)
+			assert.Contains(t, descs[0].Desc, "#", "descriptor carries a checksum")
+			assert.Equal(t, tt.wantActive, descs[0].Active)
+			assert.Equal(t, tt.wantRange, descs[0].Range)
+		})
+	}
+}
+
 // coreBumpFeeFixture stubs an unconfirmed wallet transaction that pays a
 // stranger and returns change, so a fee bump has both kinds of output.
 func coreBumpFeeFixture(t *testing.T) (*CoreBackend, *fakeBitcoind, string, string, string) {

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -730,10 +730,11 @@ func TestCoreBackendCreateCpfp(t *testing.T) {
 		targetRate  = int64(20)
 	)
 	childAddr := p2wpkhAddr(t, fixedKey(0x77), &chaincfg.RegressionNetParams)
+	parentAddr := p2wpkhAddr(t, fixedKey(0x78), &chaincfg.RegressionNetParams)
 
 	fake.handle("listunspent", func(bitcoindCall) (any, string) {
 		return []map[string]any{
-			{"txid": parentTxid, "vout": 0, "amount": 0.002, "spendable": true, "confirmations": 0},
+			{"txid": parentTxid, "vout": 0, "address": parentAddr, "amount": 0.002, "spendable": true, "confirmations": 0},
 		}, ""
 	})
 	fake.handle("getmempoolentry", func(bitcoindCall) (any, string) {
@@ -782,6 +783,75 @@ func TestCoreBackendCreateCpfp(t *testing.T) {
 	assert.Positive(t, outputSats)
 }
 
+// TestCoreBackendCreateCpfpBip47Parent proves the child's input is sized from the
+// parent outpoint's own script: a BIP47 payment window is a pkh() import, so a
+// native-segwit wallet still spends a 148 vB legacy input. Sizing it as the
+// wallet's P2WPKH pays for a 110 vB child and leaves the package below target.
+func TestCoreBackendCreateCpfpBip47Parent(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	net := &chaincfg.RegressionNetParams
+	require.Equal(t, ScriptNativeSegwit, backend.walletScriptKind(coreID))
+
+	const (
+		parentTxid  = "66666666666666666666666666666666666666666666666666666666666666dd"
+		parentValue = int64(200_000)
+		parentVsize = int64(150)
+		parentFee   = int64(150)
+		targetRate  = int64(20)
+	)
+	childAddr := p2wpkhAddr(t, fixedKey(0x77), net)
+	// The parent pays a BIP47 payment address: pkh(), not one of the wallet's
+	// own wpkh() descriptors.
+	parentAddr := p2pkhAddr(t, fixedKey(0x47), net)
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		return []map[string]any{
+			{"txid": parentTxid, "vout": 0, "address": parentAddr, "amount": 0.002, "spendable": true, "confirmations": 0},
+		}, ""
+	})
+	fake.handle("getmempoolentry", func(bitcoindCall) (any, string) {
+		return map[string]any{"vsize": parentVsize, "fees": map[string]any{"base": float64(parentFee) / 1e8}}, ""
+	})
+	fake.handle("listreceivedbyaddress", func(bitcoindCall) (any, string) {
+		return []map[string]any{{"address": childAddr, "amount": 0.0, "txids": []string{}}}, ""
+	})
+	var builtOutputs []map[string]any
+	fake.handle("createrawtransaction", func(c bitcoindCall) (any, string) {
+		require.NoError(t, json.Unmarshal(c.Params[1], &builtOutputs))
+		return "deadbeefcpfp47", ""
+	})
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		return map[string]any{"hex": mustString(t, c.Params[0]), "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "child-bip47", "" })
+
+	childTxid, err := backend.CreateCpfp(context.Background(), coreID, CpfpRequest{
+		ParentTxID: parentTxid,
+		ParentVout: 0,
+		TargetRate: targetRate,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "child-bip47", childTxid)
+
+	// Legacy input, native-segwit output: 190 vB, not the wallet-kind 110 vB.
+	childVsize := int64(11 + inputVsize(ScriptLegacy) + outputVsizeForKind(ScriptNativeSegwit))
+	require.Equal(t, int64(190), childVsize)
+	childFee, outputSats, err := cpfpChildPlan(targetRate, parentVsize, parentFee, childVsize, parentValue)
+	require.NoError(t, err)
+	require.Len(t, builtOutputs, 1, "self-send: single output")
+	assert.InDelta(t, btcutil.Amount(outputSats).ToBTC(), builtOutputs[0][childAddr], 1e-12)
+
+	// The package clears the requested rate at the child's real size.
+	assert.GreaterOrEqual(t, float64(parentFee+childFee)/float64(parentVsize+childVsize), float64(targetRate))
+
+	// The wallet-kind sizing pays for a 110 vB child, which underpays the package.
+	walletSized := int64(11 + inputVsize(ScriptNativeSegwit) + outputVsizeForKind(ScriptNativeSegwit))
+	underFee, _, err := cpfpChildPlan(targetRate, parentVsize, parentFee, walletSized, parentValue)
+	require.NoError(t, err)
+	assert.Less(t, float64(parentFee+underFee)/float64(parentVsize+childVsize), float64(targetRate))
+}
+
 // TestCoreBackendCreateCpfpTaproot proves CPFP works for a taproot-only (BIP86)
 // Core wallet: the child must be sized as P2TR and a bech32m address requested,
 // not the hardcoded native-segwit child that would break a tr()-only wallet.
@@ -814,10 +884,11 @@ func TestCoreBackendCreateCpfpTaproot(t *testing.T) {
 	// A P2TR (bech32m) child address — regtest HRP "bcrt" + "1p".
 	taprootAddr := p2trAddr(t, fixedKey(0x88), &chaincfg.RegressionNetParams)
 	require.True(t, strings.HasPrefix(taprootAddr, "bcrt1p"), "child address must be bech32m taproot")
+	parentAddr := p2trAddr(t, fixedKey(0x89), &chaincfg.RegressionNetParams)
 
 	fake.handle("listunspent", func(bitcoindCall) (any, string) {
 		return []map[string]any{
-			{"txid": parentTxid, "vout": 0, "amount": 0.002, "spendable": true, "confirmations": 0},
+			{"txid": parentTxid, "vout": 0, "address": parentAddr, "amount": 0.002, "spendable": true, "confirmations": 0},
 		}, ""
 	})
 	fake.handle("getmempoolentry", func(bitcoindCall) (any, string) {
@@ -909,7 +980,7 @@ func TestCoreBackendCpfpBase58Kinds(t *testing.T) {
 				targetRate  = int64(20)
 			)
 			fake.handle("listunspent", func(bitcoindCall) (any, string) {
-				return []map[string]any{{"txid": parentTxid, "vout": 0, "amount": 0.002, "spendable": true, "confirmations": 0}}, ""
+				return []map[string]any{{"txid": parentTxid, "vout": 0, "address": childAddr, "amount": 0.002, "spendable": true, "confirmations": 0}}, ""
 			})
 			fake.handle("getmempoolentry", func(bitcoindCall) (any, string) {
 				return map[string]any{"vsize": parentVsize, "fees": map[string]any{"base": float64(parentFee) / 1e8}}, ""

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -328,7 +328,18 @@ func TestCoreBackendEnsureTransientBackoff(t *testing.T) {
 func TestCoreBackendForgetUnloadsWallet(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()
-	fake.handle("unloadwallet", func(bitcoindCall) (any, string) { return map[string]any{}, "" })
+	// Forget unloads the wallet and moves its directory aside, so the stateful
+	// fake must drop it on both counts. Left "loaded"/"on disk", the successor
+	// Ensure would find it and adopt it instead of provisioning from scratch.
+	fake.handle("unloadwallet", func(c bitcoindCall) (any, string) {
+		var name string
+		_ = json.Unmarshal(c.Params[0], &name)
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		delete(fake.loaded, name)
+		delete(fake.onDisk, name)
+		return map[string]any{}, ""
+	})
 	ctx := context.Background()
 
 	name, err := backend.Ensure(ctx, coreID)

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -35,6 +35,8 @@ type fakeBitcoind struct {
 	mu       sync.Mutex
 	calls    []bitcoindCall
 	handlers map[string]func(c bitcoindCall) (any, string)
+	loaded   map[string]bool // wallets listwallets reports
+	onDisk   map[string]bool // wallets that exist, loaded or not
 }
 
 type bitcoindCall struct {
@@ -45,7 +47,11 @@ type bitcoindCall struct {
 
 func newFakeBitcoind(t *testing.T) *fakeBitcoind {
 	t.Helper()
-	f := &fakeBitcoind{handlers: map[string]func(bitcoindCall) (any, string){}}
+	f := &fakeBitcoind{
+		handlers: map[string]func(bitcoindCall) (any, string){},
+		loaded:   map[string]bool{},
+		onDisk:   map[string]bool{},
+	}
 	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			Method string            `json:"method"`
@@ -113,9 +119,38 @@ func (f *fakeBitcoind) client(t *testing.T) *CoreRPCClient {
 }
 
 // stubEnsureFlow installs the happy-path handlers for lazy wallet creation.
+// listwallets reports what createwallet/loadwallet actually loaded, and
+// createwallet refuses a wallet that already exists — as bitcoind does.
 func (f *fakeBitcoind) stubEnsureFlow() {
-	f.handle("listwallets", func(bitcoindCall) (any, string) { return []string{}, "" })
-	f.handle("createwallet", func(bitcoindCall) (any, string) { return map[string]any{}, "" })
+	f.handle("listwallets", func(bitcoindCall) (any, string) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		names := make([]string, 0, len(f.loaded))
+		for name := range f.loaded {
+			names = append(names, name)
+		}
+		return names, ""
+	})
+	f.handle("createwallet", func(c bitcoindCall) (any, string) {
+		var name string
+		_ = json.Unmarshal(c.Params[0], &name)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.onDisk[name] {
+			return nil, "Database already exists."
+		}
+		f.onDisk[name] = true
+		f.loaded[name] = true
+		return map[string]any{}, ""
+	})
+	f.handle("loadwallet", func(c bitcoindCall) (any, string) {
+		var name string
+		_ = json.Unmarshal(c.Params[0], &name)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.loaded[name] = true
+		return map[string]any{}, ""
+	})
 	f.handle("importdescriptors", func(c bitcoindCall) (any, string) {
 		var descs []ImportDescriptor
 		_ = json.Unmarshal(c.Params[0], &descs)
@@ -131,6 +166,14 @@ func (f *fakeBitcoind) stubEnsureFlow() {
 		_ = json.Unmarshal(c.Params[0], &address)
 		return map[string]any{"address": address, "hdkeypath": "m/84'/1'/0'/0/0", "ismine": true}, ""
 	})
+}
+
+// restart unloads every wallet, as a bitcoind restart does: the wallet files
+// stay on disk, but only a load_on_startup wallet comes back by itself.
+func (f *fakeBitcoind) restart() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.loaded = map[string]bool{}
 }
 
 // newCoreBackendFixture wires a real Service (enforcer + bitcoinCore
@@ -161,6 +204,13 @@ func TestCoreBackendEnsureCreatesDescriptorWallet(t *testing.T) {
 	creates := fake.callsFor("createwallet")
 	require.Len(t, creates, 1)
 	assert.Equal(t, name, mustString(t, creates[0].Params[0]))
+	// createwallet "name" disable_private_keys blank "passphrase" avoid_reuse
+	// descriptors load_on_startup — the last one is what makes Core reload the
+	// wallet by itself after a restart.
+	require.Len(t, creates[0].Params, 7)
+	var loadOnStartup bool
+	require.NoError(t, json.Unmarshal(creates[0].Params[6], &loadOnStartup))
+	assert.True(t, loadOnStartup, "createwallet must set load_on_startup")
 
 	imports := fake.callsFor("importdescriptors")
 	require.Len(t, imports, 2, "BIP84 pair + BIP47 notification descriptor")
@@ -193,11 +243,49 @@ func TestCoreBackendEnsureCreatesDescriptorWallet(t *testing.T) {
 	assert.Contains(t, notif[0].Desc, "#", "descriptor carries a checksum")
 	assert.Equal(t, float64(0), asFloat(t, notif[0].Timestamp), "rescan from genesis")
 
-	// Second Ensure hits the cache — no further RPC traffic.
-	before := len(fake.callsFor("listwallets"))
+	// Second Ensure hits the cache — the wallet is neither re-created nor
+	// re-imported.
 	_, err = backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err)
-	assert.Equal(t, before, len(fake.callsFor("listwallets")))
+	assert.Len(t, fake.callsFor("createwallet"), 1)
+	assert.Len(t, fake.callsFor("importdescriptors"), 2)
+}
+
+// A bitcoind restart unloads every wallet the orchestrator created. The cached
+// wallet name outlives it, so the backend must notice the wallet is gone and
+// load it back instead of serving a name Core answers -18 for.
+func TestCoreBackendReloadsWalletAfterBitcoindRestart(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("getbalance", func(c bitcoindCall) (any, string) {
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		if !fake.loaded[c.Wallet] {
+			return nil, "Requested wallet does not exist or is not loaded"
+		}
+		return 1.25, ""
+	})
+	fake.handle("getunconfirmedbalance", func(bitcoindCall) (any, string) { return 0.5, "" })
+	ctx := context.Background()
+
+	name, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.Len(t, fake.callsFor("createwallet"), 1)
+
+	fake.restart()
+
+	confirmed, unconfirmed, err := backend.Balance(ctx, coreID)
+	require.NoError(t, err)
+	assert.Equal(t, 1.25, confirmed)
+	assert.Equal(t, 0.5, unconfirmed)
+
+	// The wallet already exists on disk, so it is loaded back, not re-created.
+	loads := fake.callsFor("loadwallet")
+	require.Len(t, loads, 1)
+	assert.Equal(t, name, mustString(t, loads[0].Params[0]))
+	var loadOnStartup bool
+	require.NoError(t, json.Unmarshal(loads[0].Params[1], &loadOnStartup))
+	assert.True(t, loadOnStartup, "loadwallet must set load_on_startup")
 }
 
 // A backend constructed without chain params (unrecognized network) must

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -1276,6 +1276,35 @@ func TestCoreBackendNextReceiveAddressTaproot(t *testing.T) {
 	assert.Equal(t, "bech32m", mintedType)
 }
 
+// A watch-only wallet's default receive kind comes from the descriptor it
+// imported: Core has no bech32 descriptor to serve for a tr() import.
+func TestCoreBackendNextReceiveAddressWatchOnlyTaproot(t *testing.T) {
+	net := &chaincfg.RegressionNetParams
+	svc := newTestService(t)
+	require.NoError(t, svc.CreateWatchOnlyWallet("WO Taproot", "tr("+watchOnlyTestTpub+"/0/*)", `{"background_svg":""}`))
+	woID := svc.ActiveWalletID()
+
+	fake := newFakeBitcoind(t)
+	backend := NewCoreBackend(svc, fake.client(t), StaticParams(net), zerolog.New(zerolog.NewTestWriter(t)))
+	require.Equal(t, ScriptTaproot, backend.walletScriptKind(woID))
+	fake.stubEnsureFlow()
+
+	minted := p2trAddr(t, fixedKey(0x41), net)
+	fake.handle("listreceivedbyaddress", func(bitcoindCall) (any, string) { return []map[string]any{}, "" })
+	var mintedType string
+	fake.handle("getnewaddress", func(c bitcoindCall) (any, string) {
+		if len(c.Params) > 1 {
+			mintedType = mustString(t, c.Params[1])
+		}
+		return minted, ""
+	})
+
+	addr, err := nextAddr(backend, context.Background(), woID, ScriptUnknown)
+	require.NoError(t, err)
+	assert.Equal(t, minted, addr)
+	assert.Equal(t, "bech32m", mintedType)
+}
+
 // TestCoreBackendNextChangeAddressKind pins change addresses to the wallet's own
 // script kind: a tr()-only wallet has no bech32 ScriptPubKeyMan to serve.
 func TestCoreBackendNextChangeAddressKind(t *testing.T) {

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -142,6 +142,12 @@ func (c *CoreRPCClient) LoadWallet(ctx context.Context, name string) error {
 	return err
 }
 
+// UnloadWallet unloads a wallet from Bitcoin Core, leaving its files on disk.
+func (c *CoreRPCClient) UnloadWallet(ctx context.Context, name string) error {
+	_, err := c.call(ctx, "", "unloadwallet", name)
+	return err
+}
+
 // ListWallets returns loaded wallet names.
 func (c *CoreRPCClient) ListWallets(ctx context.Context) ([]string, error) {
 	result, err := c.call(ctx, "", "listwallets")

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -130,15 +130,18 @@ func (c *CoreRPCClient) call(ctx context.Context, walletName, method string, par
 // Wallet management RPCs
 // ============================================================================
 
-// CreateWallet creates a new Bitcoin Core wallet.
+// CreateWallet creates a new Bitcoin Core descriptor wallet. The trailing
+// arguments are passphrase, avoid_reuse, descriptors and load_on_startup;
+// without the last one Core forgets the wallet on restart.
 func (c *CoreRPCClient) CreateWallet(ctx context.Context, name string, disablePrivateKeys, blank bool) error {
-	_, err := c.call(ctx, "", "createwallet", name, disablePrivateKeys, blank)
+	_, err := c.call(ctx, "", "createwallet", name, disablePrivateKeys, blank, "", false, true, true)
 	return err
 }
 
-// LoadWallet loads an existing Bitcoin Core wallet.
+// LoadWallet loads an existing Bitcoin Core wallet, with load_on_startup so it
+// comes back by itself after the next restart.
 func (c *CoreRPCClient) LoadWallet(ctx context.Context, name string) error {
-	_, err := c.call(ctx, "", "loadwallet", name)
+	_, err := c.call(ctx, "", "loadwallet", name, true)
 	return err
 }
 

--- a/sidechain-orchestrator/wallet/deposits.go
+++ b/sidechain-orchestrator/wallet/deposits.go
@@ -7,7 +7,10 @@ import (
 )
 
 // SidechainDeposit is one deposit this install made to a sidechain treasury.
+// Network is the chain the deposit was broadcast to; empty means the one the
+// service is on now.
 type SidechainDeposit struct {
+	Network     string
 	Txid        string
 	WalletID    string
 	Slot        uint32
@@ -25,11 +28,17 @@ func (s *Service) RecordSidechainDeposit(ctx context.Context, d SidechainDeposit
 	if db == nil {
 		return fmt.Errorf("record sidechain deposit: database not open")
 	}
+	// A network swap racing this insert would otherwise file the row under the
+	// chain we swapped to, hiding it from the one it was broadcast to.
+	network := d.Network
+	if network == "" {
+		network = s.Network()
+	}
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO sidechain_deposits (network, txid, wallet_id, slot, destination, amount_sats, fee_sats, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (network, txid) DO NOTHING`,
-		s.Network(), d.Txid, d.WalletID, d.Slot, d.Destination, d.AmountSats, d.FeeSats, time.Now().Unix())
+		network, d.Txid, d.WalletID, d.Slot, d.Destination, d.AmountSats, d.FeeSats, time.Now().Unix())
 	if err != nil {
 		return fmt.Errorf("insert sidechain deposit: %w", err)
 	}

--- a/sidechain-orchestrator/wallet/deposits_test.go
+++ b/sidechain-orchestrator/wallet/deposits_test.go
@@ -57,6 +57,30 @@ func TestRecordSidechainDepositIsIdempotent(t *testing.T) {
 	assert.Len(t, got, 1)
 }
 
+// A network swap between the broadcast and the insert must not move the row to
+// the chain we swapped to, where the deposit never happened.
+func TestRecordSidechainDepositKeepsBroadcastNetwork(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(t.TempDir(), zerolog.Nop())
+	svc.SetNetwork("regtest")
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, SidechainDeposit{
+		Network: "signet", Txid: "aaa", WalletID: "w1", Slot: 9, Destination: "addr", AmountSats: 50_000,
+	}))
+
+	none, err := svc.SidechainDeposits(ctx, 9, "")
+	require.NoError(t, err)
+	assert.Empty(t, none, "regtest never saw this deposit")
+
+	require.NoError(t, svc.RebindNetwork("signet"))
+	got, err := svc.SidechainDeposits(ctx, 9, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "aaa", got[0].Txid)
+}
+
 // The table records a wallet id per row, so a caller naming one must not see
 // another wallet's deposits.
 func TestSidechainDepositsFilterByWallet(t *testing.T) {

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1626,6 +1626,25 @@ func (p *ElectrumBackend) CreateCpfp(ctx context.Context, walletID string, req C
 			fmt.Errorf("outpoint %s:%d is already confirmed; CPFP only applies to unconfirmed parents", req.ParentTxID, req.ParentVout))
 	}
 
+	// A tip outage serves a stale scan, and the Electrum client's tx status only
+	// refreshes on the address walk that outage skips. Re-read the parent's
+	// address so the outpoint's confirmation state comes from the server.
+	live, err := p.client.AddressUTXOs(ctx, parentUTXO.address)
+	if err != nil {
+		return "", fmt.Errorf("refresh parent address %s: %w", parentUTXO.address, err)
+	}
+	liveUTXO, ok := lo.Find(live, func(u EsploraUTXO) bool {
+		return u.TxID == req.ParentTxID && u.Vout == req.ParentVout
+	})
+	if !ok {
+		return "", connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("outpoint %s:%d is no longer unspent", req.ParentTxID, req.ParentVout))
+	}
+	if liveUTXO.Status.Confirmed {
+		return "", connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("outpoint %s:%d is already confirmed; CPFP only applies to unconfirmed parents", req.ParentTxID, req.ParentVout))
+	}
+
 	parentTx, err := p.client.Tx(ctx, req.ParentTxID)
 	if err != nil {
 		return "", fmt.Errorf("fetch parent tx: %w", err)

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1664,7 +1664,13 @@ func (p *ElectrumBackend) CreateCpfp(ctx context.Context, walletID string, req C
 	if err != nil {
 		return "", err
 	}
-	childVsize := int64(11 + walletInputVsize(d) + outputVsizeForKind(d.Kind))
+	// A BIP47 watch key (empty hdPath) is a P2PKH import, not one of the wallet's
+	// descriptor addresses, so its input spends far wider than the descriptor says.
+	inVsize := walletInputVsize(d)
+	if a, ok := scan.byAddr[parentUTXO.address]; ok && a.hdPath == "" {
+		inVsize = inputVsize(ScriptLegacy)
+	}
+	childVsize := int64(11 + inVsize + outputVsizeForKind(d.Kind))
 	childFee := packageChildFee(req.TargetRate, parentVsize, parentFee, childVsize, 1)
 	if childFee >= parentUTXO.amountSats {
 		return "", connect.NewError(connect.CodeInvalidArgument,

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -57,6 +58,7 @@ type fakeEsplora struct {
 	txByID    map[string]EsploraTx
 	hexByID   map[string]string
 	tip       int
+	tipErr    error
 	feeRate   float64
 	broadcast []string
 }
@@ -124,6 +126,9 @@ func (f *fakeEsplora) Broadcast(_ context.Context, rawHex string) (string, error
 func (f *fakeEsplora) TipHeight(_ context.Context) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.tipErr != nil {
+		return 0, f.tipErr
+	}
 	return f.tip, nil
 }
 
@@ -1590,6 +1595,71 @@ func TestElectrumCreateCpfpRejectsConfirmedParent(t *testing.T) {
 	_, err := p.CreateCpfp(ctx, w.ID, CpfpRequest{ParentTxID: parentTxid, ParentVout: 0, TargetRate: 10})
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// A tip outage serves a scan that predates the parent's confirmation, and the
+// Electrum client's Tx status is stale for the same reason. Only a fresh read of
+// the parent's address sees the confirmation, and it must reject the child.
+func TestElectrumCreateCpfpRejectsLiveConfirmedParent(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const parentTxid = "6666666666666666666666666666666666666666666666666666666666666666"
+	fake.stats[addr] = EsploraAddressStats{
+		Address:      addr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 100_000, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: parentTxid, Vout: 0, Value: 100_000,
+		Status: EsploraStatus{Confirmed: false},
+	}}
+	// Left unconfirmed for the whole test: ElectrumClient.Tx reads a height cache
+	// only the address walk refreshes, so it cannot report the confirmation here.
+	fake.txByID[parentTxid] = EsploraTx{TxID: parentTxid, Weight: 600, Fee: 150} // 1 sat/vB
+
+	_, _, err := p.Balance(ctx, w.ID) // warm the scan while the parent is unconfirmed
+	require.NoError(t, err)
+
+	// The parent confirms, but the tip check fails, so the stale scan is served.
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: parentTxid, Vout: 0, Value: 100_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 111},
+	}}
+	fake.tipErr = errors.New("network blip")
+
+	_, err = p.CreateCpfp(ctx, w.ID, CpfpRequest{ParentTxID: parentTxid, ParentVout: 0, TargetRate: 20})
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Empty(t, fake.broadcast, "a confirmed parent must not be paid for by a child")
+}
+
+// The same outage, with the parent's output spent out from under the cached
+// scan instead of confirmed: the child must not be built on a gone outpoint.
+func TestElectrumCreateCpfpRejectsSpentParentOutput(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const parentTxid = "7777777777777777777777777777777777777777777777777777777777777777"
+	fake.stats[addr] = EsploraAddressStats{
+		Address:      addr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 100_000, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: parentTxid, Vout: 0, Value: 100_000,
+		Status: EsploraStatus{Confirmed: false},
+	}}
+	fake.txByID[parentTxid] = EsploraTx{TxID: parentTxid, Weight: 600, Fee: 150} // 1 sat/vB
+
+	_, _, err := p.Balance(ctx, w.ID) // warm the scan while the output is unspent
+	require.NoError(t, err)
+
+	fake.utxos[addr] = nil
+	fake.tipErr = errors.New("network blip")
+
+	_, err = p.CreateCpfp(ctx, w.ID, CpfpRequest{ParentTxID: parentTxid, ParentVout: 0, TargetRate: 20})
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Empty(t, fake.broadcast)
 }
 
 func TestElectrumCreateCpfpRejectsLowTarget(t *testing.T) {

--- a/sidechain-orchestrator/wallet/electrum_client.go
+++ b/sidechain-orchestrator/wallet/electrum_client.go
@@ -381,6 +381,13 @@ func (c *ElectrumClient) setTip(height int) {
 	c.tipMu.Unlock()
 }
 
+// clearTip expires the cached tip so the next TipHeight goes to the server.
+func (c *ElectrumClient) clearTip() {
+	c.tipMu.Lock()
+	c.tipFetched = time.Time{}
+	c.tipMu.Unlock()
+}
+
 func (c *ElectrumClient) startKeepalive() {
 	go func() {
 		t := time.NewTicker(60 * time.Second)
@@ -730,6 +737,9 @@ func (c *ElectrumClient) BaseURLs() []string {
 	return []string{c.serverURL}
 }
 
+// SetBaseURLs re-points the client at another Electrum server. The tip cache is
+// dropped so the next read probes the new server instead of answering from the
+// old one's tip.
 func (c *ElectrumClient) SetBaseURLs(urls []string) {
 	if len(urls) == 0 {
 		return
@@ -738,6 +748,7 @@ func (c *ElectrumClient) SetBaseURLs(urls []string) {
 	c.serverURL = urls[0]
 	c.urlMu.Unlock()
 	c.resetConn()
+	c.clearTip()
 }
 
 func (c *ElectrumClient) ProxyConfig() (bool, string) {
@@ -768,6 +779,7 @@ func (c *ElectrumClient) SetProxy(enabled bool, proxyAddr string) error {
 	c.proxyAddr = proxyAddr
 	c.urlMu.Unlock()
 	c.resetConn()
+	c.clearTip()
 	return nil
 }
 

--- a/sidechain-orchestrator/wallet/electrum_client_test.go
+++ b/sidechain-orchestrator/wallet/electrum_client_test.go
@@ -217,6 +217,33 @@ func TestElectrumClientHeightCacheRevoked(t *testing.T) {
 	assert.Equal(t, 0, got.Status.BlockHeight)
 }
 
+// TestElectrumClientSwapDropsTipCache proves a re-point does not let the old
+// server's cached tip answer for the new one, so an unreachable endpoint fails
+// its validation probe instead of reading as connected.
+func TestElectrumClientSwapDropsTipCache(t *testing.T) {
+	ctx := context.Background()
+	url := startFakeElectrum(t, func(method string, _ []json.RawMessage) interface{} {
+		if method == "blockchain.headers.subscribe" {
+			return map[string]interface{}{"height": 800000}
+		}
+		return nil
+	})
+	c := NewElectrumClient(url, zerolog.Nop(), &chaincfg.SigNetParams)
+
+	tip, err := c.TipHeight(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 800000, tip)
+
+	c.SetBaseURLs([]string{"ssl://127.0.0.1:1"})
+	_, err = c.TipHeight(ctx)
+	assert.Error(t, err, "a swap to an unreachable server must not serve the previous server's tip")
+
+	c.SetBaseURLs([]string{url})
+	require.NoError(t, c.SetProxy(true, "127.0.0.1:1"))
+	_, err = c.TipHeight(ctx)
+	assert.Error(t, err, "a swap to an unreachable proxy must not serve the cached tip")
+}
+
 func TestElectrumClientFeeRateConversion(t *testing.T) {
 	ctx := context.Background()
 	url := startFakeElectrum(t, func(method string, _ []json.RawMessage) interface{} {

--- a/sidechain-orchestrator/wallet/enforcer_companion_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_companion_test.go
@@ -40,12 +40,37 @@ func loadEnforcerWallet(t *testing.T, network config.Network, passphrase string)
 	return svc
 }
 
-// The seed makes the wallet; the path only says where to look first. On a
-// network whose coin type is 1 the enforcer's account is the standard one, so a
-// companion would be an exact duplicate of the wallet beside it.
-func TestNoCompanionWhereTheEnforcerAccountIsStandard(t *testing.T) {
+// On a network whose coin type is 1 the enforcer's account is the standard one,
+// so the companion is a duplicate view of the wallet beside it. It is still
+// written: the migration only runs once, and the next boot may be mainnet.
+func TestCompanionEvenWhereTheEnforcerAccountIsStandard(t *testing.T) {
 	svc := loadEnforcerWallet(t, config.NetworkSignet, "")
-	assert.Len(t, svc.GetAllWallets(), 1, "the wallet already looks where the coins are")
+	require.Len(t, svc.GetAllWallets(), 2)
+}
+
+// wallet.json outlives the boot that migrated it, and the migration never runs
+// again. A first boot on signet must still leave the enforcer's account on
+// disk, or a later mainnet boot — which derives m/84'/0'/0' — reads a zero
+// balance over untouched coins.
+func TestTheEnforcerAccountOutlivesTheBootNetwork(t *testing.T) {
+	first := loadEnforcerWallet(t, config.NetworkSignet, "")
+	dir := first.bitwindowDir
+	first.Close()
+
+	later := NewService(dir, zerolog.Nop())
+	later.SetNetwork(string(config.NetworkMainnet))
+	require.NoError(t, later.Init())
+	t.Cleanup(func() { later.Close() })
+
+	wallets := later.GetAllWallets()
+	var found *WalletData
+	for i := range wallets {
+		if wallets[i].ImportedFromEnforcer {
+			found = &wallets[i]
+		}
+	}
+	require.NotNil(t, found, "the enforcer's account must outlive the boot network")
+	assert.Equal(t, EnforcerAccountPath, found.DerivationPath)
 }
 
 // On mainnet the enforcer's coin type 1 is not the standard account, so its

--- a/sidechain-orchestrator/wallet/enforcer_companion_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_companion_test.go
@@ -73,6 +73,16 @@ func TestTheEnforcerAccountOutlivesTheBootNetwork(t *testing.T) {
 	assert.Equal(t, EnforcerAccountPath, found.DerivationPath)
 }
 
+// Testnet's coin type is also 1, so the enforcer's account is standard there
+// too — the companion is still written, the same as on signet. And the
+// migration must reach that point at all: reading the network off a map of the
+// networks BIP47 sends support instead panicked the daemon before it ever
+// finished starting.
+func TestCompanionOnTestnetWithoutPanic(t *testing.T) {
+	svc := loadEnforcerWallet(t, config.NetworkTestnet, "")
+	require.Len(t, svc.GetAllWallets(), 2)
+}
+
 // On mainnet the enforcer's coin type 1 is not the standard account, so its
 // coins live in a tree the wallet would never scan.
 func TestCompanionOnMainnetWhereTheAccountDiffers(t *testing.T) {

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -56,6 +56,16 @@ func (e *WalletEngine) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
 	return b, ok
 }
 
+// ForgetWallet drops the backend state a deleted wallet held: Core unloads its
+// wallet. Call it after the wallet is out of wallet.json. No-op otherwise.
+func (e *WalletEngine) ForgetWallet(ctx context.Context, walletID string) error {
+	f, ok := e.backend.(ForgetBackend)
+	if !ok {
+		return nil
+	}
+	return f.Forget(ctx, walletID)
+}
+
 // ChainForWallet returns the chain source for a wallet's backend, dispatching
 // by wallet type so electrum wallets read/broadcast over Esplora.
 func (e *WalletEngine) ChainForWallet(walletID string) ChainSource {

--- a/sidechain-orchestrator/wallet/router.go
+++ b/sidechain-orchestrator/wallet/router.go
@@ -88,6 +88,16 @@ func (r *BackendRouter) EnsureAll(ctx context.Context) (int, error) {
 	return r.chain.EnsureAll(ctx)
 }
 
+// Forget drops a deleted wallet's chain-backend state. It can't dispatch on
+// wallet type — the wallet is gone — and only the chain backend holds any.
+func (r *BackendRouter) Forget(ctx context.Context, walletID string) error {
+	f, ok := r.chain.(ForgetBackend)
+	if !ok {
+		return nil
+	}
+	return f.Forget(ctx, walletID)
+}
+
 func (r *BackendRouter) Balance(ctx context.Context, walletID string) (float64, float64, error) {
 	p, err := r.pick(walletID)
 	if err != nil {

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -1123,10 +1123,22 @@ func (s *Service) UnlockWallet(password string) error {
 	}
 
 	s.log.Debug().Int("encrypted_data_len", len(data)).Msg("attempting decryption")
-	_, err = Decrypt(string(data), key)
-	if err != nil {
-		s.log.Warn().Msg("unlock failed: incorrect password (decryption failed)")
-		return fmt.Errorf("incorrect password")
+	if _, decErr := Decrypt(string(data), key); decErr != nil {
+		// The wallet may hold ciphertext from an interrupted ChangePassword,
+		// described by the staged salt rather than by the live metadata.
+		stagedKey, err := s.promoteStagedMetadataLocked(password, data)
+		if err != nil {
+			return err
+		}
+		if stagedKey == nil {
+			s.log.Warn().Msg("unlock failed: incorrect password (decryption failed)")
+			return fmt.Errorf("incorrect password")
+		}
+		key = stagedKey
+	} else {
+		// The live metadata opens the wallet, so any staged salt belongs to a
+		// password change that never reached the wallet file.
+		s.removeStagedMetadataLocked()
 	}
 
 	s.encryptionKey = key
@@ -1277,11 +1289,6 @@ func (s *Service) ChangePassword(oldPassword, newPassword string) error {
 		return fmt.Errorf("encrypt: %w", err)
 	}
 
-	s.setWalletDigestLocked(data)
-	if err := s.writeWalletFileLocked([]byte(encrypted)); err != nil {
-		return fmt.Errorf("write wallet: %w", err)
-	}
-
 	newMeta := EncryptionMetadata{
 		Salt:       base64.StdEncoding.EncodeToString(newSalt),
 		Iterations: DefaultIterations,
@@ -1289,8 +1296,36 @@ func (s *Service) ChangePassword(oldPassword, newPassword string) error {
 		Version:    "1.0",
 	}
 	metaBytes, _ := newMeta.Marshal()
-	if err := os.WriteFile(s.metadataFilePath(), metaBytes, 0600); err != nil {
+
+	// Stage the new salt before the wallet write. The wallet file and the
+	// metadata cannot change in one step, and a crash in between would otherwise
+	// leave new-key ciphertext described by the old salt, which no password
+	// unlocks. UnlockWallet finishes the change from the staging file.
+	if err := atomicWrite(s.stagedMetadataFilePath(), metaBytes); err != nil {
+		return fmt.Errorf("stage metadata: %w", err)
+	}
+
+	// Backup
+	walletPath := s.walletFilePath()
+	backupPath := fmt.Sprintf("%s.backup_before_password_change_%d", walletPath, time.Now().UnixMilli())
+	if err := os.WriteFile(backupPath, data, 0600); err != nil {
+		return fmt.Errorf("backup wallet: %w", err)
+	}
+	s.log.Debug().Str("backup_path", backupPath).Msg("wallet backed up before password change")
+
+	s.setWalletDigestLocked(data)
+	if err := s.writeWalletFileLocked([]byte(encrypted)); err != nil {
+		return fmt.Errorf("write wallet: %w", err)
+	}
+
+	if err := os.Rename(s.stagedMetadataFilePath(), s.metadataFilePath()); err != nil {
 		return fmt.Errorf("write metadata: %w", err)
+	}
+
+	// The change committed, so the old ciphertext is one more copy of the seed
+	// the old password opens.
+	if err := os.Remove(backupPath); err != nil {
+		s.log.Warn().Err(err).Str("backup_path", backupPath).Msg("could not remove the wallet backup taken before the password change; delete it manually")
 	}
 
 	// Adopt the new key only if we already held one. While locked there is no
@@ -1666,6 +1701,12 @@ func (s *Service) metadataFilePath() string {
 	return filepath.Join(s.bitwindowDir, "wallet_encryption.json")
 }
 
+// stagedMetadataFilePath holds the new salt ChangePassword writes before it
+// rewrites the wallet, until the rename that commits it.
+func (s *Service) stagedMetadataFilePath() string {
+	return s.metadataFilePath() + ".new"
+}
+
 func (s *Service) starterDir() string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("bitwindow_starters_%d", os.Getpid()))
 }
@@ -1704,6 +1745,45 @@ func (s *Service) dropStaleEncryptionMetadata(walletData []byte) (bool, error) {
 	s.unlockedPass = ""
 	s.log.Warn().Msg("wallet file is plaintext but metadata claimed encrypted; dropped stale encryption metadata")
 	return true, nil
+}
+
+// promoteStagedMetadataLocked finishes a ChangePassword that died between the
+// wallet write and the rename that commits the new salt, leaving a wallet only
+// the staged salt opens. Returns the key that salt derives from password, or nil
+// when there is no staging file or it does not decrypt walletData — a stale
+// staging file from a change that never reached the wallet write. Must be called
+// with mu held.
+func (s *Service) promoteStagedMetadataLocked(password string, walletData []byte) ([]byte, error) {
+	staged, err := os.ReadFile(s.stagedMetadataFilePath())
+	if err != nil {
+		return nil, nil
+	}
+	meta, err := UnmarshalEncryptionMetadata(staged)
+	if err != nil || !meta.Encrypted {
+		return nil, nil
+	}
+	salt, err := base64.StdEncoding.DecodeString(meta.Salt)
+	if err != nil {
+		return nil, nil
+	}
+	key := DeriveKey(password, salt, meta.Iterations)
+	if _, err := Decrypt(string(walletData), key); err != nil {
+		return nil, nil
+	}
+	if err := os.Rename(s.stagedMetadataFilePath(), s.metadataFilePath()); err != nil {
+		s.log.Error().Err(err).Str("path", s.stagedMetadataFilePath()).Msg("could not promote the staged encryption metadata")
+		return nil, fmt.Errorf("promote staged encryption metadata: %w", err)
+	}
+	s.log.Warn().Msg("wallet held ciphertext from an interrupted password change; finished it from the staged metadata")
+	return key, nil
+}
+
+// removeStagedMetadataLocked drops a staging file left by a password change that
+// never reached the wallet write. Must be called with mu held.
+func (s *Service) removeStagedMetadataLocked() {
+	if err := os.Remove(s.stagedMetadataFilePath()); err != nil && !os.IsNotExist(err) {
+		s.log.Warn().Err(err).Str("path", s.stagedMetadataFilePath()).Msg("could not remove stale staged encryption metadata")
+	}
 }
 
 // isPlaintextWalletFile reports whether data is an unencrypted wallet file.

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -1151,6 +1151,8 @@ func (s *Service) UnlockWallet(password string) error {
 	}
 
 	s.log.Info().Int("wallet_count", len(s.wallets)).Str("active_id", s.activeWalletID).Msg("wallet unlocked successfully")
+	// Nothing here writes the wallet file, so the watcher won't notify for us.
+	s.notifyChanged()
 	return nil
 }
 
@@ -1165,6 +1167,9 @@ func (s *Service) LockWallet() {
 	s.CleanupStarterFiles()
 
 	s.log.Info().Msg("wallet locked, starter files cleaned up")
+	// Nothing here writes the wallet file, so the watcher won't notify for us.
+	// Push the cleared state to every WatchWalletData subscriber.
+	s.notifyChanged()
 }
 
 // --- Encrypt/Decrypt ---

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -906,6 +906,20 @@ func (s *Service) CreateElectrumMultisig(
 	return &wallet, nil
 }
 
+// watchOnlyScriptType is the address kind a watch-only descriptor holds, so
+// receive and change ask Core for a family it imported. Empty keeps the
+// native-segwit default for a form Core serves but this parser does not model.
+func watchOnlyScriptType(descriptor string) string {
+	d, err := ParseDescriptor(descriptor)
+	if err != nil {
+		return ""
+	}
+	if _, ok := coreAddressType(d.Kind); !ok {
+		return ""
+	}
+	return d.Kind.String()
+}
+
 // CreateWatchOnlyWallet creates a watch-only wallet from an xpub or descriptor.
 // Dart: WalletWriterProvider.createWatchOnlyWallet (L156-214)
 func (s *Service) CreateWatchOnlyWallet(name, xpubOrDescriptor, gradientJSON string) error {
@@ -924,8 +938,10 @@ func (s *Service) CreateWatchOnlyWallet(name, xpubOrDescriptor, gradientJSON str
 	isDescriptor := strings.Contains(xpubOrDescriptor, "(") && strings.Contains(xpubOrDescriptor, ")")
 
 	watchOnly := map[string]string{}
+	scriptType := ""
 	if isDescriptor {
 		watchOnly["descriptor"] = xpubOrDescriptor
+		scriptType = watchOnlyScriptType(xpubOrDescriptor)
 	} else {
 		watchOnly["xpub"] = xpubOrDescriptor
 	}
@@ -942,6 +958,7 @@ func (s *Service) CreateWatchOnlyWallet(name, xpubOrDescriptor, gradientJSON str
 		CreatedAt:  time.Now(),
 		WalletType: WalletTypeBitcoinCore,
 		WatchOnly:  json.RawMessage(watchOnlyJSON),
+		ScriptType: scriptType,
 	}
 
 	s.wallets = append(s.wallets, wallet)
@@ -1892,6 +1909,24 @@ func (s *Service) loadWalletFile() error {
 		} else {
 			s.wallets[i].WalletType = WalletTypeBitcoinCore
 		}
+		migrated = true
+	}
+	// Backfill script_type on watch-only wallets imported before the descriptor's
+	// kind was recorded: a tr() wallet otherwise asks Core for bech32, which it
+	// imported no descriptor for.
+	for i := range s.wallets {
+		if s.wallets[i].ScriptType != "" {
+			continue
+		}
+		desc := s.wallets[i].watchOnlyField("descriptor")
+		if desc == "" {
+			continue
+		}
+		kind := watchOnlyScriptType(desc)
+		if kind == "" || kind == ScriptNativeSegwit.String() {
+			continue
+		}
+		s.wallets[i].ScriptType = kind
 		migrated = true
 	}
 	enforcerMigrated, err := s.migrateEnforcerWallets()

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47send"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
 	"github.com/btcsuite/btcd/chaincfg"
 
@@ -2008,10 +2007,11 @@ func (s *Service) migrateEnforcerWallets() (bool, error) {
 // enforcerLegacyWallet builds the wallet the enforcer daemon actually ran: the
 // bare mnemonic with no BIP39 passphrase, on the account it hardcoded.
 //
-// The seed is what makes a wallet, and the path only says where to look first.
-// So this returns nil when both already match what the wallet derives — on a
-// network whose coin type is 1, the enforcer's account is the standard one, and
-// a companion would be an exact duplicate.
+// The companion is written on every network. The migration runs once, on
+// whichever network happened to boot first, and wallet.json outlives that boot
+// — skipping it where the coin type is already 1 leaves a later mainnet boot
+// with nothing looking at the enforcer's coins. There the duplicate view of the
+// same account is only cosmetic; the missing wallet is not.
 func (s *Service) enforcerLegacyWallet(w *WalletData, target WalletType) (*WalletData, error) {
 	if w.Master.Mnemonic == "" {
 		return nil, nil
@@ -2023,9 +2023,6 @@ func (s *Service) enforcerLegacyWallet(w *WalletData, target WalletType) (*Walle
 	}
 
 	seed := MnemonicToSeed(w.Master.Mnemonic, "")
-	if hex.EncodeToString(seed) == w.Master.SeedHex && s.derivesEnforcerAccount(w) {
-		return nil, nil
-	}
 	masterKey, err := bip32.NewMasterKey(seed)
 	if err != nil {
 		return nil, fmt.Errorf("rebuild the enforcer master key: %w", err)
@@ -2189,25 +2186,6 @@ func (s *Service) StarterWalletID() string {
 		return w.ID
 	}
 	return ""
-}
-
-// derivesEnforcerAccount reports whether the wallet already looks at the
-// account the enforcer hardcoded. True on a network whose coin type is 1.
-func (s *Service) derivesEnforcerAccount(w *WalletData) bool {
-	// Forknet and ecash run on mainnet params, so a string compare against
-	// mainnet reads their coin type as 1 and skips the companion they need.
-	net, err := bip47send.NetworkParams(s.network)
-	if err != nil {
-		// Testnet params here read the coin type as 1, which is the answer this
-		// function exists to avoid. The daemon refuses an unknown network at
-		// startup, so this cannot happen.
-		panic(fmt.Sprintf("unknown network %q: %v", s.network, err))
-	}
-	ap, err := accountPathFor(w, walletReceiveKind(w), net)
-	if err != nil {
-		return false
-	}
-	return ap.String() == EnforcerAccountPath
 }
 
 // CoinbaseRecipient is an address the block reward can pay to, derived from the

--- a/sidechain-orchestrator/wallet/service_lock_guard_test.go
+++ b/sidechain-orchestrator/wallet/service_lock_guard_test.go
@@ -1,8 +1,10 @@
 package wallet
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -137,6 +139,59 @@ func TestChangePassword_UnlockedWithNoWallets_AdoptsNewKey(t *testing.T) {
 	require.NoError(t, svc.UnlockWallet("new pass"), "wallet must be decryptable with the new password")
 	require.Len(t, svc.ListWallets(), 1)
 	require.Equal(t, "Replacement", svc.ListWallets()[0].Name)
+}
+
+// Locking must wake WatchWalletData subscribers, else every open stream keeps
+// serving the unlocked wallet list until some other event happens to fire.
+func TestLockWallet_NotifiesSubscribers(t *testing.T) {
+	svc, _, _ := generateAndEncrypt(t, "correct horse")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changed := svc.Subscribe(ctx)
+
+	// Let the file watcher settle after the encrypt write, then drain, so the
+	// notification below can only come from LockWallet.
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case <-changed:
+	default:
+	}
+
+	svc.LockWallet()
+	require.False(t, svc.IsUnlocked())
+
+	select {
+	case <-changed:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("LockWallet did not notify subscribers")
+	}
+	require.Empty(t, svc.ListWallets(), "subscribers must see an empty wallet list")
+}
+
+// Unlocking repopulates the wallets in memory without touching the wallet file,
+// so it must notify too.
+func TestUnlockWallet_NotifiesSubscribers(t *testing.T) {
+	svc, _, _ := generateAndEncrypt(t, "correct horse")
+	svc.LockWallet()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changed := svc.Subscribe(ctx)
+
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case <-changed:
+	default:
+	}
+
+	require.NoError(t, svc.UnlockWallet("correct horse"))
+
+	select {
+	case <-changed:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("UnlockWallet did not notify subscribers")
+	}
 }
 
 // An unencrypted wallet is unaffected by the guard.

--- a/sidechain-orchestrator/wallet/service_test.go
+++ b/sidechain-orchestrator/wallet/service_test.go
@@ -270,6 +270,87 @@ func TestServiceStaleEncryptionMetadataRemoveEncryptionRetry(t *testing.T) {
 	assert.Len(t, svc.ListWallets(), 1)
 }
 
+// interruptedPasswordChange returns a service left in the state a ChangePassword
+// that died between the wallet write and the metadata rename produces: wallet.json
+// holds ciphertext under the new password while wallet_encryption.json still holds
+// the old salt and the new one sits in the staging file. Skips Init so the file
+// watcher cannot reload concurrently.
+func interruptedPasswordChange(t *testing.T, oldPass, newPass string) *Service {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
+	svc := NewService(t.TempDir(), log)
+
+	_, err := svc.GenerateWallet("PW Crash", "", "", testSlots)
+	require.NoError(t, err)
+	require.NoError(t, svc.EncryptWallet(oldPass))
+
+	oldMeta, err := os.ReadFile(svc.metadataFilePath())
+	require.NoError(t, err)
+	require.NoError(t, svc.ChangePassword(oldPass, newPass))
+
+	// Rewind the rename that committed the new salt.
+	newMeta, err := os.ReadFile(svc.metadataFilePath())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(svc.stagedMetadataFilePath(), newMeta, 0600))
+	require.NoError(t, os.WriteFile(svc.metadataFilePath(), oldMeta, 0600))
+
+	svc.LockWallet()
+	return svc
+}
+
+// The new password must still open a wallet left mid-change, rather than being
+// rejected forever against the old salt.
+func TestServiceInterruptedPasswordChangeUnlocksWithNewPassword(t *testing.T) {
+	svc := interruptedPasswordChange(t, "oldpass", "newpass")
+
+	require.NoError(t, svc.UnlockWallet("newpass"))
+	assert.True(t, svc.IsUnlocked())
+	assert.Len(t, svc.ListWallets(), 1)
+
+	_, err := os.Stat(svc.stagedMetadataFilePath())
+	assert.True(t, os.IsNotExist(err), "staged metadata should be promoted")
+}
+
+func TestServiceInterruptedPasswordChangeRejectsOldPassword(t *testing.T) {
+	svc := interruptedPasswordChange(t, "oldpass", "newpass")
+
+	assert.Error(t, svc.UnlockWallet("oldpass"))
+	assert.False(t, svc.IsUnlocked())
+
+	// A wrong password must not consume the staging file the right one needs.
+	_, err := os.Stat(svc.stagedMetadataFilePath())
+	assert.NoError(t, err)
+	require.NoError(t, svc.UnlockWallet("newpass"))
+}
+
+// A change that died before the wallet write leaves a staging file describing a
+// salt no wallet uses. The old password still opens the wallet, and clears it.
+func TestServiceStaleStagedMetadataDroppedOnUnlock(t *testing.T) {
+	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
+	svc := NewService(t.TempDir(), log)
+
+	_, err := svc.GenerateWallet("Stale Staged", "", "", testSlots)
+	require.NoError(t, err)
+	require.NoError(t, svc.EncryptWallet("mypass"))
+
+	salt, err := GenerateSalt()
+	require.NoError(t, err)
+	staged, err := EncryptionMetadata{
+		Salt:       base64.StdEncoding.EncodeToString(salt),
+		Iterations: DefaultIterations,
+		Encrypted:  true,
+		Version:    "1.0",
+	}.Marshal()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(svc.stagedMetadataFilePath(), staged, 0600))
+
+	svc.LockWallet()
+	require.NoError(t, svc.UnlockWallet("mypass"))
+
+	_, err = os.Stat(svc.stagedMetadataFilePath())
+	assert.True(t, os.IsNotExist(err), "stale staged metadata should be gone")
+}
+
 func TestServiceSwitchWallet(t *testing.T) {
 	svc := newTestService(t)
 

--- a/sidechain-orchestrator/wallet/service_test.go
+++ b/sidechain-orchestrator/wallet/service_test.go
@@ -832,6 +832,48 @@ func TestServiceCreateWatchOnlyWalletWithDescriptor(t *testing.T) {
 	assert.Empty(t, watchOnly["xpub"])
 }
 
+const watchOnlyTestTpub = "tpubDCBWBScQPGv4Xk3JSbhw6wYYpayMjb2eAYyArpbSqQTbLDpphHGAetB6VQgVeftLML8vDSUEWcC2xDi3qJJ3YCDChJDvqVzpgoYSuT52MhJ"
+
+// The imported descriptor decides the wallet's receive kind: a tr() wallet left
+// on the native-segwit default hands out bech32 addresses Core never imported.
+func TestServiceCreateWatchOnlyWalletRecordsDescriptorKind(t *testing.T) {
+	svc := newTestService(t)
+
+	descriptor := "tr(" + watchOnlyTestTpub + "/0/*)"
+	require.NoError(t, svc.CreateWatchOnlyWallet("Taproot WO", descriptor, `{"background_svg":""}`))
+
+	w := svc.GetWalletByID(svc.ActiveWalletID())
+	require.NotNil(t, w)
+	assert.Equal(t, "taproot", w.ScriptType)
+	assert.Equal(t, []ScriptKind{ScriptTaproot}, ReceiveKinds(w))
+}
+
+// A watch-only wallet imported before the kind was recorded is backfilled at
+// load, so an existing tr() wallet stops asking Core for bech32.
+func TestServiceBackfillsWatchOnlyScriptType(t *testing.T) {
+	dir := t.TempDir()
+	legacy := map[string]any{
+		"wallets": []map[string]any{{
+			"id":          "OLD",
+			"name":        "Taproot WO",
+			"wallet_type": "bitcoinCore",
+			"watch_only":  map[string]string{"descriptor": "tr(" + watchOnlyTestTpub + "/0/*)"},
+		}},
+		"activeWalletId": "OLD",
+	}
+	body, err := json.Marshal(legacy)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wallet.json"), body, 0o600))
+
+	svc := NewService(dir, zerolog.Nop())
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	w := svc.GetWalletByID("OLD")
+	require.NotNil(t, w)
+	assert.Equal(t, "taproot", w.ScriptType)
+}
+
 // TestServiceCreateElectrumWatchOnlyRejectsPrivateKey: importing a descriptor
 // that carries a private extended key must fail so a watch-only wallet can
 // never store or sign with private material.

--- a/sidechain-orchestrator/wallet/sidechain_core_wallet.go
+++ b/sidechain-orchestrator/wallet/sidechain_core_wallet.go
@@ -13,7 +13,10 @@ import (
 // EnsureCoreWalletFromMnemonic creates a Bitcoin Core wallet holding the keys a
 // BIP39 mnemonic describes. A Core derived sidechain takes no seed flag, so
 // this is how its slot starter reaches the node; an existing wallet is loaded
-// rather than rebuilt.
+// rather than rebuilt. The descriptors import at timestamp 0: the starter is
+// derived from the master seed, so a restored seed — or a wallet recreated over
+// chainstate the node kept — can hold coins older than the import, which "now"
+// would leave unseen.
 func EnsureCoreWalletFromMnemonic(
 	ctx context.Context, rpc *CoreRPCClient, log zerolog.Logger,
 	walletName, mnemonic string, net *chaincfg.Params,
@@ -50,13 +53,13 @@ func EnsureCoreWalletFromMnemonic(
 		{
 			Desc:      mustAddChecksum(fmt.Sprintf("%s%s/0/*%s", open, origin, close)),
 			Active:    true,
-			Timestamp: "now",
+			Timestamp: int64(0),
 			Range:     []int{0, 999},
 		},
 		{
 			Desc:      mustAddChecksum(fmt.Sprintf("%s%s/1/*%s", open, origin, close)),
 			Active:    true,
-			Timestamp: "now",
+			Timestamp: int64(0),
 			Internal:  true,
 			Range:     []int{0, 999},
 		},

--- a/sidechain-orchestrator/wallet/sidechain_core_wallet_test.go
+++ b/sidechain-orchestrator/wallet/sidechain_core_wallet_test.go
@@ -1,0 +1,37 @@
+package wallet
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The slot starter is derived from the master seed, so its wallet can hold
+// coins older than the import. Both descriptors must rescan from genesis.
+func TestEnsureCoreWalletFromMnemonicRescansFromGenesis(t *testing.T) {
+	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	fake := newFakeBitcoind(t)
+	fake.stubEnsureFlow()
+	log := zerolog.New(zerolog.NewTestWriter(t))
+
+	err := EnsureCoreWalletFromMnemonic(
+		context.Background(), fake.client(t), log,
+		"orchestrator", mnemonic, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	imports := fake.callsFor("importdescriptors")
+	require.Len(t, imports, 1)
+
+	var descs []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[0].Params[0], &descs))
+	require.Len(t, descs, 2, "external + change")
+	assert.Equal(t, float64(0), asFloat(t, descs[0].Timestamp), "rescan from genesis")
+	assert.Equal(t, float64(0), asFloat(t, descs[1].Timestamp), "rescan from genesis")
+}


### PR DESCRIPTION
A set of **15 independent fixes** to the BitWindow orchestrator wallet, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`25 files changed, 1168 insertions(+), 89 deletions(-)`).

## Fixes (oldest first)

- **`7bbfcd550`** `drivechain-frontends` ElectrumBackend `cachedScan` tip outage lets `CreateCpfp` spend an already-confirmed parent
- **`da2bbfc07`** BIP47 feature byte 79 is accepted but ignored during sends
- **`1b21ca1a1`** ChangePassword non-atomic wallet/metadata write window permanently locks wallet
- **`d119270c1`** sidechain-orchestrator `DeleteWallet` leaves Core wallet loaded
- **`650e97034`** Mainnet Electrum server switching rejects every Electrum endpoint
- **`47626fb4e`** CPFP sizes a BIP47 P2PKH parent input as the wallet's P2WPKH kind and misses the requested package rate
- **`c8a398eb7`** Fixed watch-only descriptors are imported with an invalid range
- **`aa5e02239`** orchestrator WalletEngine.coreWallets cache survives bitcoind restart that unloads `load_on_startup=false` Core wallets
- **`a0d7db223`** BIP47 reserved-byte aliases split state and reuse payment addresses
- **`b3cee69bc`** restored Core-derived sidechain starter is imported at `"now"`
- **`ec7b848a0`** Orchestrator wallet lock omits stream state notification
- **`c2b494332`** Core watch-only taproot descriptor defaults to native-segwit receive
- **`a183758ba`** first upgraded network permanently selects whether legacy enforcer account is watched
- **`a6aa696c5`** CreateDeposit records can be filed under the target network after a concurrent swap
- **`1facbfdc3`** testnet startup panics while migrating a matching legacy enforcer wallet

## Reconciliation

One commit reconciles fixes that each pass alone but interact when combined (kept every fix; the change is minimal and additive):

- `449f328b0` reconcile orch-wallet — Forget test stub must clear the load-aware core fake

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.