### PR TITLE
BitWindow wallet & cheque API (1 of 4): 9 fixes from a security review

### DIFF
--- a/bitwindow/lib/pages/wallet/check_detail_page.dart
+++ b/bitwindow/lib/pages/wallet/check_detail_page.dart
@@ -127,7 +127,7 @@ class CheckDetailViewModel extends BaseViewModel {
 
     if (!_check!.hasPrivateKeyWif() || _check!.privateKeyWif.isEmpty) {
       if (context.mounted) {
-        showSailToast(context, 'Private key not available - wallet may be locked');
+        showSailToast(context, 'Private key not available - funding is unconfirmed, or wallet is locked');
       }
       return;
     }

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -82,6 +82,8 @@ func TestCheckChequeFunding_UnfundedCheck(t *testing.T) {
 	require.False(t, resp.Msg.Funded)
 }
 
+// A payment sitting in the mempool can still be double spent, so it is
+// reported but never counted: the cheque stays unfunded.
 func TestCheckChequeFunding_DetectsUnconfirmedTx(t *testing.T) {
 	t.Parallel()
 	db := database.Test(t)
@@ -106,9 +108,95 @@ func TestCheckChequeFunding_DetectsUnconfirmedTx(t *testing.T) {
 		Id:       chequeID,
 	}))
 	require.NoError(t, err)
-	require.True(t, resp.Msg.Funded)
-	require.Equal(t, []string{fundingTxid}, resp.Msg.FundedTxids)
+	require.False(t, resp.Msg.Funded, "zero-confirmation funding must not count")
+	require.EqualValues(t, 0, resp.Msg.ActualAmountSats)
+	require.Equal(t, []string{fundingTxid}, resp.Msg.FundedTxids, "the txid is still reported so the UI can keep polling")
 	require.EqualValues(t, 0, resp.Msg.MinConfirmations)
+}
+
+// A top-up that hasn't confirmed yet must not push a cheque over its expected
+// amount.
+func TestCheckChequeFunding_UnconfirmedTopUpDoesNotCount(t *testing.T) {
+	t.Parallel()
+	db := database.Test(t)
+
+	chequeAddr := "tb1qtopuptestaddr0000000000000000000000000"
+	confirmed := "1111000011110000111100001111000011110000111100001111000011110000"
+	pending := "2222000022220000222200002222000022220000222200002222000022220000"
+
+	cli := walletv1connect.NewWalletServiceClient(
+		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
+			address: chequeAddr,
+			utxos: []*orchpb.AddressUnspentOutput{
+				{Txid: confirmed, Vout: 0, ValueSats: 100_000_000, Confirmations: 2},
+				{Txid: pending, Vout: 0, ValueSats: 100_000_000, Confirmations: 0},
+			},
+		})),
+	)
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 200_000_000, chequeAddr)
+	require.NoError(t, err)
+
+	resp, err := cli.CheckChequeFunding(context.Background(), connect.NewRequest(&walletv1.CheckChequeFundingRequest{
+		WalletId: testWalletID,
+		Id:       chequeID,
+	}))
+	require.NoError(t, err)
+	require.False(t, resp.Msg.Funded)
+	require.Equal(t, uint64(100_000_000), resp.Msg.ActualAmountSats, "only the confirmed output counts")
+	require.Len(t, resp.Msg.FundedTxids, 2)
+	require.EqualValues(t, 0, resp.Msg.MinConfirmations)
+}
+
+// The bearer private key is what spends a cheque, so it must stay hidden until
+// the funding is confirmed and can no longer be double spent.
+func TestCheckChequeFunding_WithholdsKeyUntilConfirmed(t *testing.T) {
+	t.Parallel()
+	db := database.Test(t)
+
+	chequeAddr := "tb1qbearerkeytestaddr0000000000000000000000"
+	fundingTxid := "cafe0000cafe0000cafe0000cafe0000cafe0000cafe0000cafe0000cafe0000"
+
+	cli := walletv1connect.NewWalletServiceClient(
+		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
+			address: chequeAddr,
+			perCall: func(n int32) []*orchpb.AddressUnspentOutput {
+				confirmations := int32(0)
+				if n > 1 {
+					confirmations = 1
+				}
+				return []*orchpb.AddressUnspentOutput{
+					{Txid: fundingTxid, Vout: 0, ValueSats: 100_000_000, Confirmations: confirmations},
+				}
+			},
+		})),
+	)
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, chequeAddr)
+	require.NoError(t, err)
+
+	check := func() *walletv1.Cheque {
+		t.Helper()
+		_, err := cli.CheckChequeFunding(context.Background(), connect.NewRequest(&walletv1.CheckChequeFundingRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.NoError(t, err)
+		got, err := cli.GetCheque(context.Background(), connect.NewRequest(&walletv1.GetChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.NoError(t, err)
+		return got.Msg.Cheque
+	}
+
+	unconfirmed := check()
+	require.False(t, unconfirmed.Funded)
+	require.Nil(t, unconfirmed.PrivateKeyWif, "the bearer key must not leak at zero confirmations")
+
+	confirmed := check()
+	require.True(t, confirmed.Funded)
+	require.NotEmpty(t, confirmed.GetPrivateKeyWif())
 }
 
 func TestCheckChequeFunding_DetectsConfirmedTx(t *testing.T) {
@@ -155,7 +243,7 @@ func TestCheckChequeFunding_PersistsFundingToDatabase(t *testing.T) {
 		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
 			address: chequeAddr,
 			utxos: []*orchpb.AddressUnspentOutput{
-				{Txid: fundingTxid, Vout: 0, ValueSats: 100_000_000},
+				{Txid: fundingTxid, Vout: 0, ValueSats: 100_000_000, Confirmations: 1},
 			},
 		})),
 	)
@@ -190,8 +278,8 @@ func TestCheckChequeFunding_MultipleUTXOs(t *testing.T) {
 		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
 			address: chequeAddr,
 			utxos: []*orchpb.AddressUnspentOutput{
-				{Txid: first, Vout: 0, ValueSats: 100_000_000, Confirmations: 0},
-				{Txid: second, Vout: 0, ValueSats: 100_000_000, Confirmations: 1},
+				{Txid: first, Vout: 0, ValueSats: 100_000_000, Confirmations: 1},
+				{Txid: second, Vout: 0, ValueSats: 100_000_000, Confirmations: 2},
 			},
 		})),
 	)
