### PR TITLE
BitWindow wallet & cheque API (4 of 4): 2 fixes from a security review

### DIFF
--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -786,6 +786,19 @@ func (s *Server) ListSidechainDeposits(ctx context.Context, c *connect.Request[p
 	if c.Msg.Slot < 0 || c.Msg.Slot > 255 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("slot must be 0-255"))
 	}
+
+	// Wallet ID validation only - deposit history reads the same for all wallet
+	// types. An empty ID would list every wallet's deposits.
+	_, err := s.walletEngine.GetWalletBackendType(ctx, c.Msg.WalletId)
+	if err != nil {
+		return nil, fmt.Errorf("get wallet type: %w", err)
+	}
+
+	// Deposit history is wallet data, so the wallet has to be unlocked
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	deposits, err := s.walletEngine.ListSidechainDeposits(ctx, uint32(c.Msg.Slot), c.Msg.WalletId)
 	if err != nil {
 		return nil, fmt.Errorf("list sidechain deposits: %w", err)

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1357,6 +1357,11 @@ func (s *Server) ListReceiveAddresses(ctx context.Context, c *connect.Request[pb
 func (s *Server) GetStats(ctx context.Context, c *connect.Request[pb.GetStatsRequest]) (*connect.Response[pb.GetStatsResponse], error) {
 	walletId := c.Msg.WalletId
 
+	// The stats aggregate wallet history, so the wallet has to be unlocked
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
 	// Bitcoin Core version
 	// Get UTXOs
 	utxos, err := s.ListUnspent(ctx, connect.NewRequest(&pb.ListUnspentRequest{WalletId: walletId}))

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -435,9 +435,41 @@ func TestListSidechainDepositsReadsTheOrchestrator(t *testing.T) {
 	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database,
 		apitests.WithBitcoind(mockBitcoind), apitests.WithOrchestrator(mockOrch)))
 
-	resp, err := cli.ListSidechainDeposits(context.Background(), connect.NewRequest(&walletv1.ListSidechainDepositsRequest{Slot: 9}))
+	resp, err := cli.ListSidechainDeposits(context.Background(), connect.NewRequest(&walletv1.ListSidechainDepositsRequest{
+		WalletId: "test-wallet-id-1234",
+		Slot:     9,
+	}))
 	require.NoError(t, err)
 	require.Len(t, resp.Msg.Deposits, 1)
 	require.Equal(t, "deadbeef", resp.Msg.Deposits[0].Txid)
 	require.Equal(t, int64(50_000), resp.Msg.Deposits[0].Amount)
+}
+
+// Deposit history names the amounts and counterparties a wallet dealt with, so a
+// locked wallet must not hand it out.
+func TestListSidechainDepositsRequiresUnlock(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	database := database.Test(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+	// No ListSidechainDeposits expectation: the orchestrator must not be reached.
+	mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+	apitests.ExpectOrchestratorReads(mockOrch)
+
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database,
+		apitests.WithBitcoind(mockBitcoind), apitests.WithOrchestrator(mockOrch)))
+
+	_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+
+	_, err = cli.ListSidechainDeposits(context.Background(), connect.NewRequest(&walletv1.ListSidechainDepositsRequest{
+		WalletId: "test-wallet-id-1234",
+		Slot:     9,
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "wallet is locked")
 }

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -378,6 +378,31 @@ func TestService_LockWallet(t *testing.T) {
 	})
 }
 
+func TestService_GetStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("locked wallet returns failed precondition", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		apitests.ExpectCoreWalletSetup(mockBitcoind)
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		_, err := cli.LockWallet(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+
+		_, err = cli.GetStats(context.Background(), connect.NewRequest(&walletv1.GetStatsRequest{
+			WalletId: "test-wallet-id-1234",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
+}
+
 func TestService_UnlockWallet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A set of **2 independent fixes** to the BitWindow wallet & cheque API, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`2 files changed, 76 insertions(+), 1 deletion(-)`).

## Fixes (oldest first)

- **`9d112d266`** Confirmation: BitWindow `ListSidechainDeposits` returns deposit history while locked
- **`c747e41f4`** BitWindow `GetStats` leaks per-wallet aggregate analytics while wallet is locked

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.