### PR TITLE
orchestrator: pass the sidechain conf as CLI args

### DIFF
--- a/sidechain-orchestrator/config/sidechain_conf.go
+++ b/sidechain-orchestrator/config/sidechain_conf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -193,10 +194,17 @@ func (m *SidechainConfManager) GetCliArgs() []string {
 		skipped[k] = true
 	}
 
-	for key, value := range m.Config.Settings {
+	keys := make([]string, 0, len(m.Config.Settings))
+	for key := range m.Config.Settings {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		if skipped[key] {
 			continue
 		}
+		value := m.Config.Settings[key]
 		switch value {
 		case "true":
 			args = append(args, fmt.Sprintf("--%s", key))

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -910,6 +910,7 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 		o.prepareCoreArgs(&opts)
 		o.prepareEnforcerArgs(&opts)
 		o.injectSidechainStarter(config, &opts)
+		o.prepareSidechainArgs(config, &opts)
 		o.injectHeadlessForForcedBackend(config, &opts)
 
 		// Electrum: skip the local L1 boot entirely and start the target alone.
@@ -1052,6 +1053,46 @@ func (o *Orchestrator) pointSidechainAtRemoteMainchain(cfg BinaryConfig, opts *S
 	o.log.Info().Str("binary", cfg.Name).Str("mainchain-grpc-url", remote).
 		Msg("electrum wallet active — pointing sidechain at remote mainchain")
 	return true
+}
+
+// prepareSidechainArgs appends a sidechain's own config as CLI flags.
+//
+// The daemon reads its own datadir, never the conf the orchestrator writes, so
+// without this it starts on its default ports and never listens for a peer.
+// A flag already on the command line wins, because an earlier step set it for
+// a reason.
+func (o *Orchestrator) prepareSidechainArgs(cfg BinaryConfig, opts *StartOpts) {
+	if cfg.ChainLayer != 2 || cfg.IsBitcoinCore {
+		return
+	}
+	scm := o.SidechainConfs[cfg.Name]
+	if scm == nil {
+		return
+	}
+	var added []string
+	for _, arg := range scm.GetCliArgs() {
+		if hasCLIFlag(opts.TargetArgs, arg) {
+			continue
+		}
+		opts.TargetArgs = append(opts.TargetArgs, arg)
+		added = append(added, arg)
+	}
+	if len(added) > 0 {
+		o.log.Info().Str("binary", cfg.Name).Strs("args", added).
+			Msg("auto-built sidechain args from config")
+	}
+}
+
+// hasCLIFlag reports whether args already carries the flag name that arg sets.
+func hasCLIFlag(args []string, arg string) bool {
+	name, _, _ := strings.Cut(arg, "=")
+	for _, have := range args {
+		haveName, _, _ := strings.Cut(have, "=")
+		if haveName == name {
+			return true
+		}
+	}
+	return false
 }
 
 // injectHeadlessForForcedBackend appends --headless to opts.TargetArgs when a
@@ -1284,6 +1325,7 @@ func (o *Orchestrator) RestartDaemon(ctx context.Context, name string, options .
 
 		default:
 			o.injectSidechainStarter(config, &opts)
+			o.prepareSidechainArgs(config, &opts)
 			o.injectHeadlessForForcedBackend(config, &opts)
 			// startTargetOnly emits its own "done" event.
 			o.startTargetOnly(ctx, config, opts, ch, nil)

--- a/sidechain-orchestrator/orchestrator_sidechain_args_test.go
+++ b/sidechain-orchestrator/orchestrator_sidechain_args_test.go
@@ -1,0 +1,111 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+)
+
+func thunderOrchestrator(t *testing.T, settings map[string]string) *Orchestrator {
+	t.Helper()
+	spec, ok := config.KnownSidechainSpecs["thunder"]
+	if !ok {
+		t.Fatal("thunder is missing from the known sidechain specs")
+	}
+	return &Orchestrator{
+		log: zerolog.Nop(),
+		SidechainConfs: map[string]*config.SidechainConfManager{
+			"thunder": {
+				Spec:   spec,
+				Config: &config.GenericAppConfig{Settings: settings},
+			},
+		},
+	}
+}
+
+// The daemon reads its own datadir, never the conf the orchestrator writes. So
+// the launch path has to pass net-addr, or the sidechain never listens for a
+// peer and never syncs.
+func TestPrepareSidechainArgsPassesTheConf(t *testing.T) {
+	orch := thunderOrchestrator(t, map[string]string{
+		"headless":           "true",
+		"net-addr":           "0.0.0.0:4009",
+		"rpc-addr":           "127.0.0.1:6009",
+		"mainchain-grpc-url": "http://localhost:50051",
+		"network":            "signet",
+	})
+
+	var opts StartOpts
+	orch.prepareSidechainArgs(BinaryConfig{Name: "thunder", ChainLayer: 2}, &opts)
+
+	want := []string{
+		"--headless",
+		"--mainchain-grpc-url=http://localhost:50051",
+		"--net-addr=0.0.0.0:4009",
+		"--rpc-addr=127.0.0.1:6009",
+	}
+	if len(opts.TargetArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", opts.TargetArgs, want)
+	}
+	for i, arg := range want {
+		if opts.TargetArgs[i] != arg {
+			t.Errorf("arg %d = %q, want %q", i, opts.TargetArgs[i], arg)
+		}
+	}
+}
+
+// A flag an earlier step set wins. Passing mainchain-grpc-url twice would undo
+// the remote mainchain path, which points a sidechain away from localhost.
+func TestPrepareSidechainArgsKeepsAnExistingFlag(t *testing.T) {
+	orch := thunderOrchestrator(t, map[string]string{
+		"mainchain-grpc-url": "http://localhost:50051",
+		"net-addr":           "0.0.0.0:4009",
+	})
+
+	opts := StartOpts{TargetArgs: []string{"--mainchain-grpc-url=https://remote.example/grpc"}}
+	orch.prepareSidechainArgs(BinaryConfig{Name: "thunder", ChainLayer: 2}, &opts)
+
+	var seen int
+	for _, arg := range opts.TargetArgs {
+		if len(arg) >= 21 && arg[:21] == "--mainchain-grpc-url=" {
+			seen++
+			if arg != "--mainchain-grpc-url=https://remote.example/grpc" {
+				t.Errorf("kept %q, want the remote value", arg)
+			}
+		}
+	}
+	if seen != 1 {
+		t.Errorf("passed mainchain-grpc-url %d times, want 1", seen)
+	}
+}
+
+// Core exits on an unknown option, so a Core derived sidechain takes none of
+// these flags.
+func TestPrepareSidechainArgsSkipsCoreAndLayerOne(t *testing.T) {
+	orch := thunderOrchestrator(t, map[string]string{"net-addr": "0.0.0.0:4009"})
+
+	for _, cfg := range []BinaryConfig{
+		{Name: "thunder", ChainLayer: 2, IsBitcoinCore: true},
+		{Name: "thunder", ChainLayer: 1},
+	} {
+		var opts StartOpts
+		orch.prepareSidechainArgs(cfg, &opts)
+		if len(opts.TargetArgs) != 0 {
+			t.Errorf("%+v got args %v, want none", cfg, opts.TargetArgs)
+		}
+	}
+}
+
+func TestHasCLIFlagMatchesOnName(t *testing.T) {
+	args := []string{"--headless", "--net-addr=0.0.0.0:4009"}
+	for _, arg := range []string{"--net-addr=1.2.3.4:1", "--headless"} {
+		if !hasCLIFlag(args, arg) {
+			t.Errorf("hasCLIFlag(%q) = false, want true", arg)
+		}
+	}
+	if hasCLIFlag(args, "--rpc-addr=127.0.0.1:6009") {
+		t.Error("hasCLIFlag reported a flag that is not there")
+	}
+}


### PR DESCRIPTION
A sidechain daemon reads its own datadir, never the conf the orchestrator writes. Nothing called GetCliArgs on a sidechain conf, so every sidechain started on its default ports and never listened for a peer.

On the alphanet box thunder runs as `thunder --headless --mnemonic-seed-phrase-path=...` with no net-addr, while its conf asks for 0.0.0.0:24009. It has no peers and sits at height 0.

A flag an earlier step already set wins, so the remote mainchain path keeps its own mainchain-grpc-url.