### PR TITLE
BitWindow server engines & database (2 of 3): 10 fixes from a security review

### DIFF
--- a/bitwindow/server/api/bitdrive/bitdrive.go
+++ b/bitwindow/server/api/bitdrive/bitdrive.go
@@ -132,17 +132,25 @@ func (s *Server) RetrieveContent(ctx context.Context, req *connect.Request[bitdr
 	}), nil
 }
 
-// ScanForFiles implements bitdrivev1connect.BitDriveServiceHandler.
-func (s *Server) ScanForFiles(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[bitdrivev1.ScanForFilesResponse], error) {
+// pendingFile is a BitDrive OP_RETURN output with no local copy yet.
+type pendingFile struct {
+	opReturn opreturns.OPReturn
+	metadata *engines.ParsedMetadata
+}
+
+// scanPending returns the not-yet-downloaded BitDrive OP_RETURN outputs, along
+// with the total number of BitDrive outputs seen. A transaction can carry one
+// payload per output, so entries are keyed on the outpoint, not the txid.
+func (s *Server) scanPending(ctx context.Context) ([]pendingFile, int, error) {
 	log := zerolog.Ctx(ctx)
 
 	// Get all OP_RETURNs
 	allOpReturns, err := opreturns.List(ctx, s.database, 0)
 	if err != nil {
-		return nil, fmt.Errorf("list OP_RETURNs: %w", err)
+		return nil, 0, fmt.Errorf("list OP_RETURNs: %w", err)
 	}
 
-	var pendingFiles []*bitdrivev1.PendingFile
+	var pending []pendingFile
 	totalScanned := 0
 
 	for _, opReturn := range allOpReturns {
@@ -171,23 +179,40 @@ func (s *Server) ScanForFiles(ctx context.Context, req *connect.Request[emptypb.
 		}
 
 		// Check if already downloaded
-		exists, err := bitdrive.Exists(ctx, s.database, opReturn.TxID)
+		exists, err := bitdrive.Exists(ctx, s.database, opReturn.TxID, opReturn.Vout)
 		if err != nil {
-			log.Warn().Err(err).Str("txid", opReturn.TxID).Msg("error checking if file exists")
+			log.Warn().Err(err).Str("txid", opReturn.TxID).Int32("vout", opReturn.Vout).
+				Msg("error checking if file exists")
 			continue
 		}
 		if exists {
 			continue
 		}
 
-		pendingFiles = append(pendingFiles, &bitdrivev1.PendingFile{
-			Txid:      opReturn.TxID,
-			Encrypted: metadata.Encrypted,
-			Timestamp: metadata.Timestamp,
-			FileType:  metadata.FileType,
-			Filename:  fmt.Sprintf("%d_%s.%s", metadata.Timestamp, opReturn.TxID, metadata.FileType),
-		})
+		pending = append(pending, pendingFile{opReturn: opReturn, metadata: metadata})
 	}
+
+	return pending, totalScanned, nil
+}
+
+// ScanForFiles implements bitdrivev1connect.BitDriveServiceHandler.
+func (s *Server) ScanForFiles(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[bitdrivev1.ScanForFilesResponse], error) {
+	log := zerolog.Ctx(ctx)
+
+	pending, totalScanned, err := s.scanPending(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pendingFiles := lo.Map(pending, func(p pendingFile, _ int) *bitdrivev1.PendingFile {
+		return &bitdrivev1.PendingFile{
+			Txid:      p.opReturn.TxID,
+			Encrypted: p.metadata.Encrypted,
+			Timestamp: p.metadata.Timestamp,
+			FileType:  p.metadata.FileType,
+			Filename:  fmt.Sprintf("%d_%s_%d.%s", p.metadata.Timestamp, p.opReturn.TxID, p.opReturn.Vout, p.metadata.FileType),
+		}
+	})
 
 	log.Info().
 		Int("pending", len(pendingFiles)).
@@ -205,45 +230,27 @@ func (s *Server) DownloadPendingFiles(ctx context.Context, req *connect.Request[
 	log := zerolog.Ctx(ctx)
 
 	// First scan for pending files
-	scanResp, err := s.ScanForFiles(ctx, connect.NewRequest(&emptypb.Empty{}))
+	pending, _, err := s.scanPending(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("scan for files: %w", err)
 	}
 
 	var downloadedCount, failedCount uint32
 
-	// Get all OP_RETURNs
-	allOpReturns, err := opreturns.List(ctx, s.database, 0)
-	if err != nil {
-		return nil, fmt.Errorf("list OP_RETURNs: %w", err)
-	}
-
-	for _, pending := range scanResp.Msg.PendingFiles {
-		// Find matching OP_RETURN
-		var opReturn *opreturns.OPReturn
-		for _, op := range allOpReturns {
-			if op.TxID == pending.Txid {
-				opReturn = &op
-				break
-			}
-		}
-
-		if opReturn == nil {
-			failedCount++
-			continue
-		}
-
-		opReturnMessage := opreturns.OPReturnToReadable(opReturn.Data)
+	for _, p := range pending {
+		opReturnMessage := opreturns.OPReturnToReadable(p.opReturn.Data)
 		content, metadata, err := s.bitdriveEngine.DecodeOPReturnData(ctx, opReturnMessage)
 		if err != nil {
-			log.Warn().Err(err).Str("txid", pending.Txid).Msg("failed to decode content")
+			log.Warn().Err(err).Str("txid", p.opReturn.TxID).Int32("vout", p.opReturn.Vout).
+				Msg("failed to decode content")
 			failedCount++
 			continue
 		}
 
 		// Save file
-		if err := s.bitdriveEngine.SaveFile(ctx, pending.Txid, content, metadata); err != nil {
-			log.Warn().Err(err).Str("txid", pending.Txid).Msg("failed to save file")
+		if err := s.bitdriveEngine.SaveFile(ctx, p.opReturn.TxID, p.opReturn.Vout, content, metadata); err != nil {
+			log.Warn().Err(err).Str("txid", p.opReturn.TxID).Int32("vout", p.opReturn.Vout).
+				Msg("failed to save file")
 			failedCount++
 			continue
 		}

--- a/bitwindow/server/api/bitdrive/bitdrive_test.go
+++ b/bitwindow/server/api/bitdrive/bitdrive_test.go
@@ -1,0 +1,62 @@
+package api_bitdrive
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// A transaction can carry one BitDrive payload per output. Keying downloads on
+// the txid alone made every payload after the first look already-downloaded, so
+// it never reached disk.
+func TestDownloadPendingFiles_TwoPayloadsInOneTransaction(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	const (
+		txid      = "aabbcc"
+		timestamp = uint32(1700000000)
+	)
+	metadataB64 := engines.EncodeMetadata(false, false, timestamp, "txt")
+
+	require.NoError(t, opreturns.Persist(ctx, db, []opreturns.OPReturn{
+		{TxID: txid, Vout: 0, Data: []byte(engines.FormatOPReturnData(metadataB64, "first payload"))},
+		{TxID: txid, Vout: 1, Data: []byte(engines.FormatOPReturnData(metadataB64, "second payload"))},
+	}))
+
+	// Unencrypted payloads need neither a wallet nor chain params.
+	server := &Server{
+		database:       db,
+		bitdriveEngine: engines.NewBitDriveEngine(db, nil, t.TempDir(), nil),
+	}
+
+	resp, err := server.DownloadPendingFiles(ctx, connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), resp.Msg.DownloadedCount)
+	require.Zero(t, resp.Msg.FailedCount)
+
+	files, err := bitdrive.List(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	want := map[int32]string{0: "first payload", 1: "second payload"}
+	for _, file := range files {
+		content, err := server.bitdriveEngine.GetFileContent(ctx, file.Filename)
+		require.NoError(t, err)
+		require.Equal(t, want[file.Vout], string(content))
+		delete(want, file.Vout)
+	}
+	require.Empty(t, want)
+
+	// Both payloads are downloaded now, so a second pass has nothing to do.
+	resp, err = server.DownloadPendingFiles(ctx, connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+	require.Zero(t, resp.Msg.DownloadedCount)
+}

--- a/bitwindow/server/database/migrate_atomic_test.go
+++ b/bitwindow/server/database/migrate_atomic_test.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/LayerTwo-Labs/sidesail/sqlitemigrate"
+	"github.com/stretchr/testify/require"
+)
+
+// A migration that dies part-way through must leave nothing behind, or every
+// later boot retries it and fails on the half-applied schema.
+func TestMigrationsAreAtomic(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "atomic.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const name = "001_topics.sql"
+	const good = `CREATE TABLE topics (topic TEXT);
+ALTER TABLE topics ADD COLUMN confirmed BOOLEAN NOT NULL DEFAULT FALSE;
+`
+	fsys := fstest.MapFS{
+		"migrations/" + name: &fstest.MapFile{Data: []byte(good + "NOT VALID SQL;")},
+	}
+
+	applied, err := sqlitemigrate.Run(ctx, db, fsys, "migrations")
+	require.Error(t, err)
+	require.Empty(t, applied)
+
+	var tables int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE name = 'topics'`).Scan(&tables))
+	require.Zero(t, tables)
+
+	var versions int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM migrations`).Scan(&versions))
+	require.Zero(t, versions)
+
+	// The corrected file applies cleanly on the retry.
+	fsys["migrations/"+name] = &fstest.MapFile{Data: []byte(good)}
+
+	applied, err = sqlitemigrate.Run(ctx, db, fsys, "migrations")
+	require.NoError(t, err)
+	require.Equal(t, []string{name}, applied)
+
+	var columns int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT count(*) FROM pragma_table_info('topics') WHERE name = 'confirmed'`).Scan(&columns))
+	require.Equal(t, 1, columns)
+}

--- a/bitwindow/server/database/migrate_bitdrive_vout_test.go
+++ b/bitwindow/server/database/migrate_bitdrive_vout_test.go
@@ -1,0 +1,60 @@
+package database
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// bitdrive_files was unique on txid alone, so a transaction carrying two
+// BitDrive OP_RETURNs lost the second payload. Already-downloaded files must
+// survive the rekeying.
+func TestMigration047BitdriveFilesKeyedOnOutpoint(t *testing.T) {
+	ctx := context.Background()
+	db := Test(t)
+
+	// Put the pre-047 table back, holding one downloaded file.
+	_, err := db.ExecContext(ctx, `
+		DROP TABLE bitdrive_files;
+		CREATE TABLE bitdrive_files (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			txid TEXT NOT NULL UNIQUE,
+			filename TEXT NOT NULL,
+			file_type TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			encrypted INTEGER NOT NULL DEFAULT 0,
+			timestamp INTEGER NOT NULL,
+			created_at INTEGER NOT NULL
+		);
+		INSERT INTO bitdrive_files (id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at)
+			VALUES (7, 'old-txid', '1700000000_old-txid.txt', 'txt', 4, 0, 1700000000, 1700000000);
+	`)
+	require.NoError(t, err)
+
+	body, err := fs.ReadFile(migrations, "migrations/047_bitdrive_vout.sql")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, string(body))
+	require.NoError(t, err)
+
+	// The existing row keeps its id and its file on disk, and takes vout 0.
+	var (
+		id       int64
+		vout     int64
+		filename string
+	)
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT id, vout, filename FROM bitdrive_files WHERE txid = 'old-txid'
+	`).Scan(&id, &vout, &filename))
+	require.Equal(t, int64(7), id)
+	require.Equal(t, int64(0), vout)
+	require.Equal(t, "1700000000_old-txid.txt", filename)
+
+	// A second payload of the same transaction now fits.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO bitdrive_files (txid, vout, filename, file_type, size_bytes, encrypted, timestamp, created_at)
+		VALUES ('old-txid', 1, '1700000000_old-txid_1.txt', 'txt', 4, 0, 1700000000, 1700000000)
+	`)
+	require.NoError(t, err)
+}

--- a/bitwindow/server/database/migrations/047_bitdrive_vout.sql
+++ b/bitwindow/server/database/migrations/047_bitdrive_vout.sql
@@ -1,0 +1,24 @@
+-- A transaction can carry several BitDrive OP_RETURNs, but bitdrive_files was
+-- unique on txid alone, so every payload after the first was dropped. Key on the
+-- outpoint instead. SQLite cannot alter a UNIQUE constraint, so recreate the
+-- table; existing rows keep their id and filename and take vout 0.
+
+CREATE TABLE IF NOT EXISTS bitdrive_files_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    txid TEXT NOT NULL,
+    vout INTEGER NOT NULL DEFAULT 0,
+    filename TEXT NOT NULL,
+    file_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    encrypted INTEGER NOT NULL DEFAULT 0,
+    timestamp INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    UNIQUE (txid, vout)
+);
+
+INSERT OR IGNORE INTO bitdrive_files_new
+    SELECT id, txid, 0, filename, file_type, size_bytes, encrypted, timestamp, created_at
+    FROM bitdrive_files;
+
+DROP TABLE IF EXISTS bitdrive_files;
+ALTER TABLE bitdrive_files_new RENAME TO bitdrive_files;

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -165,6 +165,11 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		if err != nil {
 			return fmt.Errorf("extract zip: %w", err)
 		}
+		if walletJSON != nil {
+			if err := validateWalletJSON(walletJSON); err != nil {
+				return fmt.Errorf("invalid wallet.json: %w", err)
+			}
+		}
 	default:
 		return fmt.Errorf("unsupported file type %q", ext)
 	}
@@ -468,15 +473,28 @@ func validateWalletJSON(data []byte) error {
 		if !ok || len(walletsList) == 0 {
 			return fmt.Errorf("wallets array is empty")
 		}
-		first, ok := walletsList[0].(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("invalid wallet entry")
-		}
-		if _, ok := first["master"]; !ok {
-			return fmt.Errorf("wallet entry missing master")
-		}
-		if _, ok := first["l1"]; !ok {
-			return fmt.Errorf("wallet entry missing l1")
+		// Every entry, not just the first: one malformed entry is enough to
+		// break the wallet sync that reads this file back.
+		for i, entry := range walletsList {
+			w, ok := entry.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("invalid wallet entry %d", i)
+			}
+			if _, ok := w["master"]; !ok {
+				return fmt.Errorf("wallet entry %d missing master", i)
+			}
+			if _, ok := w["l1"]; !ok {
+				return fmt.Errorf("wallet entry %d missing l1", i)
+			}
+			// Core wallet names take the first 8 characters of the id.
+			if id, ok := w["id"].(string); !ok || len(id) < 8 {
+				return fmt.Errorf("wallet entry %d has a missing or too-short id", i)
+			}
+			if walletType, ok := w["wallet_type"]; ok {
+				if _, ok := walletType.(string); !ok {
+					return fmt.Errorf("wallet entry %d has a non-string wallet_type", i)
+				}
+			}
 		}
 	}
 

--- a/bitwindow/server/engines/backup_engine_test.go
+++ b/bitwindow/server/engines/backup_engine_test.go
@@ -33,7 +33,7 @@ func TestValidateBackup_JSON_NewFormat(t *testing.T) {
 	e := &BackupEngine{}
 	wallet := map[string]interface{}{
 		"wallets": []map[string]interface{}{
-			{"master": "seed", "l1": "key"},
+			{"id": "deadbeefcafebabe", "master": "seed", "l1": "key"},
 		},
 	}
 	data, _ := json.Marshal(wallet)
@@ -142,6 +142,51 @@ func TestRestoreBackup_JSON(t *testing.T) {
 	_ = json.Unmarshal(content, &restored)
 	if restored["master"] != "seed" {
 		t.Fatal("wallet.json content mismatch")
+	}
+}
+
+// A wallet entry whose id is too short to name a Bitcoin Core wallet must be
+// rejected before it replaces the wallet on disk.
+func TestRestoreBackup_ShortWalletID(t *testing.T) {
+	wallet := map[string]interface{}{
+		"wallets": []map[string]interface{}{
+			{"id": "deadbeefcafebabe", "master": "seed", "l1": "key"},
+			{"id": "", "master": "seed", "l1": "key"},
+		},
+	}
+	data, _ := json.Marshal(wallet)
+
+	cases := []struct {
+		name     string
+		data     []byte
+		filename string
+	}{
+		{"json", data, "wallet.json"},
+		{"zip", zipWith(t, "wallet.json", data), "backup.zip"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			walletPath := filepath.Join(tmpDir, "wallet.json")
+			existing := []byte(`{"master":"my real seed","l1":"my real key"}`)
+			if err := os.WriteFile(walletPath, existing, 0600); err != nil {
+				t.Fatal(err)
+			}
+
+			e := &BackupEngine{walletDir: tmpDir}
+			if err := e.RestoreBackup(testCtx(), tc.data, tc.filename); err == nil {
+				t.Fatal("expected error for a wallet entry with a short id")
+			}
+
+			after, err := os.ReadFile(walletPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, existing) {
+				t.Fatal("the existing wallet must be untouched when restore fails")
+			}
+		})
 	}
 }
 

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -738,8 +738,9 @@ func (p *Parser) handleOpReturns(
 
 	var emptyHash chainhash.Hash
 	isCoinbase := len(tx.TxIn) > 0 && tx.TxIn[0].PreviousOutPoint.Hash.IsEqual(&emptyHash)
-	// every coinbase transaction has a OP_RETURN output we don't care about
-	if isCoinbase && len(tx.TxOut) == 2 {
+	// a coinbase OP_RETURN is always consensus data — the witness commitment,
+	// a BIP300/301 message or a miner tag — never a user payload
+	if isCoinbase {
 		return nil, nil
 	}
 
@@ -992,24 +993,26 @@ func isWitnessCommitment(pkScript []byte) bool {
 		bytes.Equal(pkScript[2:6], witnessCommitmentMagic)
 }
 
+// BIP300/301 message tags. A payload carrying one of these is sidechain
+// consensus data, not a user OP_RETURN.
+const (
+	tagM1ProposeSidechain = "d5e0c4af"
+	tagM2AckSidechain     = "d6e1c5df"
+	tagM3ProposeBundle    = "d45aa943"
+	tagM4AckBundleV1      = "d77d177601"
+	tagM7                 = "d1617368"
+)
+
 func shouldSkip(pkScript []byte) bool {
-	data := pkScript[2:]
-	// heck if i know what these are, but they are related to sidechains!
+	data := opreturns.OPReturnToReadable(pkScript[2:])
 	switch {
-	case strings.HasPrefix(opreturns.OPReturnToReadable(data), "d1617368"):
+	case strings.HasPrefix(data, tagM1ProposeSidechain),
+		strings.HasPrefix(data, tagM2AckSidechain),
+		strings.HasPrefix(data, tagM3ProposeBundle),
+		strings.HasPrefix(data, tagM4AckBundleV1),
+		strings.HasPrefix(data, tagM7):
 		return true
-	case strings.HasPrefix(opreturns.OPReturnToReadable(data), "d77d177601"):
-		return true
-		// thunder sidechain creation
-	case opreturns.OPReturnToReadable(data) == "d6e1c5df09879b5f8ebc8bab50ca9218849c2e173a596d1ac0e84b9f10981c3078da6571af":
-		return true
-	case opreturns.OPReturnToReadable(data) == "d6e1c5df02f82573d5420e910fe350d5e1b61da16551a269d682b51f35f2343c265285c056":
-		return true
-	case opreturns.OPReturnToReadable(data) == "64656164626565664e6f7277656769616e2042c3b8726765204272656e6465206265636f6d657320707265736964656e74206f6620574546":
-		return true
-	case opreturns.OPReturnToReadable(data) == "d5e0c4af0900077468756e6465727468756e646572206465736372697074696f6e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000":
-		return true
-	case opreturns.OPReturnToReadable(data) == "d45aa943091303c6de5739c2fb3a021a8bd2b8c9fa8bcd8f8c18954bec00aa8f9b2cf13602":
+	case data == "64656164626565664e6f7277656769616e2042c3b8726765204272656e6465206265636f6d657320707265736964656e74206f6620574546":
 		return true
 	}
 	return false

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -439,7 +439,7 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 				for _, tx := range block.Transactions {
 					blockTime := block.Header.Timestamp
 					if err := p.opReturnForTXID(ctx, tx, &height, &blockTime); err != nil {
-						return lo.Tuple2[uint32, *wire.MsgBlock]{}, fmt.Errorf("process transaction %s: %w", tx.TxID(), err)
+						return lo.Tuple2[uint32, *wire.MsgBlock]{}, fmt.Errorf("process transaction %s: %w", p.txID(tx), err)
 					}
 				}
 
@@ -495,7 +495,7 @@ func (p *Parser) processBlocks(ctx context.Context, coreBlocks []lo.Tuple2[uint3
 			Hash:      block.Header.BlockHash(),
 			BlockTime: block.Header.Timestamp,
 			Txids: lo.Map(block.Transactions, func(tx *wire.MsgTx, _ int) chainhash.Hash {
-				return tx.TxHash()
+				return p.txHash(tx)
 			}),
 		}
 	})); err != nil {
@@ -719,22 +719,22 @@ func (p *Parser) getBlock(ctx context.Context, height uint32) (*wire.MsgBlock, e
 		return nil, fmt.Errorf("decode block hex: %w", err)
 	}
 
-	var msgBlock wire.MsgBlock
-	if err := msgBlock.Deserialize(bytes.NewReader(blockBytes)); err != nil {
+	msgBlock, err := p.deserializeBlock(blockBytes)
+	if err != nil {
 		return nil, fmt.Errorf("deserialize block: %w", err)
 	}
 
 	zerolog.Ctx(ctx).Trace().
 		Msgf("bitcoind_engine/parser: fetched block %d in %s", height, time.Since(start))
 
-	return &msgBlock, nil
+	return msgBlock, nil
 }
 
 // finds all OP_RETURN outputs for a specific tx
 func (p *Parser) handleOpReturns(
 	ctx context.Context, tx *wire.MsgTx, height *uint32, createdAt *time.Time,
 ) ([]opreturns.OPReturn, error) {
-	txid := tx.TxID()
+	txid := p.txID(tx)
 
 	var emptyHash chainhash.Hash
 	isCoinbase := len(tx.TxIn) > 0 && tx.TxIn[0].PreviousOutPoint.Hash.IsEqual(&emptyHash)

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -478,6 +479,9 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 // processBlock processes a single block: checks if it contains any OP_RETURN transactions, inserts any found into the database,
 // and marks the block as processed.
 func (p *Parser) processBlocks(ctx context.Context, coreBlocks []lo.Tuple2[uint32, *wire.MsgBlock]) error {
+	// The parallel fetcher returns blocks in completion order. Every pass
+	// below applies state per height, and M4 votes are order-dependent.
+	sort.Slice(coreBlocks, func(i, j int) bool { return coreBlocks[i].A < coreBlocks[j].A })
 
 	// CoinNews indexing must commit BEFORE the block is marked processed:
 	// if it fails, we want the next sync attempt to retry, not skip the

--- a/bitwindow/server/engines/bitcoind_engine_internal_test.go
+++ b/bitwindow/server/engines/bitcoind_engine_internal_test.go
@@ -1,6 +1,7 @@
 package engines
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"slices"
@@ -330,4 +331,54 @@ func TestOpReturnHandling_WhitespaceHeadlineLooksBlank(t *testing.T) {
 	news, err := opreturns.ListCoinNews(ctx, db)
 	require.NoError(t, err)
 	assert.Empty(t, news, "whitespace-only headlines must not surface as canonical stories")
+}
+
+// TestOpReturnHandling_CoinbaseIsNeverIndexed covers both halves of the
+// coinbase gate: a coinbase's OP_RETURNs stay out of op_returns whatever
+// its output count, and a BIP300/301 message is skipped on its tag rather
+// than on a hardcoded payload.
+func TestOpReturnHandling_CoinbaseIsNeverIndexed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := database.Test(t)
+
+	// No EXPECT: a fetch here means an output was about to be indexed.
+	core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	parser := &Parser{
+		db: db,
+		bitcoind: service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return core, nil
+		}),
+	}
+
+	// M2 (ACK sidechain): 4-byte tag, 32-byte proposal hash, 1-byte slot.
+	m2 := append([]byte{0xd6, 0xe1, 0xc5, 0xdf}, bytes.Repeat([]byte{0xab}, 33)...)
+	// Merged mining tag: AuxPoW magic, 32-byte hash, size and nonce.
+	mergedMining := append([]byte{0xfa, 0xbe, 0x6d, 0x6d}, bytes.Repeat([]byte{0xcd}, 40)...)
+
+	height := uint32(400)
+	now := time.Now()
+
+	coinbase := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff}}},
+		TxOut: []*wire.TxOut{
+			{Value: 5_000_000_000, PkScript: append([]byte{txscript.OP_0, 0x14}, bytes.Repeat([]byte{0x01}, 20)...)},
+			{Value: 0, PkScript: pkScript(t, m2)},
+			{Value: 0, PkScript: pkScript(t, mergedMining)},
+		},
+	}
+	require.NoError(t, parser.opReturnForTXID(ctx, coinbase, &height, &now))
+
+	// The tag rule also holds off-coinbase, where the old blacklist only
+	// matched two specific M2 payloads.
+	spend := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{7}, Index: 0}}},
+		TxOut: []*wire.TxOut{{Value: 0, PkScript: pkScript(t, m2)}},
+	}
+	require.NoError(t, parser.opReturnForTXID(ctx, spend, &height, &now))
+
+	stored, err := opreturns.List(ctx, db, 0)
+	require.NoError(t, err)
+	assert.Empty(t, stored, "coinbase consensus messages must not reach op_returns")
 }

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -517,24 +517,27 @@ func (e *BitDriveEngine) DecodeOPReturnData(ctx context.Context, opReturnMessage
 	return content, metadata, nil
 }
 
-// SaveFile saves a file to local storage and creates a database record
-func (e *BitDriveEngine) SaveFile(ctx context.Context, txid string, content []byte, metadata *ParsedMetadata) error {
+// SaveFile saves a file to local storage and creates a database record. The
+// file is keyed on the outpoint, because a transaction can carry one BitDrive
+// payload per output.
+func (e *BitDriveEngine) SaveFile(ctx context.Context, txid string, vout int32, content []byte, metadata *ParsedMetadata) error {
 	// Check if already exists
-	exists, err := bitdrive.Exists(ctx, e.db, txid)
+	exists, err := bitdrive.Exists(ctx, e.db, txid, vout)
 	if err != nil {
 		return fmt.Errorf("check exists: %w", err)
 	}
 	if exists {
 		zerolog.Ctx(ctx).Debug().
 			Str("txid", txid).
+			Int32("vout", vout).
 			Msg("bitdrive file already exists, skipping")
 		return nil
 	}
 
-	// Generate filename. The txid is included so that two distinct
-	// transactions sharing the same timestamp and file type do not collide
-	// on the same local path and overwrite each other.
-	filename := fmt.Sprintf("%d_%s.%s", metadata.Timestamp, txid, metadata.FileType)
+	// Generate filename from the outpoint, so that neither two transactions
+	// sharing a timestamp and file type nor two payloads of one transaction
+	// collide on the same local path.
+	filename := fmt.Sprintf("%d_%s_%d.%s", metadata.Timestamp, txid, vout, metadata.FileType)
 	filePath := filepath.Join(e.bitdriveDir, filename)
 
 	// Write file
@@ -545,6 +548,7 @@ func (e *BitDriveEngine) SaveFile(ctx context.Context, txid string, content []by
 	// Create database record
 	file := bitdrive.File{
 		TxID:      txid,
+		Vout:      vout,
 		Filename:  filename,
 		FileType:  metadata.FileType,
 		SizeBytes: int64(len(content)),

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -215,52 +215,61 @@ func TestDecodeOPReturnData_MetadataTamperRejected(t *testing.T) {
 	}
 }
 
-// TestSaveFile_SameSecondNoCollision verifies that two distinct transactions
-// sharing an identical timestamp and file type are written to distinct local
-// paths, so neither overwrites the other on disk.
-func TestSaveFile_SameSecondNoCollision(t *testing.T) {
-	ctx := context.Background()
+// newSaveFileTestEngine builds a BitDriveEngine over an in-memory bitdrive_files
+// table and an empty local directory.
+func newSaveFileTestEngine(t *testing.T) *BitDriveEngine {
+	t.Helper()
 
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	defer db.Close()
+	t.Cleanup(func() { db.Close() })
 
 	if _, err := db.Exec(`
 		CREATE TABLE bitdrive_files (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			txid TEXT NOT NULL UNIQUE,
+			txid TEXT NOT NULL,
+			vout INTEGER NOT NULL DEFAULT 0,
 			filename TEXT NOT NULL,
 			file_type TEXT NOT NULL,
 			size_bytes INTEGER NOT NULL,
 			encrypted INTEGER NOT NULL DEFAULT 0,
 			timestamp INTEGER NOT NULL,
-			created_at INTEGER NOT NULL
+			created_at INTEGER NOT NULL,
+			UNIQUE (txid, vout)
 		)
 	`); err != nil {
 		t.Fatalf("create table: %v", err)
 	}
 
-	engine := &BitDriveEngine{
+	return &BitDriveEngine{
 		db:          db,
 		bitdriveDir: t.TempDir(),
 	}
+}
+
+// TestSaveFile_SameSecondNoCollision verifies that two distinct transactions
+// sharing an identical timestamp and file type are written to distinct local
+// paths, so neither overwrites the other on disk.
+func TestSaveFile_SameSecondNoCollision(t *testing.T) {
+	ctx := context.Background()
+	engine := newSaveFileTestEngine(t)
 
 	meta := &ParsedMetadata{Timestamp: 1700000000, FileType: "txt"}
 
-	if err := engine.SaveFile(ctx, "txid-first", []byte("first file"), meta); err != nil {
+	if err := engine.SaveFile(ctx, "txid-first", 0, []byte("first file"), meta); err != nil {
 		t.Fatalf("save first file: %v", err)
 	}
-	if err := engine.SaveFile(ctx, "txid-second", []byte("second file"), meta); err != nil {
+	if err := engine.SaveFile(ctx, "txid-second", 0, []byte("second file"), meta); err != nil {
 		t.Fatalf("save second file: %v", err)
 	}
 
-	first, err := bitdrive.GetByTxID(ctx, db, "txid-first")
+	first, err := bitdrive.GetByTxID(ctx, engine.db, "txid-first")
 	if err != nil || first == nil {
 		t.Fatalf("get first record: %v", err)
 	}
-	second, err := bitdrive.GetByTxID(ctx, db, "txid-second")
+	second, err := bitdrive.GetByTxID(ctx, engine.db, "txid-second")
 	if err != nil || second == nil {
 		t.Fatalf("get second record: %v", err)
 	}
@@ -283,6 +292,47 @@ func TestSaveFile_SameSecondNoCollision(t *testing.T) {
 	}
 	if string(secondContent) != "second file" {
 		t.Fatalf("second file content wrong: got %q", secondContent)
+	}
+}
+
+// TestSaveFile_SameTxidDifferentVout verifies that both payloads of a
+// transaction carrying two BitDrive OP_RETURNs are saved. Keying on the txid
+// alone made the second one look already-downloaded and dropped it.
+func TestSaveFile_SameTxidDifferentVout(t *testing.T) {
+	ctx := context.Background()
+	engine := newSaveFileTestEngine(t)
+
+	const txid = "txid-two-outputs"
+	meta := &ParsedMetadata{Timestamp: 1700000000, FileType: "txt"}
+
+	if err := engine.SaveFile(ctx, txid, 0, []byte("first payload"), meta); err != nil {
+		t.Fatalf("save vout 0: %v", err)
+	}
+	if err := engine.SaveFile(ctx, txid, 1, []byte("second payload"), meta); err != nil {
+		t.Fatalf("save vout 1: %v", err)
+	}
+
+	files, err := bitdrive.List(ctx, engine.db)
+	if err != nil {
+		t.Fatalf("list files: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(files))
+	}
+
+	want := map[int32]string{0: "first payload", 1: "second payload"}
+	for _, file := range files {
+		content, err := engine.GetFileContent(ctx, file.Filename)
+		if err != nil {
+			t.Fatalf("read content for vout %d: %v", file.Vout, err)
+		}
+		if string(content) != want[file.Vout] {
+			t.Fatalf("vout %d: got %q, want %q", file.Vout, content, want[file.Vout])
+		}
+		delete(want, file.Vout)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing records for vouts %v", want)
 	}
 }
 

--- a/bitwindow/server/engines/coin_selection.go
+++ b/bitwindow/server/engines/coin_selection.go
@@ -252,10 +252,11 @@ func selectBranchAndBound(
 		currSelection[depth] = true
 		search(depth+1, currValue+effs[depth])
 		currSelection[depth] = false
-		remaining += effs[depth]
 
-		// Omit branch.
+		// Omit branch. The budget stays spent here: it is only given back when
+		// stepping back past this depth, so the bound stays tight on omissions.
 		search(depth+1, currValue)
+		remaining += effs[depth]
 		return false
 	}
 

--- a/bitwindow/server/engines/coin_selection_bnb_test.go
+++ b/bitwindow/server/engines/coin_selection_bnb_test.go
@@ -160,6 +160,53 @@ func TestBranchAndBoundFallsBackWhenNoExactMatch(t *testing.T) {
 	}
 }
 
+func TestBranchAndBoundExactMatchBehindNonContributingCoins(t *testing.T) {
+	const feeRate = 10
+	numOutputs := 2
+
+	feePerInput := int64(InputVbytes) * feeRate
+	value := func(effectiveValue int64) int64 { return effectiveValue + feePerInput }
+
+	// The exact match is the second and third coin (400k + 300k effective). The
+	// first coin overshoots the target by more than costOfChange with either of
+	// them, and even with every tiny coin it stays short — so the whole subtree
+	// that includes it must be pruned before the search reaches the match.
+	values := []int64{value(500_000), value(400_000), value(300_000)}
+	for i := 0; i < 20; i++ {
+		values = append(values, value(1_000))
+	}
+	utxos := bnbUTXOs(values...)
+
+	target := int64(700_000)
+	sendAmount := target - int64(OverheadVbytes+OutputVbytes)*feeRate
+
+	result, err := SelectCoins(
+		utxos,
+		map[string]bool{},
+		sendAmount,
+		feeRate,
+		numOutputs,
+		walletpb.CoinSelectionStrategy_COIN_SELECTION_STRATEGY_BRANCH_AND_BOUND,
+		map[string]bool{},
+	)
+	if err != nil {
+		t.Fatalf("SelectCoins: %v", err)
+	}
+	if result.ChangeSats != 0 {
+		t.Fatalf("BnB missed the exact no-change match, produced change=%d", result.ChangeSats)
+	}
+
+	want := map[string]bool{utxos[1].Output: true, utxos[2].Output: true}
+	if len(result.SelectedUTXOs) != len(want) {
+		t.Fatalf("expected %d inputs, got %d", len(want), len(result.SelectedUTXOs))
+	}
+	for _, u := range result.SelectedUTXOs {
+		if !want[u.Output] {
+			t.Fatalf("unexpected input %s (%d sats) in selection", u.Output, u.ValueSats)
+		}
+	}
+}
+
 // exactMatchAvail returns the value of a single available UTXO whose effective
 // value, added to the required inputs, exactly funds a no-change transaction.
 // A correct BnB must select it (change == 0); the double-counted-fee bug aims

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -45,7 +45,7 @@ func (p *Parser) indexCoinNewsBlocks(ctx context.Context, blocks []lo.Tuple2[uin
 // dropped (logged at debug, never persisted).
 func (p *Parser) indexCoinNewsForBlock(ctx context.Context, height uint32, block *wire.MsgBlock) error {
 	for txIdx, tx := range block.Transactions {
-		txid := tx.TxID()
+		txid := p.txID(tx)
 		for vout, txout := range tx.TxOut {
 			data, ok := coinNewsPayload(txout.PkScript)
 			if !ok {

--- a/bitwindow/server/engines/core_send.go
+++ b/bitwindow/server/engines/core_send.go
@@ -69,15 +69,26 @@ func SendCoreWithRequiredInputs(
 	// 2 sat/vB, matching the cheque-sweep path). Output/input vbyte sizes
 	// mirror the P2WPKH estimate used in buildSweepTx.
 	var feeSats uint64
+	var hasChange bool
 	if fixedFeeSats > 0 {
 		feeSats = fixedFeeSats
+		hasChange = totalInSats >= totalOutSats+feeSats &&
+			totalInSats-totalOutSats-feeSats >= dustLimit
 	} else {
 		rate := feeSatPerVbyte
 		if rate == 0 {
 			rate = 2
 		}
-		estVbytes := uint64(len(inputs)*68 + (len(destinationsSats)+1)*31 + 11)
+		estVbytes := uint64(len(inputs)*68 + len(destinationsSats)*31 + 11)
 		feeSats = estVbytes * rate
+
+		// Only pay for a change output when the remainder is big enough to
+		// still be above dust after paying for the extra 31 vB.
+		if totalInSats >= totalOutSats+feeSats &&
+			totalInSats-totalOutSats-feeSats >= dustLimit+31*rate {
+			feeSats = (estVbytes + 31) * rate
+			hasChange = true
+		}
 	}
 
 	if totalInSats < totalOutSats+feeSats {
@@ -90,7 +101,7 @@ func SendCoreWithRequiredInputs(
 	}
 
 	changeSats := totalInSats - totalOutSats - feeSats
-	if changeSats >= dustLimit {
+	if hasChange {
 		changeResp, err := bitcoind.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
 			Wallet: walletName,
 		}))

--- a/bitwindow/server/engines/core_send_test.go
+++ b/bitwindow/server/engines/core_send_test.go
@@ -65,6 +65,112 @@ func TestSendCoreWithRequiredInputs(t *testing.T) {
 		require.ErrorIs(t, err, stop)
 	})
 
+	t.Run("does not bill a change output that is never created", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: trackedTxid, Vout: 3, Amount: 0.0001},
+				},
+			}), nil)
+
+		stop := errors.New("stop")
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateRawTransactionRequest]) (*connect.Response[corepb.CreateRawTransactionResponse], error) {
+				// 10,000 sats in, 9,780 out, 220 sats fee (110 vB at 2
+				// sat/vB) and no change output.
+				require.Len(t, req.Msg.Outputs, 1)
+				assert.Equal(t, 0.0000978, req.Msg.Outputs["tb1qdest00000000000000000000000000000000"])
+				return nil, stop
+			})
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 9_780},
+			2, 0,
+		)
+		require.ErrorIs(t, err, stop)
+	})
+
+	t.Run("drops a change output it did not budget for", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: trackedTxid, Vout: 3, Amount: 0.001},
+				},
+			}), nil)
+
+		stop := errors.New("stop")
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateRawTransactionRequest]) (*connect.Response[corepb.CreateRawTransactionResponse], error) {
+				// 100,000 sats in, 99,210 out: the 570 sat remainder is above
+				// dust but too small to also pay for the change output, so the
+				// whole remainder goes to fee rather than underpaying it.
+				require.Len(t, req.Msg.Outputs, 1)
+				assert.Equal(t, 0.0009921, req.Msg.Outputs["tb1qdest00000000000000000000000000000000"])
+				return nil, stop
+			})
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 99_210},
+			2, 0,
+		)
+		require.ErrorIs(t, err, stop)
+	})
+
+	t.Run("bills the change output when change is created", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: trackedTxid, Vout: 3, Amount: 1.0},
+				},
+			}), nil)
+
+		mockBitcoind.EXPECT().
+			GetNewAddress(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.GetNewAddressResponse{
+				Address: "tb1qchange0000000000000000000000000000000",
+			}), nil)
+
+		stop := errors.New("stop")
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateRawTransactionRequest]) (*connect.Response[corepb.CreateRawTransactionResponse], error) {
+				// 1 BTC in, 0.4 BTC out, 282 sats fee (141 vB at 2 sat/vB,
+				// change output included) -> the rest is change.
+				assert.Equal(t, 0.4, req.Msg.Outputs["tb1qdest00000000000000000000000000000000"])
+				assert.Equal(t, 0.59999718, req.Msg.Outputs["tb1qchange0000000000000000000000000000000"])
+				return nil, stop
+			})
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			2, 0,
+		)
+		require.ErrorIs(t, err, stop)
+	})
+
 	t.Run("errors when the required outpoint is not in the wallet", func(t *testing.T) {
 		t.Parallel()
 

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -234,6 +234,14 @@ func (e *DeniabilityEngine) ExecuteDenial(ctx context.Context, utxos []*UTXO, de
 	return nil
 }
 
+// denialDustLimit is the smallest output a split may pay, matching the limit
+// the send path applies to change.
+const denialDustLimit = 546
+
+// errDenialAmountTooSmall means the split would pay a dust output, which no
+// backend will relay. The denial cannot make progress, so it gets cancelled.
+var errDenialAmountTooSmall = errors.New("split amount is below the dust limit")
+
 func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *UTXO, denial deniability.Denial) error {
 	logger := zerolog.Ctx(ctx).With().
 		Int64("denial_id", denial.ID).
@@ -246,14 +254,8 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *UTXO, denial 
 	logger.Info().Msg("processing UTXO for denial")
 
 	const fee = 10000
-	if utxo.ValueSats < fee {
-		reason := "utxo is too small to split"
-		logger.Warn().Msg("cancelling denial due to insufficient UTXO amount")
-
-		if err := deniability.Cancel(ctx, e.db, denial.ID, reason); err != nil {
-			return fmt.Errorf("cancel denial: %w", err)
-		}
-		return nil
+	if utxo.ValueSats <= fee+denialDustLimit {
+		return e.cancelTooSmall(ctx, logger, denial)
 	}
 
 	// Use the denial's stored wallet_id to determine routing
@@ -279,6 +281,9 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *UTXO, denial 
 
 	destinations, err := e.chooseDenialStrategy(ctx, denial, utxo, fee, walletType, walletId)
 	if err != nil {
+		if errors.Is(err, errDenialAmountTooSmall) {
+			return e.cancelTooSmall(ctx, logger, denial)
+		}
 		return fmt.Errorf("choose denial strategy: %w", err)
 	}
 
@@ -331,6 +336,16 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *UTXO, denial 
 		Str("to_txid", txid).
 		Msg("executed denial split")
 
+	return nil
+}
+
+// cancelTooSmall terminates a denial whose tip cannot fund a non-dust split.
+func (e *DeniabilityEngine) cancelTooSmall(ctx context.Context, logger zerolog.Logger, denial deniability.Denial) error {
+	logger.Warn().Msg("cancelling denial due to insufficient UTXO amount")
+
+	if err := deniability.Cancel(ctx, e.db, denial.ID, "utxo is too small to split"); err != nil {
+		return fmt.Errorf("cancel denial: %w", err)
+	}
 	return nil
 }
 
@@ -518,16 +533,19 @@ func (e *DeniabilityEngine) simpleSplit(
 	walletType WalletType,
 	walletId string,
 ) (map[string]uint64, error) {
-	address, err := e.getNewAddress(ctx, walletType, walletId)
-	if err != nil {
-		return nil, fmt.Errorf("get new address: %w", err)
-	}
-
 	availableAmount := utxo.ValueSats - fee
 	// Send 10-90% of the utxo to a new address. Change is indistinguishable,
 	// so we don't know
 	percentage := 10 + rand.Intn(80)
 	sendAmount := (availableAmount * uint64(percentage)) / 100
+	if sendAmount < denialDustLimit {
+		return nil, errDenialAmountTooSmall
+	}
+
+	address, err := e.getNewAddress(ctx, walletType, walletId)
+	if err != nil {
+		return nil, fmt.Errorf("get new address: %w", err)
+	}
 
 	zerolog.Ctx(ctx).Info().
 		Int64("denial_id", denial.ID).
@@ -552,17 +570,21 @@ func (e *DeniabilityEngine) targetAmountSplit(
 	walletId string,
 	targetSize int64,
 ) (map[string]uint64, error) {
-	address, err := e.getNewAddress(ctx, walletType, walletId)
-	if err != nil {
-		return nil, fmt.Errorf("get new address: %w", err)
-	}
-
 	targetAmount := uint64(targetSize)
 	availableAmount := utxo.ValueSats - fee
 
 	// Ensure target amount doesn't exceed available
 	if targetAmount > availableAmount {
 		targetAmount = availableAmount
+	}
+
+	if targetAmount < denialDustLimit {
+		return nil, errDenialAmountTooSmall
+	}
+
+	address, err := e.getNewAddress(ctx, walletType, walletId)
+	if err != nil {
+		return nil, fmt.Errorf("get new address: %w", err)
 	}
 
 	zerolog.Ctx(ctx).Info().

--- a/bitwindow/server/engines/deniability_engine_test.go
+++ b/bitwindow/server/engines/deniability_engine_test.go
@@ -198,4 +198,130 @@ func TestDeniabilityEngine(t *testing.T) {
 		assert.NotNil(t, denial.CancelledAt)
 		assert.Equal(t, "utxo is too small to split", *denial.CancelReason)
 	})
+
+	// A tip that clears the fee but cannot fund a non-dust output has to
+	// terminate, not pay a zero-value destination and retry on every tick. No
+	// send is mocked here, so attempting one fails the test.
+	t.Run("processUTXO cancels when the split cannot clear dust", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return mockBitcoind, nil
+		})
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+
+		// 10,001 sats leaves one sat over the fee; 10,600 leaves 600, of which
+		// even the largest 90% roll is under the dust limit.
+		for _, valueSats := range []uint64{10_001, 10_600} {
+			denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, nil)
+			require.NoError(t, err)
+
+			err = engine.ProcessUTXO(ctx, &engines.UTXO{
+				Txid:      "test-txid",
+				Vout:      0,
+				ValueSats: valueSats,
+			}, denial)
+			require.NoError(t, err)
+
+			denial, err = deniability.Get(ctx, db, denial.ID)
+			require.NoError(t, err)
+			require.NotNil(t, denial.CancelledAt, "denial for %d sats was left running", valueSats)
+			assert.Equal(t, "utxo is too small to split", *denial.CancelReason)
+		}
+	})
+
+	t.Run("processUTXO cancels a target size below dust", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return mockBitcoind, nil
+		})
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+
+		denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, []int64{100})
+		require.NoError(t, err)
+
+		err = engine.ProcessUTXO(ctx, &engines.UTXO{
+			Txid:      "test-txid",
+			Vout:      0,
+			ValueSats: 20_000,
+		}, denial)
+		require.NoError(t, err)
+
+		denial, err = deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		require.NotNil(t, denial.CancelledAt)
+		assert.Equal(t, "utxo is too small to split", *denial.CancelReason)
+	})
+
+	// Control: a tip big enough for a non-dust split still splits.
+	t.Run("processUTXO splits a UTXO that clears dust", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return mockBitcoind, nil
+		})
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+
+		denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		mockBitcoind.EXPECT().
+			GetNewAddress(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[corepb.GetNewAddressResponse]{
+				Msg: &corepb.GetNewAddressResponse{Address: "bc1qtest"},
+			}, nil)
+
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[corepb.CreateRawTransactionResponse]{
+				Msg: &corepb.CreateRawTransactionResponse{Tx: &corepb.RawTransaction{Hex: "raw-tx-hex"}},
+			}, nil)
+
+		mockBitcoind.EXPECT().
+			SignRawTransactionWithWallet(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[corepb.SignRawTransactionWithWalletResponse]{
+				Msg: &corepb.SignRawTransactionWithWalletResponse{Hex: "signed-tx-hex", Complete: true},
+			}, nil)
+
+		mockBitcoind.EXPECT().
+			SendRawTransaction(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[corepb.SendRawTransactionResponse]{
+				Msg: &corepb.SendRawTransactionResponse{Txid: "new-txid"},
+			}, nil)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[corepb.ListUnspentResponse]{
+				Msg: &corepb.ListUnspentResponse{
+					Unspent: []*corepb.UnspentOutput{
+						{Txid: "test-txid", Address: "bc1qsource", Vout: 0, Amount: 0.0002, Confirmations: 6},
+						{Txid: "new-txid", Address: "bc1qtest", Vout: 0, Amount: 0.0001, Confirmations: 1},
+					},
+				},
+			}, nil)
+
+		err = engine.ProcessUTXO(ctx, &engines.UTXO{
+			Txid:      "test-txid",
+			Vout:      0,
+			ValueSats: 20_000,
+		}, denial)
+		require.NoError(t, err)
+
+		denial, err = deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.Nil(t, denial.CancelledAt)
+		assert.Len(t, denial.ExecutedDenials, 1)
+	})
 }

--- a/bitwindow/server/engines/forknet_tx.go
+++ b/bitwindow/server/engines/forknet_tx.go
@@ -1,0 +1,114 @@
+package engines
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// Forknet marks a replay-protected transaction with a magic version followed
+// by a single extra byte, and hashes that byte along with the rest of the
+// transaction. Stock btcd knows about neither.
+const (
+	txReplayVersion = 12566463 // 0x00bfbfbf
+	txReplayMarker  = 0x3f
+)
+
+// deserializeBlock decodes a raw block from Core.
+func (p *Parser) deserializeBlock(raw []byte) (*wire.MsgBlock, error) {
+	if p.conf.BitcoinCoreNetwork == config.NetworkForknet {
+		return decodeForknetBlock(raw)
+	}
+
+	var block wire.MsgBlock
+	if err := block.Deserialize(bytes.NewReader(raw)); err != nil {
+		return nil, err
+	}
+	return &block, nil
+}
+
+// decodeForknetBlock decodes a raw block the way forknet serializes it: a
+// stock header and transaction count, then transactions that may carry the
+// replay marker.
+func decodeForknetBlock(raw []byte) (*wire.MsgBlock, error) {
+	r := bytes.NewReader(raw)
+
+	var block wire.MsgBlock
+	if err := block.Header.Deserialize(r); err != nil {
+		return nil, fmt.Errorf("header: %w", err)
+	}
+
+	count, err := wire.ReadVarInt(r, 0)
+	if err != nil {
+		return nil, fmt.Errorf("transaction count: %w", err)
+	}
+
+	for i := uint64(0); i < count; i++ {
+		tx, err := readForknetTx(r)
+		if err != nil {
+			return nil, fmt.Errorf("transaction %d: %w", i, err)
+		}
+		block.Transactions = append(block.Transactions, tx)
+	}
+
+	return &block, nil
+}
+
+// readForknetTx reads one forknet transaction. Non-replay transactions decode
+// exactly like stock ones.
+func readForknetTx(r io.Reader) (*wire.MsgTx, error) {
+	var version [4]byte
+	if _, err := io.ReadFull(r, version[:]); err != nil {
+		return nil, fmt.Errorf("version: %w", err)
+	}
+
+	if binary.LittleEndian.Uint32(version[:]) == txReplayVersion {
+		var marker [1]byte
+		if _, err := io.ReadFull(r, marker[:]); err != nil {
+			return nil, fmt.Errorf("replay marker: %w", err)
+		}
+		if marker[0] != txReplayMarker {
+			return nil, fmt.Errorf("unexpected replay marker %#x", marker[0])
+		}
+	}
+
+	// btcd has no notion of the marker, so hand it the version followed by the
+	// stock transaction body.
+	var tx wire.MsgTx
+	if err := tx.BtcDecode(io.MultiReader(bytes.NewReader(version[:]), r), 0, wire.WitnessEncoding); err != nil {
+		return nil, err
+	}
+	return &tx, nil
+}
+
+// txHash returns the txid Core reports for tx. Forknet hashes the replay
+// marker, so btcd's serialization comes up one byte short of what Core hashed.
+func (p *Parser) txHash(tx *wire.MsgTx) chainhash.Hash {
+	if p.conf.BitcoinCoreNetwork != config.NetworkForknet || tx.Version != txReplayVersion {
+		return tx.TxHash()
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(tx.SerializeSizeStripped() + 1)
+	if err := tx.SerializeNoWitness(&buf); err != nil {
+		return tx.TxHash()
+	}
+
+	stripped := buf.Bytes()
+	marked := make([]byte, 0, len(stripped)+1)
+	marked = append(marked, stripped[:4]...)
+	marked = append(marked, txReplayMarker)
+	marked = append(marked, stripped[4:]...)
+
+	return chainhash.DoubleHashH(marked)
+}
+
+// txID is txHash in the string form Core's RPCs use.
+func (p *Parser) txID(tx *wire.MsgTx) string {
+	return p.txHash(tx).String()
+}

--- a/bitwindow/server/engines/forknet_tx_test.go
+++ b/bitwindow/server/engines/forknet_tx_test.go
@@ -1,0 +1,123 @@
+package engines
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+)
+
+func forknetTestTx(version int32, witness bool) *wire.MsgTx {
+	tx := wire.NewMsgTx(version)
+
+	in := wire.NewTxIn(wire.NewOutPoint(&chainhash.Hash{1, 2, 3}, 0), []byte{txscript.OP_TRUE}, nil)
+	if witness {
+		in.Witness = wire.TxWitness{{0xaa, 0xbb}}
+	}
+	tx.AddTxIn(in)
+	tx.AddTxOut(wire.NewTxOut(1000, []byte{txscript.OP_RETURN, 0x02, 0xde, 0xad}))
+
+	return tx
+}
+
+// forknetBlockBytes serializes a block the way forknet does: replay-versioned
+// transactions carry the marker byte right after the version.
+func forknetBlockBytes(t *testing.T, txs ...*wire.MsgTx) []byte {
+	t.Helper()
+
+	var prefix bytes.Buffer
+	header := wire.NewBlockHeader(1, &chainhash.Hash{}, &chainhash.Hash{}, 0x1d00ffff, 42)
+	require.NoError(t, header.Serialize(&prefix))
+	require.NoError(t, wire.WriteVarInt(&prefix, 0, uint64(len(txs))))
+
+	block := prefix.Bytes()
+	for _, tx := range txs {
+		var raw bytes.Buffer
+		require.NoError(t, tx.Serialize(&raw))
+
+		serialized := raw.Bytes()
+		block = append(block, serialized[:4]...)
+		if tx.Version == txReplayVersion {
+			block = append(block, txReplayMarker)
+		}
+		block = append(block, serialized[4:]...)
+	}
+
+	return block
+}
+
+// A replay-versioned transaction stalls the indexer under stock btcd, and
+// decodes under the forknet decoder.
+func TestForknetBlockWithAReplayTransactionDecodes(t *testing.T) {
+	stock := forknetTestTx(2, false)
+	replay := forknetTestTx(txReplayVersion, true)
+	raw := forknetBlockBytes(t, stock, replay)
+
+	require.Error(t, new(wire.MsgBlock).Deserialize(bytes.NewReader(raw)),
+		"stock btcd must choke on the replay marker")
+
+	block, err := parserOn(config.NetworkForknet).deserializeBlock(raw)
+	require.NoError(t, err)
+
+	require.Len(t, block.Transactions, 2)
+	assert.EqualValues(t, 2, block.Transactions[0].Version)
+	assert.EqualValues(t, txReplayVersion, block.Transactions[1].Version)
+	assert.Equal(t, replay.TxOut[0].PkScript, block.Transactions[1].TxOut[0].PkScript)
+	assert.Equal(t, replay.TxIn[0].Witness, block.Transactions[1].TxIn[0].Witness)
+}
+
+// Core hashes the marker, so the txid we store must too.
+func TestForknetReplayTxidIncludesTheMarker(t *testing.T) {
+	replay := forknetTestTx(txReplayVersion, false)
+	raw := forknetBlockBytes(t, replay)
+
+	// No witness, so the bytes forknet wrote into the block are exactly the
+	// bytes Core hashes for the txid.
+	expected := chainhash.DoubleHashH(raw[81:])
+
+	p := parserOn(config.NetworkForknet)
+	block, err := p.deserializeBlock(raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, p.txHash(block.Transactions[0]))
+	assert.NotEqual(t, replay.TxHash(), p.txHash(block.Transactions[0]))
+	assert.Equal(t, expected.String(), p.txID(block.Transactions[0]))
+
+	// A witness doesn't move the txid: it hashes the stripped bytes.
+	assert.Equal(t, expected, p.txHash(forknetTestTx(txReplayVersion, true)))
+}
+
+// Everything else keeps hashing and decoding exactly as before.
+func TestNonForknetDecodingIsUnchanged(t *testing.T) {
+	stock := forknetTestTx(2, true)
+	raw := forknetBlockBytes(t, stock)
+
+	for _, network := range []config.Network{config.NetworkMainnet, config.NetworkForknet} {
+		t.Run(string(network), func(t *testing.T) {
+			p := parserOn(network)
+
+			block, err := p.deserializeBlock(raw)
+			require.NoError(t, err)
+			require.Len(t, block.Transactions, 1)
+			assert.Equal(t, stock.TxHash(), p.txHash(block.Transactions[0]))
+		})
+	}
+
+	// A replay-versioned transaction is only special on forknet.
+	replay := forknetTestTx(txReplayVersion, false)
+	assert.Equal(t, replay.TxHash(), parserOn(config.NetworkMainnet).txHash(replay))
+}
+
+func TestForknetRejectsAnUnknownReplayMarker(t *testing.T) {
+	raw := forknetBlockBytes(t, forknetTestTx(txReplayVersion, false))
+	raw[80+1+4] = 0x40
+
+	_, err := decodeForknetBlock(raw)
+	require.ErrorContains(t, err, "unexpected replay marker")
+}

--- a/bitwindow/server/engines/m4_engine_replay_test.go
+++ b/bitwindow/server/engines/m4_engine_replay_test.go
@@ -2,10 +2,15 @@ package engines
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/m4"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,6 +81,57 @@ func TestApplyM4Votes_ReplayDoesNotDoubleCount(t *testing.T) {
 	require.NoError(t, e.applyM4Votes(ctx, 151, msg))
 	later, _, _ := bundleState(t, ctx, e, "bundle-a")
 	require.Equal(t, first+1, later, "a new height must still score")
+}
+
+// coinbaseBlockOf builds a block whose coinbase carries one raw OP_RETURN.
+func coinbaseBlockOf(script []byte, blockTime time.Time) *wire.MsgBlock {
+	coinbase := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{{PkScript: script}},
+	}
+	return &wire.MsgBlock{
+		Header:       wire.BlockHeader{Timestamp: blockTime},
+		Transactions: []*wire.MsgTx{coinbase},
+	}
+}
+
+// m3ProposalScript proposes a bundle on sidechain slot 0.
+func m3ProposalScript(bundleHash [32]byte) []byte {
+	script := binary.LittleEndian.AppendUint32([]byte{txscript.OP_RETURN}, m4.M3CommitmentHeader)
+	script = append(script, bundleHash[:]...)
+	return append(script, 0) // sidechain slot
+}
+
+// m4UpvoteScript upvotes bundle index 0 on sidechain slot 0.
+func m4UpvoteScript() []byte {
+	script := binary.LittleEndian.AppendUint32([]byte{txscript.OP_RETURN}, m4.M4CommitmentHeader)
+	return append(script, 0x01, 0x00) // version 0x01, one slot voting index 0
+}
+
+// An upvote can only score a bundle the M3 below it already proposed, so a
+// batch arriving in fetch-completion order must be applied in height order.
+func TestProcessBlocks_AppliesM4InHeightOrder(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	blockTime := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	proposal := coinbaseBlockOf(m3ProposalScript([32]byte{0xab, 0xcd}), blockTime)
+	upvote := coinbaseBlockOf(m4UpvoteScript(), blockTime.Add(10*time.Minute))
+
+	// Hand them over in completion order, not height order.
+	require.NoError(t, p.processBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(101), upvote),
+		lo.T2(uint32(100), proposal),
+	}))
+
+	var workScore, lastUpdated int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT work_score, last_updated_height FROM withdrawal_bundles WHERE sidechain_slot = 0`,
+	).Scan(&workScore, &lastUpdated))
+
+	require.Equal(t, 2, workScore, "the upvote at 101 MUST score the bundle proposed at 100")
+	require.Equal(t, 101, lastUpdated, "the vote from the highest block is the last one applied")
 }
 
 // A bundle first seen in an orphaned block must not survive the reorg purge.

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -488,6 +488,15 @@ func (e *WalletEngine) IsWatchOnly(ctx context.Context, walletId string) (bool, 
 // Bitcoin Core Wallet Management
 // ============================================================================
 
+// coreWalletName derives the bitcoind wallet name for a wallet id. An id
+// shorter than the 8-character prefix is rejected instead of sliced.
+func coreWalletName(prefix, walletId string) (string, error) {
+	if len(walletId) < 8 {
+		return "", fmt.Errorf("wallet id %q is too short to name a Bitcoin Core wallet", walletId)
+	}
+	return fmt.Sprintf("%s_%s", prefix, walletId[:8]), nil
+}
+
 // EnsureBitcoinCoreWallet ensures a Bitcoin Core wallet exists for the given walletId
 // Creates it from the seed if it doesn't exist (lazy loading).
 //
@@ -556,7 +565,10 @@ func (e *WalletEngine) ensureBitcoinCoreWalletLocked(ctx context.Context, wallet
 	}
 
 	// Generate wallet name from wallet ID
-	walletName := fmt.Sprintf("wallet_%s", walletId[:8])
+	walletName, err := coreWalletName("wallet", walletId)
+	if err != nil {
+		return "", err
+	}
 
 	// Get bitcoind client
 	bitcoindClient, err := e.bitcoindConnector(ctx)
@@ -999,7 +1011,10 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 	}
 
 	// Generate wallet name from wallet ID
-	walletName := fmt.Sprintf("wallet_%s", walletId[:8])
+	walletName, err := coreWalletName("wallet", walletId)
+	if err != nil {
+		return "", err
+	}
 
 	// Get bitcoind client
 	bitcoindClient, err := e.bitcoindConnector(ctx)
@@ -1279,7 +1294,15 @@ func (e *WalletEngine) ensureBitcoinCoreWallets(ctx context.Context, wallets []W
 
 	// Check each wallet
 	for _, wallet := range coreWallets {
-		walletName := fmt.Sprintf("wallet_%s", wallet.ID[:8])
+		// One unnameable wallet must not stop the others from syncing.
+		walletName, err := coreWalletName("wallet", wallet.ID)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("wallet_id", wallet.ID).
+				Msg("wallet sync: skipping wallet")
+			continue
+		}
 		walletExists := lo.Contains(listResp.Msg.Wallets, walletName)
 
 		if !walletExists {
@@ -1480,7 +1503,10 @@ func (e *WalletEngine) legacyWatchOnlyWallet(ctx context.Context, walletId strin
 }
 
 func (e *WalletEngine) probeLegacyWatchOnlyWallet(ctx context.Context, walletId string) (string, error) {
-	name := fmt.Sprintf("watch_%s", walletId[:8])
+	name, err := coreWalletName("watch", walletId)
+	if err != nil {
+		return "", err
+	}
 
 	// A failure here is not proof that the legacy wallet is absent. To read it
 	// that way lets the orchestrator create wallet_<prefix> beside a populated

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -873,6 +873,12 @@ func (e *WalletEngine) RequireFullNode(ctx context.Context, op string) error {
 // orchestrator wallet manager now — the same path the normal "Send" flow uses.
 // This is the single broadcast seam every server-side OP_RETURN sender shares.
 func (e *WalletEngine) BroadcastOpReturn(ctx context.Context, data []byte, feeSatPerVByte, feeSats uint64) (string, error) {
+	// An unencrypted wallet keeps reading wallet.json after Lock, so the spend
+	// has to be refused here.
+	if !e.IsUnlocked() {
+		return "", errors.New("wallet is locked")
+	}
+
 	activeWallet, err := e.GetActiveWallet(ctx)
 	if err != nil {
 		return "", fmt.Errorf("get active wallet: %w", err)

--- a/bitwindow/server/engines/wallet_engine_lock_test.go
+++ b/bitwindow/server/engines/wallet_engine_lock_test.go
@@ -1,0 +1,66 @@
+package engines
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/wallet"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingSendClient records every SendTransaction that reaches the orchestrator.
+type recordingSendClient struct {
+	orchrpc.WalletManagerServiceClient
+	sent []*orchpb.SendTransactionRequest
+}
+
+func (c *recordingSendClient) SendTransaction(_ context.Context, req *connect.Request[orchpb.SendTransactionRequest]) (*connect.Response[orchpb.SendTransactionResponse], error) {
+	c.sent = append(c.sent, req.Msg)
+	return connect.NewResponse(&orchpb.SendTransactionResponse{Txid: "txid"}), nil
+}
+
+// An unencrypted wallet auto-unlocks at startup and GetActiveWallet reads
+// wallet.json regardless of the lock, so BroadcastOpReturn has to refuse the
+// spend itself after Lock.
+func TestBroadcastOpReturnRefusesLockedWallet(t *testing.T) {
+	walletDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(walletDir, "wallet.json"), []byte(`{
+		"version": 1,
+		"activeWalletId": "deadbeefcafebabe",
+		"wallets": [{
+			"id": "deadbeefcafebabe",
+			"name": "spender",
+			"wallet_type": "electrum",
+			"master": {"seed_hex": "000102030405060708090a0b0c0d0e0f"}
+		}]
+	}`), 0o600))
+
+	orch := &recordingSendClient{}
+	e := NewWalletEngine(nil, walletDir, &chaincfg.MainNetParams)
+	e.SetOrchestratorClient(orch)
+	require.True(t, e.IsUnlocked())
+
+	e.Lock()
+
+	_, err := e.BroadcastOpReturn(context.Background(), []byte("news"), 5, 0)
+	require.ErrorContains(t, err, "wallet is locked")
+	require.Empty(t, orch.sent)
+
+	// Positive control: unlocking again lets the payload through.
+	walletData, err := wallet.LoadUnencryptedWallet(walletDir)
+	require.NoError(t, err)
+	require.NoError(t, e.Unlock(walletData))
+
+	txid, err := e.BroadcastOpReturn(context.Background(), []byte("news"), 5, 0)
+	require.NoError(t, err)
+	require.Equal(t, "txid", txid)
+	require.Len(t, orch.sent, 1)
+	require.Equal(t, hex.EncodeToString([]byte("news")), orch.sent[0].OpReturnHex)
+}

--- a/bitwindow/server/engines/wallet_engine_short_id_test.go
+++ b/bitwindow/server/engines/wallet_engine_short_id_test.go
@@ -1,0 +1,49 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// A wallet id too short to name a Core wallet must be skipped rather than
+// panic, and must not stop the well-formed wallets from syncing.
+func TestEnsureBitcoinCoreWalletsSkipsShortWalletID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{}},
+		}, nil).
+		AnyTimes()
+
+	var created []string
+	mockBitcoind.EXPECT().
+		CreateWallet(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateWalletRequest]) (*connect.Response[corepb.CreateWalletResponse], error) {
+			created = append(created, req.Msg.Name)
+			return nil, errors.New("bitcoind unavailable")
+		}).
+		AnyTimes()
+
+	e := NewWalletEngine(func(context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	}, t.TempDir(), &chaincfg.MainNetParams)
+
+	short := WalletInfo{ID: "abc", WalletType: WalletTypeBitcoinCore}
+	good := WalletInfo{ID: "deadbeefcafebabe", WalletType: WalletTypeBitcoinCore}
+	good.Master.SeedHex = strings.Repeat("ab", 32)
+
+	require.NoError(t, e.ensureBitcoinCoreWallets(testCtx(), []WalletInfo{short, good}))
+	require.Equal(t, []string{"wallet_deadbeef"}, created, "the short id must be skipped and the well-formed wallet still ensured")
+}

--- a/bitwindow/server/engines/zmq_engine.go
+++ b/bitwindow/server/engines/zmq_engine.go
@@ -129,11 +129,11 @@ func (e *ZMQ) broadcastTransactions(ctx context.Context) {
 
 // decodeTransaction decodes a raw transaction from bytes
 func decodeTransaction(rawTx []byte) (*wire.MsgTx, error) {
-	var tx wire.MsgTx
-	if err := tx.Deserialize(bytes.NewReader(rawTx)); err != nil {
+	tx, err := readForknetTx(bytes.NewReader(rawTx))
+	if err != nil {
 		return nil, fmt.Errorf("deserialize transaction: %w", err)
 	}
-	return &tx, nil
+	return tx, nil
 }
 
 // HashMsg is a subscription event coming from a "hash"-type ZMQ message.

--- a/bitwindow/server/models/bitdrive/bitdrive.go
+++ b/bitwindow/server/models/bitdrive/bitdrive.go
@@ -13,6 +13,7 @@ import (
 type File struct {
 	ID        int64
 	TxID      string
+	Vout      int32
 	Filename  string
 	FileType  string
 	SizeBytes int64
@@ -29,9 +30,10 @@ func Create(ctx context.Context, db *sql.DB, file File) (int64, error) {
 
 	builder := sq.
 		Insert("bitdrive_files").
-		Columns("txid", "filename", "file_type", "size_bytes", "encrypted", "timestamp", "created_at").
+		Columns("txid", "vout", "filename", "file_type", "size_bytes", "encrypted", "timestamp", "created_at").
 		Values(
 			file.TxID,
+			file.Vout,
 			file.Filename,
 			file.FileType,
 			file.SizeBytes,
@@ -54,6 +56,7 @@ func Create(ctx context.Context, db *sql.DB, file File) (int64, error) {
 	zerolog.Ctx(ctx).Info().
 		Int64("id", id).
 		Str("txid", file.TxID).
+		Int32("vout", file.Vout).
 		Str("filename", file.Filename).
 		Msg("created bitdrive file record")
 
@@ -62,7 +65,7 @@ func Create(ctx context.Context, db *sql.DB, file File) (int64, error) {
 
 func List(ctx context.Context, db *sql.DB) ([]File, error) {
 	query := sq.
-		Select("id", "txid", "filename", "file_type", "size_bytes", "encrypted", "timestamp", "created_at").
+		Select("id", "txid", "vout", "filename", "file_type", "size_bytes", "encrypted", "timestamp", "created_at").
 		From("bitdrive_files").
 		OrderBy("created_at DESC")
 
@@ -82,6 +85,7 @@ func List(ctx context.Context, db *sql.DB) ([]File, error) {
 		err := rows.Scan(
 			&file.ID,
 			&file.TxID,
+			&file.Vout,
 			&file.Filename,
 			&file.FileType,
 			&file.SizeBytes,
@@ -111,12 +115,13 @@ func GetByID(ctx context.Context, db *sql.DB, id int64) (*File, error) {
 	var createdAt int64
 
 	err := db.QueryRowContext(ctx, `
-		SELECT id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at
+		SELECT id, txid, vout, filename, file_type, size_bytes, encrypted, timestamp, created_at
 		FROM bitdrive_files
 		WHERE id = ?
 	`, id).Scan(
 		&file.ID,
 		&file.TxID,
+		&file.Vout,
 		&file.Filename,
 		&file.FileType,
 		&file.SizeBytes,
@@ -136,18 +141,22 @@ func GetByID(ctx context.Context, db *sql.DB, id int64) (*File, error) {
 	return &file, nil
 }
 
+// GetByTxID returns the lowest-vout file of a transaction, which can hold one
+// BitDrive payload per output.
 func GetByTxID(ctx context.Context, db *sql.DB, txid string) (*File, error) {
 	var file File
 	var encrypted int64
 	var createdAt int64
 
 	err := db.QueryRowContext(ctx, `
-		SELECT id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at
+		SELECT id, txid, vout, filename, file_type, size_bytes, encrypted, timestamp, created_at
 		FROM bitdrive_files
 		WHERE txid = ?
+		ORDER BY vout
 	`, txid).Scan(
 		&file.ID,
 		&file.TxID,
+		&file.Vout,
 		&file.Filename,
 		&file.FileType,
 		&file.SizeBytes,
@@ -183,11 +192,11 @@ func Delete(ctx context.Context, db *sql.DB, id int64) error {
 	return nil
 }
 
-func Exists(ctx context.Context, db *sql.DB, txid string) (bool, error) {
+func Exists(ctx context.Context, db *sql.DB, txid string, vout int32) (bool, error) {
 	var count int
 	err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM bitdrive_files WHERE txid = ?
-	`, txid).Scan(&count)
+		SELECT COUNT(*) FROM bitdrive_files WHERE txid = ? AND vout = ?
+	`, txid, vout).Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("check bitdrive file exists: %w", err)
 	}

--- a/sqlitemigrate/sqlitemigrate.go
+++ b/sqlitemigrate/sqlitemigrate.go
@@ -25,8 +25,10 @@ import (
 // Run applies every *.sql file in dir of fsys whose name sorts after the last
 // applied migration, in ascending filename order, and records progress in the
 // `migrations` table. Already-applied files are skipped, so it is safe to call
-// on every startup. It returns the filenames applied this call (empty when the
-// schema was already up to date) so the caller can log as it sees fit.
+// on every startup, and each file is applied in one transaction with its version
+// bump, so a failed migration is retried from a clean slate. It returns the
+// filenames applied this call (empty when the schema was already up to date) so
+// the caller can log as it sees fit.
 func Run(ctx context.Context, db *sql.DB, fsys fs.FS, dir string) ([]string, error) {
 	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS migrations (
 		id INTEGER PRIMARY KEY CHECK (id = 1), -- hard-coded id so REPLACE INTO updates the single row
@@ -62,11 +64,22 @@ func Run(ctx context.Context, db *sql.DB, fsys fs.FS, dir string) ([]string, err
 		if err != nil {
 			return applied, fmt.Errorf("read migration %s: %w", name, err)
 		}
-		if _, err := db.ExecContext(ctx, string(body)); err != nil {
+		// The file body and its version bump share one transaction, so a failure
+		// part-way through a file leaves nothing behind for the retry to trip on.
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return applied, fmt.Errorf("begin migration %s: %w", name, err)
+		}
+		if _, err := tx.ExecContext(ctx, string(body)); err != nil {
+			_ = tx.Rollback()
 			return applied, fmt.Errorf("apply migration %s: %w", name, err)
 		}
-		if _, err := db.ExecContext(ctx, `REPLACE INTO migrations (id, latest_version) VALUES (1, ?)`, name); err != nil {
+		if _, err := tx.ExecContext(ctx, `REPLACE INTO migrations (id, latest_version) VALUES (1, ?)`, name); err != nil {
+			_ = tx.Rollback()
 			return applied, fmt.Errorf("record migration %s: %w", name, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return applied, fmt.Errorf("commit migration %s: %w", name, err)
 		}
 		applied = append(applied, name)
 	}


### PR DESCRIPTION
A set of **10 independent fixes** to the BitWindow server engines & database, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`27 files changed, 1290 insertions(+), 133 deletions(-)`).

## Fixes (oldest first)

- **`ee2e11d5e`** BitWindow deniability exact-fee UTXO emits zero-value output and leaves plan due
- **`254c045bd`** BitWindow `sendWithRequiredInputs` phantom change-output fee rejects valid exact-spend required-input sends
- **`e64bd4235`** BitWindow BnB stale omit bound exhausts search before exact match
- **`22730d506`** BitWindow migration 024_coin_news_4byte_topics.sql is non-idempotent — partial-failure retry stalls upgrades and re-wipes CoinNews resync progress every restart
- **`ed26deaf9`** BitDrive SaveFile Exists(txid) short-circuit drops second OP_RETURN payload of a multi-output same-txid transaction
- **`e9b6652cc`** BitWindow RestoreBackup writes wallet.json with short/empty id wallets[1+] -> WalletEngine ensureBitcoinCoreWallets panics on `wallet.ID[:8]`
- **`9d83799c8`** BitWindow `WalletEngine.BroadcastOpReturn` broadcasts OP_RETURNs while wallet is locked
- **`17c2e7638`** BitWindow bitcoind_engine indexes BIP300/301 M2/M3 coinbase consensus messages into the public OP_RETURN table
- **`f8a36f9bf`** Confirmation: Forknet replay-version block permanently stalls BitWindow L1 indexing
- **`54076c301`** BitWindow applies M4 votes in parallel block-fetch completion order

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.