### PR TITLE
BitWindow server engines & database (3 of 3): 6 fixes from a security review

### DIFF
--- a/bitwindow/server/api/bitdrive/bitdrive.go
+++ b/bitwindow/server/api/bitdrive/bitdrive.go
@@ -248,6 +248,14 @@ func (s *Server) DownloadPendingFiles(ctx context.Context, req *connect.Request[
 			continue
 		}
 
+		// Stamp the block the OP_RETURN was mined in, so a fork purge can drop
+		// the file if that block goes away. Mempool OP_RETURNs have no height.
+		if opReturn.Height != nil {
+			if err := bitdrive.MarkConfirmed(ctx, s.database, pending.Txid, int64(*opReturn.Height)); err != nil {
+				log.Warn().Err(err).Str("txid", pending.Txid).Msg("failed to mark file confirmed")
+			}
+		}
+
 		downloadedCount++
 	}
 

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -1549,7 +1549,9 @@ func (s *Server) checkBitcoinCoreUTXO(ctx context.Context, walletID string, txid
 	}
 
 	utxos, err := s.data.ListUnspent(ctx, &corepb.ListUnspentRequest{
-		Wallet: walletName,
+		// An unconfirmed output is still one the user can start a denial on.
+		MinimumConfirmations: lo.ToPtr(uint32(0)),
+		Wallet:               walletName,
 	})
 	if err != nil {
 		return false, fmt.Errorf("list bitcoin core utxos: %w", err)

--- a/bitwindow/server/database/migrations/047_bitdrive_block_height.sql
+++ b/bitwindow/server/database/migrations/047_bitdrive_block_height.sql
@@ -1,0 +1,4 @@
+-- Records the block a stored file's OP_RETURN was mined in. Without it a fork
+-- purge cannot tell which files came from a branch that went away, and they
+-- keep listing as if the chain still carried them.
+ALTER TABLE bitdrive_files ADD COLUMN block_height INTEGER;

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -189,9 +189,19 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		log.Info().Msg("restore: imported transactions")
 	}
 
-	// Restore wallet.json
+	// Restore wallet.json. A restore replaces the resident wallet, so it reads
+	// the file it replaces first and may drop the wallets that file holds.
 	walletPath := filepath.Join(e.walletDir, walletfile.Name)
-	if err := walletfile.Write(walletPath, walletJSON, walletfile.Options{}); err != nil {
+	opts := walletfile.Options{AllowDrop: true}
+	switch current, err := os.ReadFile(walletPath); {
+	case err == nil:
+		opts.Expected, opts.ExpectedKnown = walletfile.DigestOf(current), true
+	case os.IsNotExist(err):
+		opts.Expected, opts.ExpectedKnown = walletfile.DigestOf(nil), true
+	default:
+		return fmt.Errorf("read the wallet file before the restore: %w", err)
+	}
+	if err := walletfile.Write(walletPath, walletJSON, opts); err != nil {
 		return fmt.Errorf("write wallet.json: %w", err)
 	}
 	log.Info().Msg("restore: wrote wallet.json")

--- a/bitwindow/server/engines/backup_engine_test.go
+++ b/bitwindow/server/engines/backup_engine_test.go
@@ -145,6 +145,42 @@ func TestRestoreBackup_JSON(t *testing.T) {
 	}
 }
 
