### PR TITLE
orchestrator: read the balance with getbalances

### DIFF
--- a/sidechain-orchestrator/mainchain_balance_test.go
+++ b/sidechain-orchestrator/mainchain_balance_test.go
@@ -1,0 +1,39 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseMainchainBalance(t *testing.T) {
+	raw := json.RawMessage(`{"mine":{"trusted":1.25,"untrusted_pending":0.5,"immature":0}}`)
+
+	got, err := parseMainchainBalance(raw)
+	if err != nil {
+		t.Fatalf("parseMainchainBalance: %v", err)
+	}
+	if got.Confirmed != 1.25 {
+		t.Errorf("confirmed = %v, want 1.25", got.Confirmed)
+	}
+	if got.Unconfirmed != 0.5 {
+		t.Errorf("unconfirmed = %v, want 0.5", got.Unconfirmed)
+	}
+}
+
+func TestParseMainchainBalanceWatchOnlyWalletStaysZero(t *testing.T) {
+	raw := json.RawMessage(`{"mine":{"trusted":0,"untrusted_pending":0,"immature":0},"watchonly":{"trusted":9}}`)
+
+	got, err := parseMainchainBalance(raw)
+	if err != nil {
+		t.Fatalf("parseMainchainBalance: %v", err)
+	}
+	if got.Confirmed != 0 || got.Unconfirmed != 0 {
+		t.Errorf("got %+v, want zero balances", got)
+	}
+}
+
+func TestParseMainchainBalanceRejectsBadJSON(t *testing.T) {
+	if _, err := parseMainchainBalance(json.RawMessage(`not json`)); err == nil {
+		t.Fatal("want an error for bad JSON")
+	}
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -3470,32 +3470,36 @@ func connectJSONPost(ctx context.Context, client *http.Client, url string, out i
 	return nil
 }
 
-// GetMainchainBalance proxies getbalance + getunconfirmedbalance from bitcoind.
+// GetMainchainBalance proxies getbalances from bitcoind.
 func (o *Orchestrator) GetMainchainBalance(ctx context.Context) (*MainchainBalance, error) {
 	client, err := o.CoreStatusClient()
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := client.call(ctx, "getbalance")
+	result, err := client.call(ctx, "getbalances")
 	if err != nil {
-		return nil, fmt.Errorf("getbalance: %w", err)
-	}
-	var confirmed float64
-	if err := json.Unmarshal(result, &confirmed); err != nil {
-		return nil, fmt.Errorf("decode getbalance: %w", err)
+		return nil, fmt.Errorf("getbalances: %w", err)
 	}
 
-	result, err = client.call(ctx, "getunconfirmedbalance")
-	if err != nil {
-		return nil, fmt.Errorf("getunconfirmedbalance: %w", err)
+	return parseMainchainBalance(result)
+}
+
+func parseMainchainBalance(raw json.RawMessage) (*MainchainBalance, error) {
+	var balances struct {
+		Mine struct {
+			Trusted          float64 `json:"trusted"`
+			UntrustedPending float64 `json:"untrusted_pending"`
+		} `json:"mine"`
 	}
-	var unconfirmed float64
-	if err := json.Unmarshal(result, &unconfirmed); err != nil {
-		return nil, fmt.Errorf("decode getunconfirmedbalance: %w", err)
+	if err := json.Unmarshal(raw, &balances); err != nil {
+		return nil, fmt.Errorf("decode getbalances: %w", err)
 	}
 
-	return &MainchainBalance{Confirmed: confirmed, Unconfirmed: unconfirmed}, nil
+	return &MainchainBalance{
+		Confirmed:   balances.Mine.Trusted,
+		Unconfirmed: balances.Mine.UntrustedPending,
+	}, nil
 }
 
 // CoreStatusClient builds a CoreStatusClient from the current config.


### PR DESCRIPTION
Core v31 removed getunconfirmedbalance, so the balance command failed on the eCash alphanet. One getbalances call now returns both numbers.