### PR TITLE
BitWindow server APIs: 8 fixes from a security review

### DIFF
--- a/bitwindow/lib/widgets/create_multisig_modal.dart
+++ b/bitwindow/lib/widgets/create_multisig_modal.dart
@@ -845,8 +845,9 @@ class CreateMultisigModalViewModel extends BaseViewModel {
       final firstHash = sha256.convert(xpubBytes).bytes;
       final secondHash = sha256.convert(firstHash).bytes;
 
-      final idBytes = secondHash.sublist(0, 3);
-      return hex.encode(idBytes);
+      // Full digest: a truncated id collides, and the colliding group's save
+      // overwrites the other group's stored state.
+      return hex.encode(secondHash);
     } catch (e) {
       throw Exception('Failed to compute multisig ID: $e');
     }

--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -404,12 +404,15 @@ func (s *Server) ListWithdrawals(
 	// Determine start block for fetching
 	var startBlockHash string
 	var existingBundles []*pb.WithdrawalBundle
+	var incremental bool
 
-	if cache != nil && cache.activationHeight == activationHeight && cache.lastBlockHeight > 0 {
+	if cache != nil && cache.activationHeight == activationHeight && cache.lastBlockHeight > 0 &&
+		s.cachedTipOnActiveChain(ctx, cache, chainTipResp.BlockHeaderInfo) {
 		// We have a cache - only fetch new blocks since last fetch
 		// Start from the block AFTER our last cached block
 		startBlockHash = cache.lastBlockHash
 		existingBundles = cache.bundles
+		incremental = true
 		log.Debug().
 			Uint32("sidechain", sidechainId).
 			Uint32("fromHeight", cache.lastBlockHeight).
@@ -417,7 +420,8 @@ func (s *Server) ListWithdrawals(
 			Int("cachedBundles", len(existingBundles)).
 			Msg("ListWithdrawals: incremental fetch")
 	} else {
-		// No cache or activation height changed - need full fetch from activation
+		// No usable cache (missing, stale activation height, or reorged away) -
+		// need full fetch from activation
 		// Get the activation block hash
 		ancestorsNeeded := currentHeight - activationHeight
 		activationBlockResp, err := s.data.BlockHeaderInfo(ctx, &validatorpb.GetBlockHeaderInfoRequest{
@@ -454,6 +458,13 @@ func (s *Server) ListWithdrawals(
 		EndBlockHash:   &commonpb.ReverseHex{Hex: wrapperspb.String(currentBlockHash)},
 	})
 	if err != nil {
+		if incremental {
+			// The cached start block may be unusable. Drop the cache so the next
+			// call rescans from activation instead of re-sending it.
+			s.withdrawalCacheMu.Lock()
+			delete(s.withdrawalCaches, sidechainId)
+			s.withdrawalCacheMu.Unlock()
+		}
 		log.Error().Err(err).Msg("could not get two-way peg data")
 		return nil, connect.NewError(connect.CodeInternal,
 			fmt.Errorf("get two-way peg data: %w", err))
@@ -478,6 +489,31 @@ func (s *Server) ListWithdrawals(
 	return connect.NewResponse(&pb.ListWithdrawalsResponse{
 		Bundles: s.updateBundleAges(allBundles, currentHeight),
 	}), nil
+}
+
+// cachedTipOnActiveChain reports whether the cached block is still an ancestor
+// of the current tip. A reorg can orphan it, which makes it useless as an
+// incremental start block.
+func (s *Server) cachedTipOnActiveChain(ctx context.Context, cache *withdrawalCache, tip *validatorpb.BlockHeaderInfo) bool {
+	if cache.lastBlockHeight > tip.Height {
+		return false
+	}
+
+	ancestorsNeeded := tip.Height - cache.lastBlockHeight
+	resp, err := s.data.BlockHeaderInfo(ctx, &validatorpb.GetBlockHeaderInfoRequest{
+		BlockHash:    tip.BlockHash,
+		MaxAncestors: &ancestorsNeeded,
+	})
+	if err != nil {
+		zerolog.Ctx(ctx).Warn().Err(err).Msg("could not verify cached withdrawal block, rescanning")
+		return false
+	}
+
+	_, found := lo.Find(resp.HeaderInfos, func(headerInfo *validatorpb.BlockHeaderInfo) bool {
+		return headerInfo.Height == cache.lastBlockHeight &&
+			headerInfo.GetBlockHash().GetHex().GetValue() == cache.lastBlockHash
+	})
+	return found
 }
 
 // BIP300 withdrawal verification period (max age for a bundle)

--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -1,10 +1,12 @@
 package api_drivechain
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 
 	"connectrpc.com/connect"
@@ -573,10 +575,6 @@ func (s *Server) processPegDataBlocks(blocks []*validatorpb.GetTwoWayPegDataResp
 
 // mergeBundles merges existing cached bundles with new bundles, updating statuses
 func (s *Server) mergeBundles(existing, new []*pb.WithdrawalBundle) []*pb.WithdrawalBundle {
-	if len(existing) == 0 {
-		return new
-	}
-
 	// Create a map of existing bundles by M6Id for quick lookup
 	bundleMap := lo.KeyBy(existing, func(b *pb.WithdrawalBundle) string {
 		return b.M6Id
@@ -609,11 +607,14 @@ func (s *Server) mergeBundles(existing, new []*pb.WithdrawalBundle) []*pb.Withdr
 		}
 	}
 
-	// Convert map back to slice
+	// Convert map back to slice, ordered so the response is stable across calls
 	result := make([]*pb.WithdrawalBundle, 0, len(bundleMap))
 	for _, b := range bundleMap {
 		result = append(result, b)
 	}
+	slices.SortFunc(result, func(a, b *pb.WithdrawalBundle) int {
+		return cmp.Or(cmp.Compare(a.BlockHeight, b.BlockHeight), cmp.Compare(a.M6Id, b.M6Id))
+	})
 
 	return result
 }

--- a/bitwindow/server/api/drivechain/merge_bundles_test.go
+++ b/bitwindow/server/api/drivechain/merge_bundles_test.go
@@ -39,3 +39,48 @@ func TestMergeBundlesRevivesFailedBundle(t *testing.T) {
 	require.Equal(t, uint32(10), aged[0].Age)
 	require.Equal(t, withdrawalVerificationPeriod-10, aged[0].BlocksLeft)
 }
+
+// TestMergeBundlesCollapsesColdScan proves a full scan with no cache collapses
+// the submitted and succeeded events of one M6ID into a single row that keeps
+// the submission height, instead of emitting both.
+func TestMergeBundlesCollapsesColdScan(t *testing.T) {
+	s := &Server{}
+
+	const m6id = "abc123"
+
+	scanned := []*pb.WithdrawalBundle{{
+		M6Id:        m6id,
+		BlockHeight: 60,
+		Status:      "pending",
+		MaxAge:      withdrawalVerificationPeriod,
+	}, {
+		M6Id:           m6id,
+		BlockHeight:    70,
+		Status:         "succeeded",
+		MaxAge:         withdrawalVerificationPeriod,
+		SequenceNumber: 7,
+		TransactionHex: "deadbeef",
+	}}
+
+	merged := s.mergeBundles(nil, scanned)
+	require.Len(t, merged, 1)
+	require.Equal(t, "succeeded", merged[0].Status)
+	require.Equal(t, uint32(60), merged[0].BlockHeight)
+	require.Equal(t, uint64(7), merged[0].SequenceNumber)
+	require.Equal(t, "deadbeef", merged[0].TransactionHex)
+}
+
+// TestMergeBundlesSortsByHeight proves the map rebuild returns a stable order.
+func TestMergeBundlesSortsByHeight(t *testing.T) {
+	s := &Server{}
+
+	scanned := []*pb.WithdrawalBundle{
+		{M6Id: "c", BlockHeight: 90, Status: "pending"},
+		{M6Id: "a", BlockHeight: 60, Status: "pending"},
+		{M6Id: "b", BlockHeight: 60, Status: "pending"},
+	}
+
+	merged := s.mergeBundles(nil, scanned)
+	require.Len(t, merged, 3)
+	require.Equal(t, []string{"a", "b", "c"}, []string{merged[0].M6Id, merged[1].M6Id, merged[2].M6Id})
+}

--- a/bitwindow/server/api/drivechain/withdrawal_cache_test.go
+++ b/bitwindow/server/api/drivechain/withdrawal_cache_test.go
@@ -1,0 +1,136 @@
+package api_drivechain
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/datasource"
+	commonpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
+	v1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+const testActivationHeight uint32 = 50
+
+// chainReader is a DrivechainReader backed by an in-memory active chain, so a
+// test can reorg it and see which start block the handler asks peg data from.
+type chainReader struct {
+	datasource.DrivechainReader
+	tipHeight uint32
+	chain     map[uint32]string // height -> block hash on the active chain
+	pegStarts []string
+	pegErr    error
+}
+
+func newChainReader() *chainReader {
+	f := &chainReader{tipHeight: 100, chain: make(map[uint32]string)}
+	for h := testActivationHeight; h <= f.tipHeight; h++ {
+		f.chain[h] = fmt.Sprintf("a%d", h)
+	}
+	return f
+}
+
+func header(height uint32, hash string) *v1.BlockHeaderInfo {
+	return &v1.BlockHeaderInfo{
+		Height:    height,
+		BlockHash: &commonpb.ReverseHex{Hex: wrapperspb.String(hash)},
+	}
+}
+
+func (f *chainReader) ChainTip(context.Context, *v1.GetChainTipRequest) (*v1.GetChainTipResponse, error) {
+	return &v1.GetChainTipResponse{
+		BlockHeaderInfo: header(f.tipHeight, f.chain[f.tipHeight]),
+	}, nil
+}
+
+func (f *chainReader) Sidechains(context.Context, *v1.GetSidechainsRequest) (*v1.GetSidechainsResponse, error) {
+	return &v1.GetSidechainsResponse{
+		Sidechains: []*v1.GetSidechainsResponse_SidechainInfo{{
+			SidechainNumber:  wrapperspb.UInt32(0),
+			ActivationHeight: wrapperspb.UInt32(testActivationHeight),
+		}},
+	}, nil
+}
+
+func (f *chainReader) BlockHeaderInfo(_ context.Context, req *v1.GetBlockHeaderInfoRequest) (*v1.GetBlockHeaderInfoResponse, error) {
+	var infos []*v1.BlockHeaderInfo
+	for h := f.tipHeight; h >= f.tipHeight-req.GetMaxAncestors(); h-- {
+		infos = append(infos, header(h, f.chain[h]))
+	}
+	return &v1.GetBlockHeaderInfoResponse{HeaderInfos: infos}, nil
+}
+
+func (f *chainReader) TwoWayPegData(_ context.Context, req *v1.GetTwoWayPegDataRequest) (*v1.GetTwoWayPegDataResponse, error) {
+	if f.pegErr != nil {
+		return nil, f.pegErr
+	}
+	f.pegStarts = append(f.pegStarts, req.GetStartBlockHash().GetHex().GetValue())
+	return &v1.GetTwoWayPegDataResponse{}, nil
+}
+
+func listWithdrawals(t *testing.T, s *Server) error {
+	t.Helper()
+	_, err := s.ListWithdrawals(context.Background(), connect.NewRequest(&pb.ListWithdrawalsRequest{
+		SidechainId: 0,
+	}))
+	return err
+}
+
+// TestListWithdrawalsRescansAfterReorg proves a reorg that orphans the cached
+// block makes the handler rescan from activation, instead of forever asking peg
+// data from a block that is no longer on the chain.
+func TestListWithdrawalsRescansAfterReorg(t *testing.T) {
+	t.Run("orphaned cache rescans from activation", func(t *testing.T) {
+		fake := newChainReader()
+		s := &Server{data: fake, withdrawalCaches: make(map[uint32]*withdrawalCache)}
+
+		require.NoError(t, listWithdrawals(t, s))
+		require.Equal(t, []string{"a50"}, fake.pegStarts)
+
+		// A reorg replaces the block the cache ended on, and extends the chain.
+		fake.tipHeight = 101
+		fake.chain[100] = "b100"
+		fake.chain[101] = "b101"
+
+		require.NoError(t, listWithdrawals(t, s))
+		require.Equal(t, []string{"a50", "a50"}, fake.pegStarts,
+			"an orphaned cached block must not be reused as the incremental start")
+	})
+
+	t.Run("cached block still on chain fetches incrementally", func(t *testing.T) {
+		fake := newChainReader()
+		s := &Server{data: fake, withdrawalCaches: make(map[uint32]*withdrawalCache)}
+
+		require.NoError(t, listWithdrawals(t, s))
+
+		fake.tipHeight = 101
+		fake.chain[101] = "a101"
+
+		require.NoError(t, listWithdrawals(t, s))
+		require.Equal(t, []string{"a50", "a100"}, fake.pegStarts)
+	})
+}
+
+// TestListWithdrawalsDropsCacheOnPegDataError proves a failed incremental fetch
+// leaves no cache behind, so the next call rescans rather than re-sending a
+// start block the enforcer just rejected.
+func TestListWithdrawalsDropsCacheOnPegDataError(t *testing.T) {
+	fake := newChainReader()
+	s := &Server{data: fake, withdrawalCaches: make(map[uint32]*withdrawalCache)}
+
+	require.NoError(t, listWithdrawals(t, s))
+
+	fake.tipHeight = 101
+	fake.chain[101] = "a101"
+	fake.pegErr = fmt.Errorf("start block is not an ancestor of the end block")
+
+	require.Error(t, listWithdrawals(t, s))
+
+	s.withdrawalCacheMu.RLock()
+	defer s.withdrawalCacheMu.RUnlock()
+	require.NotContains(t, s.withdrawalCaches, uint32(0))
+}

--- a/bitwindow/server/api/m4/m4.go
+++ b/bitwindow/server/api/m4/m4.go
@@ -10,15 +10,18 @@ import (
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	m4pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/m4/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/datasource"
+	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	"github.com/samber/lo"
 )
 
 type Server struct {
 	m4Engine *engines.M4Engine
+	data     datasource.DrivechainReader
 }
 
-func NewServer(m4Engine *engines.M4Engine) *Server {
-	return &Server{m4Engine: m4Engine}
+func NewServer(m4Engine *engines.M4Engine, data datasource.DrivechainReader) *Server {
+	return &Server{m4Engine: m4Engine, data: data}
 }
 
 func (s *Server) GetM4History(
@@ -167,8 +170,21 @@ func (s *Server) GenerateM4Bytes(
 		return p.SidechainSlot
 	})
 
+	// The enforcer requires exactly one vote per active sidechain, so the
+	// active set - not the set with bundles - decides the vector length.
+	sidechains, err := s.data.Sidechains(ctx, &validatorpb.GetSidechainsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("get sidechains: %w", err)
+	}
+
+	activeSlots := make(map[uint8]bool, len(sidechains.Sidechains))
+	for _, sc := range sidechains.Sidechains {
+		if n := sc.GetSidechainNumber().GetValue(); n <= 255 {
+			activeSlots[uint8(n)] = true
+		}
+	}
+
 	// Generate M4 bytes using version 0x02 (2 bytes per sidechain)
-	// Only include sidechains that have pending bundles
 	var m4Bytes []byte
 	m4Bytes = append(m4Bytes, 0x02) // Version
 
@@ -177,10 +193,12 @@ func (s *Server) GenerateM4Bytes(
 
 	// Process sidechains in order
 	for slot := 0; slot <= 255; slot++ {
-		sidechainBundles, hasBundles := bundlesBySidechain[uint8(slot)]
-		if !hasBundles {
+		if !activeSlots[uint8(slot)] {
 			continue
 		}
+
+		// Active sidechains without a pending bundle get an abstain entry.
+		sidechainBundles := bundlesBySidechain[uint8(slot)]
 
 		pref, hasPreference := prefMap[uint8(slot)]
 

--- a/bitwindow/server/api/m4/m4_test.go
+++ b/bitwindow/server/api/m4/m4_test.go
@@ -11,8 +11,12 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/m4/v1/m4v1connect"
 	m4models "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/m4"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	mainchainv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestService_GetVotePreferences(t *testing.T) {
@@ -259,6 +263,48 @@ func TestService_GenerateM4Bytes(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, resp.Msg.Hex)
 		assert.Contains(t, resp.Msg.Interpretation, "Not required")
+	})
+
+	t.Run("abstains for active sidechains without a bundle", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctx := context.Background()
+
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO withdrawal_bundles (sidechain_slot, bundle_hash, work_score, blocks_left,
+				first_seen_height, last_updated_height, status)
+			VALUES (0, 'bundle-a', 1, 26300, 100, 100, 'pending')`)
+		require.NoError(t, err)
+
+		// Both sidechains are active, only slot 0 has a pending bundle.
+		mockValidator := mocks.NewMockValidatorServiceClient(gomock.NewController(t))
+		mockValidator.EXPECT().
+			GetSidechains(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[mainchainv1.GetSidechainsResponse]{
+				Msg: &mainchainv1.GetSidechainsResponse{
+					Sidechains: []*mainchainv1.GetSidechainsResponse_SidechainInfo{
+						{SidechainNumber: wrapperspb.UInt32(0)},
+						{SidechainNumber: wrapperspb.UInt32(1)},
+					},
+				},
+			}, nil).
+			AnyTimes()
+
+		cli := m4v1connect.NewM4ServiceClient(apitests.API(t, db, apitests.WithValidator(mockValidator)))
+
+		bundleHash := "bundle-a"
+		_, err = cli.SetVotePreference(ctx, connect.NewRequest(&m4pb.SetVotePreferenceRequest{
+			SidechainSlot: 0,
+			VoteType:      "upvote",
+			BundleHash:    &bundleHash,
+		}))
+		require.NoError(t, err)
+
+		resp, err := cli.GenerateM4Bytes(ctx, connect.NewRequest(&m4pb.GenerateM4BytesRequest{}))
+		require.NoError(t, err)
+		// Version, upvote of bundle #0 on slot 0, abstain on slot 1.
+		assert.Equal(t, "020000ffff", resp.Msg.Hex)
 	})
 }
 

--- a/bitwindow/server/api/misc/misc.go
+++ b/bitwindow/server/api/misc/misc.go
@@ -540,6 +540,10 @@ func commentToProto(c cnstore.Comment, _ int) *miscv1.Comment {
 
 // TimestampFile implements miscv1connect.MiscServiceHandler.
 func (s *Server) TimestampFile(ctx context.Context, req *connect.Request[miscv1.TimestampFileRequest]) (*connect.Response[miscv1.TimestampFileResponse], error) {
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	if req.Msg.Filename == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("filename must be set"))
 	}

--- a/bitwindow/server/api/misc/misc_test.go
+++ b/bitwindow/server/api/misc/misc_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	miscv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/misc/v1"
 	miscv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/misc/v1/miscv1connect"
+	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
 	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	coinnews "github.com/LayerTwo-Labs/sidesail/coinnews/codec"
@@ -737,6 +739,34 @@ func TestService_TimestampFile(t *testing.T) {
 		}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "file data must be set")
+	})
+
+	t.Run("timestamp file with locked wallet", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+		apitests.ExpectOrchestratorReads(mockOrch)
+		// No SendTransaction expectation: a broadcast here fails the test.
+
+		database := database.Test(t)
+		httpClient, url := apitests.API(t, database, apitests.WithOrchestrator(mockOrch))
+
+		_, err := walletv1connect.NewWalletServiceClient(httpClient, url).
+			LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = miscv1connect.NewMiscServiceClient(httpClient, url).
+			TimestampFile(context.Background(), connect.NewRequest(&miscv1.TimestampFileRequest{
+				Filename: "locked.pdf",
+				FileData: []byte("content"),
+			}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		list, err := timestamps.List(context.Background(), database)
+		require.NoError(t, err)
+		assert.Empty(t, list)
 	})
 
 	t.Run("timestamp same file twice returns same timestamp", func(t *testing.T) {

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -287,7 +287,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		register(path, h)
 	}
 	{
-		m4Svc := api_m4.NewServer(rt.m4Engine)
+		m4Svc := api_m4.NewServer(rt.m4Engine, dataSource)
 		path, h := m4v1connect.NewM4ServiceHandler(m4Svc, stdOpts...)
 		register(path, h)
 	}

--- a/bitwindow/server/cpuminer/jsonrpc.go
+++ b/bitwindow/server/cpuminer/jsonrpc.go
@@ -86,8 +86,9 @@ func (m *Miner) jsonRpcCall(
 		return nil, fmt.Errorf("JSON decode failed: %v", err)
 	}
 
-	// Check for error
-	if val.Error != nil {
+	// Check for error. 1.0-style responders send "error":null on success, which
+	// decodes to a non-nil raw message.
+	if len(val.Error) > 0 && !bytes.Equal(val.Error, []byte("null")) {
 		return nil, fmt.Errorf("JSON-RPC call failed: %s", string(val.Error))
 	}
 

--- a/bitwindow/server/cpuminer/miner_test.go
+++ b/bitwindow/server/cpuminer/miner_test.go
@@ -141,3 +141,52 @@ func TestRunRoutineHighHashDoesNotLoopForever(t *testing.T) {
 		t.Fatalf("fetched %d templates for %d submissions", got, submits.Load())
 	}
 }
+
+// JSON-RPC 1.0 responders (older Bitcoin Core, proxies) spell success as
+// "error":null. That decodes to a non-nil raw message, which the miner used to
+// treat as a failure, so every call against such a node failed.
+func TestJsonRpcCallErrorMember(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     string
+	}{
+		{name: "explicit null error", response: `{"result":{"height":1},"error":null,"id":1}`},
+		{name: "omitted error", response: `{"result":{"height":1},"id":1}`},
+		{
+			name:     "real error",
+			response: `{"result":null,"error":{"code":-1,"message":"boom"},"id":1}`,
+			want:     "boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				//nolint:errcheck
+				w.Write([]byte(tt.response))
+			}))
+			defer srv.Close()
+
+			miner, err := New(Config{RpcURL: srv.URL})
+			if err != nil {
+				t.Fatalf("new miner: %v", err)
+			}
+
+			result, err := miner.jsonRpcCall(context.Background(), "getblocktemplate", nil)
+			if tt.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.want) {
+					t.Fatalf("expected an error containing %q, got: %v", tt.want, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("jsonRpcCall: %v", err)
+			}
+			if got := string(result); got != `{"height":1}` {
+				t.Fatalf("got result %s", got)
+			}
+		})
+	}
+}

--- a/bitwindow/server/models/m4/parser.go
+++ b/bitwindow/server/models/m4/parser.go
@@ -7,31 +7,49 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 )
 
+// opReturnPayload returns the single data push of an OP_RETURN script, so the
+// commitment is read past the push opcode rather than at a fixed offset.
+func opReturnPayload(script []byte) ([]byte, error) {
+	if len(script) == 0 || script[0] != txscript.OP_RETURN {
+		return nil, fmt.Errorf("not an OP_RETURN")
+	}
+
+	pushes, err := txscript.PushedData(script)
+	if err != nil {
+		return nil, fmt.Errorf("parse script: %w", err)
+	}
+	if len(pushes) != 1 {
+		return nil, fmt.Errorf("expected a single data push, got %d", len(pushes))
+	}
+
+	return pushes[0], nil
+}
+
 // ParseM4Bytes parses raw M4 bytes from a coinbase OP_RETURN
-// Format: OP_RETURN | 0xD77D1776 (4 bytes) | Version (1 byte) | Upvote Vector (n bytes)
+// Format: OP_RETURN | push( 0xD77D1776 (4 bytes) | Version (1 byte) | Upvote Vector (n bytes) )
 func ParseM4Bytes(opReturnScript []byte) (*M4Message, error) {
-	// Must have at least: OP_RETURN(1) + Header(4) + Version(1)
-	if len(opReturnScript) < 6 {
-		return nil, fmt.Errorf("M4: script too short: %d bytes", len(opReturnScript))
+	payload, err := opReturnPayload(opReturnScript)
+	if err != nil {
+		return nil, fmt.Errorf("M4: %w", err)
 	}
 
-	// Check OP_RETURN
-	if opReturnScript[0] != txscript.OP_RETURN {
-		return nil, fmt.Errorf("M4: not an OP_RETURN: %x", opReturnScript[0])
+	// Must have at least: Header(4) + Version(1)
+	if len(payload) < 5 {
+		return nil, fmt.Errorf("M4: script too short: %d bytes", len(payload))
 	}
 
-	// Check M4 commitment header (0xD77D1776) - little endian
-	header := binary.LittleEndian.Uint32(opReturnScript[1:5])
+	// Check M4 commitment header (0xD77D1776) - the tag is those bytes in order
+	header := binary.BigEndian.Uint32(payload[0:4])
 	if header != M4CommitmentHeader {
 		return nil, fmt.Errorf("M4: invalid header: %x (expected %x)", header, M4CommitmentHeader)
 	}
 
-	version := opReturnScript[5]
-	upvoteVector := opReturnScript[6:]
+	version := payload[4]
+	upvoteVector := payload[5:]
 
 	msg := &M4Message{
 		Version:  version,
-		RawBytes: opReturnScript[5:], // Version + upvote vector
+		RawBytes: payload[4:], // Version + upvote vector
 	}
 
 	// Parse votes based on version
@@ -152,48 +170,46 @@ func EncodeVotePreferences(prefs []VotePreference) []byte {
 
 // IsM4Commitment checks if the script is an M4 commitment
 func IsM4Commitment(script []byte) bool {
-	if len(script) < 6 {
+	payload, err := opReturnPayload(script)
+	if err != nil || len(payload) < 5 {
 		return false
 	}
-	if script[0] != txscript.OP_RETURN {
-		return false
-	}
-	header := binary.LittleEndian.Uint32(script[1:5])
-	return header == M4CommitmentHeader
+	return binary.BigEndian.Uint32(payload[0:4]) == M4CommitmentHeader
 }
 
+// m3PayloadLen is the pushed M3 payload: Header(4) + Slot(1) + Bundle Hash(32)
+const m3PayloadLen = 37
+
 // ParseM3Bytes parses raw M3 bytes from a coinbase OP_RETURN
-// Format: OP_RETURN | 0xD45AA943 (4 bytes) | Bundle Hash (32 bytes) | Sidechain Slot (1 byte)
-// Total: 38 bytes
+// Format: OP_RETURN | push( 0xD45AA943 (4 bytes) | Sidechain Slot (1 byte) | Bundle Hash (32 bytes) )
 func ParseM3Bytes(opReturnScript []byte) (*M3Message, error) {
-	// Must have exactly: OP_RETURN(1) + Header(4) + Hash(32) + Slot(1) = 38 bytes
-	if len(opReturnScript) != 38 {
-		return nil, fmt.Errorf("M3: invalid length: %d bytes (expected 38)", len(opReturnScript))
+	payload, err := opReturnPayload(opReturnScript)
+	if err != nil {
+		return nil, fmt.Errorf("M3: %w", err)
 	}
 
-	// Check OP_RETURN
-	if opReturnScript[0] != txscript.OP_RETURN {
-		return nil, fmt.Errorf("M3: not an OP_RETURN: %x", opReturnScript[0])
+	if len(payload) != m3PayloadLen {
+		return nil, fmt.Errorf("M3: invalid length: %d bytes (expected %d)", len(payload), m3PayloadLen)
 	}
 
-	// Check M3 commitment header (0xD45AA943) - little endian
-	header := binary.LittleEndian.Uint32(opReturnScript[1:5])
+	// Check M3 commitment header (0xD45AA943) - the tag is those bytes in order
+	header := binary.BigEndian.Uint32(payload[0:4])
 	if header != M3CommitmentHeader {
 		return nil, fmt.Errorf("M3: invalid header: %x (expected %x)", header, M3CommitmentHeader)
 	}
 
+	// Extract sidechain slot (1 byte)
+	sidechainSlot := payload[4]
+
 	// Extract bundle hash (32 bytes, reversed for display)
 	bundleHashBytes := make([]byte, 32)
-	copy(bundleHashBytes, opReturnScript[5:37])
+	copy(bundleHashBytes, payload[5:m3PayloadLen])
 
 	// Reverse for hex display (Bitcoin uses reverse byte order for hashes)
 	for i := 0; i < 16; i++ {
 		bundleHashBytes[i], bundleHashBytes[31-i] = bundleHashBytes[31-i], bundleHashBytes[i]
 	}
 	bundleHash := fmt.Sprintf("%x", bundleHashBytes)
-
-	// Extract sidechain slot (1 byte)
-	sidechainSlot := opReturnScript[37]
 
 	msg := &M3Message{
 		SidechainSlot: sidechainSlot,
@@ -205,12 +221,9 @@ func ParseM3Bytes(opReturnScript []byte) (*M3Message, error) {
 
 // IsM3Commitment checks if the script is an M3 commitment
 func IsM3Commitment(script []byte) bool {
-	if len(script) != 38 {
+	payload, err := opReturnPayload(script)
+	if err != nil || len(payload) != m3PayloadLen {
 		return false
 	}
-	if script[0] != txscript.OP_RETURN {
-		return false
-	}
-	header := binary.LittleEndian.Uint32(script[1:5])
-	return header == M3CommitmentHeader
+	return binary.BigEndian.Uint32(payload[0:4]) == M3CommitmentHeader
 }

--- a/bitwindow/server/models/m4/parser_test.go
+++ b/bitwindow/server/models/m4/parser_test.go
@@ -2,6 +2,7 @@ package m4
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"testing"
 
 	"github.com/btcsuite/btcd/txscript"
@@ -9,23 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// opReturn builds the on-chain form of a commitment: OP_RETURN + a data push.
+func opReturn(t *testing.T, payload []byte) []byte {
+	t.Helper()
+
+	script, err := txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(payload).Script()
+	require.NoError(t, err)
+	return script
+}
+
+func headerBytes(header uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, header)
+	return b
+}
+
 func TestParseM4Bytes_Version01(t *testing.T) {
 	// Create valid M4 v0x01 message
-	script := make([]byte, 0)
-	script = append(script, txscript.OP_RETURN) // 0x6a
-
-	// Add M4 header (little-endian)
-	header := make([]byte, 4)
-	binary.LittleEndian.PutUint32(header, M4CommitmentHeader)
-	script = append(script, header...)
+	payload := headerBytes(M4CommitmentHeader)
 
 	// Version 0x01
-	script = append(script, 0x01)
+	payload = append(payload, 0x01)
 
 	// Upvote vector: SC0=abstain, SC1=alarm, SC2=upvote index 5
-	script = append(script, 0xFF, 0xFE, 0x05)
+	payload = append(payload, 0xFF, 0xFE, 0x05)
 
-	msg, err := ParseM4Bytes(script)
+	msg, err := ParseM4Bytes(opReturn(t, payload))
 	require.NoError(t, err)
 	require.NotNil(t, msg)
 
@@ -51,26 +61,21 @@ func TestParseM4Bytes_Version01(t *testing.T) {
 
 func TestParseM4Bytes_Version02(t *testing.T) {
 	// Create valid M4 v0x02 message
-	script := make([]byte, 0)
-	script = append(script, txscript.OP_RETURN)
-
-	header := make([]byte, 4)
-	binary.LittleEndian.PutUint32(header, M4CommitmentHeader)
-	script = append(script, header...)
+	payload := headerBytes(M4CommitmentHeader)
 
 	// Version 0x02
-	script = append(script, 0x02)
+	payload = append(payload, 0x02)
 
 	// Upvote vector: SC0=abstain (0xFFFF), SC1=upvote index 1000
 	vote0 := make([]byte, 2)
 	binary.LittleEndian.PutUint16(vote0, VoteAbstain)
-	script = append(script, vote0...)
+	payload = append(payload, vote0...)
 
 	vote1 := make([]byte, 2)
 	binary.LittleEndian.PutUint16(vote1, 1000)
-	script = append(script, vote1...)
+	payload = append(payload, vote1...)
 
-	msg, err := ParseM4Bytes(script)
+	msg, err := ParseM4Bytes(opReturn(t, payload))
 	require.NoError(t, err)
 	require.NotNil(t, msg)
 
@@ -88,40 +93,61 @@ func TestParseM4Bytes_Version02(t *testing.T) {
 	assert.Equal(t, uint16(1000), *msg.Votes[1].BundleIndex)
 }
 
+// A vote vector for more than 75 sidechains is pushed with OP_PUSHDATA1, so the
+// payload does not start at a fixed offset.
+func TestParseM4Bytes_PushData1(t *testing.T) {
+	payload := headerBytes(M4CommitmentHeader)
+	payload = append(payload, 0x01)
+	for i := 0; i < 100; i++ {
+		payload = append(payload, 0xFF)
+	}
+
+	script := opReturn(t, payload)
+	require.Equal(t, byte(txscript.OP_PUSHDATA1), script[1])
+	assert.True(t, IsM4Commitment(script))
+
+	msg, err := ParseM4Bytes(script)
+	require.NoError(t, err)
+	assert.Len(t, msg.Votes, 100)
+}
+
+// The on-chain tag byte order, per the "d77d177601" prefix the engines package
+// matches against real coinbase payloads.
+func TestParseM4Bytes_OnChainHeader(t *testing.T) {
+	payload, err := hex.DecodeString("d77d177601ffff")
+	require.NoError(t, err)
+
+	script := opReturn(t, payload)
+	require.True(t, IsM4Commitment(script))
+
+	msg, err := ParseM4Bytes(script)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(0x01), msg.Version)
+	assert.Len(t, msg.Votes, 2)
+}
+
 func TestParseM4Bytes_InvalidHeader(t *testing.T) {
-	script := make([]byte, 0)
-	script = append(script, txscript.OP_RETURN)
-
 	// Wrong header
-	header := make([]byte, 4)
-	binary.LittleEndian.PutUint32(header, 0x12345678)
-	script = append(script, header...)
+	payload := headerBytes(0x12345678)
+	payload = append(payload, 0x01, 0xFF)
 
-	script = append(script, 0x01)
-	script = append(script, 0xFF)
-
-	_, err := ParseM4Bytes(script)
+	_, err := ParseM4Bytes(opReturn(t, payload))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid header")
 }
 
 func TestParseM4Bytes_TooShort(t *testing.T) {
-	script := []byte{txscript.OP_RETURN, 0x01, 0x02}
-
-	_, err := ParseM4Bytes(script)
+	_, err := ParseM4Bytes(opReturn(t, []byte{0x01, 0x02}))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "script too short")
 }
 
 func TestParseM4Bytes_NotOPReturn(t *testing.T) {
-	script := make([]byte, 0)
-	script = append(script, 0x00) // Not OP_RETURN
+	payload := headerBytes(M4CommitmentHeader)
+	payload = append(payload, 0x01)
 
-	header := make([]byte, 4)
-	binary.LittleEndian.PutUint32(header, M4CommitmentHeader)
-	script = append(script, header...)
-
-	script = append(script, 0x01)
+	script := opReturn(t, payload)
+	script[0] = txscript.OP_DUP // Not OP_RETURN
 
 	_, err := ParseM4Bytes(script)
 	assert.Error(t, err)
@@ -130,27 +156,88 @@ func TestParseM4Bytes_NotOPReturn(t *testing.T) {
 
 func TestIsM4Commitment(t *testing.T) {
 	// Valid M4
-	script := make([]byte, 0)
-	script = append(script, txscript.OP_RETURN)
-
-	header := make([]byte, 4)
-	binary.LittleEndian.PutUint32(header, M4CommitmentHeader)
-	script = append(script, header...)
-
-	script = append(script, 0x01, 0xFF)
-
-	assert.True(t, IsM4Commitment(script))
+	payload := headerBytes(M4CommitmentHeader)
+	payload = append(payload, 0x01, 0xFF)
+	assert.True(t, IsM4Commitment(opReturn(t, payload)))
 
 	// Not M4 (wrong header)
-	script2 := make([]byte, 0)
-	script2 = append(script2, txscript.OP_RETURN)
-
-	header2 := make([]byte, 4)
-	binary.LittleEndian.PutUint32(header2, 0x11111111)
-	script2 = append(script2, header2...)
-
-	assert.False(t, IsM4Commitment(script2))
+	payload2 := headerBytes(0x11111111)
+	payload2 = append(payload2, 0x01, 0xFF)
+	assert.False(t, IsM4Commitment(opReturn(t, payload2)))
 
 	// Too short
 	assert.False(t, IsM4Commitment([]byte{txscript.OP_RETURN}))
+	assert.False(t, IsM4Commitment(opReturn(t, headerBytes(M4CommitmentHeader))))
+}
+
+// m3Payload is the enforcer serialization: header | slot | bundle txid.
+func m3Payload(slot byte, txid []byte) []byte {
+	payload := headerBytes(M3CommitmentHeader)
+	payload = append(payload, slot)
+	return append(payload, txid...)
+}
+
+func TestParseM3Bytes(t *testing.T) {
+	txid := make([]byte, 32)
+	for i := range txid {
+		txid[i] = byte(i + 1)
+	}
+
+	script := opReturn(t, m3Payload(7, txid))
+	require.True(t, IsM3Commitment(script))
+
+	msg, err := ParseM3Bytes(script)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(7), msg.SidechainSlot)
+
+	// Hashes are displayed in reverse byte order
+	reversed := make([]byte, 32)
+	for i, b := range txid {
+		reversed[31-i] = b
+	}
+	assert.Equal(t, hex.EncodeToString(reversed), msg.BundleHash)
+}
+
+// A commitment seen on chain, recorded verbatim in the engines package's
+// shouldSkip: tag | slot 9 (thunder) | bundle txid, pushed with OP_DATA_37.
+func TestParseM3Bytes_OnChain(t *testing.T) {
+	payload, err := hex.DecodeString("d45aa943091303c6de5739c2fb3a021a8bd2b8c9fa8bcd8f8c18954bec00aa8f9b2cf13602")
+	require.NoError(t, err)
+
+	script := opReturn(t, payload)
+	require.Equal(t, byte(txscript.OP_DATA_37), script[1])
+	require.True(t, IsM3Commitment(script))
+
+	msg, err := ParseM3Bytes(script)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(9), msg.SidechainSlot)
+	assert.Equal(t, "0236f12c9b8faa00ec4b95188c8fcd8bfac9b8d28b1a023afbc23957dec60313", msg.BundleHash)
+}
+
+func TestParseM3Bytes_InvalidHeader(t *testing.T) {
+	payload := headerBytes(0x12345678)
+	payload = append(payload, 7)
+	payload = append(payload, make([]byte, 32)...)
+
+	_, err := ParseM3Bytes(opReturn(t, payload))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid header")
+}
+
+func TestIsM3Commitment(t *testing.T) {
+	txid := make([]byte, 32)
+
+	assert.True(t, IsM3Commitment(opReturn(t, m3Payload(0, txid))))
+
+	// Wrong header
+	wrong := headerBytes(0x11111111)
+	wrong = append(wrong, 0)
+	wrong = append(wrong, txid...)
+	assert.False(t, IsM3Commitment(opReturn(t, wrong)))
+
+	// Wrong payload length
+	assert.False(t, IsM3Commitment(opReturn(t, m3Payload(0, txid[:31]))))
+
+	// Not a single data push
+	assert.False(t, IsM3Commitment([]byte{txscript.OP_RETURN}))
 }

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -772,6 +772,15 @@ func (s *Store) SaveGroupAtomic(ctx context.Context, p SaveGroupAtomicParams) er
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	// Group IDs are client-supplied (and derived from a hash of the group's
+	// xpubs), so they can collide across groups. The upsert plus the child-table
+	// replaces below would hand the existing row to the caller and wipe the
+	// original group's keys, addresses, UTXOs and PSBTs. Refuse a save for an
+	// existing id whose key set is a different one.
+	if err := checkGroupKeysOn(ctx, tx, p.Group.ID, p.Keys); err != nil {
+		return err
+	}
+
 	if err := saveGroupOn(ctx, tx, p.Group); err != nil {
 		return fmt.Errorf("save group: %w", err)
 	}
@@ -817,6 +826,42 @@ func (s *Store) SaveGroupAtomic(ctx context.Context, p SaveGroupAtomicParams) er
 	}
 
 	return tx.Commit()
+}
+
+// checkGroupKeysOn errors when groupID already has keys stored and their xpub
+// set differs from the incoming one. A stored group with no keys yet, or a set
+// that only differs in owner/path/PSBT data, is accepted.
+func checkGroupKeysOn(ctx context.Context, e execer, groupID string, keys []Key) error {
+	stored, err := listKeysForGroupOn(ctx, e, groupID)
+	if err != nil {
+		return fmt.Errorf("list existing keys: %w", err)
+	}
+	if len(stored) == 0 {
+		return nil
+	}
+
+	storedXpubs := make(map[string]struct{}, len(stored))
+	for _, k := range stored {
+		storedXpubs[k.Xpub] = struct{}{}
+	}
+	incomingXpubs := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		incomingXpubs[k.Xpub] = struct{}{}
+	}
+
+	same := len(storedXpubs) == len(incomingXpubs)
+	if same {
+		for xpub := range incomingXpubs {
+			if _, ok := storedXpubs[xpub]; !ok {
+				same = false
+				break
+			}
+		}
+	}
+	if !same {
+		return fmt.Errorf("group %s already exists with a different key set, refusing to overwrite it", groupID)
+	}
+	return nil
 }
 
 // SaveTransactionAtomicParams contains all data for an atomic transaction save.

--- a/bitwindow/server/models/multisig/multisig_test.go
+++ b/bitwindow/server/models/multisig/multisig_test.go
@@ -501,12 +501,12 @@ func TestSaveGroupAtomic_UpdateExisting(t *testing.T) {
 		Keys:  []multisig.Key{{GroupID: g.ID, Owner: "alice", Xpub: "xpub1", DerivationPath: "m/48'/0'/0'"}},
 	}))
 
-	// Update with different keys and balance
+	// Update the key metadata and balance; the xpub set stays the same.
 	g.Balance = 2.5
 	g.Name = "Updated"
 	require.NoError(t, store.SaveGroupAtomic(ctx, multisig.SaveGroupAtomicParams{
 		Group: g,
-		Keys:  []multisig.Key{{GroupID: g.ID, Owner: "charlie", Xpub: "xpub3", DerivationPath: "m/48'/0'/2'"}},
+		Keys:  []multisig.Key{{GroupID: g.ID, Owner: "charlie", Xpub: "xpub1", DerivationPath: "m/48'/0'/2'"}},
 	}))
 
 	groups, err := store.ListGroups(ctx)
@@ -519,6 +519,53 @@ func TestSaveGroupAtomic_UpdateExisting(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dbKeys, 1)
 	assert.Equal(t, "charlie", dbKeys[0].Owner)
+}
+
+func TestSaveGroupAtomic_CollidingIdRejected(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	g := sampleGroup()
+	require.NoError(t, store.SaveGroupAtomic(ctx, multisig.SaveGroupAtomicParams{
+		Group: g,
+		Keys: []multisig.Key{
+			{GroupID: g.ID, Owner: "alice", Xpub: "xpub1", DerivationPath: "m/48'/0'/0'"},
+			{GroupID: g.ID, Owner: "bob", Xpub: "xpub2", DerivationPath: "m/48'/0'/1'"},
+		},
+		Addresses:      []multisig.Address{{GroupID: g.ID, AddrType: "receive", Index: 0, Addr: "bc1q-a"}},
+		TransactionIDs: []string{"tx-a"},
+	}))
+
+	// A different group whose id collides must not take over the stored group.
+	other := g
+	other.Name = "Colliding Group"
+	err := store.SaveGroupAtomic(ctx, multisig.SaveGroupAtomicParams{
+		Group: other,
+		Keys: []multisig.Key{
+			{GroupID: other.ID, Owner: "carol", Xpub: "xpub3", DerivationPath: "m/48'/0'/2'"},
+			{GroupID: other.ID, Owner: "dave", Xpub: "xpub4", DerivationPath: "m/48'/0'/3'"},
+		},
+	})
+	require.Error(t, err, "colliding group id with a different key set must be rejected")
+
+	groups, err := store.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, g.Name, groups[0].Name)
+
+	dbKeys, err := store.ListKeysForGroup(ctx, g.ID)
+	require.NoError(t, err)
+	require.Len(t, dbKeys, 2)
+	assert.Equal(t, "xpub1", dbKeys[0].Xpub)
+	assert.Equal(t, "xpub2", dbKeys[1].Xpub)
+
+	dbAddrs, err := store.ListAddresses(ctx, g.ID)
+	require.NoError(t, err)
+	require.Len(t, dbAddrs, 1)
+
+	txIDs, err := store.ListGroupTransactionIDs(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tx-a"}, txIDs)
 }
 
 func TestGetNextAccountIndex(t *testing.T) {

--- a/bitwindow/server/utils/bandwidth/bandwidth.go
+++ b/bitwindow/server/utils/bandwidth/bandwidth.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -27,6 +28,7 @@ type Stats struct {
 
 // Tracker maintains bandwidth statistics for multiple processes
 type Tracker struct {
+	mu    sync.Mutex
 	stats map[int]*Stats
 }
 
@@ -42,6 +44,9 @@ func (t *Tracker) GetStats(pid int, processName string) (*Stats, error) {
 	if pid <= 0 {
 		return nil, fmt.Errorf("invalid PID: %d", pid)
 	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	// Get or create stats entry
 	stats, exists := t.stats[pid]
@@ -59,7 +64,9 @@ func (t *Tracker) GetStats(pid int, processName string) (*Stats, error) {
 		return nil, fmt.Errorf("update stats: %w", err)
 	}
 
-	return stats, nil
+	// Return a copy so callers never read fields the next sample overwrites
+	out := *stats
+	return &out, nil
 }
 
 // updateStats updates the bandwidth statistics for a process

--- a/bitwindow/server/utils/bandwidth/bandwidth_test.go
+++ b/bitwindow/server/utils/bandwidth/bandwidth_test.go
@@ -1,0 +1,33 @@
+package bandwidth
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+// GetStats is called from concurrent gRPC handlers, so it must be race-free.
+func TestGetStatsConcurrent(t *testing.T) {
+	tracker := NewTracker()
+	pid := os.Getpid()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				stats, err := tracker.GetStats(pid, "test")
+				if err != nil {
+					// Platform may not expose per-process stats; only races matter here.
+					continue
+				}
+				if stats.PID != pid {
+					t.Errorf("got PID %d, want %d", stats.PID, pid)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
A set of **8 independent fixes** to the BitWindow server APIs, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`17 files changed, 713 insertions(+), 114 deletions(-)`).

## Fixes (oldest first)

- **`0e2ee8bb6`** BitWindow CPU miner rejects Bitcoin Core JSON-RPC success responses
- **`a329d108c`** BitWindow multisig group ID is only 24 bits, so a colliding group overwrites another group's saved state
- **`80c451245`** BitWindow's GenerateM4Bytes only emits a 2-byte vote per sidechain that has a pending withdrawal bundle and never pads abstains (0xFFFF) for active sidechains without a bundle, so the M4 v0x02 vector is shorter than the enforcer's active-sidechain count and is rejected as InvalidVotes
- **`2c3f91cd6`** BitWindow's BIP300 M3/M4 coinbase parser reads the commitment tag at a fixed offset that ignores the OP_RETURN data-push opcode (and uses a hardcoded length 38), and decodes the M3 sidechain-slot/hash fields in the wrong order, so it fails to recognize real enforcer-produced withdrawal-bundle commitments and mis-decodes the M3 slot
- **`21c2d444d`** BitWindow ListWithdrawals never invalidates its in-memory withdrawalCache when a mainchain reorg orphans the cached tip hash, so it keeps sending that orphaned hash as the incremental GetTwoWayPegData StartBlockHash and the endpoint stays permanently broken until restart
- **`9e347fef6`** BitWindow `GetNetworkStats` races shared bandwidth tracker
- **`c0d049276`** BitWindow `ListWithdrawals` cold scan emits duplicate pending and succeeded rows for the same withdrawal bundle
- **`e00fe12a9`** BitWindow `TimestampFile` Missing Wallet Unlock Guard

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.