+func TestRestoreBackup_ReplacesExistingWallet(t *testing.T) {
+	resident := []byte(`{"wallets":[{"id":"old","master":"old-seed","l1":"old-key"}]}`)
+	backup := []byte(`{"wallets":[{"id":"new","master":"new-seed","l1":"new-key"}]}`)
+
+	for _, tc := range []struct {
+		name    string
+		current []byte
+	}{
+		{"valid", resident},
+		{"corrupt", []byte("not json")},
+		{"empty", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			e := &BackupEngine{walletDir: tmpDir}
+
+			walletPath := filepath.Join(tmpDir, "wallet.json")
+			if err := os.WriteFile(walletPath, tc.current, 0600); err != nil {
+				t.Fatalf("seed wallet.json: %v", err)
+			}
+
+			if err := e.RestoreBackup(testCtx(), backup, "wallet.json"); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			content, err := os.ReadFile(walletPath)
+			if err != nil {
+				t.Fatalf("wallet.json not found: %v", err)
+			}
+			if !bytes.Equal(content, backup) {
+				t.Fatalf("wallet.json holds %s, want the backup", content)
+			}
+		})
+	}
+}
+
 func TestHasCurrentWallet(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := &BackupEngine{walletDir: tmpDir}

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -14,6 +14,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
 	logpool "github.com/LayerTwo-Labs/sidesail/bitwindow/server/logpool"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/blocks"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
@@ -551,6 +552,15 @@ func (p *Parser) opReturnForTXID(
 
 	if err := opreturns.Persist(ctx, p.db, opReturns); err != nil {
 		return err
+	}
+
+	// A file downloaded from the mempool has no height yet, and one the fork
+	// purge dropped is downloaded again. Either way the block that carries the
+	// OP_RETURN is what confirms it.
+	if height != nil && len(opReturns) > 0 {
+		if err := bitdrive.MarkConfirmed(ctx, p.db, tx.TxID(), int64(*height)); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -461,6 +462,18 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 			return fmt.Errorf("process blocks: %w", err)
 		}
 
+		if err := p.checkBatchAncestry(ctx, results); err != nil {
+			if !errors.Is(err, errChainMoved) {
+				return fmt.Errorf("check batch ancestry: %w", err)
+			}
+
+			zerolog.Ctx(ctx).Warn().Err(err).
+				Uint32("batch_start", batchStart).
+				Uint32("batch_end", batchEnd).
+				Msg("bitcoind_engine/parser: the chain moved while the batch was fetched, retrying next tick")
+			return nil
+		}
+
 		if err := p.processBlocks(ctx, results); err != nil {
 			return fmt.Errorf("process blocks: %w", err)
 		}
@@ -472,6 +485,57 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 
 	zerolog.Ctx(ctx).Trace().
 		Msgf("bitcoind_engine/parser: finished processing blocks")
+
+	return nil
+}
+
+// errChainMoved marks a batch that spans more than one chain, as opposed to a
+// failure to check it.
+var errChainMoved = errors.New("the batch is not one chain")
+
+// checkBatchAncestry reports whether a fetched batch is one chain: every block
+// links to the one below it, and the lowest links to what we already processed.
+// A mixed batch is reported as errChainMoved; anything else is a failed check.
+//
+// The batch fans out one getblockhash + getblock per height, so Core switching
+// branches part way through hands back blocks from two chains. processBlocks
+// would commit that mix as canonical, and forkPoint's tip-only fast path never
+// revisits an interior height. Abandoning the batch costs one tick.
+func (p *Parser) checkBatchAncestry(ctx context.Context, coreBlocks []lo.Tuple2[uint32, *wire.MsgBlock]) error {
+	sorted := append([]lo.Tuple2[uint32, *wire.MsgBlock]{}, coreBlocks...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].A < sorted[j].A })
+
+	for i, t := range sorted {
+		height, block := t.Unpack()
+
+		var parent chainhash.Hash
+		switch {
+		case i > 0:
+			if prev := sorted[i-1].A; prev != height-1 {
+				return fmt.Errorf("%w: block %d does not follow %d", errChainMoved, height, prev)
+			}
+			parent = sorted[i-1].B.Header.BlockHash()
+
+		case height == 0:
+			continue // genesis has no parent
+
+		default:
+			stored, err := blocks.GetProcessedBlock(ctx, p.db, height-1)
+			if errors.Is(err, sql.ErrNoRows) {
+				// Nothing processed below the batch — the scan floor skips
+				// ahead, and a replay starts at the fork. No anchor to check.
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("get processed block %d: %w", height-1, err)
+			}
+			parent = stored.Hash
+		}
+
+		if block.Header.PrevBlock != parent {
+			return fmt.Errorf("%w: block %d links to %s, not %s", errChainMoved, height, block.Header.PrevBlock, parent)
+		}
+	}
 
 	return nil
 }

--- a/bitwindow/server/engines/bitcoind_engine_internal_test.go
+++ b/bitwindow/server/engines/bitcoind_engine_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
 	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
@@ -117,10 +118,10 @@ func TestOpReturnHandling(t *testing.T) {
 	assert.Equal(t, "The Known Topic", news[0].TopicName)
 }
 
-// TestPurgeChainDerivedAtOrAbove proves the reorg purge covers the two
+// TestPurgeChainDerivedAtOrAbove proves the reorg purge covers the three
 // tables the replay can't heal on its own: op_returns keeps its stale