@@ -209,7 +297,7 @@ func TestCheckChequeFunding_MultipleUTXOs(t *testing.T) {
 	require.Len(t, resp.Msg.FundedTxids, 2)
 	require.Contains(t, resp.Msg.FundedTxids, first)
 	require.Contains(t, resp.Msg.FundedTxids, second)
-	require.EqualValues(t, 0, resp.Msg.MinConfirmations, "the least-confirmed output sets the floor")
+	require.EqualValues(t, 1, resp.Msg.MinConfirmations, "the least-confirmed output sets the floor")
 }
 
 func TestCheckChequeFunding_PartialFunding(t *testing.T) {
@@ -246,7 +334,8 @@ func TestCheckChequeFunding_PartialFunding(t *testing.T) {
 }
 
 // Mirrors the Flutter polling loop: the first poll can race the broadcast and
-// must report unfunded; a later one flips the cheque to funded and persists it.
+// must report unfunded; a later one, once the funding has confirmed, flips the
+// cheque to funded and persists it.
 func TestCheckChequeFunding_PollAfterSend(t *testing.T) {
 	t.Parallel()
 	db := database.Test(t)
@@ -262,7 +351,7 @@ func TestCheckChequeFunding_PollAfterSend(t *testing.T) {
 					return nil
 				}
 				return []*orchpb.AddressUnspentOutput{
-					{Txid: fundingTxid, Vout: 0, ValueSats: 210_000_000},
+					{Txid: fundingTxid, Vout: 0, ValueSats: 210_000_000, Confirmations: 1},
 				}
 			},
 		})),

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,8 +30,9 @@ type fakeOrchestrator struct {
 	address string
 	utxos   []*orchpb.AddressUnspentOutput
 	// perCall serves a different answer per poll, for the poll-after-send case.
-	perCall func(n int32) []*orchpb.AddressUnspentOutput
-	calls   atomic.Int32
+	perCall       func(n int32) []*orchpb.AddressUnspentOutput
+	calls         atomic.Int32
+	broadcastTxid string
 }
 
 // The pollers ask before each tick. A full-mode answer keeps them running,
@@ -60,6 +64,12 @@ func (f *fakeOrchestrator) GetAddressUnspent(
 		utxos = f.perCall(f.calls.Add(1))
 	}
 	return connect.NewResponse(&orchpb.GetAddressUnspentResponse{Utxos: utxos, TipHeight: 100}), nil
+}
+
+func (f *fakeOrchestrator) BroadcastElectrumTransaction(
+	_ context.Context, _ *connect.Request[orchpb.BroadcastElectrumTransactionRequest],
+) (*connect.Response[orchpb.BroadcastElectrumTransactionResponse], error) {
+	return connect.NewResponse(&orchpb.BroadcastElectrumTransactionResponse{Txid: f.broadcastTxid}), nil
 }
 
 func TestCheckChequeFunding_UnfundedCheck(t *testing.T) {
@@ -403,4 +413,57 @@ func TestCheckChequeFunding_NeedsElectrum(t *testing.T) {
 		Id:       chequeID,
 	}))
 	require.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}
