### PR TITLE
BitWindow wallet & cheque API (2 of 4): 12 fixes from a security review

### DIFF
--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -191,7 +191,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	}
 
 	rt.chequeChain = engines.NewElectrumChequeChain(rt.walletEngine)
-	rt.chequeEngine = engines.NewChequeEngine(rt.walletEngine, rt.chainParams, rt.chequeChain)
+	rt.chequeEngine = engines.NewChequeEngine(rt.db, rt.walletEngine, rt.chainParams, rt.chequeChain)
 	walletAdapter := engines.NewWalletAdapter(rt.walletEngine)
 	timestampLogger := log.With().Str("component", "timestamp").Logger()
 	rt.timestampEngine = engines.NewTimestampEngine(rt.db, timestampLogger, walletAdapter, s.Bitcoind)

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -15,6 +15,7 @@ import (
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const testWalletID = "test-wallet-id-1234"
@@ -293,6 +294,45 @@ func TestCheckChequeFunding_PollAfterSend(t *testing.T) {
 	require.True(t, persisted.IsFunded())
 	require.NotNil(t, persisted.FundedAt)
 	require.Equal(t, []string{fundingTxid}, persisted.FundedTxids)
+}
+
+// A locked wallet must not report funding, nor persist it.
+func TestCheckChequeFunding_WalletLocked(t *testing.T) {
+	t.Parallel()
+	db := database.Test(t)
+
+	chequeAddr := "tb1qlockedtestaddr000000000000000000000000"
+
+	cli := walletv1connect.NewWalletServiceClient(
+		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
+			address: chequeAddr,
+			utxos: []*orchpb.AddressUnspentOutput{
+				{
+					Txid:          "10ck000010ck000010ck000010ck000010ck000010ck000010ck000010ck0000",
+					Vout:          0,
+					ValueSats:     100_000_000,
+					Confirmations: 1,
+				},
+			},
+		})),
+	)
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, chequeAddr)
+	require.NoError(t, err)
+
+	_, err = cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+
+	_, err = cli.CheckChequeFunding(context.Background(), connect.NewRequest(&walletv1.CheckChequeFundingRequest{
+		WalletId: testWalletID,
+		Id:       chequeID,
+	}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	cheque, err := cheques.Get(context.Background(), db, testWalletID, chequeID)
+	require.NoError(t, err)
+	require.Nil(t, cheque.FundedAt)
+	require.Empty(t, cheque.FundedTxids)
 }
 
 // With no orchestrator wired — regtest, or any dev setup without an electrum

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -12,9 +12,12 @@ import (
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	bitcoindv1alpha "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -354,4 +357,45 @@ func TestCheckChequeFunding_NeedsElectrum(t *testing.T) {
 		Id:       chequeID,
 	}))
 	require.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}
+
+// Core's bumpfee evicts the sweep transaction, so a cheque swept by the old
+// txid has to end up pointing at the replacement.
+func TestBumpFee_RepointsSweptCheque(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+
+	oldTxid := "1111000011110000111100001111000011110000111100001111000011110000"
+	newTxid := "2222000022220000222200002222000022220000222200002222000022220000"
+
+	// BumpFee walks the loaded wallets, so Core has to report one.
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+			Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{"test_wallet"}},
+		}, nil).
+		AnyTimes()
+	mockBitcoind.EXPECT().
+		BumpFee(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.BumpFeeResponse]{
+			Msg: &bitcoindv1alpha.BumpFeeResponse{Txid: newTxid, OriginalFee: 0.0001, NewFee: 0.0002},
+		}, nil)
+	apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qbumpfeetestaddr0000000000000000000000000")
+	require.NoError(t, err)
+	require.NoError(t, cheques.UpdateSwept(context.Background(), db, testWalletID, chequeID, oldTxid))
+
+	resp, err := cli.BumpFee(context.Background(), connect.NewRequest(&walletv1.BumpFeeRequest{Txid: oldTxid}))
+	require.NoError(t, err)
+	require.Equal(t, newTxid, resp.Msg.Txid)
+
+	persisted, err := cheques.Get(context.Background(), db, testWalletID, chequeID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted.SweptTxid)
+	require.Equal(t, newTxid, *persisted.SweptTxid, "the cheque must follow the replacement")
 }

