### PR TITLE
BitWindow wallet & cheque API (3 of 4): 4 fixes from a security review

### DIFF
--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -12,9 +12,12 @@ import (
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	bitcoindv1alpha "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 const testWalletID = "test-wallet-id-1234"
@@ -314,4 +317,45 @@ func TestCheckChequeFunding_NeedsElectrum(t *testing.T) {
 		Id:       chequeID,
 	}))
 	require.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}
+
+// Core's bumpfee evicts the sweep transaction, so a cheque swept by the old
+// txid has to end up pointing at the replacement.
+func TestBumpFee_RepointsSweptCheque(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+
+	oldTxid := "1111000011110000111100001111000011110000111100001111000011110000"
+	newTxid := "2222000022220000222200002222000022220000222200002222000022220000"
+
+	// BumpFee walks the loaded wallets, so Core has to report one.
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+			Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{"test_wallet"}},
+		}, nil).
+		AnyTimes()
+	mockBitcoind.EXPECT().
+		BumpFee(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.BumpFeeResponse]{
+			Msg: &bitcoindv1alpha.BumpFeeResponse{Txid: newTxid, OriginalFee: 0.0001, NewFee: 0.0002},
+		}, nil)
+	apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qbumpfeetestaddr0000000000000000000000000")
+	require.NoError(t, err)
+	require.NoError(t, cheques.UpdateSwept(context.Background(), db, testWalletID, chequeID, oldTxid))
+
+	resp, err := cli.BumpFee(context.Background(), connect.NewRequest(&walletv1.BumpFeeRequest{Txid: oldTxid}))
+	require.NoError(t, err)
+	require.Equal(t, newTxid, resp.Msg.Txid)
+
+	persisted, err := cheques.Get(context.Background(), db, testWalletID, chequeID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted.SweptTxid)
+	require.Equal(t, newTxid, *persisted.SweptTxid, "the cheque must follow the replacement")
 }

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -99,47 +99,13 @@ type Server struct {
 }
 
 // CreateBitcoinCoreWallet implements walletv1connect.WalletServiceHandler.