-// height through the upsert, and a confirmed timestamp is never
-// re-examined.
+// height through the upsert, a confirmed timestamp is never
+// re-examined, and a stored file is only ever written by a download.
 func TestPurgeChainDerivedAtOrAbove(t *testing.T) {
 	t.Parallel()
 
@@ -139,6 +140,13 @@ func TestPurgeChainDerivedAtOrAbove(t *testing.T) {
 		INSERT INTO file_timestamps (filename, file_hash, txid, block_height, status, created_at, confirmed_at)
 		VALUES ('below.txt', 'hash-below', 'txid-below', 100, 'confirmed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 		       ('orphaned.txt', 'hash-orphaned', 'txid-orphaned', 200, 'confirmed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO bitdrive_files (txid, filename, file_type, size_bytes, encrypted, timestamp, created_at, block_height)
+		VALUES ('below', 'below.txt', 'txt', 1, 0, 0, 0, 100),
+		       ('orphaned', 'orphaned.txt', 'txt', 1, 0, 0, 0, 200),
+		       ('mempool', 'mempool.txt', 'txt', 1, 0, 0, 0, NULL)`)
 	require.NoError(t, err)
 
 	require.NoError(t, parser.purgeChainDerivedAtOrAbove(ctx, 181))
@@ -165,6 +173,23 @@ func TestPurgeChainDerivedAtOrAbove(t *testing.T) {
 	assert.Equal(t, timestamps.StatusConfirming, orphaned.Status, "orphaned timestamps go back to confirming")
 	assert.Nil(t, orphaned.BlockHeight, "orphaned timestamps lose their stale height")
 	assert.Nil(t, orphaned.ConfirmedAt, "orphaned timestamps lose their stale confirmation time")
+
+	files, err := bitdrive.List(ctx, db)
+	require.NoError(t, err)
+	var fileTxids []string
+	for _, file := range files {
+		fileTxids = append(fileTxids, file.TxID)
+	}
+	slices.Sort(fileTxids)
+	assert.Equal(t, []string{"below", "mempool"}, fileTxids,
+		"a file the orphaned branch carried stops listing, confirmed-below and mempool rows survive")
+
+	// What the replay does when the new chain mines the transaction again.
+	require.NoError(t, bitdrive.MarkConfirmed(ctx, db, "mempool", 190))
+	confirmed, err := bitdrive.GetByTxID(ctx, db, "mempool")
+	require.NoError(t, err)
+	require.NotNil(t, confirmed.BlockHeight, "a replayed block confirms the file")
+	assert.EqualValues(t, 190, *confirmed.BlockHeight)
 }
 
 func pkScript(t *testing.T, data []byte) []byte {

--- a/bitwindow/server/engines/bitcoind_engine_internal_test.go
+++ b/bitwindow/server/engines/bitcoind_engine_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -355,4 +356,66 @@ func TestOpReturnHandling_WhitespaceHeadlineLooksBlank(t *testing.T) {
 	news, err := opreturns.ListCoinNews(ctx, db)
 	require.NoError(t, err)
 	assert.Empty(t, news, "whitespace-only headlines must not surface as canonical stories")
+}
+
+// blockRun builds n linked blocks from height, each descending from the last.
+// Distinct nonces give two runs off the same parent distinct hashes.
+func blockRun(parent chainhash.Hash, height uint32, n int, nonce uint32) []lo.Tuple2[uint32, *wire.MsgBlock] {
+	var run []lo.Tuple2[uint32, *wire.MsgBlock]
+	for i := 0; i < n; i++ {
+		block := &wire.MsgBlock{Header: wire.BlockHeader{PrevBlock: parent, Nonce: nonce}}
+		run = append(run, lo.T2(height+uint32(i), block))
+		parent = block.Header.BlockHash()
+	}
+	return run
+}
+
+// A batch that mixes two branches must never commit: forkPoint's tip-only fast
+// path never revisits an interior height, so the orphans stay marked processed.
+func TestCheckBatchAncestryRejectsAMixedBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	parser := &Parser{db: database.Test(t)}
+
+	anchor := chainhash.Hash{0xaa}
+	branchA := blockRun(anchor, 100, 6, 1)
+	branchB := blockRun(anchor, 100, 6, 2)
+
+	// Core switched branches halfway through the fan-out.
+	mixed := append(append([]lo.Tuple2[uint32, *wire.MsgBlock]{}, branchA[:3]...), branchB[3:]...)
+	require.ErrorIs(t, parser.checkBatchAncestry(ctx, mixed), errChainMoved)
+
+	require.NoError(t, parser.checkBatchAncestry(ctx, branchA), "one branch commits")
+}
+
+// The lowest block in a batch has to descend from what we already processed.
+func TestCheckBatchAncestryChecksTheStoredAnchor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	parser := &Parser{db: database.Test(t)}
+
+	anchor := chainhash.Hash{0xaa}
+	_, err := parser.db.ExecContext(ctx, `
+		INSERT INTO processed_blocks (height, block_hash, txids, block_time)
+		VALUES (?, ?, '[]', 0)`, 99, anchor.String())
+	require.NoError(t, err)
+
+	require.NoError(t, parser.checkBatchAncestry(ctx, blockRun(anchor, 100, 3, 1)))
+	require.ErrorIs(t, parser.checkBatchAncestry(ctx, blockRun(chainhash.Hash{0xbb}, 100, 3, 1)), errChainMoved,
+		"a batch built on another branch is rejected")
+}
+
+// A database that cannot answer must fail the tick, not quietly skip the anchor.
+func TestCheckBatchAncestryFailsOnADatabaseError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	parser := &Parser{db: database.Test(t)}
+	require.NoError(t, parser.db.Close())
+
+	err := parser.checkBatchAncestry(ctx, blockRun(chainhash.Hash{0xaa}, 100, 3, 1))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errChainMoved)
 }

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -236,7 +236,8 @@ func TestSaveFile_SameSecondNoCollision(t *testing.T) {
 			size_bytes INTEGER NOT NULL,
 			encrypted INTEGER NOT NULL DEFAULT 0,
 			timestamp INTEGER NOT NULL,
-			created_at INTEGER NOT NULL
+			created_at INTEGER NOT NULL,
+			block_height INTEGER
 		)
 	`); err != nil {
 		t.Fatalf("create table: %v", err)

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -262,13 +262,16 @@ func purgeM4AtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) (uin
 	return replayFrom, nil
 }
 
-// purgeChainDerivedAtOrAbove drops the block-derived op_returns and
-// file_timestamps state from blocks at or above `fromHeight`. Neither
-// heals itself on replay: the op_returns upsert keeps the old height
-// (`COALESCE(excluded.height, op_returns.height)`), and a confirmed
-// timestamp is never re-examined. Mempool OP_RETURNs have a NULL height
-// and are left alone; reset timestamps go back through the confirming
-// loop, which re-confirms them against the new chain or fails them.
+// purgeChainDerivedAtOrAbove drops the block-derived op_returns,
+// file_timestamps and bitdrive_files state from blocks at or above
+// `fromHeight`. None of them heals itself on replay: the op_returns upsert
+// keeps the old height (`COALESCE(excluded.height, op_returns.height)`), a
+// confirmed timestamp is never re-examined, and a stored file is only ever
+// written by a download. Mempool OP_RETURNs have a NULL height and are left
+// alone; reset timestamps go back through the confirming loop, which
+// re-confirms them against the new chain or fails them. A dropped file row
+// leaves its local copy on disk, and the next scan re-offers it if the new
+// chain still carries the transaction.
 func purgeChainDerivedAtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) error {
 
 	if _, err := tx.ExecContext(ctx,
@@ -281,6 +284,11 @@ func purgeChainDerivedAtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight ui
 		SET status = ?, block_height = NULL, confirmed_at = NULL
 		WHERE block_height >= ?`,
 		timestamps.StatusConfirming, fromHeight,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM bitdrive_files WHERE block_height >= ?`, fromHeight,
 	); err != nil {
 		return err
 	}

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -697,7 +697,9 @@ func (e *DeniabilityEngine) listBitcoinCoreUTXOs(ctx context.Context, walletId s
 	}
 
 	resp, err := bitcoind.ListUnspent(ctx, connect.NewRequest(&corepb.ListUnspentRequest{
-		Wallet: coreWalletName,
+		// A hop spends the previous hop's output, which is still unconfirmed.
+		MinimumConfirmations: lo.ToPtr(uint32(0)),
+		Wallet:               coreWalletName,
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("bitcoin core list unspent: %w", err)

--- a/bitwindow/server/engines/deniability_engine_test.go
+++ b/bitwindow/server/engines/deniability_engine_test.go
@@ -198,4 +198,44 @@ func TestDeniabilityEngine(t *testing.T) {
 		assert.NotNil(t, denial.CancelledAt)
 		assert.Equal(t, "utxo is too small to split", *denial.CancelReason)
 	})
+
+	t.Run("unconfirmed tip is not cancelled", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return mockBitcoind, nil
+		})
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+
+		denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// A hop's tip is the previous hop's output, so Core only reports it at
+		// minconf 0.
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Times(1).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.ListUnspentRequest]) (*connect.Response[corepb.ListUnspentResponse], error) {
+				var unspent []*corepb.UnspentOutput
+				if req.Msg.MinimumConfirmations != nil && *req.Msg.MinimumConfirmations == 0 {
+					unspent = append(unspent, &corepb.UnspentOutput{
+						Txid: "test-txid", Vout: 0, Amount: 0.01, Confirmations: 0,
+					})
+				}
+				return &connect.Response[corepb.ListUnspentResponse]{
+					Msg: &corepb.ListUnspentResponse{Unspent: unspent},
+				}, nil
+			})
+
+		utxos, denials, err := engine.CleanupDenials(ctx)
+		require.NoError(t, err)
+		assert.Len(t, utxos, 1)
+		assert.Len(t, denials, 1)
+
+		denial, err = deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.Nil(t, denial.CancelledAt)
+	})
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine.go
@@ -178,6 +178,22 @@ func (e *SidechainMonitorEngine) GetWithdrawalByTxid(ctx context.Context, txid s
 
 // RegisterPendingFastWithdrawal adds a pending fast withdrawal to monitor for
 func (e *SidechainMonitorEngine) RegisterPendingFastWithdrawal(ctx context.Context, withdrawal PendingFastWithdrawal) error {
+	// Reject malformed server responses: they can never be completed, so they
+	// would sit in the map forever and pin the poll interval.
+	if err := validateWithdrawalHash(withdrawal.Hash); err != nil {
+		return fmt.Errorf("invalid withdrawal hash: %w", err)
+	}
+	if withdrawal.ServerAddress == "" {
+		return fmt.Errorf("missing server address")
+	}
+	if withdrawal.ExpectedAmount <= 0 {
+		return fmt.Errorf("invalid expected amount: %d", withdrawal.ExpectedAmount)
+	}
+
+	if withdrawal.CreatedAt.IsZero() {
+		withdrawal.CreatedAt = time.Now()
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -287,7 +303,8 @@ func (e *SidechainMonitorEngine) getPollInterval() time.Duration {
 	}
 }
 
-// cleanupOldWithdrawals removes withdrawals older than 1 hour to prevent memory bloat
+// cleanupOldWithdrawals removes detected withdrawals older than 1 hour, and pending
+// fast withdrawals older than 24 hours, to prevent memory bloat
 func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -296,6 +313,15 @@ func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
 	for txid, withdrawal := range e.detectedWithdrawals {
 		if withdrawal.DetectedAt.Before(cutoff) {
 			delete(e.detectedWithdrawals, txid)
+		}
+	}
+
+	// Longer TTL, so a withdrawal that never gets paid eventually stops
+	// pinning the poll interval.
+	pendingCutoff := time.Now().Add(-24 * time.Hour)
+	for hash, pending := range e.pendingFastWithdrawals {
+		if pending.CreatedAt.Before(pendingCutoff) {
+			delete(e.pendingFastWithdrawals, hash)
 		}
 	}
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine_test.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine_test.go
@@ -55,6 +55,49 @@ func TestSidechainMonitorEngine_RegisterPendingFastWithdrawal(t *testing.T) {
 	assert.Equal(t, "thunder1test456", pending[0].ServerAddress)
 }
 
+func TestSidechainMonitorEngine_RegisterPendingFastWithdrawal_Invalid(t *testing.T) {
+	ctx := context.Background()
+
+	valid := PendingFastWithdrawal{
+		Hash:           "test-hash-123456789abcdef",
+		Sidechain:      "thunder",
+		ServerAddress:  "thunder1test456",
+		ExpectedAmount: 105000,
+		ServerURL:      "https://fw1.drivechain.info",
+		CreatedAt:      time.Now(),
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*PendingFastWithdrawal)
+	}{
+		{"malformed hash", func(w *PendingFastWithdrawal) { w.Hash = "test-hash-1234567!9abcdef" }},
+		{"short hash", func(w *PendingFastWithdrawal) { w.Hash = "short" }},
+		{"missing server address", func(w *PendingFastWithdrawal) { w.ServerAddress = "" }},
+		{"non-positive amount", func(w *PendingFastWithdrawal) { w.ExpectedAmount = 0 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := NewSidechainMonitorEngine(
+				nil, nil, nil, nil, nil, nil,
+				nil,
+			)
+
+			withdrawal := valid
+			tt.mutate(&withdrawal)
+
+			require.Error(t, engine.RegisterPendingFastWithdrawal(ctx, withdrawal))
+
+			// Nothing entered the map, so the poll interval stays relaxed
+			pending, err := engine.GetPendingFastWithdrawals(ctx)
+			require.NoError(t, err)
+			assert.Len(t, pending, 0)
+			assert.Equal(t, 30*time.Second, engine.getPollInterval())
+		})
+	}
+}
+
 func TestSidechainMonitorEngine_CompleteWithdrawal(t *testing.T) {
 	ctx := zerolog.New(zerolog.NewTestWriter(t)).WithContext(context.Background())
 
@@ -195,4 +238,33 @@ func TestSidechainMonitorEngine_CleanupOldWithdrawals(t *testing.T) {
 	// Old withdrawal should be removed, new one should remain
 	assert.NotContains(t, engine.detectedWithdrawals, "old-txid")
 	assert.Contains(t, engine.detectedWithdrawals, "new-txid")
+}
+
+func TestSidechainMonitorEngine_CleanupOldPendingFastWithdrawals(t *testing.T) {
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	// Three stuck withdrawals, older than the 24 hour cutoff
+	stale := time.Now().Add(-25 * time.Hour)
+	for _, hash := range []string{"stale-hash-1234567890ab", "stale-hash-2234567890ab", "stale-hash-3234567890ab"} {
+		engine.pendingFastWithdrawals[hash] = PendingFastWithdrawal{
+			Hash:      hash,
+			CreatedAt: stale,
+		}
+	}
+	engine.pendingFastWithdrawals["fresh-hash-1234567890ab"] = PendingFastWithdrawal{
+		Hash:      "fresh-hash-1234567890ab",
+		CreatedAt: time.Now(),
+	}
+
+	// They pin the poll interval at its floor until evicted
+	assert.Equal(t, 2*time.Second, engine.getPollInterval())
+
+	engine.cleanupOldWithdrawals()
+
+	assert.Len(t, engine.pendingFastWithdrawals, 1)
+	assert.Contains(t, engine.pendingFastWithdrawals, "fresh-hash-1234567890ab")
+	assert.Equal(t, 5*time.Second, engine.getPollInterval())
 }

--- a/bitwindow/server/models/bitdrive/bitdrive.go
+++ b/bitwindow/server/models/bitdrive/bitdrive.go
@@ -19,6 +19,9 @@ type File struct {
 	Encrypted bool
 	Timestamp uint32
 	CreatedAt time.Time
+
+	// Block the file's OP_RETURN was mined in. Nil while it is unconfirmed.
+	BlockHeight *int64
 }
 
 func Create(ctx context.Context, db *sql.DB, file File) (int64, error) {
@@ -62,7 +65,7 @@ func Create(ctx context.Context, db *sql.DB, file File) (int64, error) {
 
 func List(ctx context.Context, db *sql.DB) ([]File, error) {
 	query := sq.
-		Select("id", "txid", "filename", "file_type", "size_bytes", "encrypted", "timestamp", "created_at").
+		Select("id", "txid", "filename", "file_type", "size_bytes", "encrypted", "timestamp", "created_at", "block_height").
 		From("bitdrive_files").
 		OrderBy("created_at DESC")
 
@@ -78,6 +81,7 @@ func List(ctx context.Context, db *sql.DB) ([]File, error) {
 		var file File
 		var encrypted int64
 		var createdAt int64
+		var blockHeight sql.NullInt64
 
 		err := rows.Scan(
 			&file.ID,
@@ -88,6 +92,7 @@ func List(ctx context.Context, db *sql.DB) ([]File, error) {
 			&encrypted,
 			&file.Timestamp,
 			&createdAt,
+			&blockHeight,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan bitdrive file: %w", err)
@@ -95,6 +100,9 @@ func List(ctx context.Context, db *sql.DB) ([]File, error) {
 
 		file.Encrypted = encrypted == 1
 		file.CreatedAt = time.Unix(createdAt, 0)
+		if blockHeight.Valid {
+			file.BlockHeight = &blockHeight.Int64
+		}
 		files = append(files, file)
 	}
 
@@ -109,9 +117,10 @@ func GetByID(ctx context.Context, db *sql.DB, id int64) (*File, error) {
 	var file File
 	var encrypted int64
 	var createdAt int64
+	var blockHeight sql.NullInt64
 
 	err := db.QueryRowContext(ctx, `
-		SELECT id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at
+		SELECT id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at, block_height
 		FROM bitdrive_files
 		WHERE id = ?
 	`, id).Scan(
@@ -123,6 +132,7 @@ func GetByID(ctx context.Context, db *sql.DB, id int64) (*File, error) {
 		&encrypted,
 		&file.Timestamp,
 		&createdAt,
+		&blockHeight,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -133,6 +143,9 @@ func GetByID(ctx context.Context, db *sql.DB, id int64) (*File, error) {
 
 	file.Encrypted = encrypted == 1
 	file.CreatedAt = time.Unix(createdAt, 0)
+	if blockHeight.Valid {
+		file.BlockHeight = &blockHeight.Int64
+	}
 	return &file, nil
 }
 
@@ -140,9 +153,10 @@ func GetByTxID(ctx context.Context, db *sql.DB, txid string) (*File, error) {
 	var file File
 	var encrypted int64
 	var createdAt int64
+	var blockHeight sql.NullInt64
 
 	err := db.QueryRowContext(ctx, `
-		SELECT id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at
+		SELECT id, txid, filename, file_type, size_bytes, encrypted, timestamp, created_at, block_height
 		FROM bitdrive_files
 		WHERE txid = ?
 	`, txid).Scan(
@@ -154,6 +168,7 @@ func GetByTxID(ctx context.Context, db *sql.DB, txid string) (*File, error) {
 		&encrypted,
 		&file.Timestamp,
 		&createdAt,
+		&blockHeight,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -164,7 +179,26 @@ func GetByTxID(ctx context.Context, db *sql.DB, txid string) (*File, error) {
 
 	file.Encrypted = encrypted == 1
 	file.CreatedAt = time.Unix(createdAt, 0)
+	if blockHeight.Valid {
+		file.BlockHeight = &blockHeight.Int64
+	}
 	return &file, nil
+}
+
+// MarkConfirmed stamps the block a stored file's OP_RETURN was mined in, so the
+// fork purge can tell the file apart from one an orphaned branch carried. A
+// txid with no stored file is a no-op.
+func MarkConfirmed(ctx context.Context, db *sql.DB, txid string, height int64) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE bitdrive_files
+		SET block_height = ?
+		WHERE txid = ?
+	`, height, txid)
+	if err != nil {
+		return fmt.Errorf("mark bitdrive file confirmed: %w", err)
+	}
+
+	return nil
 }
 
 func Delete(ctx context.Context, db *sql.DB, id int64) error {

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -173,8 +173,39 @@ func saveGroupOn(ctx context.Context, e execer, g Group) error {
 }
 
 func (s *Store) DeleteGroup(ctx context.Context, id string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM multisig_groups WHERE id = ?`, id)
-	return err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := deleteGroupChildrenOn(ctx, tx, id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM multisig_groups WHERE id = ?`, id); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// deleteGroupChildrenOn removes every row belonging to the group. The database is
+// opened without foreign_keys=ON, so the declared ON DELETE CASCADE never runs.
+func deleteGroupChildrenOn(ctx context.Context, e execer, groupID string) error {
+	for _, query := range []string{
+		`DELETE FROM multisig_tx_inputs WHERE transaction_id IN (SELECT id FROM multisig_transactions WHERE group_id = ?)`,
+		`DELETE FROM multisig_tx_key_psbts WHERE transaction_id IN (SELECT id FROM multisig_transactions WHERE group_id = ?)`,
+		`DELETE FROM multisig_transactions WHERE group_id = ?`,
+		`DELETE FROM multisig_group_transactions WHERE group_id = ?`,
+		`DELETE FROM multisig_utxo_details WHERE group_id = ?`,
+		`DELETE FROM multisig_addresses WHERE group_id = ?`,
+		`DELETE FROM multisig_key_psbts WHERE key_id IN (SELECT id FROM multisig_keys WHERE group_id = ?)`,
+		`DELETE FROM multisig_keys WHERE group_id = ?`,
+	} {
+		if _, err := e.ExecContext(ctx, query, groupID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ─── Keys ──────────────────────────────────────────────────────────
@@ -771,6 +802,18 @@ func (s *Store) SaveGroupAtomic(ctx context.Context, p SaveGroupAtomicParams) er
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
+
+	// An id not yet in the table is a new or imported group: drop anything an
+	// earlier group of the same id left behind, so it doesn't inherit its spends.
+	var exists int
+	switch err := tx.QueryRowContext(ctx, `SELECT 1 FROM multisig_groups WHERE id = ?`, p.Group.ID).Scan(&exists); {
+	case err == sql.ErrNoRows:
+		if err := deleteGroupChildrenOn(ctx, tx, p.Group.ID); err != nil {
+			return fmt.Errorf("clear stale group data: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("lookup group: %w", err)
+	}
 
 	if err := saveGroupOn(ctx, tx, p.Group); err != nil {
 		return fmt.Errorf("save group: %w", err)

--- a/bitwindow/server/models/multisig/multisig_test.go
+++ b/bitwindow/server/models/multisig/multisig_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -198,6 +199,92 @@ func TestDeleteGroupCascades(t *testing.T) {
 	dbKeys, err := store.ListKeysForGroup(ctx, g.ID)
 	require.NoError(t, err)
 	assert.Empty(t, dbKeys)
+}
+
+// The shipped database is opened without foreign_keys=ON, so DeleteGroup has to
+// remove the group's rows itself instead of relying on ON DELETE CASCADE.
+func TestDeleteGroupRemovesChildrenWithoutForeignKeys(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(database.Test(t))
+
+	g := sampleGroup()
+	require.NoError(t, store.SaveGroupAtomic(ctx, multisig.SaveGroupAtomicParams{
+		Group:          g,
+		Keys:           []multisig.Key{{GroupID: g.ID, Owner: "alice", Xpub: "xpub1", DerivationPath: "m/48'/0'/0'"}},
+		Addresses:      []multisig.Address{{GroupID: g.ID, AddrType: "receive", Index: 0, Addr: "bc1q1"}},
+		UtxoDetails:    []multisig.UtxoDetail{{GroupID: g.ID, Txid: "utxo-tx", Vout: 0, Amount: 1.0}},
+		TransactionIDs: []string{"tx-1"},
+	}))
+	require.NoError(t, store.SaveTransactionAtomic(ctx, multisig.SaveTransactionAtomicParams{
+		Transaction: multisig.Transaction{
+			ID: "tx-1", GroupID: g.ID, InitialPSBT: "psbt", Status: 1, Type: 1,
+			Created: 1700000500, Amount: 0.5, Destination: "bc1qdestination",
+		},
+		KeyPSBTs: []multisig.TxKeyPSBT{{TransactionID: "tx-1", KeyID: "key-1", PSBT: "signed-psbt", IsSigned: true}},
+		Inputs:   []multisig.TxInput{{TransactionID: "tx-1", Txid: "input-txid", Vout: 0, Amount: 1.0}},
+	}))
+
+	require.NoError(t, store.DeleteGroup(ctx, g.ID))
+
+	txns, err := store.ListTransactions(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, txns, "deleted group's transactions survived")
+
+	txPSBTs, err := store.ListTxKeyPSBTs(ctx, "tx-1")
+	require.NoError(t, err)
+	assert.Empty(t, txPSBTs, "deleted group's signed PSBTs survived")
+
+	txInputs, err := store.ListTxInputs(ctx, "tx-1")
+	require.NoError(t, err)
+	assert.Empty(t, txInputs)
+
+	txIDs, err := store.ListGroupTransactionIDs(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, txIDs)
+
+	dbKeys, err := store.ListKeysForGroup(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, dbKeys)
+
+	dbAddrs, err := store.ListAddresses(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, dbAddrs)
+
+	dbUtxos, err := store.ListUtxoDetails(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, dbUtxos)
+}
+
+// Databases written before DeleteGroup cleaned up after itself still hold orphan
+// rows; recreating a group under a reused id must not adopt them.
+func TestSaveGroupAtomicDropsOrphanedTransactions(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	store := multisig.NewStore(db)
+
+	g := sampleGroup()
+	require.NoError(t, store.SaveGroup(ctx, g))
+	require.NoError(t, store.SaveTransactionAtomic(ctx, multisig.SaveTransactionAtomicParams{
+		Transaction: multisig.Transaction{
+			ID: "tx-1", GroupID: g.ID, InitialPSBT: "psbt", Status: 1, Type: 1,
+			Created: 1700000500, Amount: 0.5, Destination: "bc1qdestination",
+		},
+		KeyPSBTs: []multisig.TxKeyPSBT{{TransactionID: "tx-1", KeyID: "key-1", PSBT: "signed-psbt", IsSigned: true}},
+	}))
+
+	// Delete the way the old DeleteGroup did, leaving the transaction orphaned.
+	_, err := db.ExecContext(ctx, `DELETE FROM multisig_groups WHERE id = ?`, g.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveGroupAtomic(ctx, multisig.SaveGroupAtomicParams{Group: g}))
+
+	txns, err := store.ListTransactions(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, txns, "recreated group inherited the deleted group's spend")
+
+	txPSBTs, err := store.ListTxKeyPSBTs(ctx, "tx-1")
+	require.NoError(t, err)
+	assert.Empty(t, txPSBTs)
 }
 
 func TestReplaceKeysForGroup(t *testing.T) {


### PR DESCRIPTION
A set of **6 independent fixes** to the BitWindow server engines & database, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`16 files changed, 556 insertions(+), 21 deletions(-)`).

## Fixes (oldest first)

- **`13834c8e0`** BitWindow opens its SQLite database with foreign_keys OFF, so multisig DeleteGroup deletes only the parent multisig_groups row and orphans the group's signed-PSBT transactions; recreating or importing a group with the same client-supplied ID then inherits the deleted group's pending multisig spend (destination/amount/signed PSBT)
- **`972f56e07`** BitWindow's bitdrive_files table stores no confirming block hash/height and is never invalidated on reorg, so ListFiles/GetFile keep serving a file whose source OP_RETURN/timestamp transaction was orphaned by a mainchain reorg as if still confirmed
- **`f7dd4e949`** BitWindow `SidechainMonitorEngine` orphan pending fast-withdrawal rows from malformed-hash fw1 response
- **`610f312b5`** BitWindow DeniabilityEngine Core-path listunspent omits minconf -> 0-conf destination hidden -> wait timeout -> plan cancelled next tick, remaining hops dropped
- **`31c1f3780`** BitWindow accepts mixed ancestry when Core switches branches during replay
- **`de1567aa9`** RestoreBackup rejects every existing valid wallet with ErrUnread

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.