--- a/bitwindow/server/api/wallet/get_balance_test.go
+++ b/bitwindow/server/api/wallet/get_balance_test.go
@@ -1,0 +1,51 @@
+package api_wallet
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// A locked wallet must not hand out balances.
+func TestGetBalanceRejectsLockedWallet(t *testing.T) {
+	const walletID = "80CEBA2163224572BDEADD2D2181C51B"
+
+	tempDir := t.TempDir()
+	walletData, err := json.Marshal(map[string]any{
+		"version":        1,
+		"activeWalletId": walletID,
+		"wallets": []map[string]any{{
+			"version":     1,
+			"master":      map[string]any{"seed_hex": testSeedHex},
+			"id":          walletID,
+			"name":        "test",
+			"wallet_type": "electrum",
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "wallet.json"), walletData, 0o600))
+
+	walletEngine := engines.NewWalletEngine(
+		func(ctx context.Context) (corerpc.BitcoinServiceClient, error) { return nil, nil },
+		tempDir,
+		&chaincfg.SigNetParams,
+	)
+	walletEngine.Lock()
+
+	server := &Server{walletEngine: walletEngine}
+
+	_, err = server.GetBalance(context.Background(), connect.NewRequest(&pb.GetBalanceRequest{
+		WalletId: walletID,
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1277,6 +1277,11 @@ func (s *Server) denialToProtoCore(txid string, vout int32, d deniability.Denial
 func (s *Server) ListReceiveAddresses(ctx context.Context, c *connect.Request[pb.ListReceiveAddressesRequest]) (*connect.Response[pb.ListReceiveAddressesResponse], error) {
 	walletId := c.Msg.WalletId
 
+	// Addresses and their balances are wallet state, so the wallet has to be unlocked
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	// Bitcoin Core version
 	coreWalletName, err := s.walletEngine.GetBitcoinCoreWalletName(ctx, walletId)
 	if err != nil {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -203,6 +203,19 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 		}), nil
 	}
 
+	// Core's send RPC has no absolute fee field, only a rate, so an exact fee
+	// has to go through the raw transaction path.
+	if c.Msg.FixedFeeSats > 0 {
+		txid, err := engines.SendCoreWithFixedFee(ctx, bitcoind, coreWalletName, c.Msg.Destinations, c.Msg.FixedFeeSats)
+		if err != nil {
+			return nil, err
+		}
+		log.Info().Msgf("send tx: broadcast transaction with fixed fee (Bitcoin Core): %s", txid)
+		return connect.NewResponse(&pb.SendTransactionResponse{
+			Txid: txid,
+		}), nil
+	}
+
 	sendReq := &corepb.SendRequest{
 		Destinations: destinations,
 		Wallet:       coreWalletName,

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -541,6 +541,10 @@ func (s *Server) GetBalance(ctx context.Context, c *connect.Request[pb.GetBalanc
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	switch walletType {
 	case engines.WalletTypeBitcoinCore:
 		watchOnly, err := s.walletEngine.IsWatchOnly(ctx, walletId)

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1588,6 +1588,10 @@ func (s *Server) ListCheques(ctx context.Context, c *connect.Request[pb.ListCheq
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	chequeList, err := cheques.List(ctx, s.database, walletId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list cheques: %w", err))

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1619,6 +1619,10 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	cheque, err := cheques.Get(ctx, s.database, walletId, c.Msg.Id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2401,6 +2401,15 @@ func (s *Server) BumpFee(ctx context.Context, c *connect.Request[pb.BumpFeeReque
 		Float64("new_fee", bumpResp.Msg.NewFee).
 		Msg("RBF transaction broadcast via Core bumpfee")
 
+	// The replacement evicts the old txid, so a cheque swept by it must follow.
+	rebound, err := cheques.ReplaceSweptTxid(ctx, s.database, txid, bumpResp.Msg.Txid)
+	if err != nil {
+		// The bump already broadcast, so don't fail the call over bookkeeping.
+		log.Warn().Err(err).Msg("failed to point swept cheques at the replacement txid")
+	} else if rebound > 0 {
+		log.Info().Int64("cheques", rebound).Msg("pointed swept cheques at the replacement txid")
+	}
+
 	return connect.NewResponse(&pb.BumpFeeResponse{
 		Txid:        bumpResp.Msg.Txid,
 		OriginalFee: bumpResp.Msg.OriginalFee,

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1353,6 +1353,11 @@ func (s *Server) ListReceiveAddresses(ctx context.Context, c *connect.Request[pb
 func (s *Server) GetStats(ctx context.Context, c *connect.Request[pb.GetStatsRequest]) (*connect.Response[pb.GetStatsResponse], error) {
 	walletId := c.Msg.WalletId
 
+	// The stats aggregate wallet history, so the wallet has to be unlocked
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	// Bitcoin Core version
 	// Get UTXOs
 	utxos, err := s.ListUnspent(ctx, connect.NewRequest(&pb.ListUnspentRequest{WalletId: walletId}))

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1187,7 +1187,7 @@ func (s *Server) listUnspentBitcoinCore(ctx context.Context, walletId string, ge
 		return nil, fmt.Errorf("bitcoin Core list unspent: %w", err)
 	}
 
-	denials, err := deniability.List(ctx, s.database)
+	denials, err := deniability.List(ctx, s.database, deniability.WithWalletID(walletId))
 	if err != nil {
 		return nil, fmt.Errorf("bitcoin core: could not list denials: %w", err)
 	}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1851,6 +1851,10 @@ func (s *Server) DeleteCheque(ctx context.Context, c *connect.Request[pb.DeleteC
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	// Check if cheque exists
 	cheque, err := cheques.Get(ctx, s.database, walletId, c.Msg.Id)
 	if err != nil {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1535,6 +1535,10 @@ func (s *Server) GetCheque(ctx context.Context, c *connect.Request[pb.GetChequeR
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	cheque, err := cheques.Get(ctx, s.database, walletId, c.Msg.Id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2167,6 +2167,10 @@ func (s *Server) GetUTXODistribution(ctx context.Context, c *connect.Request[pb.
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get wallet type: %w", err))
 	}
 
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	// Simple label getter since we don't need labels for distribution
 	getLabel := func(addr string) string { return "" }
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -150,6 +150,38 @@ func TestService_ListCheques(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, resp.Msg.Cheques)
 	})
+
+	// Cheque rows are wallet-derived data: addresses and amounts must not be
+	// readable once the wallet is locked.
+	t.Run("locked wallet returns failed precondition", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "test_wallet"},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.ListCheques(context.Background(), connect.NewRequest(&walletv1.ListChequesRequest{
+			WalletId: "test-wallet-id-1234",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
 }
 
 func TestService_GetCheque(t *testing.T) {

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -378,6 +378,27 @@ func TestService_LockWallet(t *testing.T) {
 	})
 }
 
+func TestService_ListReceiveAddresses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("locked wallet returns no addresses", func(t *testing.T) {
+		t.Parallel()
+
+		database := database.Test(t)
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database))
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.ListReceiveAddresses(context.Background(), connect.NewRequest(&walletv1.ListReceiveAddressesRequest{
+			WalletId: "test-wallet-id-1234",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
+}
+
 func TestService_UnlockWallet(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -320,6 +320,46 @@ func TestService_DeleteChequeFundingGuard(t *testing.T) {
 	})
 }
 
+// A locked wallet must not be able to drop a cheque row: the row is the only
+// record of the derivation index that address belongs to.
+func TestService_DeleteChequeRequiresUnlockedWallet(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+			Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+		}, nil).AnyTimes()
+	mockBitcoind.EXPECT().
+		CreateWallet(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+			Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "test_wallet"},
+		}, nil).AnyTimes()
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+	// Unfunded and unswept, so only the lock can stop the delete.
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qlockeddelete00000000000000000000000000000")
+	require.NoError(t, err)
+
+	_, err = cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+
+	_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+		WalletId: testWalletID,
+		Id:       chequeID,
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+	require.NoError(t, err)
+}
+
 func TestService_IsWalletUnlocked(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -564,6 +564,32 @@ func TestService_UnlockWallet(t *testing.T) {
 	})
 }
 
+// The distribution buckets carry outpoints, so a locked wallet must not answer.
+func TestService_GetUTXODistribution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("locked wallet returns failed precondition", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.GetUTXODistribution(context.Background(), connect.NewRequest(&walletv1.GetUTXODistributionRequest{
+			WalletId: testWalletID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
+}
+
 // The orchestrator records each deposit as it broadcasts it, because an M5 is
 // an ordinary transaction on the wire.
 func TestListSidechainDepositsReadsTheOrchestrator(t *testing.T) {

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -471,6 +471,31 @@ func TestService_ListReceiveAddresses(t *testing.T) {
 	})
 }
 
+func TestService_GetStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("locked wallet returns failed precondition", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.GetStats(context.Background(), connect.NewRequest(&walletv1.GetStatsRequest{
+			WalletId: "test-wallet-id-1234",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
+}
+
 func TestService_UnlockWallet(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -216,6 +216,42 @@ func TestService_GetCheque(t *testing.T) {
 		// "no rows" internal error.
 		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 	})
+
+	t.Run("locked wallet cannot read a cheque", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		db := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "test_wallet"},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qlockedcheque00000000000000000000000000000")
+		require.NoError(t, err)
+
+		_, err = cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		// A cheque address is derived from the seed, so a locked wallet must
+		// not hand it out.
+		_, err = cli.GetCheque(context.Background(), connect.NewRequest(&walletv1.GetChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
 }
 
 func TestService_DeleteCheque(t *testing.T) {

--- a/bitwindow/server/engines/cheque_engine.go
+++ b/bitwindow/server/engines/cheque_engine.go
@@ -2,11 +2,13 @@ package engines
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"sync/atomic"
 	"time"
 
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -21,20 +23,22 @@ type ChequeRecovery struct {
 	Index   uint32
 	Address string
 	Amount  uint64
-	Txid    string
+	Txids   []string
 }
 
 // ChequeEngine derives cheque keys from the wallet seed, and reads their
 // addresses off the chain.
 type ChequeEngine struct {
+	db           *sql.DB
 	walletEngine *WalletEngine
 	chainParams  *chaincfg.Params
 	chain        ChequeChain
 }
 
 // NewChequeEngine creates a new cheque engine
-func NewChequeEngine(walletEngine *WalletEngine, chainParams *chaincfg.Params, chain ChequeChain) *ChequeEngine {
+func NewChequeEngine(db *sql.DB, walletEngine *WalletEngine, chainParams *chaincfg.Params, chain ChequeChain) *ChequeEngine {
 	return &ChequeEngine{
+		db:           db,
 		walletEngine: walletEngine,
 		chainParams:  chainParams,
 		chain:        chain,
@@ -172,17 +176,17 @@ func (e *ChequeEngine) ScanForFunds(ctx context.Context, walletId string, count 
 		}
 
 		var amountSats uint64
-		var txid string
+		var txids []string
 		for _, utxo := range utxos {
 			amountSats += uint64(utxo.ValueSats)
-			txid = utxo.TxID
+			txids = append(txids, utxo.TxID)
 		}
 
 		recoveries = append(recoveries, ChequeRecovery{
 			Index:   i,
 			Address: address,
 			Amount:  amountSats,
-			Txid:    txid,
+			Txids:   txids,
 		})
 
 		log.Info().
@@ -254,12 +258,26 @@ func (e *ChequeEngine) recoverChequesOnUnlock(ctx context.Context) {
 			continue
 		}
 
+		// Write what the scan found back to the DB, otherwise a cheque that
+		// only exists on chain never shows up in the UI.
+		for _, recovery := range recoveries {
+			if err := cheques.CreateOrUpdateFromRecovery(
+				ctx, e.db, wallet.ID, recovery.Index, recovery.Address, recovery.Txids, recovery.Amount,
+			); err != nil {
+				log.Warn().Err(err).
+					Str("wallet_id", wallet.ID).
+					Uint32("index", recovery.Index).
+					Msg("failed to persist recovered cheque")
+				continue
+			}
+			totalRecoveries++
+		}
+
 		if len(recoveries) > 0 {
 			log.Info().
 				Str("wallet_id", wallet.ID).
 				Int("count", len(recoveries)).
 				Msg("found funded cheques during recovery scan")
-			totalRecoveries += len(recoveries)
 		}
 	}
 

--- a/bitwindow/server/engines/cheque_engine_test.go
+++ b/bitwindow/server/engines/cheque_engine_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
@@ -38,7 +40,7 @@ func testChequeEngine(t *testing.T, chain ChequeChain) *ChequeEngine {
 		dir,
 		&chaincfg.SigNetParams,
 	)
-	return NewChequeEngine(walletEngine, &chaincfg.SigNetParams, chain)
+	return NewChequeEngine(database.Test(t), walletEngine, &chaincfg.SigNetParams, chain)
 }
 
 func TestScanForFundsReportsFundedIndex(t *testing.T) {
@@ -55,7 +57,38 @@ func TestScanForFundsReportsFundedIndex(t *testing.T) {
 	require.Equal(t, uint32(3), recoveries[0].Index)
 	require.Equal(t, address, recoveries[0].Address)
 	require.Equal(t, uint64(100_000), recoveries[0].Amount)
+	require.Equal(t, []string{testUTXOs()[0].TxID}, recoveries[0].Txids)
 	require.Len(t, chain.queried, 20, "the scan reads every index up to the count")
+}
+
+// A cheque that only exists on chain must come back into the DB under the
+// scanning wallet, and must not be duplicated by a second scan.
+func TestRecoverChequesOnUnlockPersistsFundedCheques(t *testing.T) {
+	chain := &fakeChain{funded: map[string][]ChequeUTXO{}}
+	engine := testChequeEngine(t, chain)
+	ctx := context.Background()
+
+	address, err := engine.DeriveChequeAddress(chequeWalletID, 0)
+	require.NoError(t, err)
+	chain.funded[address] = testUTXOs()
+
+	// The unencrypted fixture auto-unlocks; without it the recovery blocks.
+	require.True(t, engine.walletEngine.IsUnlocked())
+
+	engine.recoverChequesOnUnlock(ctx)
+	engine.recoverChequesOnUnlock(ctx)
+
+	list, err := cheques.List(ctx, engine.db, chequeWalletID)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, uint32(0), list[0].DerivationIndex)
+	require.Equal(t, address, list[0].Address)
+	require.Equal(t, []string{testUTXOs()[0].TxID}, list[0].FundedTxids)
+	require.True(t, list[0].IsFunded())
+
+	next, err := cheques.GetNextIndex(ctx, engine.db, chequeWalletID)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), next)
 }
 
 // A chain read that fails means the electrum backend is down, so the scan must

--- a/bitwindow/server/engines/core_send.go
+++ b/bitwindow/server/engines/core_send.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 
 	"connectrpc.com/connect"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
@@ -16,6 +17,51 @@ import (
 type CoreOutpoint struct {
 	Txid string
 	Vout uint32
+}
+
+// SendCoreWithFixedFee creates and broadcasts a Bitcoin Core transaction paying
+// exactly fixedFeeSats. Core's send RPC takes a fee rate and no absolute fee, so
+// the inputs are picked here (largest first) and spent through the raw
+// transaction path, which pays the fee as given.
+func SendCoreWithFixedFee(
+	ctx context.Context,
+	bitcoind corerpc.BitcoinServiceClient,
+	walletName string,
+	destinationsSats map[string]uint64,
+	fixedFeeSats uint64,
+) (string, error) {
+	unspent, err := bitcoind.ListUnspent(ctx, connect.NewRequest(&corepb.ListUnspentRequest{
+		Wallet: walletName,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("list unspent: %w", err)
+	}
+
+	neededSats := fixedFeeSats
+	for _, sats := range destinationsSats {
+		neededSats += sats
+	}
+
+	candidates := unspent.Msg.Unspent
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Amount > candidates[j].Amount
+	})
+
+	var totalInSats uint64
+	selected := make([]CoreOutpoint, 0, len(candidates))
+	for _, u := range candidates {
+		if totalInSats >= neededSats {
+			break
+		}
+		selected = append(selected, CoreOutpoint{Txid: u.Txid, Vout: u.Vout})
+		totalInSats += uint64(math.Round(u.Amount * 1e8))
+	}
+
+	if totalInSats < neededSats {
+		return "", fmt.Errorf("wallet UTXOs (%d sats) insufficient for outputs + fee (%d sats)", totalInSats, neededSats)
+	}
+
+	return SendCoreWithRequiredInputs(ctx, bitcoind, walletName, selected, destinationsSats, 0, fixedFeeSats)
 }
 
 // SendCoreWithRequiredInputs creates and broadcasts a Bitcoin Core transaction

--- a/bitwindow/server/engines/core_send_test.go
+++ b/bitwindow/server/engines/core_send_test.go
@@ -87,3 +87,75 @@ func TestSendCoreWithRequiredInputs(t *testing.T) {
 		require.ErrorContains(t, err, "not found in wallet UTXO set")
 	})
 }
+
+func TestSendCoreWithFixedFee(t *testing.T) {
+	t.Parallel()
+
+	const smallTxid = "cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33"
+	const largeTxid = "dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44dd44"
+
+	t.Run("selects inputs and pays exactly the fixed fee", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		// Once to select the inputs, once to resolve their values.
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: smallTxid, Vout: 3, Amount: 1.0},
+					{Txid: largeTxid, Vout: 0, Amount: 5.0},
+				},
+			}), nil).
+			Times(2)
+
+		mockBitcoind.EXPECT().
+			GetNewAddress(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.GetNewAddressResponse{
+				Address: "tb1qchange0000000000000000000000000000000",
+			}), nil)
+
+		stop := errors.New("stop")
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateRawTransactionRequest]) (*connect.Response[corepb.CreateRawTransactionResponse], error) {
+				// Largest first: the 5 BTC UTXO covers outputs + fee on its own.
+				require.Len(t, req.Msg.Inputs, 1)
+				assert.Equal(t, largeTxid, req.Msg.Inputs[0].Txid)
+
+				// 5 BTC in, 0.4 BTC out, exactly 5k sats fee -> the rest is change.
+				assert.Equal(t, 0.4, req.Msg.Outputs["tb1qdest00000000000000000000000000000000"])
+				assert.Equal(t, 4.59995, req.Msg.Outputs["tb1qchange0000000000000000000000000000000"])
+				return nil, stop
+			})
+
+		_, err := engines.SendCoreWithFixedFee(context.Background(), mockBitcoind, "wallet",
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			5_000,
+		)
+		require.ErrorIs(t, err, stop)
+	})
+
+	t.Run("errors when the wallet cannot cover outputs plus fee", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: smallTxid, Vout: 3, Amount: 0.1},
+				},
+			}), nil)
+
+		_, err := engines.SendCoreWithFixedFee(context.Background(), mockBitcoind, "wallet",
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			5_000,
+		)
+		require.ErrorContains(t, err, "insufficient for outputs + fee")
+	})
+}

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -280,6 +280,27 @@ func UpdateSwept(ctx context.Context, db *sql.DB, walletID string, id int64, txi
 	return nil
 }
 
+// ReplaceSweptTxid points cheques swept by oldTxid at its replacement, and
+// returns how many rows moved. Txids are unique, so this spans all wallets.
+func ReplaceSweptTxid(ctx context.Context, db *sql.DB, oldTxid string, newTxid string) (int64, error) {
+	result, err := db.ExecContext(ctx, `
+		UPDATE cheques
+		SET swept_txid = ?
+		WHERE swept_txid = ?
+	`, newTxid, oldTxid)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to replace swept txid: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return rows, nil
+}
+
 // GetNextIndex returns the next available cheque index for a specific wallet
 func GetNextIndex(ctx context.Context, db *sql.DB, walletID string) (uint32, error) {
 	var maxIndex sql.NullInt64

--- a/bitwindow/server/models/deniability/deniability.go
+++ b/bitwindow/server/models/deniability/deniability.go
@@ -125,6 +125,7 @@ func selectDenialQuery() string {
 
 type config struct {
 	excludeCancelled bool
+	walletID         *string
 }
 
 type Option func(c *config)
@@ -132,6 +133,14 @@ type Option func(c *config)
 func WithExcludeCancelled() Option {
 	return func(c *config) {
 		c.excludeCancelled = true
+	}
+}
+
+// WithWalletID limits the results to one wallet's denials, plus the ones from
+// before wallet_id existed.
+func WithWalletID(id string) Option {
+	return func(c *config) {
+		c.walletID = &id
 	}
 }
 
@@ -170,12 +179,23 @@ func List(ctx context.Context, db *sql.DB, opts ...Option) ([]Denial, error) {
 	conf := newConfig(opts)
 
 	query := selectDenialQuery()
+	var where []string
+	var args []any
 	if conf.excludeCancelled {
-		query += ` WHERE d.cancelled_at IS NULL`
+		where = append(where, `d.cancelled_at IS NULL`)
+	}
+	if conf.walletID != nil {
+		// A denial from before wallet_id existed names no wallet, so it belongs
+		// to whichever wallet asks. Same as the engine treats it.
+		where = append(where, `(d.wallet_id = ? OR d.wallet_id IS NULL OR d.wallet_id = '')`)
+		args = append(args, *conf.walletID)
+	}
+	if len(where) > 0 {
+		query += ` WHERE ` + strings.Join(where, ` AND `)
 	}
 	query += ` ORDER BY d.updated_at ASC`
 
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("could not query deniabilities: %w", err)
 	}

--- a/bitwindow/server/models/deniability/deniability_test.go
+++ b/bitwindow/server/models/deniability/deniability_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	"github.com/brianvoe/gofakeit/v7"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -101,6 +102,29 @@ func TestDeniability(t *testing.T) {
 		require.Equal(t, int32(1), denials[1].TipVout)
 		require.Equal(t, 2*time.Hour, denials[1].DelayDuration)
 		require.Equal(t, int32(4), denials[1].NumHops)
+	})
+
+	t.Run("List with wallet ID", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+
+		_, err := Create(ctx, db, "wallet-a", "txid-a", 0, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+		_, err = Create(ctx, db, "wallet-b", "txid-b", 0, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// A denial from before wallet_id existed.
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO denials (wallet_id, initial_txid, initial_vout, delay_duration, num_hops, created_at)
+			VALUES (NULL, 'txid-legacy', 0, ?, 3, ?)
+		`, 1*time.Hour, time.Now())
+		require.NoError(t, err)
+
+		denials, err := List(ctx, db, WithWalletID("wallet-b"))
+		require.NoError(t, err)
+
+		tips := lo.Map(denials, func(d Denial, _ int) string { return d.TipTXID })
+		require.ElementsMatch(t, []string{"txid-b", "txid-legacy"}, tips)
 	})
 
 	t.Run("Cancel", func(t *testing.T) {


### PR DESCRIPTION
A set of **12 independent fixes** to the BitWindow wallet & cheque API, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`12 files changed, 616 insertions(+), 11 deletions(-)`).

## Fixes (oldest first)

- **`ad9d1dec0`** Confirmation: BitWindow `ListReceiveAddresses` leaks receive-address state while locked
- **`74d7355ce`** Confirmation: BitWindow `GetBalance` returns balances while locked
- **`fa0a21c1f`** BitWindow `DeleteCheque` deletes cheque rows while wallet is locked
- **`464af4c8f`** BitWindow `ListCheques` returns cheque metadata while wallet is locked
- **`0e9b81150`** BitWindow `CheckChequeFunding` returns cheque funding state while wallet is locked
- **`7fc40801b`** BitWindow `GetStats` leaks per-wallet aggregate analytics while wallet is locked
- **`f39dcb9f8`** BitWindow `GetCheque` returns cheque metadata while wallet is locked
- **`31b2376fb`** BitWindow `GetUTXODistribution` locked-wallet UTXO distribution + outpoints leak
- **`405570df4`** Migration 025 strands legacy cheques under an empty wallet ID
- **`808d4f616`** BitWindow drops fixed fees on Bitcoin Core sends without required inputs
- **`492d75baf`** Confirmation: BitWindow `BumpFee` leaves cheque `swept_txid` stale after Core RBF bump
- **`b70b5c055`** BitWindow `listUnspentBitcoinCore` leaks cross-wallet deniability metadata via unscoped join

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.