+
+// The sweep spends the WIF's coins whatever wallet the caller passes, so the
+// owner's row must be marked swept even when another wallet asks.
+func TestSweepCheque_MarksOwnerRowFromAnotherWallet(t *testing.T) {
+	t.Parallel()
+	db := database.Test(t)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	wif, err := btcutil.NewWIF(privKey, &chaincfg.SigNetParams, true)
+	require.NoError(t, err)
+
+	source, err := btcutil.NewAddressWitnessPubKeyHash(
+		btcutil.Hash160(privKey.PubKey().SerializeCompressed()), &chaincfg.SigNetParams,
+	)
+	require.NoError(t, err)
+	chequeAddr := source.EncodeAddress()
+
+	const (
+		ownerWalletID = "other-wallet-id-5678"
+		destAddress   = "tb1q6rz28mcfaxtmd6v789l9rrlrusdprr9pqcpvkl"
+		fundingTxid   = "c0de0000c0de0000c0de0000c0de0000c0de0000c0de0000c0de0000c0de0000"
+		sweepTxid     = "5eed00005eed00005eed00005eed00005eed00005eed00005eed00005eed0000"
+	)
+
+	cli := walletv1connect.NewWalletServiceClient(
+		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
+			address: chequeAddr,
+			utxos: []*orchpb.AddressUnspentOutput{
+				{Txid: fundingTxid, Vout: 0, ValueSats: 100_000_000, Confirmations: 1},
+			},
+			broadcastTxid: sweepTxid,
+		})),
+	)
+
+	_, err = cheques.Create(context.Background(), db, ownerWalletID, 0, 100_000_000, chequeAddr)
+	require.NoError(t, err)
+
+	resp, err := cli.SweepCheque(context.Background(), connect.NewRequest(&walletv1.SweepChequeRequest{
+		WalletId:           testWalletID,
+		PrivateKeyWif:      wif.String(),
+		DestinationAddress: destAddress,
+		FeeSatPerVbyte:     1,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, sweepTxid, resp.Msg.Txid)
+
+	owned, err := cheques.GetByAddress(context.Background(), db, ownerWalletID, chequeAddr)
+	require.NoError(t, err)
+	require.NotNil(t, owned.SweptTxid, "the owner's cheque should be marked swept")
+	require.Equal(t, sweepTxid, *owned.SweptTxid)
+	require.NotNil(t, owned.SweptAt)
 }

--- a/bitwindow/server/api/wallet/restore_backup_test.go
+++ b/bitwindow/server/api/wallet/restore_backup_test.go
@@ -1,0 +1,94 @@
+package api_wallet
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// restoreServer builds a Server whose wallet lives in dir.
+func restoreServer(dir string) *Server {
+	return &Server{
+		walletEngine: engines.NewWalletEngine(nil, dir, &chaincfg.SigNetParams),
+		backupEngine: engines.NewBackupEngine(nil, dir),
+		walletDir:    dir,
+	}
+}
+
+// A restore swaps out wallet.json, so it must not run behind the lock screen -
+// otherwise anyone at the machine can replace the wallet without the password.
+func TestRestoreBackupRejectedWhileLocked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	walletPath := filepath.Join(dir, "wallet.json")
+	existing := []byte("aXY=:Y2lwaGVy")
+	require.NoError(t, os.WriteFile(walletPath, existing, 0600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "wallet_encryption.json"),
+		[]byte(`{"salt":"c2FsdA==","iterations":100000,"encrypted":true,"version":"1"}`), 0600,
+	))
+
+	server := restoreServer(dir)
+	require.False(t, server.walletEngine.IsUnlocked(), "an encrypted wallet starts locked")
+
+	_, err := server.RestoreBackup(context.Background(), connect.NewRequest(&pb.RestoreBackupRequest{
+		BackupData: []byte(`{"master":"backup seed","l1":"backup key"}`),
+		Filename:   "wallet.json",
+	}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	after, err := os.ReadFile(walletPath)
+	require.NoError(t, err)
+	require.Equal(t, existing, after, "the locked wallet must be untouched")
+}
+
+// First launch has no wallet to protect, so the restore that seeds one still runs.
+func TestRestoreBackupWithoutExistingWallet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	server := restoreServer(dir)
+
+	backup := []byte(`{"master":"backup seed","l1":"backup key"}`)
+	_, err := server.RestoreBackup(context.Background(), connect.NewRequest(&pb.RestoreBackupRequest{
+		BackupData: backup,
+		Filename:   "wallet.json",
+	}))
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(filepath.Join(dir, "wallet.json"))
+	require.NoError(t, err)
+	require.Equal(t, backup, written)
+}
+
+// An unencrypted wallet that fails to auto-unlock reads as locked, and it has no
+// unlock path - gating on it would brick the restore that repairs it.
+func TestRestoreBackupOverCorruptUnencryptedWallet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	walletPath := filepath.Join(dir, "wallet.json")
+	require.NoError(t, os.WriteFile(walletPath, []byte(`{"master": "truncated`), 0600))
+
+	server := restoreServer(dir)
+	require.False(t, server.walletEngine.IsUnlocked(), "a corrupt wallet never auto-unlocks")
+
+	backup := []byte(`{"master":"backup seed","l1":"backup key"}`)
+	_, err := server.RestoreBackup(context.Background(), connect.NewRequest(&pb.RestoreBackupRequest{
+		BackupData: backup,
+		Filename:   "wallet.json",
+	}))
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(walletPath)
+	require.NoError(t, err)
+	require.Equal(t, backup, written)
+}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -142,9 +142,23 @@ func (s *Server) CreateBitcoinCoreWallet(ctx context.Context, c *connect.Request
 	}), nil
 }
 