-// Test endpoint to verify descriptor import to Bitcoin Core.
-func (s *Server) CreateBitcoinCoreWallet(ctx context.Context, c *connect.Request[pb.CreateBitcoinCoreWalletRequest]) (*connect.Response[pb.CreateBitcoinCoreWalletResponse], error) {
-	seedHex := strings.TrimSpace(c.Msg.SeedHex)
-	if seedHex == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("seed_hex required"))
-	}
-
-	coreWalletName := c.Msg.Name
-	if coreWalletName == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name required"))
-	}
-
-	// Directly import to Bitcoin Core - no wallet.json needed
-	if err := s.walletEngine.CreateBitcoinCoreWalletFromSeed(ctx, coreWalletName, seedHex, 0, ""); err != nil {
-		zerolog.Ctx(ctx).Error().Err(err).Msg("create Bitcoin Core wallet failed")
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create wallet: %w", err))
-	}
-
-	// Get first address for verification
-	bitcoindClient, err := s.bitcoind.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	addrResp, err := bitcoindClient.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
-		Wallet: coreWalletName,
-	}))
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get new address: %w", err))
-	}
-
-	zerolog.Ctx(ctx).Info().
-		Str("core_wallet_name", coreWalletName).
-		Str("first_address", addrResp.Msg.Address).
-		Msg("Created Bitcoin Core wallet from seed")
-
-	return connect.NewResponse(&pb.CreateBitcoinCoreWalletResponse{
-		WalletId:       "", // Not used in test
-		CoreWalletName: coreWalletName,
-		FirstAddress:   addrResp.Msg.Address,
-	}), nil
+// The orchestrator owns wallet.json, so bitwindowd cannot mint a wallet ID:
+// creating the Core wallet here would leave one no other RPC can address.
+// Rejected before bitcoind is touched.
+func (s *Server) CreateBitcoinCoreWallet(_ context.Context, _ *connect.Request[pb.CreateBitcoinCoreWalletRequest]) (*connect.Response[pb.CreateBitcoinCoreWalletResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New(
+		"create wallets through walletmanager.v1.WalletManagerService/GenerateWallet",
+	))
 }
 
 // SendTransaction implements drivechainv1connect.DrivechainServiceHandler.

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2320,6 +2320,15 @@ func (s *Server) BumpFee(ctx context.Context, c *connect.Request[pb.BumpFeeReque
 		Float64("new_fee", bumpResp.Msg.NewFee).
 		Msg("RBF transaction broadcast via Core bumpfee")
 
+	// The replacement evicts the old txid, so a cheque swept by it must follow.
+	rebound, err := cheques.ReplaceSweptTxid(ctx, s.database, txid, bumpResp.Msg.Txid)
+	if err != nil {
+		// The bump already broadcast, so don't fail the call over bookkeeping.
+		log.Warn().Err(err).Msg("failed to point swept cheques at the replacement txid")
+	} else if rebound > 0 {
+		log.Info().Int64("cheques", rebound).Msg("pointed swept cheques at the replacement txid")
+	}
+
 	return connect.NewResponse(&pb.BumpFeeResponse{
 		Txid:        bumpResp.Msg.Txid,
 		OriginalFee: bumpResp.Msg.OriginalFee,

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -770,6 +770,10 @@ func (s *Server) ListSidechainDeposits(ctx context.Context, c *connect.Request[p
 
 // CreateSidechainDeposit implements walletv1connect.WalletServiceHandler.
 func (s *Server) CreateSidechainDeposit(ctx context.Context, c *connect.Request[pb.CreateSidechainDepositRequest]) (*connect.Response[pb.CreateSidechainDepositResponse], error) {
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
+
 	walletId := c.Msg.WalletId
 	walletType, err := s.walletEngine.GetWalletBackendType(ctx, walletId)
 	if err != nil {
@@ -818,6 +822,12 @@ func (s *Server) createWalletSidechainDeposit(
 	depositAddress string,
 	amount, fee btcutil.Amount,
 ) (*connect.Response[pb.CreateSidechainDepositResponse], error) {
+	// Re-check with the broadcast one call away: the address and amount
+	// validation above leaves room for a lock.
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
+
 	txid, err := s.walletEngine.CreateDeposit(ctx, &orchpb.CreateDepositRequest{
 		Slot:        int32(slot),
 		WalletId:    walletId,
@@ -1426,6 +1436,16 @@ func (s *Server) IsWalletUnlocked(ctx context.Context, c *connect.Request[emptyp
 	return connect.NewResponse(&emptypb.Empty{}), nil
 }
 
+// requireUnlocked rejects a fund-moving call while the wallet is locked. A
+// handler checks it on entry and again just before it broadcasts, because a
+// lock can land in between.
+func (s *Server) requireUnlocked() error {
+	if !s.walletEngine.IsUnlocked() {
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+	return nil
+}
+
 // CreateCheque implements walletv1connect.WalletServiceHandler.
 func (s *Server) CreateCheque(ctx context.Context, c *connect.Request[pb.CreateChequeRequest]) (*connect.Response[pb.CreateChequeResponse], error) {
 	log := zerolog.Ctx(ctx)
@@ -1708,6 +1728,12 @@ func sweepAddressKindToPb(kind engines.SweepAddressKind) pb.SweepAddressKind {
 func (s *Server) SweepCheque(ctx context.Context, c *connect.Request[pb.SweepChequeRequest]) (*connect.Response[pb.SweepChequeResponse], error) {
 	log := zerolog.Ctx(ctx)
 
+	// The sweep key comes from the caller, so this gate only holds the sweep to
+	// the lock state the operator sees — it is not what keeps the seed safe.
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
+
 	walletId := c.Msg.WalletId
 
 	// Wallet ID validation only - cheques work the same for all wallet types
@@ -1754,6 +1780,12 @@ func (s *Server) SweepCheque(ctx context.Context, c *connect.Request[pb.SweepChe
 	txHex, err := s.serializeTx(signedTx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("serialize transaction: %w", err))
+	}
+
+	// Re-check with the broadcast one call away: the UTXO query, build and sign
+	// above leave room for a lock.
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
 	}
 
 	txid, err := s.chequeChain.Broadcast(ctx, txHex)
@@ -2281,6 +2313,10 @@ func (s *Server) BumpFee(ctx context.Context, c *connect.Request[pb.BumpFeeReque
 	log := zerolog.Ctx(ctx)
 	txid := c.Msg.Txid
 
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
+
 	if txid == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("txid required"))
 	}
@@ -2294,6 +2330,12 @@ func (s *Server) BumpFee(ctx context.Context, c *connect.Request[pb.BumpFeeReque
 	listResp, err := s.data.ListWallets(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, fmt.Errorf("list wallets: %w", err)
+	}
+
+	// Re-check with the broadcast one call away: the wallet listing above
+	// leaves room for a lock.
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
 	}
 
 	// Try each wallet until one successfully bumps the fee

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -573,6 +573,11 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	// History is wallet data, so a locked wallet must not hand it out.
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	if walletType == engines.WalletTypeElectrum {
 		entries, err := s.walletEngine.GetElectrumTransactions(ctx, walletId)
 		if err != nil {

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -121,6 +121,25 @@ func TestService_GetNewAddress(t *testing.T) {
 	})
 }
 
+func TestService_CreateBitcoinCoreWallet(t *testing.T) {
+	t.Parallel()
+
+	// Only the orchestrator mints wallet IDs, so this must be rejected rather
+	// than reporting success with an empty one and orphaning a Core wallet.
+	database := database.Test(t)
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database))
+
+	resp, err := cli.CreateBitcoinCoreWallet(context.Background(), connect.NewRequest(&walletv1.CreateBitcoinCoreWalletRequest{
+		SeedHex: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+			"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+		Name: "orphan-wallet",
+	}))
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, connect.CodeUnimplemented, connect.CodeOf(err))
+}
+
 func TestService_ListCheques(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	bitcoindv1alpha "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -459,4 +462,88 @@ func TestListSidechainDepositsReadsTheOrchestrator(t *testing.T) {
 	require.Len(t, resp.Msg.Deposits, 1)
 	require.Equal(t, "deadbeef", resp.Msg.Deposits[0].Txid)
 	require.Equal(t, int64(50_000), resp.Msg.Deposits[0].Amount)
+}
+
+// TestFundMovingCallsRejectALockedWallet pins the lock gate on the handlers
+// that end in a broadcast: a locked wallet must refuse them, and the spend must
+// never reach the node.
+func TestFundMovingCallsRejectALockedWallet(t *testing.T) {
+	t.Parallel()
+
+	// lockedClient stands up an API server and locks the wallet. The mocks
+	// allow only the background reads, so any spend a handler still attempts
+	// fails the test as an unexpected call.
+	lockedClient := func(t *testing.T) walletv1connect.WalletServiceClient {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		db := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+		mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+		apitests.ExpectOrchestratorReads(mockOrch)
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db,
+			apitests.WithBitcoind(mockBitcoind), apitests.WithOrchestrator(mockOrch)))
+
+		// The fixture wallet is unencrypted, so it starts unlocked.
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		return cli
+	}
+
+	requireLocked := func(t *testing.T, err error) {
+		t.Helper()
+
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		require.Contains(t, err.Error(), "wallet is locked")
+	}
+
+	t.Run("create sidechain deposit", func(t *testing.T) {
+		t.Parallel()
+
+		cli := lockedClient(t)
+
+		_, err := cli.CreateSidechainDeposit(context.Background(), connect.NewRequest(&walletv1.CreateSidechainDepositRequest{
+			WalletId:    testWalletID,
+			Destination: "s9_tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+			Amount:      0.1,
+			Fee:         0.0001,
+		}))
+		requireLocked(t, err)
+	})
+
+	t.Run("bump fee", func(t *testing.T) {
+		t.Parallel()
+
+		cli := lockedClient(t)
+
+		_, err := cli.BumpFee(context.Background(), connect.NewRequest(&walletv1.BumpFeeRequest{
+			Txid: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		}))
+		requireLocked(t, err)
+	})
+
+	t.Run("sweep cheque", func(t *testing.T) {
+		t.Parallel()
+
+		cli := lockedClient(t)
+
+		key, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		wif, err := btcutil.NewWIF(key, &chaincfg.SigNetParams, true)
+		require.NoError(t, err)
+
+		_, err = cli.SweepCheque(context.Background(), connect.NewRequest(&walletv1.SweepChequeRequest{
+			WalletId:           testWalletID,
+			PrivateKeyWif:      wif.String(),
+			DestinationAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+			FeeSatPerVbyte:     2,
+		}))
+		requireLocked(t, err)
+	})
 }

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -12,6 +12,7 @@ import (
 	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/transactions"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	bitcoindv1alpha "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
@@ -397,6 +398,44 @@ func TestService_LockWallet(t *testing.T) {
 
 		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
 		require.NoError(t, err)
+	})
+}
+
+func TestService_ListTransactionsLocked(t *testing.T) {
+	t.Parallel()
+
+	t.Run("locked wallet does not return history", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "test_wallet"},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		require.NoError(t, transactions.SetNote(context.Background(), database, testWalletID,
+			"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "secret note"))
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.ListTransactions(context.Background(), connect.NewRequest(&walletv1.ListTransactionsRequest{
+			WalletId: testWalletID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		require.NotContains(t, err.Error(), "secret note")
 	})
 }
 

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -280,6 +280,27 @@ func UpdateSwept(ctx context.Context, db *sql.DB, walletID string, id int64, txi
 	return nil
 }
 
+// ReplaceSweptTxid points cheques swept by oldTxid at its replacement, and
+// returns how many rows moved. Txids are unique, so this spans all wallets.
+func ReplaceSweptTxid(ctx context.Context, db *sql.DB, oldTxid string, newTxid string) (int64, error) {
+	result, err := db.ExecContext(ctx, `
+		UPDATE cheques
+		SET swept_txid = ?
+		WHERE swept_txid = ?
+	`, newTxid, oldTxid)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to replace swept txid: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return rows, nil
+}
+
 // GetNextIndex returns the next available cheque index for a specific wallet
 func GetNextIndex(ctx context.Context, db *sql.DB, walletID string) (uint32, error) {
 	var maxIndex sql.NullInt64

--- a/bitwindow/server/proto/wallet/v1/wallet.proto
+++ b/bitwindow/server/proto/wallet/v1/wallet.proto
@@ -7,6 +7,8 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
 service WalletService {
+  // Deprecated: always returns unimplemented. Wallets are created through
+  // walletmanager.v1.WalletManagerService/GenerateWallet, which owns the IDs.
   rpc CreateBitcoinCoreWallet(CreateBitcoinCoreWalletRequest) returns (CreateBitcoinCoreWalletResponse);
   rpc SendTransaction(SendTransactionRequest) returns (SendTransactionResponse);
   rpc GetBalance(GetBalanceRequest) returns (GetBalanceResponse);


### PR DESCRIPTION
A set of **4 independent fixes** to the BitWindow wallet & cheque API, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`5 files changed, 275 insertions(+), 41 deletions(-)`).

## Fixes (oldest first)

- **`3eb1f2f72`** BitWindow `CreateBitcoinCoreWallet` returns an unusable empty `WalletId`
- **`8f368455b`** Confirmation: BitWindow `BumpFee` leaves cheque `swept_txid` stale after Core RBF bump
- **`7897ae8d9`** BitWindow `CreateSidechainDeposit` / `BumpFee` / `SweepCheque` lock TOCTOU
- **`39910f899`** BitWindow `ListTransactions` leaks transaction history while locked

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.