### PR TITLE
BitWindow server engines & database (1 of 3): 12 fixes from a security review

### DIFF
--- a/bitwindow/server/api/fast_withdrawal/fast_withdrawal.go
+++ b/bitwindow/server/api/fast_withdrawal/fast_withdrawal.go
@@ -113,6 +113,10 @@ func (s *Server) InitiateFastWithdrawal(
 func (s *Server) initiateSidechainWithdrawal(ctx context.Context, sidechain string, amount int64, destination string) (string, error) {
 	log := zerolog.Ctx(ctx)
 
+	if amount <= 0 || amount > engines.MaxFastWithdrawalSats {
+		return "", fmt.Errorf("withdrawal amount out of range: %d", amount)
+	}
+
 	// Call external fast withdrawal server (like fw1.drivechain.info)
 	withdrawalRequest := map[string]interface{}{
 		"withdrawal_destination": destination,
@@ -172,6 +176,10 @@ func (s *Server) initiateSidechainWithdrawal(ctx context.Context, sidechain stri
 	serverFeeSatsFloat, ok := data["server_fee_sats"].(float64)
 	if !ok {
 		return "", fmt.Errorf("invalid response format: missing server_fee_sats")
+	}
+	// Rejects NaN and anything that would push the expected amount past the supply cap.
+	if !(serverFeeSatsFloat >= 0 && serverFeeSatsFloat <= float64(engines.MaxFastWithdrawalSats-amount)) {
+		return "", fmt.Errorf("invalid response format: server_fee_sats out of range: %v", serverFeeSatsFloat)
 	}
 	serverFeeSats := int64(serverFeeSatsFloat)
 

--- a/bitwindow/server/api/multisig/multisig.go
+++ b/bitwindow/server/api/multisig/multisig.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/multisig/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/multisig/v1/multisigv1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
@@ -17,17 +18,44 @@ import (
 
 var _ rpc.MultisigServiceHandler = new(Server)
 
-type Server struct {
-	store *multisig.Store
+// walletReader resolves the wallet that scopes the caller's multisig data.
+type walletReader interface {
+	GetActiveWallet(ctx context.Context) (*engines.WalletInfo, error)
 }
 
-func New(db *sql.DB) *Server {
-	return &Server{store: multisig.NewStore(db)}
+type Server struct {
+	store        *multisig.Store
+	walletEngine walletReader
+}
+
+func New(db *sql.DB, walletEngine walletReader) *Server {
+	return &Server{store: multisig.NewStore(db), walletEngine: walletEngine}
 }
 
 // Store exposes the underlying store for migration use.
 func (s *Server) Store() *multisig.Store {
 	return s.store
+}
+
+func (s *Server) activeWalletID(ctx context.Context) (string, error) {
+	active, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		return "", connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("get active wallet: %w", err))
+	}
+	return active.ID, nil
+}
+
+// requireGroupVisible rejects a group owned by another wallet. Groups saved
+// before wallet scoping existed carry no owner and stay visible to all.
+func (s *Server) requireGroupVisible(ctx context.Context, groupID, walletID string) error {
+	visible, err := s.store.GroupVisibleTo(ctx, groupID, walletID)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("group wallet: %w", err))
+	}
+	if !visible {
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("group %s belongs to another wallet", groupID))
+	}
+	return nil
 }
 
 // ─── Groups ────────────────────────────────────────────────────────
@@ -36,7 +64,12 @@ func (s *Server) ListGroups(
 	ctx context.Context,
 	req *connect.Request[emptypb.Empty],
 ) (*connect.Response[pb.ListGroupsResponse], error) {
-	groups, err := s.store.ListGroups(ctx)
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := s.store.ListGroupsForWallet(ctx, walletID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list groups: %w", err))
 	}
@@ -65,8 +98,17 @@ func (s *Server) SaveGroup(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("group id is required"))
 	}
 
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireGroupVisible(ctx, pg.Id, walletID); err != nil {
+		return nil, err
+	}
+
 	g := multisig.Group{
 		ID:                pg.Id,
+		WalletID:          walletID,
 		Name:              pg.Name,
 		N:                 int(pg.N),
 		M:                 int(pg.M),
@@ -171,6 +213,14 @@ func (s *Server) DeleteGroup(
 	ctx context.Context,
 	req *connect.Request[pb.DeleteGroupRequest],
 ) (*connect.Response[emptypb.Empty], error) {
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireGroupVisible(ctx, req.Msg.GroupId, walletID); err != nil {
+		return nil, err
+	}
+
 	if err := s.store.DeleteGroup(ctx, req.Msg.GroupId); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("delete group: %w", err))
 	}
@@ -183,7 +233,20 @@ func (s *Server) ListTransactions(
 	ctx context.Context,
 	req *connect.Request[pb.ListTransactionsRequest],
 ) (*connect.Response[pb.ListTransactionsResponse], error) {
-	txns, err := s.store.ListTransactions(ctx, req.Msg.GroupId)
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var txns []multisig.Transaction
+	if req.Msg.GroupId == "" {
+		txns, err = s.store.ListTransactionsForWallet(ctx, walletID)
+	} else {
+		if err := s.requireGroupVisible(ctx, req.Msg.GroupId, walletID); err != nil {
+			return nil, err
+		}
+		txns, err = s.store.ListTransactions(ctx, req.Msg.GroupId)
+	}
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list transactions: %w", err))
 	}
@@ -204,12 +267,20 @@ func (s *Server) GetTransaction(
 	ctx context.Context,
 	req *connect.Request[pb.GetTransactionRequest],
 ) (*connect.Response[pb.MultisigTransaction], error) {
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	t, err := s.store.GetTransaction(ctx, req.Msg.TransactionId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if t == nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("transaction not found: %s", req.Msg.TransactionId))
+	}
+	if err := s.requireGroupVisible(ctx, t.GroupID, walletID); err != nil {
+		return nil, err
 	}
 
 	pbTx, err := s.txToProto(ctx, *t)
@@ -224,12 +295,20 @@ func (s *Server) GetTransactionByTxid(
 	ctx context.Context,
 	req *connect.Request[pb.GetTransactionByTxidRequest],
 ) (*connect.Response[pb.MultisigTransaction], error) {
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	t, err := s.store.GetTransactionByTxid(ctx, req.Msg.Txid)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if t == nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("transaction not found for txid: %s", req.Msg.Txid))
+	}
+	if err := s.requireGroupVisible(ctx, t.GroupID, walletID); err != nil {
+		return nil, err
 	}
 
 	pbTx, err := s.txToProto(ctx, *t)
@@ -247,6 +326,14 @@ func (s *Server) SaveTransaction(
 	pt := req.Msg.Transaction
 	if pt == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("transaction is required"))
+	}
+
+	walletID, err := s.activeWalletID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireGroupVisible(ctx, pt.GroupId, walletID); err != nil {
+		return nil, err
 	}
 
 	t := multisig.Transaction{

--- a/bitwindow/server/api/multisig/multisig_test.go
+++ b/bitwindow/server/api/multisig/multisig_test.go
@@ -1,0 +1,121 @@
+package api_multisig_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	api_multisig "github.com/LayerTwo-Labs/sidesail/bitwindow/server/api/multisig"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/multisig/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// activeWallet stands in for the wallet engine, always active.
+type activeWallet string
+
+func (w activeWallet) GetActiveWallet(context.Context) (*engines.WalletInfo, error) {
+	return &engines.WalletInfo{ID: string(w)}, nil
+}
+
+func saveGroup(t *testing.T, srv *api_multisig.Server, id string) {
+	t.Helper()
+
+	_, err := srv.SaveGroup(context.Background(), connect.NewRequest(&pb.SaveGroupRequest{
+		Group: &pb.MultisigGroup{Id: id, Name: id, N: 2, M: 3, Created: 1700000000},
+	}))
+	require.NoError(t, err)
+}
+
+func TestGroupsAreScopedToTheActiveWallet(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	walletA := api_multisig.New(db, activeWallet("wallet-a"))
+	walletB := api_multisig.New(db, activeWallet("wallet-b"))
+
+	saveGroup(t, walletA, "grp-a")
+	saveGroup(t, walletB, "grp-b")
+
+	groups, err := walletA.ListGroups(ctx, connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+	require.Len(t, groups.Msg.Groups, 1)
+	assert.Equal(t, "grp-a", groups.Msg.Groups[0].Id)
+
+	// Wallet B cannot read, mutate or delete wallet A's group.
+	_, err = walletB.SaveGroup(ctx, connect.NewRequest(&pb.SaveGroupRequest{
+		Group: &pb.MultisigGroup{Id: "grp-a", Name: "stolen", N: 2, M: 3},
+	}))
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	_, err = walletB.DeleteGroup(ctx, connect.NewRequest(&pb.DeleteGroupRequest{GroupId: "grp-a"}))
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	_, err = walletB.ListTransactions(ctx, connect.NewRequest(&pb.ListTransactionsRequest{GroupId: "grp-a"}))
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// The group survived both attempts, unchanged.
+	groups, err = walletA.ListGroups(ctx, connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+	require.Len(t, groups.Msg.Groups, 1)
+	assert.Equal(t, "grp-a", groups.Msg.Groups[0].Name)
+}
+
+func TestTransactionsAreScopedToTheActiveWallet(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	walletA := api_multisig.New(db, activeWallet("wallet-a"))
+	walletB := api_multisig.New(db, activeWallet("wallet-b"))
+
+	saveGroup(t, walletA, "grp-a")
+
+	_, err := walletA.SaveTransaction(ctx, connect.NewRequest(&pb.SaveTransactionRequest{
+		Transaction: &pb.MultisigTransaction{
+			Id: "tx-a", GroupId: "grp-a", Txid: "abc123", InitialPsbt: "psbt",
+			Status: pb.TxStatus_TX_STATUS_NEEDS_SIGNATURES,
+		},
+	}))
+	require.NoError(t, err)
+
+	txns, err := walletB.ListTransactions(ctx, connect.NewRequest(&pb.ListTransactionsRequest{}))
+	require.NoError(t, err)
+	assert.Empty(t, txns.Msg.Transactions)
+
+	_, err = walletB.GetTransaction(ctx, connect.NewRequest(&pb.GetTransactionRequest{TransactionId: "tx-a"}))
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	_, err = walletB.GetTransactionByTxid(ctx, connect.NewRequest(&pb.GetTransactionByTxidRequest{Txid: "abc123"}))
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// Voiding, like every other status change, goes through SaveTransaction.
+	_, err = walletB.SaveTransaction(ctx, connect.NewRequest(&pb.SaveTransactionRequest{
+		Transaction: &pb.MultisigTransaction{Id: "tx-a", GroupId: "grp-a", Status: pb.TxStatus_TX_STATUS_VOIDED},
+	}))
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	txns, err = walletA.ListTransactions(ctx, connect.NewRequest(&pb.ListTransactionsRequest{}))
+	require.NoError(t, err)
+	require.Len(t, txns.Msg.Transactions, 1)
+	assert.Equal(t, pb.TxStatus_TX_STATUS_NEEDS_SIGNATURES, txns.Msg.Transactions[0].Status)
+}
+
+func TestGroupsSavedBeforeWalletScopingStayVisible(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO multisig_groups (id, name, n, m, created) VALUES ('grp-legacy', 'legacy', 2, 3, 1700000000)`)
+	require.NoError(t, err)
+
+	for _, walletID := range []string{"wallet-a", "wallet-b"} {
+		groups, err := api_multisig.New(db, activeWallet(walletID)).
+			ListGroups(ctx, connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+		require.Len(t, groups.Msg.Groups, 1, walletID)
+		assert.Equal(t, "grp-legacy", groups.Msg.Groups[0].Id)
+	}
+}

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -312,7 +312,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		register(path, h)
 	}
 	{
-		multisigSvc := api_multisig.New(rt.db)
+		multisigSvc := api_multisig.New(rt.db, rt.walletEngine)
 		path, h := multisigv1connect.NewMultisigServiceHandler(multisigSvc, stdOpts...)
 		register(path, h)
 	}

--- a/bitwindow/server/database/migrations/047_denials_failure_backoff.sql
+++ b/bitwindow/server/database/migrations/047_denials_failure_backoff.sql
@@ -1,0 +1,5 @@
+-- A denial whose execution failed was retried on every engine tick, forever.
+-- These track the consecutive failures and when the next attempt is allowed,
+-- so a persistent failure backs off and is eventually given up on.
+ALTER TABLE denials ADD COLUMN failed_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE denials ADD COLUMN retry_after TIMESTAMP;

--- a/bitwindow/server/database/migrations/047_multisig_wallet_id.sql
+++ b/bitwindow/server/database/migrations/047_multisig_wallet_id.sql
@@ -1,0 +1,6 @@
+-- Scope multisig groups to the wallet that created them, so one wallet cannot
+-- list, read, mutate or delete another's groups and their transactions.
+-- Existing groups keep a NULL wallet_id and stay visible to every wallet.
+ALTER TABLE multisig_groups ADD COLUMN wallet_id TEXT;
+
+CREATE INDEX idx_multisig_groups_wallet_id ON multisig_groups (wallet_id);

--- a/bitwindow/server/database/migrations/047_notified_events_height.sql
+++ b/bitwindow/server/database/migrations/047_notified_events_height.sql
@@ -1,0 +1,4 @@
+-- Records the block that confirmed an event, so a fork purge can drop the rows
+-- whose confirming block went away and let the notification fire again. NULL
+-- for events that aren't tied to a block.
+ALTER TABLE notified_events ADD COLUMN height INTEGER;

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/wallet"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
 	"github.com/rs/zerolog"
 )
@@ -36,9 +37,10 @@ func NewBackupEngine(db *sql.DB, walletDir string) *BackupEngine {
 
 // BackupContents describes what a backup file contains.
 type BackupContents struct {
-	HasWallet       bool
-	HasMultisig     bool
-	HasTransactions bool
+	HasWallet             bool
+	HasMultisig           bool
+	HasTransactions       bool
+	HasEncryptionMetadata bool
 }
 
 // CreateBackup produces a ZIP archive containing wallet.json plus
@@ -58,6 +60,7 @@ CONTENTS
 2. multisig/multisig.json - Multisig group configurations (exported from DB)
 3. transactions.json - Transaction history (exported from DB)
 4. metadata.json - Latest known wallet balance metadata
+5. wallet_encryption.json - Password encryption parameters (only if the wallet is encrypted)
 
 All sidechain wallets are DERIVED from the master seed in wallet.json.
 Restoring this backup restores ALL your sidechain wallets automatically.
@@ -85,6 +88,18 @@ Keep this file secure. Anyone with access can control ALL your funds.
 		log.Info().Msg("backup: added wallet.json")
 	} else {
 		log.Warn().Err(err).Msg("backup: wallet.json not found")
+	}
+
+	// Without this an encrypted wallet.json restores into a dir that reads as
+	// unencrypted, and the correct password can never decrypt it again.
+	encryptionPath := filepath.Join(e.walletDir, "wallet_encryption.json")
+	if data, err := os.ReadFile(encryptionPath); err == nil {
+		if err := addToZip(zw, "wallet_encryption.json", data); err != nil {
+			return nil, "", fmt.Errorf("write wallet_encryption.json: %w", err)
+		}
+		log.Info().Msg("backup: added wallet_encryption.json")
+	} else if !os.IsNotExist(err) {
+		log.Warn().Err(err).Msg("backup: wallet_encryption.json not readable")
 	}
 
 	metadataPath := filepath.Join(e.walletDir, "metadata.json")
@@ -150,7 +165,7 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 	log := zerolog.Ctx(ctx)
 	ext := strings.ToLower(filepath.Ext(filename))
 
-	var walletJSON, metadataJSON, multisigJSON, txJSON []byte
+	var walletJSON, encryptionJSON, metadataJSON, multisigJSON, txJSON []byte
 	var err error
 
 	switch ext {
@@ -161,7 +176,7 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 			return fmt.Errorf("invalid wallet.json: %w", err)
 		}
 	case ".zip":
-		walletJSON, metadataJSON, multisigJSON, txJSON, err = extractZIP(data)
+		walletJSON, encryptionJSON, metadataJSON, multisigJSON, txJSON, err = extractZIP(data)
 		if err != nil {
 			return fmt.Errorf("extract zip: %w", err)
 		}
@@ -195,6 +210,24 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		return fmt.Errorf("write wallet.json: %w", err)
 	}
 	log.Info().Msg("restore: wrote wallet.json")
+
+	// wallet_encryption.json is the encryption sentinel: without it an encrypted
+	// wallet.json reads as plaintext, and a leftover one makes a plaintext
+	// wallet.json read as encrypted. Either way the wallet is unreadable.
+	encryptionPath := filepath.Join(e.walletDir, "wallet_encryption.json")
+	switch {
+	case encryptionJSON != nil:
+		if err := os.WriteFile(encryptionPath, encryptionJSON, 0600); err != nil {
+			return fmt.Errorf("write wallet_encryption.json: %w", err)
+		}
+		log.Info().Msg("restore: wrote wallet_encryption.json")
+	case validateWalletJSON(walletJSON) == nil:
+		// Only drop the existing marker once the restored wallet.json is known
+		// plaintext — a pre-fix backup of an encrypted wallet still needs it.
+		if err := os.Remove(encryptionPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove wallet_encryption.json: %w", err)
+		}
+	}
 
 	if metadataJSON != nil {
 		metadataPath := filepath.Join(e.walletDir, "metadata.json")
@@ -497,17 +530,24 @@ func (e *BackupEngine) validateZIP(data []byte) (*BackupContents, error) {
 	}
 
 	contents := &BackupContents{}
+	var walletData []byte
 	for _, f := range r.File {
 		switch f.Name {
 		case "wallet.json":
-			walletData, err := readZipEntry(f)
+			walletData, err = readZipEntry(f)
 			if err != nil {
 				return nil, fmt.Errorf("read wallet.json in zip: %w", err)
 			}
-			if err := validateWalletJSON(walletData); err != nil {
-				return nil, fmt.Errorf("wallet.json invalid: %w", err)
-			}
 			contents.HasWallet = true
+		case "wallet_encryption.json":
+			encData, err := readZipEntry(f)
+			if err != nil {
+				continue
+			}
+			var meta wallet.EncryptionMetadata
+			if json.Unmarshal(encData, &meta) == nil && meta.Encrypted {
+				contents.HasEncryptionMetadata = true
+			}
 		case "multisig/multisig.json", "multisig\\multisig.json":
 			msData, err := readZipEntry(f)
 			if err != nil {
@@ -533,13 +573,21 @@ func (e *BackupEngine) validateZIP(data []byte) (*BackupContents, error) {
 		return nil, fmt.Errorf("backup is missing wallet.json")
 	}
 
+	// An encrypted wallet.json is "iv:ciphertext", not JSON — the encryption
+	// metadata that ships with it is what vouches for the file.
+	if !contents.HasEncryptionMetadata {
+		if err := validateWalletJSON(walletData); err != nil {
+			return nil, fmt.Errorf("wallet.json invalid: %w", err)
+		}
+	}
+
 	return contents, nil
 }
 
-func extractZIP(data []byte) (walletJSON, metadataJSON, multisigJSON, txJSON []byte, err error) {
+func extractZIP(data []byte) (walletJSON, encryptionJSON, metadataJSON, multisigJSON, txJSON []byte, err error) {
 	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("invalid zip: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("invalid zip: %w", err)
 	}
 
 	for _, f := range r.File {
@@ -547,6 +595,8 @@ func extractZIP(data []byte) (walletJSON, metadataJSON, multisigJSON, txJSON []b
 		switch f.Name {
 		case "wallet.json":
 			dst = &walletJSON
+		case "wallet_encryption.json":
+			dst = &encryptionJSON
 		case "metadata.json":
 			dst = &metadataJSON
 		case "multisig/multisig.json", "multisig\\multisig.json":
@@ -558,7 +608,7 @@ func extractZIP(data []byte) (walletJSON, metadataJSON, multisigJSON, txJSON []b
 		}
 		content, rerr := readZipEntry(f)
 		if rerr != nil {
-			return nil, nil, nil, nil, fmt.Errorf("read %s in zip: %w", f.Name, rerr)
+			return nil, nil, nil, nil, nil, fmt.Errorf("read %s in zip: %w", f.Name, rerr)
 		}
 		*dst = content
 	}

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -188,20 +188,13 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		return fmt.Errorf("backup does not contain wallet.json")
 	}
 
-	// Import into the DB before touching the wallet files, so a backup that
-	// fails to import leaves the current wallet in place.
-	if multisigJSON != nil {
-		if err := e.multisigStore.ImportFromJSON(ctx, multisigJSON); err != nil {
+	// A zip holds the wallet's whole multisig state, so it replaces rather than
+	// merges. It runs first, so a failed import leaves the current wallet in place.
+	if ext == ".zip" {
+		if err := e.multisigStore.ReplaceFromBackup(ctx, multisigJSON, txJSON); err != nil {
 			return fmt.Errorf("import multisig data: %w", err)
 		}
-		log.Info().Msg("restore: imported multisig data")
-	}
-
-	if txJSON != nil {
-		if err := e.multisigStore.ImportTransactionsFromJSON(ctx, txJSON); err != nil {
-			return fmt.Errorf("import transactions: %w", err)
-		}
-		log.Info().Msg("restore: imported transactions")
+		log.Info().Msg("restore: replaced multisig data")
 	}
 
 	// Restore wallet.json

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -544,21 +544,23 @@ func (e *BackupEngine) validateZIP(data []byte) (*BackupContents, error) {
 		case "multisig/multisig.json", "multisig\\multisig.json":
 			msData, err := readZipEntry(f)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("read %s in zip: %w", f.Name, err)
 			}
 			var tmp interface{}
-			if json.Unmarshal(msData, &tmp) == nil {
-				contents.HasMultisig = true
+			if err := json.Unmarshal(msData, &tmp); err != nil {
+				return nil, fmt.Errorf("%s invalid: %w", f.Name, err)
 			}
+			contents.HasMultisig = true
 		case "transactions.json":
 			txData, err := readZipEntry(f)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("read %s in zip: %w", f.Name, err)
 			}
 			var tmp interface{}
-			if json.Unmarshal(txData, &tmp) == nil {
-				contents.HasTransactions = true
+			if err := json.Unmarshal(txData, &tmp); err != nil {
+				return nil, fmt.Errorf("%s invalid: %w", f.Name, err)
 			}
+			contents.HasTransactions = true
 		}
 	}
 

--- a/bitwindow/server/engines/backup_engine_encryption_test.go
+++ b/bitwindow/server/engines/backup_engine_encryption_test.go
@@ -1,0 +1,88 @@
+package engines
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// An encrypted wallet.json is "base64(iv):base64(ciphertext)", not JSON.
+var (
+	testEncryptedWallet = []byte("AAAAAAAAAAAAAAAA:c2VjcmV0")
+	testEncryptionMeta  = []byte(`{"salt":"c2FsdA==","iterations":100000,"encrypted":true,"version":"1"}`)
+)
+
+// Backing up an encrypted wallet without its encryption metadata restores a
+// wallet that reads as plaintext, and the correct password never opens it again.
+func TestBackupRoundTrip_CarriesEncryptionMetadata(t *testing.T) {
+	ctx := testCtx()
+	db := database.Test(t)
+	srcDir := t.TempDir()
+	e := &BackupEngine{db: db, walletDir: srcDir, multisigStore: multisig.NewStore(db)}
+
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "wallet.json"), testEncryptedWallet, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "wallet_encryption.json"), testEncryptionMeta, 0600))
+
+	data, _, err := e.CreateBackup(ctx)
+	require.NoError(t, err)
+
+	contents, err := e.ValidateBackup(ctx, data, "backup.zip")
+	require.NoError(t, err, "an encrypted backup must validate")
+	require.True(t, contents.HasEncryptionMetadata, "backup must carry wallet_encryption.json")
+
+	restoreDir := t.TempDir()
+	r := &BackupEngine{db: db, walletDir: restoreDir, multisigStore: multisig.NewStore(db)}
+	require.NoError(t, r.RestoreBackup(ctx, data, "backup.zip"))
+
+	require.True(t, wallet.IsWalletEncrypted(restoreDir), "the restored wallet must still read as encrypted")
+	gotMeta, err := os.ReadFile(filepath.Join(restoreDir, "wallet_encryption.json"))
+	require.NoError(t, err)
+	require.JSONEq(t, string(testEncryptionMeta), string(gotMeta), "salt and iterations must survive the round trip")
+	gotWallet, err := os.ReadFile(filepath.Join(restoreDir, "wallet.json"))
+	require.NoError(t, err)
+	require.Equal(t, testEncryptedWallet, gotWallet)
+}
+
+// A leftover marker would make the restored plaintext wallet read as encrypted.
+func TestRestoreBackup_PlaintextDropsStaleEncryptionMetadata(t *testing.T) {
+	ctx := testCtx()
+	db := database.Test(t)
+	dir := t.TempDir()
+	e := &BackupEngine{db: db, walletDir: dir, multisigStore: multisig.NewStore(db)}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wallet_encryption.json"), testEncryptionMeta, 0600))
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	require.NoError(t, addToZip(zw, "wallet.json", []byte(`{"master":"seed","l1":"key"}`)))
+	require.NoError(t, zw.Close())
+
+	require.NoError(t, e.RestoreBackup(ctx, buf.Bytes(), "backup.zip"))
+	require.False(t, wallet.IsWalletEncrypted(dir), "a plaintext wallet must not read as encrypted")
+}
+
+// Backups taken before the metadata was included carry ciphertext only, so the
+// marker already on disk is the last thing that can decrypt them.
+func TestRestoreBackup_EncryptedWithoutMetadata_KeepsExistingMarker(t *testing.T) {
+	ctx := testCtx()
+	db := database.Test(t)
+	dir := t.TempDir()
+	e := &BackupEngine{db: db, walletDir: dir, multisigStore: multisig.NewStore(db)}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wallet_encryption.json"), testEncryptionMeta, 0600))
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	require.NoError(t, addToZip(zw, "wallet.json", testEncryptedWallet))
+	require.NoError(t, zw.Close())
+
+	require.NoError(t, e.RestoreBackup(ctx, buf.Bytes(), "backup.zip"))
+	require.True(t, wallet.IsWalletEncrypted(dir), "the existing marker must be kept")
+}

--- a/bitwindow/server/engines/backup_engine_restore_replaces_test.go
+++ b/bitwindow/server/engines/backup_engine_restore_replaces_test.go
@@ -1,0 +1,105 @@
+package engines
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
+	"github.com/stretchr/testify/require"
+)
+
+// Group IDs are short hashes, so a restored group can collide with one already
+// in the DB. Restoring must replace the multisig data, not merge into it, or
+// the previous wallet's transactions are read back as the restored group's.
+func TestRestoreBackup_ReplacesExistingMultisigData(t *testing.T) {
+	ctx := testCtx()
+	db := database.Test(t)
+	store := multisig.NewStore(db)
+	e := &BackupEngine{db: db, walletDir: t.TempDir(), multisigStore: store}
+
+	// The wallet being replaced: one group colliding with the backup's, one not.
+	require.NoError(t, store.SaveGroup(ctx, multisig.Group{ID: "shared-id", Name: "Old Group", N: 2, M: 2}))
+	require.NoError(t, store.SaveGroup(ctx, multisig.Group{ID: "old-only", Name: "Other Old Group", N: 2, M: 2}))
+	require.NoError(t, store.SaveTransactionAtomic(ctx, multisig.SaveTransactionAtomicParams{
+		Transaction: multisig.Transaction{ID: "tx-old", GroupID: "shared-id", InitialPSBT: "psbt-old", Status: 1, Type: 1},
+		Inputs:      []multisig.TxInput{{TransactionID: "tx-old", Txid: "old-input", Vout: 0, Amount: 1.0}},
+	}))
+	require.NoError(t, store.AddSoloKey(ctx, multisig.SoloKey{Xpub: "tpubOld", DerivationPath: "m/84'/1'/0'"}))
+
+	multisigJSON := []byte(`{
+		"groups": [
+			{
+				"id": "shared-id",
+				"name": "Restored Group",
+				"n": 2,
+				"m": 3,
+				"created": 1751400000,
+				"transaction_ids": ["tx-new"]
+			}
+		],
+		"solo_keys": []
+	}`)
+	txJSON := []byte(`[
+		{
+			"id": "tx-new",
+			"groupId": "shared-id",
+			"initialPSBT": "psbt-new",
+			"status": "needsSignatures",
+			"type": "deposit",
+			"created": "2025-07-01T00:00:00Z"
+		}
+	]`)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	require.NoError(t, addToZip(zw, "wallet.json", []byte(`{"master":"restored seed","l1":"restored key"}`)))
+	require.NoError(t, addToZip(zw, "multisig/multisig.json", multisigJSON))
+	require.NoError(t, addToZip(zw, "transactions.json", txJSON))
+	require.NoError(t, zw.Close())
+
+	require.NoError(t, e.RestoreBackup(ctx, buf.Bytes(), "backup.zip"))
+
+	groups, err := store.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "groups from the replaced wallet must not survive")
+	require.Equal(t, "shared-id", groups[0].ID)
+	require.Equal(t, "Restored Group", groups[0].Name)
+
+	txns, err := store.ListTransactions(ctx, "shared-id")
+	require.NoError(t, err)
+	require.Len(t, txns, 1, "the replaced wallet's transaction must not be attributed to the restored group")
+	require.Equal(t, "tx-new", txns[0].ID)
+
+	inputs, err := store.ListTxInputs(ctx, "tx-old")
+	require.NoError(t, err)
+	require.Empty(t, inputs, "child rows of the replaced wallet's transactions must go too")
+
+	soloKeys, err := store.ListSoloKeys(ctx)
+	require.NoError(t, err)
+	require.Empty(t, soloKeys, "solo keys from the replaced wallet must not survive")
+}
+
+// A backup that fails to import must not leave the multisig tables cleared.
+func TestRestoreBackup_FailedImport_KeepsExistingMultisigData(t *testing.T) {
+	ctx := testCtx()
+	db := database.Test(t)
+	store := multisig.NewStore(db)
+	e := &BackupEngine{db: db, walletDir: t.TempDir(), multisigStore: store}
+
+	require.NoError(t, store.SaveGroup(ctx, multisig.Group{ID: "old-only", Name: "Old Group", N: 2, M: 2}))
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	require.NoError(t, addToZip(zw, "wallet.json", []byte(`{"master":"backup seed","l1":"backup key"}`)))
+	require.NoError(t, addToZip(zw, "multisig/multisig.json", []byte(`"not an object"`)))
+	require.NoError(t, zw.Close())
+
+	require.Error(t, e.RestoreBackup(ctx, buf.Bytes(), "backup.zip"))
+
+	groups, err := store.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "a failed restore must roll the clear back")
+	require.Equal(t, "old-only", groups[0].ID)
+}

--- a/bitwindow/server/engines/backup_engine_test.go
+++ b/bitwindow/server/engines/backup_engine_test.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"hash/crc32"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -86,6 +88,49 @@ func TestValidateBackup_ZIP_Valid(t *testing.T) {
 	}
 	if !contents.HasMultisig {
 		t.Fatal("expected HasMultisig true")
+	}
+}
+
+// a present-but-unreadable multisig entry must fail validation, not read as absent
+func TestValidateBackup_ZIP_CorruptMultisig(t *testing.T) {
+	e := &BackupEngine{}
+
+	wallet := map[string]interface{}{"master": "seed", "l1": "key"}
+	walletData, _ := json.Marshal(wallet)
+
+	multisig := map[string]interface{}{"groups": []interface{}{}}
+	msData, _ := json.Marshal(multisig)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("wallet.json")
+	_, _ = w.Write(walletData)
+	// stored uncompressed with a wrong CRC32, so reading it fails the checksum
+	w, err := zw.CreateRaw(&zip.FileHeader{
+		Name:               "multisig/multisig.json",
+		Method:             zip.Store,
+		CRC32:              ^crc32.ChecksumIEEE(msData),
+		CompressedSize64:   uint64(len(msData)),
+		UncompressedSize64: uint64(len(msData)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.Write(msData)
+	_ = zw.Close()
+
+	_, err = e.ValidateBackup(context.TODO(), buf.Bytes(), "backup.zip")
+	if err == nil {
+		t.Fatal("expected error for corrupt multisig.json")
+	}
+	if !strings.Contains(err.Error(), "multisig.json") {
+		t.Fatalf("error does not name multisig.json: %v", err)
+	}
+
+	// restore must reject it too, rather than importing zero groups
+	e2 := &BackupEngine{walletDir: t.TempDir()}
+	if err := e2.RestoreBackup(testCtx(), buf.Bytes(), "backup.zip"); err == nil {
+		t.Fatal("expected RestoreBackup to reject a corrupt multisig.json")
 	}
 }
 

--- a/bitwindow/server/engines/backup_engine_zipbomb_test.go
+++ b/bitwindow/server/engines/backup_engine_zipbomb_test.go
@@ -26,7 +26,7 @@ func TestBackupZipEntryCapped(t *testing.T) {
 	defer func() { maxBackupEntrySize = orig }()
 
 	bomb := zipWith(t, "wallet.json", bytes.Repeat([]byte("a"), 8<<10))
-	if _, _, _, _, err := extractZIP(bomb); err == nil {
+	if _, _, _, _, _, err := extractZIP(bomb); err == nil {
 		t.Fatal("extractZIP accepted an over-cap entry")
 	}
 	e := &BackupEngine{}
@@ -36,7 +36,7 @@ func TestBackupZipEntryCapped(t *testing.T) {
 
 	// a valid within-cap backup still works
 	ok := zipWith(t, "wallet.json", []byte(`{"master":"x","l1":"y"}`))
-	wallet, _, _, _, err := extractZIP(ok)
+	wallet, _, _, _, _, err := extractZIP(ok)
 	if err != nil {
 		t.Fatalf("extractZIP rejected a valid backup: %v", err)
 	}

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -632,14 +632,20 @@ func (p *Parser) handleTimestamp(
 		return nil
 	}
 
-	// Create discovered timestamp
+	// Create discovered timestamp. A mempool-only discovery has no block yet,
+	// so it starts out confirming and checkConfirmations settles it.
+	status := timestamps.StatusConfirmed
+	if blockHeight == nil {
+		status = timestamps.StatusConfirming
+	}
+
 	now := time.Now()
 	timestamp := timestamps.FileTimestamp{
 		Filename:    "", // Unknown for discovered timestamps
 		FileHash:    fileHash,
 		TxID:        &txid,
 		BlockHeight: blockHeight,
-		Status:      timestamps.StatusConfirmed,
+		Status:      status,
 		CreatedAt:   now,
 		ConfirmedAt: confirmedAt,
 	}

--- a/bitwindow/server/engines/bitcoind_engine_internal_test.go
+++ b/bitwindow/server/engines/bitcoind_engine_internal_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // seedTopic indexes a TopicCreation directly into cn_topics so stories
@@ -165,6 +166,79 @@ func TestPurgeChainDerivedAtOrAbove(t *testing.T) {
 	assert.Equal(t, timestamps.StatusConfirming, orphaned.Status, "orphaned timestamps go back to confirming")
 	assert.Nil(t, orphaned.BlockHeight, "orphaned timestamps lose their stale height")
 	assert.Nil(t, orphaned.ConfirmedAt, "orphaned timestamps lose their stale confirmation time")
+}
+
+// A timestamp discovered in the mempool has no block yet. Recording it as
+// confirmed strands it: checkConfirmations only revisits confirming rows, so
+// it would never be promoted for real, nor failed if the transaction is
+// dropped.
+func TestHandleTimestamp_DiscoveredStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		blockhash  string
+		wantStatus timestamps.Status
+		wantHeight int64
+	}{
+		{
+			name:       "mempool transaction is confirming",
+			wantStatus: timestamps.StatusConfirming,
+		},
+		{
+			name:       "mined transaction is confirmed",
+			blockhash:  "0000000000000000000000000000000000000000000000000000000000000abc",
+			wantStatus: timestamps.StatusConfirmed,
+			wantHeight: 101,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := database.Test(t)
+
+			core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+			parser := &Parser{
+				db: db,
+				bitcoind: service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+					return core, nil
+				}),
+			}
+
+			core.EXPECT().
+				GetRawTransaction(gomock.Any(), gomock.Any()).
+				Return(connect.NewResponse(&corepb.GetRawTransactionResponse{
+					Blockhash: tc.blockhash,
+				}), nil)
+
+			if tc.blockhash != "" {
+				core.EXPECT().
+					GetBlock(gomock.Any(), gomock.Any()).
+					Return(connect.NewResponse(&corepb.GetBlockResponse{
+						Height: uint32(tc.wantHeight),
+						Time:   timestamppb.Now(),
+					}), nil)
+			}
+
+			hash := chainhash.Hash{byte(i + 1)}
+			data := append([]byte(TimestampPrefix), hash[:]...)
+			txid := fmt.Sprintf("%064x", i+1)
+
+			require.NoError(t, parser.handleTimestamp(ctx, data, txid, nil))
+
+			got, err := timestamps.GetByHash(ctx, db, fmt.Sprintf("%x", hash[:]))
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantStatus, got.Status)
+			if tc.wantHeight == 0 {
+				assert.Nil(t, got.BlockHeight)
+			} else {
+				require.NotNil(t, got.BlockHeight)
+				assert.Equal(t, tc.wantHeight, *got.BlockHeight)
+			}
+		})
+	}
 }
 
 func pkScript(t *testing.T, data []byte) []byte {

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -598,6 +598,12 @@ func (e *BitDriveEngine) ListFiles(ctx context.Context) ([]bitdrive.File, error)
 
 // WipeData removes all BitDrive local data
 func (e *BitDriveEngine) WipeData(ctx context.Context) error {
+	// Drop the records first, so a disk failure can never leave rows pointing
+	// at files that are already gone.
+	if err := bitdrive.DeleteAll(ctx, e.db); err != nil {
+		return fmt.Errorf("delete db records: %w", err)
+	}
+
 	if err := os.RemoveAll(e.bitdriveDir); err != nil {
 		return fmt.Errorf("remove bitdrive dir: %w", err)
 	}

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -351,3 +351,65 @@ func TestEncodeOPReturnData_NonASCIIRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// TestWipeData_ClearsDatabaseRecords verifies that wiping also drops the
+// bitdrive_files rows, so the file list does not keep listing files whose
+// local content was deleted.
+func TestWipeData_ClearsDatabaseRecords(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE bitdrive_files (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			txid TEXT NOT NULL UNIQUE,
+			filename TEXT NOT NULL,
+			file_type TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			encrypted INTEGER NOT NULL DEFAULT 0,
+			timestamp INTEGER NOT NULL,
+			created_at INTEGER NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	bitdriveDir := t.TempDir()
+	engine := &BitDriveEngine{
+		db:          db,
+		bitdriveDir: bitdriveDir,
+	}
+
+	meta := &ParsedMetadata{Timestamp: 1700000000, FileType: "txt"}
+	if err := engine.SaveFile(ctx, "txid-first", []byte("first file"), meta); err != nil {
+		t.Fatalf("save first file: %v", err)
+	}
+	if err := engine.SaveFile(ctx, "txid-second", []byte("second file"), meta); err != nil {
+		t.Fatalf("save second file: %v", err)
+	}
+
+	if err := engine.WipeData(ctx); err != nil {
+		t.Fatalf("wipe data: %v", err)
+	}
+
+	files, err := engine.ListFiles(ctx)
+	if err != nil {
+		t.Fatalf("list files: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected no file records after wipe, got %d", len(files))
+	}
+
+	entries, err := os.ReadDir(bitdriveDir)
+	if err != nil {
+		t.Fatalf("read bitdrive dir after wipe: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty bitdrive dir after wipe, got %d entries", len(entries))
+	}
+}

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -269,6 +269,11 @@ func purgeM4AtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) (uin
 // timestamp is never re-examined. Mempool OP_RETURNs have a NULL height
 // and are left alone; reset timestamps go back through the confirming
 // loop, which re-confirms them against the new chain or fails them.
+//
+// The confirmation notifications those blocks produced go too: they are
+// recorded for good, so without this the re-confirmation on the new chain is
+// swallowed as a duplicate. Events not tied to a block have a NULL height and
+// are left alone.
 func purgeChainDerivedAtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) error {
 
 	if _, err := tx.ExecContext(ctx,
@@ -281,6 +286,11 @@ func purgeChainDerivedAtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight ui
 		SET status = ?, block_height = NULL, confirmed_at = NULL
 		WHERE block_height >= ?`,
 		timestamps.StatusConfirming, fromHeight,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM notified_events WHERE height >= ?`, fromHeight,
 	); err != nil {
 		return err
 	}

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -76,6 +76,12 @@ func (e *DeniabilityEngine) checkDenials(ctx context.Context) error {
 			continue
 		}
 
+		// A denial that just failed backs off, so a failure that persists does
+		// not re-issue the same send on every tick.
+		if denial.RetryAfter != nil && now.Before(*denial.RetryAfter) {
+			continue
+		}
+
 		logger.Info().
 			Int64("denial_id", denial.ID).
 			Time("next_execution", *denial.NextExecution).
@@ -89,6 +95,13 @@ func (e *DeniabilityEngine) checkDenials(ctx context.Context) error {
 				Int64("denial_id", denial.ID).
 				Dur("duration", time.Since(execStart)).
 				Msg("deniability: could not execute denial")
+
+			if ferr := e.recordDenialFailure(ctx, denial, err); ferr != nil {
+				logger.Error().
+					Err(ferr).
+					Int64("denial_id", denial.ID).
+					Msg("deniability: could not record failed denial")
+			}
 			continue
 		}
 		logger.Info().
@@ -98,6 +111,26 @@ func (e *DeniabilityEngine) checkDenials(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// maxDenialFailures is how many executions may fail in a row before the denial
+// is given up on, so the user gets a reason instead of a retry that never ends.
+const maxDenialFailures = 10
+
+// recordDenialFailure backs the denial off, and cancels it once it has failed
+// maxDenialFailures times in a row.
+func (e *DeniabilityEngine) recordDenialFailure(ctx context.Context, denial deniability.Denial, cause error) error {
+	attempts, err := deniability.RecordFailure(ctx, e.db, denial)
+	if err != nil {
+		return fmt.Errorf("record failure: %w", err)
+	}
+
+	if attempts < maxDenialFailures {
+		return nil
+	}
+
+	return deniability.Cancel(ctx, e.db, denial.ID,
+		fmt.Sprintf("cancelled after %d failed attempts: %s", attempts, cause))
 }
 
 // UTXO is one spendable output. Bitcoin Core and electrum report different

--- a/bitwindow/server/engines/deniability_engine_run_test.go
+++ b/bitwindow/server/engines/deniability_engine_run_test.go
@@ -2,14 +2,22 @@ package engines_test
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/deniability"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 // Every other test calls a sub-method, so a field the constructor stopped
@@ -37,4 +45,106 @@ func TestDeniabilityEngineRunSurvivesItsFirstTick(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Run did not return after its context ended")
 	}
+}
+
+// newFailingDenialEngine wires an engine whose Bitcoin Core broadcast always
+// fails, plus a denial that is due right away. sends is how many broadcasts the
+// test allows before gomock fails it.
+func newFailingDenialEngine(t *testing.T, sends int) (*sql.DB, *engines.DeniabilityEngine, deniability.Denial) {
+	t.Helper()
+
+	db := database.Test(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+	mockBitcoind.EXPECT().
+		ListUnspent(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[corepb.ListUnspentResponse]{
+			Msg: &corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: "test-txid", Address: "bc1qsource", Vout: 0, Amount: 0.01, Confirmations: 6},
+				},
+			},
+		}, nil)
+
+	mockBitcoind.EXPECT().
+		GetNewAddress(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[corepb.GetNewAddressResponse]{
+			Msg: &corepb.GetNewAddressResponse{Address: "bc1qtest"},
+		}, nil)
+
+	mockBitcoind.EXPECT().
+		CreateRawTransaction(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[corepb.CreateRawTransactionResponse]{
+			Msg: &corepb.CreateRawTransactionResponse{Tx: &corepb.RawTransaction{Hex: "raw-tx-hex"}},
+		}, nil)
+
+	mockBitcoind.EXPECT().
+		SignRawTransactionWithWallet(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[corepb.SignRawTransactionWithWalletResponse]{
+			Msg: &corepb.SignRawTransactionWithWalletResponse{Hex: "signed-tx-hex", Complete: true},
+		}, nil)
+
+	// The broadcast fails every time, as it would against a node that is down.
+	mockBitcoind.EXPECT().
+		SendRawTransaction(gomock.Any(), gomock.Any()).
+		Times(sends).
+		Return(nil, errors.New("bitcoind is down"))
+
+	bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	})
+	engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+
+	// A zero delay makes the first hop due immediately.
+	denial, err := deniability.Create(context.Background(), db, denialWalletID, "test-txid", 0, 0, 3, nil)
+	require.NoError(t, err)
+
+	return db, engine, denial
+}
+
+// A denial whose send keeps failing used to re-issue the identical transaction
+// on every one-second tick, forever.
+func TestDeniabilityEngineRunBacksOffFailingDenials(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("does not retry within the backoff", func(t *testing.T) {
+		db, engine, denial := newFailingDenialEngine(t, 1)
+
+		runCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		require.NoError(t, engine.Run(runCtx))
+
+		denial, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), denial.FailedAttempts)
+		require.NotNil(t, denial.RetryAfter)
+		require.True(t, denial.RetryAfter.After(time.Now()))
+		require.Nil(t, denial.CancelledAt)
+	})
+
+	t.Run("cancels once the failures pile up", func(t *testing.T) {
+		db, engine, denial := newFailingDenialEngine(t, 1)
+
+		// One failure short of the limit, and due again right away.
+		_, err := db.ExecContext(ctx, `
+			UPDATE denials SET failed_attempts = 9, retry_after = NULL WHERE id = ?
+		`, denial.ID)
+		require.NoError(t, err)
+
+		runCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		require.NoError(t, engine.Run(runCtx))
+
+		denial, err = deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		require.Equal(t, int32(10), denial.FailedAttempts)
+		require.NotNil(t, denial.CancelledAt)
+		require.NotNil(t, denial.CancelReason)
+		require.Contains(t, *denial.CancelReason, "cancelled after 10 failed attempts")
+	})
 }

--- a/bitwindow/server/engines/m4_engine.go
+++ b/bitwindow/server/engines/m4_engine.go
@@ -348,13 +348,24 @@ func (e *M4Engine) persistM3Message(ctx context.Context, msg *m4.M3Message) erro
 		return fmt.Errorf("insert M3 message: %w", err)
 	}
 
-	// Create withdrawal bundle if it doesn't exist
+	// Create withdrawal bundle if it doesn't exist. A bundle that already
+	// failed or expired may be proposed again, which starts its life over —
+	// the clock, the score and the status all reset to the new proposal. A
+	// pending or approved bundle keeps what it has.
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO withdrawal_bundles (
 			sidechain_slot, bundle_hash, work_score, blocks_left,
 			first_seen_height, last_updated_height, status
 		) VALUES (?, ?, 1, ?, ?, ?, 'pending')
-		ON CONFLICT(sidechain_slot, bundle_hash) DO NOTHING
+		ON CONFLICT(sidechain_slot, bundle_hash) DO UPDATE SET
+			status = 'pending',
+			work_score = 1,
+			blocks_left = excluded.blocks_left,
+			first_seen_height = excluded.first_seen_height,
+			last_updated_height = excluded.last_updated_height,
+			status_stamped = 0,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE withdrawal_bundles.status IN ('failed', 'expired')
 	`, msg.SidechainSlot, msg.BundleHash, m4.WithdrawalMaxAge, msg.BlockHeight, msg.BlockHeight)
 	if err != nil {
 		return fmt.Errorf("insert withdrawal bundle: %w", err)

--- a/bitwindow/server/engines/m4_engine_replay_test.go
+++ b/bitwindow/server/engines/m4_engine_replay_test.go
@@ -2,7 +2,9 @@ package engines
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/m4"
@@ -76,6 +78,59 @@ func TestApplyM4Votes_ReplayDoesNotDoubleCount(t *testing.T) {
 	require.NoError(t, e.applyM4Votes(ctx, 151, msg))
 	later, _, _ := bundleState(t, ctx, e, "bundle-a")
 	require.Equal(t, first+1, later, "a new height must still score")
+}
+
+// A bundle that died can be proposed again, and the new M3 restarts it.
+func TestPersistM3Message_ReproposalRevivesDeadBundle(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	e := NewM4Engine(db)
+
+	propose := func(height uint32) {
+		t.Helper()
+		require.NoError(t, e.persistM3Message(ctx, &m4.M3Message{
+			BlockHeight:   height,
+			BlockHash:     fmt.Sprintf("block-%d", height),
+			BlockTime:     time.Now(),
+			SidechainSlot: 0,
+			BundleHash:    "bundle-a",
+		}))
+	}
+	firstSeen := func() (height uint32) {
+		t.Helper()
+		require.NoError(t, db.QueryRowContext(ctx,
+			`SELECT first_seen_height FROM withdrawal_bundles WHERE bundle_hash = ?`, "bundle-a").Scan(&height))
+		return
+	}
+
+	propose(100)
+
+	// Age it out without the votes to approve it.
+	require.NoError(t, e.updateBundleStates(ctx, 100+m4.WithdrawalMaxAge))
+	_, _, status := bundleState(t, ctx, e, "bundle-a")
+	require.Equal(t, "failed", status)
+
+	const reproposed = 100 + m4.WithdrawalMaxAge + 10
+	propose(reproposed)
+
+	score, blocksLeft, status := bundleState(t, ctx, e, "bundle-a")
+	require.Equal(t, "pending", status, "a re-proposed bundle takes votes again")
+	require.Equal(t, 1, score, "the score starts over")
+	require.Equal(t, m4.WithdrawalMaxAge, blocksLeft, "so does the clock")
+	require.Equal(t, uint32(reproposed), firstSeen())
+
+	// A bundle still in play keeps what it has.
+	idx := uint16(0)
+	require.NoError(t, e.applyM4Votes(ctx, reproposed+1, &m4.M4Message{Votes: []m4.M4Vote{{
+		SidechainSlot: 0,
+		VoteType:      m4.VoteTypeUpvote,
+		BundleIndex:   &idx,
+	}}}))
+	propose(reproposed + 5)
+
+	score, _, _ = bundleState(t, ctx, e, "bundle-a")
+	require.Equal(t, 2, score, "a pending bundle keeps its score")
+	require.Equal(t, uint32(reproposed), firstSeen(), "and its clock")
 }
 
 // A bundle first seen in an orphaned block must not survive the reorg purge.

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -160,7 +160,7 @@ func (e *NotificationEngine) checkTimestampConfirmations(ctx context.Context) er
 			e.broadcast(ctx, event)
 
 			// Mark as notified
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTimestamp, eventID); err != nil {
+			if err := notifications.MarkNotifiedAt(ctx, e.db, notifications.EventTypeTimestamp, eventID, blockHeight); err != nil {
 				log.Warn().Err(err).Int64("id", ts.ID).Msg("mark timestamp notified")
 			}
 
@@ -213,6 +213,13 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 		return err
 	}
 
+	// The tip turns a confirmation count into the height that confirmed the
+	// transaction, which is what a fork purge matches on.
+	chainInfo, err := bitcoind.GetBlockchainInfo(ctx, connect.NewRequest(&corepb.GetBlockchainInfoRequest{}))
+	if err != nil {
+		return err
+	}
+
 	// Check transactions for each wallet
 	for _, walletName := range walletsResp.Msg.Wallets {
 		resp, err := bitcoind.ListTransactions(ctx, connect.NewRequest(&corepb.ListTransactionsRequest{
@@ -227,7 +234,7 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 			continue
 		}
 
-		e.processWalletTransactions(ctx, walletName, resp.Msg.Transactions)
+		e.processWalletTransactions(ctx, walletName, chainInfo.Msg.Blocks, resp.Msg.Transactions)
 	}
 
 	return nil
@@ -274,7 +281,17 @@ func aggregateByTxid(transactions []*corepb.GetTransactionResponse) []walletTx {
 	return aggregated
 }
 
-func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, transactions []*corepb.GetTransactionResponse) {
+// confirmingHeight is the height of the block that gave a transaction its first
+// confirmation, or nil when the tip doesn't place it.
+func confirmingHeight(tipHeight, confirmations uint32) *int64 {
+	if tipHeight == 0 || confirmations == 0 || confirmations > tipHeight {
+		return nil
+	}
+	height := int64(tipHeight - confirmations + 1)
+	return &height
+}
+
+func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, tipHeight uint32, transactions []*corepb.GetTransactionResponse) {
 	log := zerolog.Ctx(ctx)
 	for _, tx := range aggregateByTxid(transactions) {
 		txid := tx.txid
@@ -312,7 +329,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 				}
 			}
 			if !confNotified && confirmations >= 1 {
-				if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransactionConf, confEventID); err != nil {
+				if err := notifications.MarkNotifiedAt(ctx, e.db, notifications.EventTypeTransactionConf, confEventID, confirmingHeight(tipHeight, confirmations)); err != nil {
 					log.Warn().Err(err).Str("txid", txid).Msg("mark backlog transaction confirmation notified")
 				}
 			}
@@ -384,7 +401,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransactionConf, confEventID); err != nil {
+			if err := notifications.MarkNotifiedAt(ctx, e.db, notifications.EventTypeTransactionConf, confEventID, confirmingHeight(tipHeight, confirmations)); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction confirmation notified")
 			}
 			log.Info().

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -23,7 +23,7 @@ func TestProcessWalletTransactions_HistoryIsNotAnnounced(t *testing.T) {
 	events := engine.Subscribe(ctx)
 
 	const txid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{{
+	engine.processWalletTransactions(ctx, "wallet-a", 200, []*corepb.GetTransactionResponse{{
 		Txid:          txid,
 		Amount:        1,
 		Confirmations: 6,
@@ -64,12 +64,12 @@ func TestProcessWalletTransactions_DedupIsPerWallet(t *testing.T) {
 		Confirmations: 0,
 	}}
 
-	engine.processWalletTransactions(ctx, "wallet-a", txs)
-	engine.processWalletTransactions(ctx, "wallet-b", txs)
+	engine.processWalletTransactions(ctx, "wallet-a", 200, txs)
+	engine.processWalletTransactions(ctx, "wallet-b", 200, txs)
 
 	// A second pass must not notify again for either wallet.
-	engine.processWalletTransactions(ctx, "wallet-a", txs)
-	engine.processWalletTransactions(ctx, "wallet-b", txs)
+	engine.processWalletTransactions(ctx, "wallet-a", 200, txs)
+	engine.processWalletTransactions(ctx, "wallet-b", 200, txs)
 
 	var received int
 	for done := false; !done; {
@@ -97,7 +97,7 @@ func TestProcessWalletTransactions_SumsOutputsWithSameTxid(t *testing.T) {
 	events := engine.Subscribe(ctx)
 
 	const txid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{
+	engine.processWalletTransactions(ctx, "wallet-a", 200, []*corepb.GetTransactionResponse{
 		{Txid: txid, Amount: 1.5, Confirmations: 0},
 		{Txid: txid, Amount: 0.25, Confirmations: 0},
 	})
@@ -128,7 +128,7 @@ func TestProcessWalletTransactions_SelfSendIsNotNettedToZero(t *testing.T) {
 	events := engine.Subscribe(ctx)
 
 	const txid = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{
+	engine.processWalletTransactions(ctx, "wallet-a", 200, []*corepb.GetTransactionResponse{
 		{Txid: txid, Amount: -1.0, Confirmations: 0},
 		{Txid: txid, Amount: 1.0, Confirmations: 0},
 	})
@@ -141,4 +141,47 @@ func TestProcessWalletTransactions_SelfSendIsNotNettedToZero(t *testing.T) {
 	default:
 		t.Fatal("expected a sent notification, got none")
 	}
+}
+
+// A confirmation is recorded for good, so a fork that orphans the confirming
+// block has to clear it. Otherwise the re-confirmation on the new chain is
+// swallowed as a duplicate and the wallet never hears the transaction landed.
+func TestProcessWalletTransactions_ForkReArmsConfirmation(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	// Seen in the mempool, then confirmed by the block at height 120.
+	engine.processWalletTransactions(ctx, "wallet-a", 119, []*corepb.GetTransactionResponse{
+		{Txid: txid, Amount: 1, Confirmations: 0},
+	})
+	engine.processWalletTransactions(ctx, "wallet-a", 120, []*corepb.GetTransactionResponse{
+		{Txid: txid, Amount: 1, Confirmations: 1},
+	})
+
+	parser := &Parser{db: db}
+	require.NoError(t, parser.purgeChainDerivedAtOrAbove(ctx, 110))
+
+	// The new chain confirms it again, at height 121.
+	engine.processWalletTransactions(ctx, "wallet-a", 121, []*corepb.GetTransactionResponse{
+		{Txid: txid, Amount: 1, Confirmations: 1},
+	})
+
+	seen := make(map[notificationv1.TransactionEvent_Type]int)
+	for done := false; !done; {
+		select {
+		case event := <-events:
+			seen[event.GetTransaction().GetType()]++
+		default:
+			done = true
+		}
+	}
+
+	require.Equal(t, 1, seen[notificationv1.TransactionEvent_TYPE_RECEIVED],
+		"the receive isn't tied to a block, so the fork leaves it alone")
+	require.Equal(t, 2, seen[notificationv1.TransactionEvent_TYPE_CONFIRMED],
+		"the re-confirmation after the fork is announced again")
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"connectrpc.com/connect"
 	notificationv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/notification/v1"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitassets"
@@ -70,6 +71,10 @@ type PendingFastWithdrawal struct {
 	ServerURL      string    `json:"server_url"`      // Fast withdrawal server URL
 	CreatedAt      time.Time `json:"created_at"`
 }
+
+// MaxFastWithdrawalSats is the total bitcoin supply in sats. Any expected
+// amount above it comes from a bogus or hostile server response.
+const MaxFastWithdrawalSats = 21_000_000 * 100_000_000
 
 // NewSidechainMonitorEngine creates a new sidechain monitoring engine
 func NewSidechainMonitorEngine(
@@ -178,6 +183,11 @@ func (e *SidechainMonitorEngine) GetWithdrawalByTxid(ctx context.Context, txid s
 
 // RegisterPendingFastWithdrawal adds a pending fast withdrawal to monitor for
 func (e *SidechainMonitorEngine) RegisterPendingFastWithdrawal(ctx context.Context, withdrawal PendingFastWithdrawal) error {
+	if withdrawal.ExpectedAmount <= 0 || withdrawal.ExpectedAmount > MaxFastWithdrawalSats {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("expected amount out of range: %d", withdrawal.ExpectedAmount))
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -702,6 +712,14 @@ func (e *SidechainMonitorEngine) findTransactionToAddressViaUTXOs(
 ) string {
 	log := zerolog.Ctx(ctx)
 
+	// A non-positive expectation can never be satisfied by a payment.
+	if expectedAmount <= 0 {
+		return ""
+	}
+
+	// Allow 5% tolerance for fees, computed without overflowing int64.
+	minAmount := expectedAmount - expectedAmount/20
+
 	// Get all UTXOs to check for transactions to our target address
 	utxosRaw, err := getUTXOs()
 	if err != nil {
@@ -728,7 +746,7 @@ func (e *SidechainMonitorEngine) findTransactionToAddressViaUTXOs(
 			// Check amount (UTXOs typically store in sats)
 			if amountFloat, ok := utxo["amount"].(float64); ok {
 				amount := int64(amountFloat)
-				if amount >= expectedAmount*95/100 { // Allow 5% tolerance for fees
+				if amount >= minAmount {
 					// Found matching transaction, extract txid
 					if txid, ok := utxo["txid"].(string); ok {
 						log.Info().

--- a/bitwindow/server/engines/sidechain_monitor_engine_test.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine_test.go
@@ -3,11 +3,13 @@ package engines
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	notificationv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/notification/v1"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -53,6 +55,69 @@ func TestSidechainMonitorEngine_RegisterPendingFastWithdrawal(t *testing.T) {
 	assert.Equal(t, "test-hash-123456789abcdef", pending[0].Hash)
 	assert.Equal(t, "thunder", pending[0].Sidechain)
 	assert.Equal(t, "thunder1test456", pending[0].ServerAddress)
+}
+
+func TestSidechainMonitorEngine_RegisterPendingFastWithdrawal_RejectsBadAmount(t *testing.T) {
+	ctx := context.Background()
+
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	for _, amount := range []int64{0, -1, MaxFastWithdrawalSats + 1, math.MaxInt64} {
+		err := engine.RegisterPendingFastWithdrawal(ctx, PendingFastWithdrawal{
+			Hash:           "test-hash-123456789abcdef",
+			Sidechain:      "thunder",
+			ServerAddress:  "thunder1test456",
+			ExpectedAmount: amount,
+			ServerURL:      "https://fw1.drivechain.info",
+			CreatedAt:      time.Now(),
+		})
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	}
+
+	pending, err := engine.GetPendingFastWithdrawals(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+func TestSidechainMonitorEngine_FindTransactionToAddressViaUTXOs_Tolerance(t *testing.T) {
+	ctx := zerolog.New(zerolog.NewTestWriter(t)).WithContext(context.Background())
+
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	utxosOf := func(amount int64) func() (json.RawMessage, error) {
+		return func() (json.RawMessage, error) {
+			return json.Marshal([]map[string]interface{}{{
+				"address": "thunder1test456",
+				"amount":  amount,
+				"txid":    "utxo-txid-123456789abcdef",
+			}})
+		}
+	}
+
+	// An expected amount whose *95 wraps int64 must not match a 1 sat UTXO.
+	txid := engine.findTransactionToAddressViaUTXOs(
+		ctx, utxosOf(1), "thunder1test456", math.MaxInt64/50, "Thunder",
+	)
+	assert.Empty(t, txid)
+
+	// A non-positive expectation never matches.
+	txid = engine.findTransactionToAddressViaUTXOs(
+		ctx, utxosOf(100_000), "thunder1test456", 0, "Thunder",
+	)
+	assert.Empty(t, txid)
+
+	// Control: 96% of the expected amount is still inside the 5% tolerance.
+	txid = engine.findTransactionToAddressViaUTXOs(
+		ctx, utxosOf(96_000), "thunder1test456", 100_000, "Thunder",
+	)
+	assert.Equal(t, "utxo-txid-123456789abcdef", txid)
 }
 
 func TestSidechainMonitorEngine_CompleteWithdrawal(t *testing.T) {

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -378,6 +378,13 @@ func (e *WalletEngine) GetActiveWallet(ctx context.Context) (*WalletInfo, error)
 		}
 		activeWalletId = e.activeWalletId
 		e.mu.RUnlock()
+
+		// The orchestrator owns the active wallet, and a SwitchWallet there
+		// never reaches the id cached at unlock — an encrypted wallet.json
+		// can't be re-read. Ask it, and keep the cached id if it can't answer.
+		if id := e.orchestratorActiveWalletId(ctx); id != "" {
+			activeWalletId = id
+		}
 	} else {
 		// For unencrypted wallets, read directly from wallet.json
 		walletData, err := wallet.LoadUnencryptedWallet(e.walletDir)
@@ -393,6 +400,23 @@ func (e *WalletEngine) GetActiveWallet(ctx context.Context) (*WalletInfo, error)
 	}
 
 	return e.GetWalletInfo(ctx, activeWalletId)
+}
+
+// orchestratorActiveWalletId asks the orchestrator which wallet is active and
+// refreshes the cached id, returning "" when it has no answer.
+func (e *WalletEngine) orchestratorActiveWalletId(ctx context.Context) string {
+	if e.orchClient == nil {
+		return ""
+	}
+	resp, err := e.orchClient.ListWallets(ctx, connect.NewRequest(&orchpb.ListWalletsRequest{}))
+	if err != nil || resp.Msg.ActiveWalletId == "" {
+		return ""
+	}
+
+	e.mu.Lock()
+	e.activeWalletId = resp.Msg.ActiveWalletId
+	e.mu.Unlock()
+	return resp.Msg.ActiveWalletId
 }
 
 // ============================================================================

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -537,15 +537,8 @@ func (e *WalletEngine) ensureBitcoinCoreWalletLocked(ctx context.Context, wallet
 		// Otherwise fall through to local fallback.
 	}
 
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	// Check cache
-	if walletName, exists := e.coreWallets[walletId]; exists {
-		return walletName, nil
-	}
-
-	// Get wallet info
+	// Get wallet info before taking the write lock — for an encrypted wallet
+	// GetWalletInfo read-locks e.mu, which self-deadlocks under a held write lock.
 	wallet, err := e.GetWalletInfo(ctx, walletId)
 	if err != nil {
 		return "", err
@@ -553,6 +546,14 @@ func (e *WalletEngine) ensureBitcoinCoreWalletLocked(ctx context.Context, wallet
 
 	if wallet.WalletType != WalletTypeBitcoinCore {
 		return "", fmt.Errorf("wallet %s is not a Bitcoin Core wallet", walletId)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Check cache
+	if walletName, exists := e.coreWallets[walletId]; exists {
+		return walletName, nil
 	}
 
 	// Generate wallet name from wallet ID
@@ -980,15 +981,8 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 		// Otherwise fall through to local on error
 	}
 
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	// Check cache
-	if walletName, exists := e.coreWallets[walletId]; exists {
-		return walletName, nil
-	}
-
-	// Get wallet info
+	// Get wallet info before taking the write lock — for an encrypted wallet
+	// GetWalletInfo read-locks e.mu, which self-deadlocks under a held write lock.
 	wallet, err := e.GetWalletInfo(ctx, walletId)
 	if err != nil {
 		return "", err
@@ -996,6 +990,14 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 
 	if !wallet.IsWatchOnly() {
 		return "", fmt.Errorf("wallet %s is not a watch-only wallet", walletId)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Check cache
+	if walletName, exists := e.coreWallets[walletId]; exists {
+		return walletName, nil
 	}
 
 	// Generate wallet name from wallet ID

--- a/bitwindow/server/engines/wallet_engine_active_test.go
+++ b/bitwindow/server/engines/wallet_engine_active_test.go
@@ -1,0 +1,118 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	activeWalletA = "aaaaaaaacafebabe"
+	activeWalletB = "bbbbbbbbcafebabe"
+	activeSeedA   = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+	activeSeedB   = "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+)
+
+// twoWalletData is the decrypted wallet.json shape: wallets A and B, A active.
+func twoWalletData() map[string]any {
+	return map[string]any{
+		"version":        float64(1),
+		"activeWalletId": activeWalletA,
+		"wallets": []any{
+			map[string]any{
+				"id":          activeWalletA,
+				"name":        "A",
+				"wallet_type": "bitcoinCore",
+				"master":      map[string]any{"seed_hex": activeSeedA},
+			},
+			map[string]any{
+				"id":          activeWalletB,
+				"name":        "B",
+				"wallet_type": "bitcoinCore",
+				"master":      map[string]any{"seed_hex": activeSeedB},
+			},
+		},
+	}
+}
+
+// unlockedTwoWalletEngine returns an engine unlocked over an encrypted install
+// holding both wallets, with A active.
+func unlockedTwoWalletEngine(t *testing.T) *WalletEngine {
+	t.Helper()
+
+	walletDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(walletDir, "wallet_encryption.json"),
+		[]byte(`{"salt": "c2FsdA==", "iterations": 1, "encrypted": true, "version": "1"}`),
+		0o600,
+	))
+
+	e := NewWalletEngine(nil, walletDir, &chaincfg.MainNetParams)
+	require.NoError(t, e.Unlock(twoWalletData()))
+	return e
+}
+
+// A switch on the orchestrator must reach an encrypted install, whose active
+// wallet id would otherwise stay frozen at the one cached during unlock.
+func TestGetActiveWalletFollowsOrchestratorSwitch(t *testing.T) {
+	e := unlockedTwoWalletEngine(t)
+
+	orch := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	orch.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[orchpb.ListWalletsResponse]{
+			Msg: &orchpb.ListWalletsResponse{ActiveWalletId: activeWalletB},
+		}, nil)
+	e.SetOrchestratorClient(orch)
+
+	active, err := e.GetActiveWallet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, activeWalletB, active.ID)
+}
+
+// An orchestrator that cannot answer leaves the id from unlock in place.
+func TestGetActiveWalletKeepsCachedIdOnOrchestratorError(t *testing.T) {
+	e := unlockedTwoWalletEngine(t)
+
+	orch := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	orch.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(nil, errors.New("connection refused"))
+	e.SetOrchestratorClient(orch)
+
+	active, err := e.GetActiveWallet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, activeWalletA, active.ID)
+}
+
+// An unencrypted install reads wallet.json, which the orchestrator rewrites on
+// every switch, so it asks no one. The mock fails the test on any call.
+func TestGetActiveWalletUnencryptedReadsWalletFile(t *testing.T) {
+	walletDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(walletDir, "wallet.json"), []byte(`{
+		"version": 1,
+		"activeWalletId": "`+activeWalletA+`",
+		"wallets": [
+			{"id": "`+activeWalletA+`", "name": "A", "wallet_type": "bitcoinCore", "master": {"seed_hex": "`+activeSeedA+`"}},
+			{"id": "`+activeWalletB+`", "name": "B", "wallet_type": "bitcoinCore", "master": {"seed_hex": "`+activeSeedB+`"}}
+		]
+	}`), 0o600))
+
+	e := NewWalletEngine(nil, walletDir, &chaincfg.MainNetParams)
+	e.SetOrchestratorClient(mocks.NewMockWalletManagerServiceClient(gomock.NewController(t)))
+
+	active, err := e.GetActiveWallet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, activeWalletA, active.ID)
+}

--- a/bitwindow/server/engines/wallet_engine_encrypted_test.go
+++ b/bitwindow/server/engines/wallet_engine_encrypted_test.go
@@ -1,0 +1,106 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// mustReturn fails the test if fn is still running after 3s.
+func mustReturn(t *testing.T, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("call did not return, engine deadlocked")
+	}
+}
+
+// An encrypted wallet resolves its info from the cache under a read lock, which
+// the ensure paths used to take while already holding the write lock.
+func TestEnsureWalletsEncryptedDoesNotDeadlock(t *testing.T) {
+	walletDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(walletDir, "wallet_encryption.json"), []byte(`{
+		"encrypted": true,
+		"salt": "c2FsdA==",
+		"iterations": 1000
+	}`), 0o600))
+
+	ctrl := gomock.NewController(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{"wallet_deadbeef", "wallet_feedface"}},
+		}, nil).
+		AnyTimes()
+	// No wallet from before the rename, so the local name applies.
+	mockBitcoind.EXPECT().
+		LoadWallet(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("Wallet file verification failed. Path does not exist.")).
+		AnyTimes()
+
+	e := NewWalletEngine(func(context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	}, walletDir, &chaincfg.MainNetParams)
+
+	require.NoError(t, e.Unlock(map[string]any{
+		"version":        1,
+		"activeWalletId": "deadbeefcafebabe",
+		"wallets": []any{
+			map[string]any{
+				"id":          "deadbeefcafebabe",
+				"name":        "spender",
+				"wallet_type": "bitcoinCore",
+				"master":      map[string]any{"seed_hex": "000102030405060708090a0b0c0d0e0f"},
+			},
+			map[string]any{
+				"id":          "feedfacedeadbeef",
+				"name":        "watcher",
+				"wallet_type": "bitcoinCore",
+				"master":      map[string]any{"seed_hex": ""},
+				"watch_only": map[string]any{
+					"xpub": "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+				},
+			},
+		},
+	}))
+
+	t.Run("bitcoin core", func(t *testing.T) {
+		var walletName string
+		var err error
+		mustReturn(t, func() {
+			walletName, err = e.EnsureBitcoinCoreWallet(context.Background(), "deadbeefcafebabe")
+		})
+		require.NoError(t, err)
+		require.Equal(t, "wallet_deadbeef", walletName)
+	})
+
+	t.Run("watch-only", func(t *testing.T) {
+		var walletName string
+		var err error
+		mustReturn(t, func() {
+			walletName, err = e.EnsureWatchOnlyWallet(context.Background(), "feedfacedeadbeef")
+		})
+		require.NoError(t, err)
+		require.Equal(t, "wallet_feedface", walletName)
+	})
+}

--- a/bitwindow/server/models/bitdrive/bitdrive.go
+++ b/bitwindow/server/models/bitdrive/bitdrive.go
@@ -183,6 +183,20 @@ func Delete(ctx context.Context, db *sql.DB, id int64) error {
 	return nil
 }
 
+func DeleteAll(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
+		DELETE FROM bitdrive_files
+	`)
+	if err != nil {
+		return fmt.Errorf("delete all bitdrive files: %w", err)
+	}
+
+	zerolog.Ctx(ctx).Info().
+		Msg("deleted all bitdrive file records")
+
+	return nil
+}
+
 func Exists(ctx context.Context, db *sql.DB, txid string) (bool, error) {
 	var count int
 	err := db.QueryRowContext(ctx, `

--- a/bitwindow/server/models/deniability/deniability.go
+++ b/bitwindow/server/models/deniability/deniability.go
@@ -27,6 +27,8 @@ type Denial struct {
 	CancelledAt     *time.Time
 	CancelReason    *string
 	PausedAt        *time.Time
+	FailedAttempts  int32
+	RetryAfter      *time.Time
 	NextExecution   *time.Time
 	ExecutedDenials []ExecutedDenial
 }
@@ -94,7 +96,64 @@ func RecordExecution(ctx context.Context, db *sql.DB, denialID int64, fromTxID s
 			created_at
 		) VALUES (?, ?, ?, ?, ?, ?)
 	`, denialID, fromTxID, fromVout, toTxID, toVout, time.Now())
+	if err != nil {
+		return err
+	}
+
+	// A hop landed, so whatever failure streak preceded it is over.
+	_, err = db.ExecContext(ctx, `
+		UPDATE denials
+			SET failed_attempts = 0,
+			retry_after = NULL
+		WHERE id = ?
+	`, denialID)
 	return err
+}
+
+// Backoff bounds for a denial whose execution keeps failing.
+const (
+	minRetryBackoff = time.Minute
+	maxRetryBackoff = time.Hour
+)
+
+// RecordFailure counts one failed execution and pushes the next attempt out.
+// Without it a persistent send error re-issues the same transaction on every
+// engine tick. Returns the new consecutive failure count.
+func RecordFailure(ctx context.Context, db *sql.DB, denial Denial) (int32, error) {
+	attempts := denial.FailedAttempts + 1
+
+	rows, err := db.ExecContext(ctx, `
+		UPDATE denials
+			SET failed_attempts = ?,
+			retry_after = ?
+		WHERE id = ?
+	`, attempts, time.Now().Add(retryBackoff(denial.DelayDuration, attempts)), denial.ID)
+	if err != nil {
+		return 0, fmt.Errorf("could not record denial failure: %w", err)
+	}
+
+	if rows, _ := rows.RowsAffected(); rows == 0 {
+		return 0, connect.NewError(connect.CodeNotFound, fmt.Errorf("denial not found"))
+	}
+
+	return attempts, nil
+}
+
+// retryBackoff waits the denial's own hop delay after the first failure and
+// doubles from there, clamped to between a minute and an hour.
+func retryBackoff(delay time.Duration, attempts int32) time.Duration {
+	backoff := delay
+	for i := int32(1); i < attempts && backoff > 0 && backoff < maxRetryBackoff; i++ {
+		backoff *= 2
+	}
+
+	if backoff < minRetryBackoff {
+		return minRetryBackoff
+	}
+	if backoff > maxRetryBackoff {
+		return maxRetryBackoff
+	}
+	return backoff
 }
 
 // selectDenialQuery returns the common SELECT part of denial queries
@@ -111,6 +170,8 @@ func selectDenialQuery() string {
 			d.cancelled_at,
 			d.cancelled_reason,
 			d.paused_at,
+			d.failed_attempts,
+			d.retry_after,
 			COALESCE(e.to_txid, d.initial_txid) as tip_txid,
 			COALESCE(e.to_vout, d.initial_vout) as tip_vout
 		FROM denials d
@@ -196,6 +257,8 @@ func List(ctx context.Context, db *sql.DB, opts ...Option) ([]Denial, error) {
 			&denial.CancelledAt,
 			&denial.CancelReason,
 			&denial.PausedAt,
+			&denial.FailedAttempts,
+			&denial.RetryAfter,
 			&denial.TipTXID,
 			&denial.TipVout,
 		)
@@ -397,6 +460,8 @@ func GetByTip(ctx context.Context, db *sql.DB, tipTxID string, tipVout *int32) (
 		&denial.CancelledAt,
 		&denial.CancelReason,
 		&denial.PausedAt,
+		&denial.FailedAttempts,
+		&denial.RetryAfter,
 		&denial.TipTXID,
 		&denial.TipVout,
 	)
@@ -423,7 +488,7 @@ func GetByTip(ctx context.Context, db *sql.DB, tipTxID string, tipVout *int32) (
 func Update(ctx context.Context, db *sql.DB, id int64, delay time.Duration, numHops int32, txid string, vout int32) error {
 	_, err := db.ExecContext(ctx, `
 		UPDATE denials
-		SET delay_duration = ?, num_hops = num_hops + ?, initial_txid = ?, initial_vout = ?, cancelled_at = NULL, cancelled_reason = NULL, updated_at = ?
+		SET delay_duration = ?, num_hops = num_hops + ?, initial_txid = ?, initial_vout = ?, cancelled_at = NULL, cancelled_reason = NULL, failed_attempts = 0, retry_after = NULL, updated_at = ?
 		WHERE id = ?
 	`, delay, numHops, txid, vout, time.Now(), id)
 	if err != nil {
@@ -451,6 +516,8 @@ func Get(ctx context.Context, db *sql.DB, id int64) (Denial, error) {
 		&denial.CancelledAt,
 		&denial.CancelReason,
 		&denial.PausedAt,
+		&denial.FailedAttempts,
+		&denial.RetryAfter,
 		&denial.TipTXID,
 		&denial.TipVout,
 	)

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -685,7 +685,11 @@ func (s *Store) ListSoloKeys(ctx context.Context) ([]SoloKey, error) {
 }
 
 func (s *Store) AddSoloKey(ctx context.Context, k SoloKey) error {
-	_, err := s.db.ExecContext(ctx, `
+	return addSoloKeyOn(ctx, s.db, k)
+}
+
+func addSoloKeyOn(ctx context.Context, e execer, k SoloKey) error {
+	_, err := e.ExecContext(ctx, `
 		INSERT OR IGNORE INTO multisig_solo_keys (xpub, derivation_path, fingerprint, origin_path, owner)
 		VALUES (?, ?, ?, ?, ?)`, k.Xpub, k.DerivationPath, nullStr(k.Fingerprint), nullStr(k.OriginPath), nullStr(k.Owner))
 	return err
@@ -850,10 +854,61 @@ func (s *Store) SaveTransactionAtomic(ctx context.Context, p SaveTransactionAtom
 	return tx.Commit()
 }
 
+// ─── Backup restore ────────────────────────────────────────────────
+
+// Every multisig table, children before parents.
+var multisigTables = []string{
+	"multisig_tx_inputs",
+	"multisig_tx_key_psbts",
+	"multisig_transactions",
+	"multisig_group_transactions",
+	"multisig_utxo_details",
+	"multisig_addresses",
+	"multisig_key_psbts",
+	"multisig_keys",
+	"multisig_groups",
+	"multisig_solo_keys",
+}
+
+// ReplaceFromBackup makes the backup's data the only multisig data in the DB,
+// so no row of the wallet being replaced survives under a colliding group id.
+// Clearing and importing share one transaction, so a failed import changes nothing.
+func (s *Store) ReplaceFromBackup(ctx context.Context, multisigJSON, txJSON []byte) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for _, table := range multisigTables {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM `+table); err != nil {
+			return fmt.Errorf("clear %s: %w", table, err)
+		}
+	}
+
+	if multisigJSON != nil {
+		if err := importFromJSONOn(ctx, tx, multisigJSON); err != nil {
+			return err
+		}
+	}
+
+	if txJSON != nil {
+		if err := importTransactionsFromJSONOn(ctx, tx, txJSON); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
 // ─── Migration helper ──────────────────────────────────────────────
 
 // ImportFromJSON imports groups + solo_keys from the old multisig.json format.
 func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
+	return importFromJSONOn(ctx, s.db, data)
+}
+
+func importFromJSONOn(ctx context.Context, e execer, data []byte) error {
 	var raw struct {
 		Groups   []json.RawMessage        `json:"groups"`
 		SoloKeys []map[string]interface{} `json:"solo_keys"`
@@ -888,7 +943,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 			continue
 		}
 
-		if err := s.SaveGroup(ctx, g); err != nil {
+		if err := saveGroupOn(ctx, e, g); err != nil {
 			return fmt.Errorf("save group %s: %w", g.ID, err)
 		}
 
@@ -911,7 +966,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 					SortOrder:      i,
 				})
 			}
-			if err := s.ReplaceKeysForGroup(ctx, g.ID, keys); err != nil {
+			if err := replaceKeysForGroupOn(ctx, e, g.ID, keys); err != nil {
 				return fmt.Errorf("replace keys for %s: %w", g.ID, err)
 			}
 		}
@@ -937,7 +992,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 				}
 			}
 			if len(addrs) > 0 {
-				if err := s.ReplaceAddresses(ctx, g.ID, addrs); err != nil {
+				if err := replaceAddressesOn(ctx, e, g.ID, addrs); err != nil {
 					return fmt.Errorf("replace addresses for %s: %w", g.ID, err)
 				}
 			}
@@ -952,7 +1007,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 				}
 			}
 			if len(ids) > 0 {
-				if err := s.ReplaceGroupTransactionIDs(ctx, g.ID, ids); err != nil {
+				if err := replaceGroupTransactionIDsOn(ctx, e, g.ID, ids); err != nil {
 					return fmt.Errorf("replace tx ids for %s: %w", g.ID, err)
 				}
 			}
@@ -961,7 +1016,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 
 	// Import solo keys
 	for _, sk := range raw.SoloKeys {
-		if err := s.AddSoloKey(ctx, SoloKey{
+		if err := addSoloKeyOn(ctx, e, SoloKey{
 			Xpub:           getString(sk, "xpub"),
 			DerivationPath: getString(sk, "path"),
 			Fingerprint:    getString(sk, "fingerprint"),
@@ -977,6 +1032,10 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 
 // ImportTransactionsFromJSON imports transactions from the old transactions.json format.
 func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) error {
+	return importTransactionsFromJSONOn(ctx, s.db, data)
+}
+
+func importTransactionsFromJSONOn(ctx context.Context, e execer, data []byte) error {
 	var txns []map[string]interface{}
 	if err := json.Unmarshal(data, &txns); err != nil {
 		return fmt.Errorf("unmarshal: %w", err)
@@ -1049,7 +1108,7 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 			continue
 		}
 
-		if err := s.SaveTransaction(ctx, t); err != nil {
+		if err := saveTransactionOn(ctx, e, t); err != nil {
 			return fmt.Errorf("save tx %s: %w", t.ID, err)
 		}
 
@@ -1077,7 +1136,7 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 				})
 			}
 			if len(psbts) > 0 {
-				if err := s.ReplaceTxKeyPSBTs(ctx, t.ID, psbts); err != nil {
+				if err := replaceTxKeyPSBTsOn(ctx, e, t.ID, psbts); err != nil {
 					return fmt.Errorf("replace key psbts for tx %s: %w", t.ID, err)
 				}
 			}
@@ -1101,7 +1160,7 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 				})
 			}
 			if len(txInputs) > 0 {
-				if err := s.ReplaceTxInputs(ctx, t.ID, txInputs); err != nil {
+				if err := replaceTxInputsOn(ctx, e, t.ID, txInputs); err != nil {
 					return fmt.Errorf("replace inputs for tx %s: %w", t.ID, err)
 				}
 			}

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -10,7 +10,10 @@ import (
 
 // Group represents a multisig group stored in the DB.
 type Group struct {
-	ID                string
+	ID string
+	// WalletID is the wallet that created the group. Empty on groups saved
+	// before wallet scoping existed, which stay visible to every wallet.
+	WalletID          string
 	Name              string
 	N                 int
 	M                 int
@@ -127,12 +130,23 @@ type execer interface {
 
 // ─── Groups ────────────────────────────────────────────────────────
 
+// ListGroups returns every group, regardless of which wallet owns it.
 func (s *Store) ListGroups(ctx context.Context) ([]Group, error) {
+	return s.listGroups(ctx, "", nil)
+}
+
+// ListGroupsForWallet returns the groups walletID may see: its own, plus the
+// legacy groups that carry no wallet stamp.
+func (s *Store) ListGroupsForWallet(ctx context.Context, walletID string) ([]Group, error) {
+	return s.listGroups(ctx, `WHERE wallet_id IS NULL OR wallet_id = ?`, []interface{}{walletID})
+}
+
+func (s *Store) listGroups(ctx context.Context, where string, args []interface{}) ([]Group, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, name, n, m, created, COALESCE(txid,''), COALESCE(descriptor,''),
+		SELECT id, COALESCE(wallet_id,''), name, n, m, created, COALESCE(txid,''), COALESCE(descriptor,''),
 		       COALESCE(descriptor_receive,''), COALESCE(descriptor_change,''),
 		       COALESCE(watch_wallet_name,''), balance, utxos, next_receive_index, next_change_index
-		FROM multisig_groups ORDER BY created ASC`)
+		FROM multisig_groups `+where+` ORDER BY created ASC`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list groups: %w", err)
 	}
@@ -141,7 +155,7 @@ func (s *Store) ListGroups(ctx context.Context) ([]Group, error) {
 	var groups []Group
 	for rows.Next() {
 		var g Group
-		if err := rows.Scan(&g.ID, &g.Name, &g.N, &g.M, &g.Created,
+		if err := rows.Scan(&g.ID, &g.WalletID, &g.Name, &g.N, &g.M, &g.Created,
 			&g.Txid, &g.Descriptor, &g.DescriptorReceive, &g.DescriptorChange,
 			&g.WatchWalletName, &g.Balance, &g.Utxos, &g.NextReceiveIndex, &g.NextChangeIndex); err != nil {
 			return nil, fmt.Errorf("scan group: %w", err)
@@ -151,22 +165,39 @@ func (s *Store) ListGroups(ctx context.Context) ([]Group, error) {
 	return groups, rows.Err()
 }
 
+// GroupVisibleTo reports whether walletID may read or write the group. A group
+// with no wallet stamp is visible to every wallet, and so is one that does not
+// exist yet — the caller is about to create it.
+func (s *Store) GroupVisibleTo(ctx context.Context, groupID, walletID string) (bool, error) {
+	var owner sql.NullString
+	err := s.db.QueryRowContext(ctx, `SELECT wallet_id FROM multisig_groups WHERE id = ?`, groupID).Scan(&owner)
+	if err == sql.ErrNoRows {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !owner.Valid || owner.String == walletID, nil
+}
+
 func (s *Store) SaveGroup(ctx context.Context, g Group) error {
 	return saveGroupOn(ctx, s.db, g)
 }
 
 func saveGroupOn(ctx context.Context, e execer, g Group) error {
+	// wallet_id is stamped on insert only: a legacy group stays unstamped, and an
+	// owned one keeps its owner, whichever wallet is active on a later save.
 	_, err := e.ExecContext(ctx, `
-		INSERT INTO multisig_groups (id, name, n, m, created, txid, descriptor, descriptor_receive,
+		INSERT INTO multisig_groups (id, wallet_id, name, n, m, created, txid, descriptor, descriptor_receive,
 		    descriptor_change, watch_wallet_name, balance, utxos, next_receive_index, next_change_index)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 		    name=excluded.name, n=excluded.n, m=excluded.m, created=excluded.created,
 		    txid=excluded.txid, descriptor=excluded.descriptor,
 		    descriptor_receive=excluded.descriptor_receive, descriptor_change=excluded.descriptor_change,
 		    watch_wallet_name=excluded.watch_wallet_name, balance=excluded.balance, utxos=excluded.utxos,
 		    next_receive_index=excluded.next_receive_index, next_change_index=excluded.next_change_index`,
-		g.ID, g.Name, g.N, g.M, g.Created, nullStr(g.Txid), nullStr(g.Descriptor),
+		g.ID, nullStr(g.WalletID), g.Name, g.N, g.M, g.Created, nullStr(g.Txid), nullStr(g.Descriptor),
 		nullStr(g.DescriptorReceive), nullStr(g.DescriptorChange), nullStr(g.WatchWalletName),
 		g.Balance, g.Utxos, g.NextReceiveIndex, g.NextChangeIndex)
 	return err
@@ -430,19 +461,26 @@ func replaceGroupTransactionIDsOn(ctx context.Context, e execer, groupID string,
 // ─── Transactions ──────────────────────────────────────────────────
 
 func (s *Store) ListTransactions(ctx context.Context, groupID string) ([]Transaction, error) {
-	query := `
-		SELECT id, group_id, initial_psbt, COALESCE(combined_psbt,''), COALESCE(final_hex,''),
-		       COALESCE(txid,''), status, type, created, broadcast_time, amount, destination, fee,
-		       confirmations, required_signatures
-		FROM multisig_transactions`
-	var args []interface{}
-	if groupID != "" {
-		query += ` WHERE group_id = ?`
-		args = append(args, groupID)
+	if groupID == "" {
+		return s.listTransactions(ctx, "", nil)
 	}
-	query += ` ORDER BY created ASC`
+	return s.listTransactions(ctx, `WHERE t.group_id = ?`, []interface{}{groupID})
+}
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+// ListTransactionsForWallet returns the transactions of every group walletID
+// may see: its own, plus the legacy groups that carry no wallet stamp.
+func (s *Store) ListTransactionsForWallet(ctx context.Context, walletID string) ([]Transaction, error) {
+	return s.listTransactions(ctx, `
+		JOIN multisig_groups g ON g.id = t.group_id
+		WHERE g.wallet_id IS NULL OR g.wallet_id = ?`, []interface{}{walletID})
+}
+
+func (s *Store) listTransactions(ctx context.Context, clause string, args []interface{}) ([]Transaction, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT t.id, t.group_id, t.initial_psbt, COALESCE(t.combined_psbt,''), COALESCE(t.final_hex,''),
+		       COALESCE(t.txid,''), t.status, t.type, t.created, t.broadcast_time, t.amount, t.destination,
+		       t.fee, t.confirmations, t.required_signatures
+		FROM multisig_transactions t `+clause+` ORDER BY t.created ASC`, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/bitwindow/server/models/multisig/multisig_test.go
+++ b/bitwindow/server/models/multisig/multisig_test.go
@@ -17,10 +17,11 @@ func setupTestDB(t *testing.T) *sql.DB {
 	db, err := sql.Open("sqlite3", ":memory:?_foreign_keys=on")
 	require.NoError(t, err)
 
-	// Replicate the schema from migrations 031 + 032.
+	// Replicate the schema from migrations 031 + 032 + 047.
 	for _, ddl := range []string{
 		`CREATE TABLE multisig_groups (
 			id TEXT PRIMARY KEY,
+			wallet_id TEXT,
 			name TEXT NOT NULL,
 			n INTEGER NOT NULL,
 			m INTEGER NOT NULL,
@@ -177,6 +178,118 @@ func TestSaveGroupUpsert(t *testing.T) {
 	require.Len(t, groups, 1)
 	assert.Equal(t, "Updated Name", groups[0].Name)
 	assert.Equal(t, 1.5, groups[0].Balance)
+}
+
+func TestListGroupsForWallet(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	legacy := sampleGroup()
+	require.NoError(t, store.SaveGroup(ctx, legacy))
+
+	a := sampleGroup()
+	a.ID, a.WalletID = "grp-a", "wallet-a"
+	require.NoError(t, store.SaveGroup(ctx, a))
+
+	b := sampleGroup()
+	b.ID, b.WalletID = "grp-b", "wallet-b"
+	require.NoError(t, store.SaveGroup(ctx, b))
+
+	groups, err := store.ListGroupsForWallet(ctx, "wallet-a")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{legacy.ID, "grp-a"}, groupIDs(groups))
+
+	groups, err = store.ListGroupsForWallet(ctx, "wallet-b")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{legacy.ID, "grp-b"}, groupIDs(groups))
+
+	// ListGroups stays global — the backup export takes every group.
+	all, err := store.ListGroups(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+func TestSaveGroupKeepsOwningWallet(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	g := sampleGroup()
+	g.WalletID = "wallet-a"
+	require.NoError(t, store.SaveGroup(ctx, g))
+
+	// A save under another wallet updates the group, but not its owner.
+	g.WalletID = "wallet-b"
+	g.Name = "Updated Name"
+	require.NoError(t, store.SaveGroup(ctx, g))
+
+	groups, err := store.ListGroupsForWallet(ctx, "wallet-a")
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "Updated Name", groups[0].Name)
+	assert.Equal(t, "wallet-a", groups[0].WalletID)
+
+	groups, err = store.ListGroupsForWallet(ctx, "wallet-b")
+	require.NoError(t, err)
+	assert.Empty(t, groups)
+}
+
+func TestGroupVisibleTo(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	legacy := sampleGroup()
+	require.NoError(t, store.SaveGroup(ctx, legacy))
+
+	owned := sampleGroup()
+	owned.ID, owned.WalletID = "grp-a", "wallet-a"
+	require.NoError(t, store.SaveGroup(ctx, owned))
+
+	for _, tc := range []struct {
+		groupID string
+		visible bool
+	}{
+		{legacy.ID, true},  // no owner: visible to every wallet
+		{"grp-a", false},   // owned by wallet-a
+		{"grp-gone", true}, // unknown: wallet-b is about to create it
+	} {
+		visible, err := store.GroupVisibleTo(ctx, tc.groupID, "wallet-b")
+		require.NoError(t, err)
+		assert.Equal(t, tc.visible, visible, tc.groupID)
+	}
+}
+
+func TestListTransactionsForWallet(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	a := sampleGroup()
+	a.ID, a.WalletID = "grp-a", "wallet-a"
+	require.NoError(t, store.SaveGroup(ctx, a))
+
+	b := sampleGroup()
+	b.ID, b.WalletID = "grp-b", "wallet-b"
+	require.NoError(t, store.SaveGroup(ctx, b))
+
+	require.NoError(t, store.SaveTransaction(ctx, multisig.Transaction{ID: "tx-a", GroupID: "grp-a", Created: 1700000500}))
+	require.NoError(t, store.SaveTransaction(ctx, multisig.Transaction{ID: "tx-b", GroupID: "grp-b", Created: 1700000600}))
+
+	txns, err := store.ListTransactionsForWallet(ctx, "wallet-a")
+	require.NoError(t, err)
+	require.Len(t, txns, 1)
+	assert.Equal(t, "tx-a", txns[0].ID)
+
+	// ListTransactions stays global — the backup export takes every one.
+	all, err := store.ListTransactions(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+}
+
+func groupIDs(groups []multisig.Group) []string {
+	ids := make([]string, 0, len(groups))
+	for _, g := range groups {
+		ids = append(ids, g.ID)
+	}
+	return ids
 }
 
 func TestDeleteGroupCascades(t *testing.T) {

--- a/bitwindow/server/models/notifications/notifications.go
+++ b/bitwindow/server/models/notifications/notifications.go
@@ -36,10 +36,17 @@ func HasBeenNotified(ctx context.Context, db *sql.DB, eventType, eventID string)
 
 // MarkNotified marks an event as notified
 func MarkNotified(ctx context.Context, db *sql.DB, eventType, eventID string) error {
+	return MarkNotifiedAt(ctx, db, eventType, eventID, nil)
+}
+
+// MarkNotifiedAt marks an event as notified by the block at `height`. A fork
+// that orphans that block drops the row, so the event is announced again once
+// the new chain confirms it.
+func MarkNotifiedAt(ctx context.Context, db *sql.DB, eventType, eventID string, height *int64) error {
 	query, args := sq.
 		Insert("notified_events").
-		Columns("event_type", "event_id", "notified_at").
-		Values(eventType, eventID, time.Now().UTC().Format(time.RFC3339)).
+		Columns("event_type", "event_id", "notified_at", "height").
+		Values(eventType, eventID, time.Now().UTC().Format(time.RFC3339), height).
 		MustSql()
 
 	_, err := db.ExecContext(ctx, query, args...)


### PR DESCRIPTION
A set of **12 independent fixes** to the BitWindow server engines & database, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`33 files changed, 1676 insertions(+), 104 deletions(-)`).

## Fixes (oldest first)

- **`79d1a474c`** BitWindow WalletEngine EnsureBitcoinCoreWallet / EnsureWatchOnlyWallet self-deadlock for encrypted wallets
- **`6358515a2`** BitWindow BackupEngine zips encrypted `wallet.json` but NEVER backs up / restores `wallet_encryption.json` → permanent correct-password lockout after restore to a clean dir
- **`ba8143644`** BitWindow RestoreBackup never truncates the multisig tables before import, so a pre-existing wallet's surviving multisig_transactions rows are cross-attributed to a restored wallet under any colliding 24-bit group_id, because ListTransactions filters only by group_id with no wallet scoping
- **`f09259f85`** BitWindow's NotificationEngine permanently records emitted transaction/timestamp confirmation events in notified_events with no reorg-invalidation hook, so after a reorg orphans the confirming block and a later block re-confirms, the engine never re-emits the confirmation to subscribers
- **`b9922c282`** BitDrive WipeData deletes files but leaves bitdrive_files rows
- **`06377a1be`** BitWindow M4 engine never revives a failed/expired withdrawal bundle on M3 re-proposal
- **`7a84ae444`** BitWindow WalletEngine caches encrypted active wallet ID across SwitchWallet
- **`466aa01b7`** BitWindow `api/multisig.Server` Connect RPCs carry NO wallet context — cross-wallet list / read / mutate / delete of signed multisig txs, group descriptors, and signing xpubs on shared BitWindow server
- **`79815123d`** BitWindow DeniabilityEngine Core-path fee asymmetry infinite-retry stall
- **`d16ef7a71`** BitWindow `file_timestamps` marked `StatusConfirmed` on ZMQ mempool-tx observation (pre-block)
- **`0f71779b2`** BitWindow sidechain monitor `findTransactionToAddressViaUTXOs` 5% tolerance int64 overflow bypass
- **`eb47a739c`** BitWindow backup restore silently skips unreadable multisig ZIP entry

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.