+// requireUnlocked rejects an operation that spends or derives keys while the
+// wallet is locked.
+func (s *Server) requireUnlocked() error {
+	if !s.walletEngine.IsUnlocked() {
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+	return nil
+}
+
 // SendTransaction implements drivechainv1connect.DrivechainServiceHandler.
 func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.SendTransactionRequest]) (*connect.Response[pb.SendTransactionResponse], error) {
 	walletId := c.Msg.WalletId
+
+	// Spending needs an unlocked wallet.
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
 
 	if len(c.Msg.Destinations) == 0 {
 		err := errors.New("must provide a destination")
@@ -189,6 +203,11 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 	destinations := make(map[string]float64)
 	for addr, sats := range c.Msg.Destinations {
 		destinations[addr] = float64(sats) / 1e8
+	}
+
+	// Re-check as late as possible: a lock can land while we resolve the wallet.
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
 	}
 
 	// If requiredInputs is specified, use raw transaction flow

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1594,6 +1594,10 @@ func (s *Server) ListCheques(ctx context.Context, c *connect.Request[pb.ListCheq
 	}), nil
 }
 
+// A funding output must be this deep to count: an unconfirmed payment can still
+// be double spent, and funding is what releases the bearer private key.
+const chequeMinConfirmations = 1
+
 // CheckChequeFunding implements walletv1connect.WalletServiceHandler.
 func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.CheckChequeFundingRequest]) (*connect.Response[pb.CheckChequeFundingResponse], error) {
 	log := zerolog.Ctx(ctx)
@@ -1626,11 +1630,15 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 		Msg("CheckChequeFunding: UTXOs found")
 
 	if len(utxos) > 0 {
-		var amountSats uint64
+		// Only confirmed value counts, but every txid is recorded so a cheque
+		// with a payment in flight still reads as partially funded.
+		var confirmedSats uint64
 		var txids []string
 		var minConfirmations uint32 = math.MaxUint32
 		for _, utxo := range utxos {
-			amountSats += uint64(utxo.ValueSats)
+			if utxo.Confirmations >= chequeMinConfirmations {
+				confirmedSats += uint64(utxo.ValueSats)
+			}
 			txids = append(txids, utxo.TxID)
 			if confs := uint32(utxo.Confirmations); confs < minConfirmations {
 				minConfirmations = confs
@@ -1638,7 +1646,7 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 		}
 
 		// Always update — handles new fundings arriving after first one
-		if err := cheques.UpdateFunding(ctx, s.database, walletId, c.Msg.Id, txids, amountSats); err != nil {
+		if err := cheques.UpdateFunding(ctx, s.database, walletId, c.Msg.Id, txids, confirmedSats); err != nil {
 			log.Error().Err(err).Msg("failed to update cheque funding")
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update funding: %w", err))
 		}
@@ -1646,9 +1654,10 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 		log.Info().
 			Int64("id", c.Msg.Id).
 			Str("address", cheque.Address).
-			Uint64("amount_sats", amountSats).
+			Uint64("confirmed_sats", confirmedSats).
+			Uint32("min_confirmations", minConfirmations).
 			Int("utxo_count", len(txids)).
-			Msg("cheque funded")
+			Msg("cheque funding checked")
 
 		// Re-fetch to get updated funded_at timestamp
 		cheque, err = cheques.Get(ctx, s.database, walletId, c.Msg.Id)
@@ -1658,7 +1667,7 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 
 		resp := &pb.CheckChequeFundingResponse{
 			Funded:           cheque.IsFunded(),
-			ActualAmountSats: amountSats,
+			ActualAmountSats: confirmedSats,
 			FundedTxids:      txids,
 			MinConfirmations: minConfirmations,
 		}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -819,8 +819,9 @@ func (s *Server) CreateSidechainDeposit(ctx context.Context, c *connect.Request[
 	} else if slot == nil {
 		slot = &c.Msg.Slot
 	}
-	if *slot > 255 {
-		return nil, fmt.Errorf("invalid sidechain slot %d: must be 0-255", *slot)
+	if *slot < 0 || *slot > 255 {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("invalid sidechain slot %d: must be 0-255", *slot))
 	}
 
 	amount, err := btcutil.NewAmount(c.Msg.Amount)

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1477,6 +1477,12 @@ func (s *Server) CreateCheque(ctx context.Context, c *connect.Request[pb.CreateC
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
 	}
 
+	// A zero-amount cheque is satisfied by any funding, which then locks the row
+	// against deletion.
+	if c.Msg.ExpectedAmountSats == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("expected_amount_sats must be greater than zero"))
+	}
+
 	// Get next index for this wallet
 	nextIndex, err := cheques.GetNextIndex(ctx, s.database, walletId)
 	if err != nil {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2487,6 +2487,13 @@ func (s *Server) RestoreBackup(ctx context.Context, c *connect.Request[pb.Restor
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("filename is required"))
 	}
 
+	// Restoring overwrites the current wallet.json, so an existing encrypted
+	// wallet has to be unlocked first. First launch has no wallet to protect,
+	// and an unencrypted wallet has no unlock to wait for.
+	if s.backupEngine.HasCurrentWallet() && wallet.IsWalletEncrypted(s.walletDir) && !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	if err := s.backupEngine.RestoreBackup(ctx, c.Msg.BackupData, c.Msg.Filename); err != nil {
 		return nil, fmt.Errorf("restore backup: %w", err)
 	}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1811,10 +1811,18 @@ func (s *Server) SweepCheque(ctx context.Context, c *connect.Request[pb.SweepChe
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("broadcast transaction: %w", err))
 	}
 
-	// Try to find and mark the cheque as swept in database if it exists
-	cheque, err := cheques.GetByAddress(ctx, s.database, walletId, addressStr)
+	// Try to find and mark the cheque as swept in database if it exists. The
+	// sweep spends the WIF's coins whatever wallet asked, so the row is looked
+	// up and updated by its own owner, not the requesting wallet.
+	cheque, err := cheques.GetByAddressAnyWallet(ctx, s.database, addressStr)
 	if err == nil && cheque.SweptTxid == nil {
-		if err := cheques.UpdateSwept(ctx, s.database, walletId, cheque.ID, txid); err != nil {
+		if cheque.WalletID != walletId {
+			log.Warn().
+				Str("cheque_wallet_id", cheque.WalletID).
+				Str("request_wallet_id", walletId).
+				Msg("swept a cheque owned by another wallet")
+		}
+		if err := cheques.UpdateSwept(ctx, s.database, cheque.WalletID, cheque.ID, txid); err != nil {
 			log.Warn().Err(err).Msg("failed to mark cheque as swept in database")
 		}
 	}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -281,6 +281,17 @@ func (s *Server) GetNewAddress(ctx context.Context, c *connect.Request[pb.GetNew
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	// Deriving an address needs the seed, so the wallet has to be unlocked.
+	// A watch-only wallet has no seed, and serves addresses from its imported
+	// descriptor.
+	watchOnly, err := s.walletEngine.IsWatchOnly(ctx, walletId)
+	if err != nil {
+		return nil, err
+	}
+	if !watchOnly && !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	addressType := c.Msg.AddressType
 	if addressType == pb.AddressType_ADDRESS_TYPE_UNSPECIFIED {
 		addressType = pb.AddressType_ADDRESS_TYPE_SEGWIT
@@ -329,10 +340,6 @@ func (s *Server) GetNewAddress(ctx context.Context, c *connect.Request[pb.GetNew
 		// Watch-only Core wallets import a descriptor; full wallets use the
 		// seed-derived wallet. Both serve addresses from Bitcoin Core.
 		ensure := s.walletEngine.GetBitcoinCoreWalletName
-		watchOnly, err := s.walletEngine.IsWatchOnly(ctx, walletId)
-		if err != nil {
-			return nil, err
-		}
 		if watchOnly {
 			ensure = s.walletEngine.EnsureWatchOnlyWallet
 		}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2467,6 +2467,12 @@ func (s *Server) SelectCoins(ctx context.Context, c *connect.Request[pb.SelectCo
 
 // CreateBackup implements walletv1connect.WalletServiceHandler.
 func (s *Server) CreateBackup(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[pb.CreateBackupResponse], error) {
+	// The archive carries wallet.json plus the multisig and transaction
+	// exports, so it needs an unlocked wallet.
+	if s.backupEngine.HasCurrentWallet() && !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	data, filename, err := s.backupEngine.CreateBackup(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("create backup: %w", err)

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -3,6 +3,7 @@ package api_wallet_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
@@ -440,4 +441,38 @@ func TestListSidechainDepositsReadsTheOrchestrator(t *testing.T) {
 	require.Len(t, resp.Msg.Deposits, 1)
 	require.Equal(t, "deadbeef", resp.Msg.Deposits[0].Txid)
 	require.Equal(t, int64(50_000), resp.Msg.Deposits[0].Amount)
+}
+
+// A negative slot must be rejected here, not cast to uint32 and forwarded: the
+// cast wraps, and -4294967289 lands on slot 7 — someone else's sidechain.
+func TestCreateSidechainDepositRejectsNegativeSlot(t *testing.T) {
+	t.Parallel()
+
+	for _, slot := range []int64{-1, -4294967289} {
+		t.Run(fmt.Sprint(slot), func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			database := database.Test(t)
+			mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+			apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+			// No CreateDeposit expectation: the request must not reach it.
+			mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+			apitests.ExpectOrchestratorReads(mockOrch)
+
+			cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database,
+				apitests.WithBitcoind(mockBitcoind), apitests.WithOrchestrator(mockOrch)))
+
+			_, err := cli.CreateSidechainDeposit(context.Background(), connect.NewRequest(&walletv1.CreateSidechainDepositRequest{
+				WalletId:    "test-wallet-id-1234",
+				Destination: "13tqn1jxdcrbDycej4bp5S5PcffYtdGNPy",
+				Slot:        slot,
+				Amount:      0.001,
+				Fee:         0.0001,
+			}))
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		})
+	}
 }

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/addressbook"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
@@ -114,12 +115,52 @@ func TestService_GetNewAddress(t *testing.T) {
 
 		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithOrchestrator(mockOrch), apitests.WithBitcoind(mockBitcoind)))
 
+		// Addresses need an unlocked wallet, and the unencrypted fixture wallet
+		// auto-unlocks in the background.
+		require.Eventually(t, func() bool {
+			_, err := cli.IsWalletUnlocked(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+			return err == nil
+		}, 5*time.Second, 10*time.Millisecond)
+
 		// Use the test wallet ID from apitests.createTestWalletJSON
 		resp, err := cli.GetNewAddress(context.Background(), connect.NewRequest(&walletv1.GetNewAddressRequest{
 			WalletId: "test-wallet-id-1234",
 		}))
 		require.NoError(t, err)
 		require.Equal(t, "bc1qtest123456789", resp.Msg.Address)
+	})
+
+	t.Run("locked wallet gets no address", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+		apitests.ExpectOrchestratorReads(mockOrch)
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithOrchestrator(mockOrch)))
+
+		// The unencrypted fixture wallet auto-unlocks in the background. Wait for
+		// that, so the unlock cannot land after the lock below.
+		require.Eventually(t, func() bool {
+			_, err := cli.IsWalletUnlocked(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+			return err == nil
+		}, 5*time.Second, 10*time.Millisecond)
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.GetNewAddress(context.Background(), connect.NewRequest(&walletv1.GetNewAddressRequest{
+			WalletId: "test-wallet-id-1234",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		// Nothing was derived, so nothing reached the address book either.
+		entries, err := addressbook.ListByWallet(context.Background(), database, "test-wallet-id-1234")
+		require.NoError(t, err)
+		require.Empty(t, entries)
 	})
 }
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -122,6 +122,28 @@ func TestService_GetNewAddress(t *testing.T) {
 	})
 }
 
+// A cheque expecting zero sats is satisfied by any funding that arrives, so the
+// row reads as funded and refuses deletion. It must never be created.
+func TestService_CreateChequeRejectsZeroAmount(t *testing.T) {
+	t.Parallel()
+
+	db := database.Test(t)
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db))
+
+	_, err := cli.CreateCheque(context.Background(), connect.NewRequest(&walletv1.CreateChequeRequest{
+		WalletId:           testWalletID,
+		ExpectedAmountSats: 0,
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// No row was persisted, and no derivation index was burned.
+	list, err := cheques.List(context.Background(), db, testWalletID)
+	require.NoError(t, err)
+	require.Empty(t, list)
+}
+
 func TestService_ListCheques(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 
@@ -399,6 +400,37 @@ func TestService_LockWallet(t *testing.T) {
 		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
 		require.NoError(t, err)
 	})
+}
+
+// A send that starts after the wallet is locked must not reach bitcoind.
+func TestService_SendTransactionRequiresUnlocked(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	database := database.Test(t)
+
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	apitests.ExpectCoreWalletSetup(mockBitcoind)
+	mockBitcoind.EXPECT().Send(gomock.Any(), gomock.Any()).Times(0)
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+	// The unencrypted fixture wallet auto-unlocks in the background: wait for
+	// that, otherwise the unlock can land after the lock below.
+	require.Eventually(t, func() bool {
+		_, err := cli.IsWalletUnlocked(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+
+	_, err = cli.SendTransaction(context.Background(), connect.NewRequest(&walletv1.SendTransactionRequest{
+		WalletId:     "test-wallet-id-1234",
+		Destinations: map[string]uint64{"bcrt1qsendlocked00000000000000000000000000000000": 100_000},
+	}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "wallet is locked")
 }
 
 func TestService_UnlockWallet(t *testing.T) {

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -506,6 +506,44 @@ func TestService_UnlockWallet(t *testing.T) {
 	})
 }
 
+func TestService_CreateBackup(t *testing.T) {
+	t.Parallel()
+
+	// The unencrypted fixture wallet auto-unlocks in a startup goroutine.
+	waitUnlocked := func(t *testing.T, cli walletv1connect.WalletServiceClient) {
+		require.Eventually(t, func() bool {
+			_, err := cli.IsWalletUnlocked(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+			return err == nil
+		}, 5*time.Second, 10*time.Millisecond)
+	}
+
+	t.Run("unlocked wallet backs up", func(t *testing.T) {
+		t.Parallel()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database.Test(t)))
+		waitUnlocked(t, cli)
+
+		resp, err := cli.CreateBackup(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Msg.BackupData)
+	})
+
+	t.Run("locked wallet cannot back up", func(t *testing.T) {
+		t.Parallel()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database.Test(t)))
+		waitUnlocked(t, cli)
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		resp, err := cli.CreateBackup(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		require.Nil(t, resp)
+	})
+}
+
 // The orchestrator records each deposit as it broadcasts it, because an M5 is
 // an ordinary transaction on the wire.
 func TestListSidechainDepositsReadsTheOrchestrator(t *testing.T) {

--- a/bitwindow/server/database/migrations/047_cheque_index_counters.sql
+++ b/bitwindow/server/database/migrations/047_cheque_index_counters.sql
@@ -1,0 +1,9 @@
+-- Deleting a cheque lowered MAX(derivation_index), so the next cheque re-derived
+-- the deleted one's index and address. This allocator only ever grows.
+CREATE TABLE cheque_index_counters (
+    wallet_id TEXT PRIMARY KEY,
+    next_index INTEGER NOT NULL
+);
+
+INSERT INTO cheque_index_counters (wallet_id, next_index)
+SELECT wallet_id, MAX(derivation_index) + 1 FROM cheques GROUP BY wallet_id;

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -24,9 +24,10 @@ type Cheque struct {
 	SweptAt            *time.Time
 }
 
-// IsFunded returns true if actual funds meet or exceed the expected amount
+// IsFunded returns true if actual funds meet or exceed the expected amount.
+// Zero never counts: CheckChequeFunding records confirmed value only.
 func (c *Cheque) IsFunded() bool {
-	return c.ActualAmountSats != nil && *c.ActualAmountSats >= c.ExpectedAmountSats
+	return c.ActualAmountSats != nil && *c.ActualAmountSats > 0 && *c.ActualAmountSats >= c.ExpectedAmountSats
 }
 
 // IsPartiallyFunded returns true if some funds arrived but less than expected

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -44,7 +44,13 @@ func Create(ctx context.Context, db *sql.DB, walletID string, index uint32, expe
 		return 0, fmt.Errorf("address cannot be empty")
 	}
 
-	result, err := db.ExecContext(ctx, `
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO cheques (wallet_id, derivation_index, expected_amount_sats, address)
 		VALUES (?, ?, ?, ?)
 	`, walletID, index, expectedAmount, address)
@@ -57,7 +63,35 @@ func Create(ctx context.Context, db *sql.DB, walletID string, index uint32, expe
 		return 0, fmt.Errorf("failed to get last insert id: %w", err)
 	}
 
+	if err := bumpIndexCounter(ctx, tx, walletID, index); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit cheque: %w", err)
+	}
+
 	return id, nil
+}
+
+// execer is satisfied by both *sql.DB and *sql.Tx.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// bumpIndexCounter raises the wallet's index allocator past index. The counter
+// never decreases, so deleting a cheque cannot hand its index — and with it its
+// address — to the next one.
+func bumpIndexCounter(ctx context.Context, db execer, walletID string, index uint32) error {
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO cheque_index_counters (wallet_id, next_index)
+		VALUES (?, ?)
+		ON CONFLICT (wallet_id) DO UPDATE
+		SET next_index = MAX(cheque_index_counters.next_index, excluded.next_index)
+	`, walletID, uint64(index)+1); err != nil {
+		return fmt.Errorf("failed to bump cheque index counter: %w", err)
+	}
+	return nil
 }
 
 // scanCheque scans a cheque row from the database
@@ -281,24 +315,24 @@ func UpdateSwept(ctx context.Context, db *sql.DB, walletID string, id int64, txi
 	return nil
 }
 
-// GetNextIndex returns the next available cheque index for a specific wallet
+// GetNextIndex returns the next available cheque index for a specific wallet.
+// It takes the higher of the monotonic counter and the live rows, so an index
+// is never handed out twice even after the cheque that used it was deleted.
 func GetNextIndex(ctx context.Context, db *sql.DB, walletID string) (uint32, error) {
-	var maxIndex sql.NullInt64
+	var nextIndex int64
 
 	err := db.QueryRowContext(ctx, `
-		SELECT MAX(derivation_index) FROM cheques WHERE wallet_id = ?
-	`, walletID).Scan(&maxIndex)
+		SELECT MAX(
+			COALESCE((SELECT next_index FROM cheque_index_counters WHERE wallet_id = ?), 0),
+			COALESCE((SELECT MAX(derivation_index) + 1 FROM cheques WHERE wallet_id = ?), 0)
+		)
+	`, walletID, walletID).Scan(&nextIndex)
 
 	if err != nil && err != sql.ErrNoRows {
 		return 0, fmt.Errorf("failed to get max index: %w", err)
 	}
 
-	if !maxIndex.Valid {
-		// No cheques yet for this wallet, start at 0
-		return 0, nil
-	}
-
-	return uint32(maxIndex.Int64) + 1, nil
+	return uint32(nextIndex), nil
 }
 
 // Delete deletes a cheque by ID for a specific wallet
@@ -359,5 +393,5 @@ func CreateOrUpdateFromRecovery(ctx context.Context, db *sql.DB, walletID string
 		}
 	}
 
-	return nil
+	return bumpIndexCounter(ctx, db, walletID, index)
 }

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -179,6 +179,28 @@ func GetByAddress(ctx context.Context, db *sql.DB, walletID string, address stri
 	return cheque, nil
 }
 
+// GetByAddressAnyWallet retrieves a cheque by address, whichever wallet owns
+// it. Addresses are globally unique, so the match is unambiguous.
+func GetByAddressAnyWallet(ctx context.Context, db *sql.DB, address string) (*Cheque, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, wallet_id, derivation_index, expected_amount_sats, address,
+		       actual_amount_sats, created_at, funded_at,
+		       swept_txid, swept_at
+		FROM cheques
+		WHERE address = ?
+	`, address)
+
+	cheque, err := scanCheque(row)
+	if err != nil {
+		return nil, fmt.Errorf("get cheque by address: %w", err)
+	}
+	if err := attachFundingOutputs(ctx, db, cheque.WalletID, []*Cheque{cheque}); err != nil {
+		return nil, err
+	}
+
+	return cheque, nil
+}
+
 // List retrieves all cheques for a specific wallet
 func List(ctx context.Context, db *sql.DB, walletID string) ([]Cheque, error) {
 	rows, err := db.QueryContext(ctx, `

--- a/bitwindow/server/models/cheques/cheques_test.go
+++ b/bitwindow/server/models/cheques/cheques_test.go
@@ -1,0 +1,67 @@
+package cheques_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
+)
+
+const testWalletID = "wallet-1"
+
+// Each index maps to one HD address, so reissuing a deleted cheque's index
+// would send new funds to an address an old payer may still hold.
+func TestGetNextIndex_SkipsDeletedIndex(t *testing.T) {
+	db := database.Test(t)
+	ctx := context.Background()
+
+	first, err := cheques.GetNextIndex(ctx, db, testWalletID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, first)
+	_, err = cheques.Create(ctx, db, testWalletID, first, 1000, "addr-0")
+	require.NoError(t, err)
+
+	second, err := cheques.GetNextIndex(ctx, db, testWalletID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, second)
+	id, err := cheques.Create(ctx, db, testWalletID, second, 1000, "addr-1")
+	require.NoError(t, err)
+
+	require.NoError(t, cheques.Delete(ctx, db, testWalletID, id))
+
+	third, err := cheques.GetNextIndex(ctx, db, testWalletID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, third, "a deleted cheque's index must not be handed out again")
+}
+
+func TestGetNextIndex_SkipsDeletedRecoveredIndex(t *testing.T) {
+	db := database.Test(t)
+	ctx := context.Background()
+
+	txid := "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000"
+	require.NoError(t, cheques.CreateOrUpdateFromRecovery(ctx, db, testWalletID, 4, "addr-4", []string{txid}, 1000))
+
+	recovered, err := cheques.GetByAddress(ctx, db, testWalletID, "addr-4")
+	require.NoError(t, err)
+	require.NoError(t, cheques.Delete(ctx, db, testWalletID, recovered.ID))
+
+	next, err := cheques.GetNextIndex(ctx, db, testWalletID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, next)
+}
+
+func TestGetNextIndex_PerWallet(t *testing.T) {
+	db := database.Test(t)
+	ctx := context.Background()
+
+	_, err := cheques.Create(ctx, db, testWalletID, 0, 1000, "addr-0")
+	require.NoError(t, err)
+
+	next, err := cheques.GetNextIndex(ctx, db, "wallet-2")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, next, "another wallet's cheques must not advance this one")
+}

--- a/bitwindow/server/proto/wallet/v1/wallet.proto
+++ b/bitwindow/server/proto/wallet/v1/wallet.proto
@@ -333,6 +333,8 @@ message CheckChequeFundingRequest {
 
 message CheckChequeFundingResponse {
   bool funded = 1;
+  // Confirmed value only. Unconfirmed payments are listed in funded_txids with
+  // min_confirmations 0, but never count towards funding.
   uint64 actual_amount_sats = 2;
   repeated string funded_txids = 3;
   optional google.protobuf.Timestamp funded_at = 4;


### PR DESCRIPTION
A set of **9 independent fixes** to the BitWindow wallet & cheque API, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`9 files changed, 652 insertions(+), 40 deletions(-)`).

## Fixes (oldest first)

- **`4af0a2431`** BitWindow marks zero-confirmation cheques as funded and exposes the bearer private key before any confirmation
- **`3dba42257`** BitWindow `CreateSidechainDeposit` accepts negative `int64 slot` and wraps it to `uint32`, forwarding `0xffffffff` as `SidechainId` to the enforcer
- **`142a663e3`** BitWindow CreateCheque accepts zero expected amount and locks the record once funded
- **`47aaea5b3`** BitWindow `cheques.GetNextIndex` reuses HD indices after delete → deterministic address reuse and cross-cheque fund attribution
- **`59109e8e2`** BitWindow `SweepCheque` cross-wallet `walletId` skips `UpdateSwept`, leaving owner cheque row with `swept_txid = NULL`
- **`2a673ddfd`** BitWindow LockWallet lets an in-flight send complete after locked
- **`2eaa85a74`** BitWindow GetNewAddress succeeds while wallet is locked
- **`91d1e766b`** BitWindow `RestoreBackup` missing `IsUnlocked()` guard — wallet.json overwrite while observably locked
- **`cd263494b`** BitWindow `CreateBackup` missing `IsUnlocked()` guard — wallet.json + multisig + tx DB exfiltration while observably locked

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.