### PR TITLE
drivechain: read the sidechains with no enforcer

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -288,9 +288,7 @@ class SidechainsList extends ViewModelWidget<SidechainsViewModel> {
       );
     }
 
-    final error = viewModel.sidechainsUnavailable
-        ? 'Sidechains need full mode. Switch it on in Settings.'
-        : viewModel.error('sidechain');
+    final error = viewModel.error('sidechain');
 
     return SailCard(
       title: 'Sidechains',
@@ -826,6 +824,8 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
   /// Sidechains need the local enforcer, which only full mode runs. The wallet
   /// backend does not decide this — light mode with any wallet cannot serve them.
+  /// True when no enforcer runs, so no BIP300 state is readable here. The
+  /// sidechain list itself still reads, because a hosted index answers it.
   bool get sidechainsUnavailable => !NodeModeProvider.runsLocalBackends;
 
   String? _depositWalletId;
@@ -1629,7 +1629,7 @@ class SeeWithdrawalsView extends ViewModelWidget<SidechainsViewModel> {
     final isDisabled = viewModel.sidechainsUnavailable;
 
     return SailCard(
-      error: isDisabled ? 'Sidechains need full mode. Switch it on in Settings.' : null,
+      error: isDisabled ? 'Withdrawals come from the enforcer, which light mode does not run.' : null,
       bottomPadding: false,
       child: const RecentWithdrawalsTable(),
     );

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.188
+version: 0.2.189
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1/drivechainv1connect"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	orchconfig "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/datasource"
 	commonpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
 	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
@@ -90,6 +91,12 @@ type Server struct {
 func (s *Server) ListSidechainProposals(ctx context.Context, c *connect.Request[pb.ListSidechainProposalsRequest]) (*connect.Response[pb.ListSidechainProposalsResponse], error) {
 	log := zerolog.Ctx(ctx)
 
+	// A proposal is escrow state. With no enforcer there are none to show, and
+	// an error here would empty the sidechain list beside it.
+	if s.readsNoEscrow(ctx) {
+		return connect.NewResponse(&pb.ListSidechainProposalsResponse{}), nil
+	}
+
 	// Get current block hash to check cache validity
 	chainTipResp, err := s.data.ChainTip(ctx, &validatorpb.GetChainTipRequest{})
 	if err != nil {
@@ -158,6 +165,17 @@ func (s *Server) ListSidechainProposals(ctx context.Context, c *connect.Request[
 // Uses caching to avoid repeated enforcer calls for GetCtip on every sidechain.
 func (s *Server) ListSidechains(ctx context.Context, _ *connect.Request[pb.ListSidechainsRequest]) (*connect.Response[pb.ListSidechainsResponse], error) {
 	log := zerolog.Ctx(ctx)
+
+	// A light install runs no enforcer, and a hosted index reads one on its
+	// behalf. Every sidechain here comes from the chain, never from a list this
+	// build carries.
+	if s.readsNoEscrow(ctx) {
+		chains, err := s.escrowFromIndex(ctx)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeUnavailable, err)
+		}
+		return connect.NewResponse(&pb.ListSidechainsResponse{Sidechains: chains}), nil
+	}
 
 	// Get current block hash to check cache validity
 	chainTipResp, err := s.data.ChainTip(ctx, &validatorpb.GetChainTipRequest{})
@@ -341,6 +359,11 @@ func (s *Server) ListWithdrawals(
 	c *connect.Request[pb.ListWithdrawalsRequest],
 ) (*connect.Response[pb.ListWithdrawalsResponse], error) {
 	log := zerolog.Ctx(ctx)
+
+	// A withdrawal is escrow state, and no enforcer holds it here.
+	if s.readsNoEscrow(ctx) {
+		return connect.NewResponse(&pb.ListWithdrawalsResponse{}), nil
+	}
 
 	sidechainId := c.Msg.SidechainId
 
@@ -618,4 +641,30 @@ func (s *Server) ListRecentActions(
 	_ *connect.Request[pb.ListRecentActionsRequest],
 ) (*connect.Response[pb.ListRecentActionsResponse], error) {
 	return connect.NewResponse(&pb.ListRecentActionsResponse{}), nil
+}
+
+// readsNoEscrow is true when no enforcer answers, so no BIP300 state exists to
+// read. Every drivechain read answers what it can rather than failing, or one
+// unreadable call empties the whole page.
+func (s *Server) readsNoEscrow(ctx context.Context) bool {
+	return s.walletEngine != nil && !s.walletEngine.NodeMode().RunsLocalNode(ctx)
+}
+
+// escrowFromIndex reads the sidechain escrow through a hosted index. A network
+// with no index has no source, and says so rather than inventing a list.
+func (s *Server) escrowFromIndex(ctx context.Context) ([]*pb.ListSidechainsResponse_Sidechain, error) {
+	network, known := orchconfig.LookupNetwork(string(s.conf.BitcoinCoreNetwork))
+	if !known {
+		return nil, fmt.Errorf("the network %q is not known", s.conf.BitcoinCoreNetwork)
+	}
+	url := orchconfig.DrivechainIndexURLForNetwork(network)
+	if url == "" {
+		return nil, fmt.Errorf("light mode reads the sidechains from a hosted index, and %s has none",
+			network)
+	}
+	chains, err := newEscrowIndex(url).Sidechains(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read the sidechains from %s: %w", url, err)
+	}
+	return chains, nil
 }

--- a/bitwindow/server/api/drivechain/escrow_index.go
+++ b/bitwindow/server/api/drivechain/escrow_index.go
@@ -1,0 +1,96 @@
+package api_drivechain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1"
+)
+
+// escrowReadTimeout bounds one read of the hosted index. A light install shows
+// a page rather than waiting, so this stays short.
+const escrowReadTimeout = 8 * time.Second
+
+// escrowIndex reads the BIP300 escrow from a hosted Esplora index.
+//
+// A light install runs no enforcer, and the index reads one on its behalf. It
+// answers the same state the enforcer holds: which slots activated, how they
+// were voted in, and what each treasury holds.
+type escrowIndex struct {
+	baseURL string
+	http    *http.Client
+}
+
+func newEscrowIndex(baseURL string) *escrowIndex {
+	return &escrowIndex{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: escrowReadTimeout},
+	}
+}
+
+// Sidechains reads every activated slot the index knows.
+func (i *escrowIndex) Sidechains(ctx context.Context) ([]*pb.ListSidechainsResponse_Sidechain, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		i.baseURL+"/sidechains", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build the escrow request: %w", err)
+	}
+
+	resp, err := i.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("read the escrow from %s: %w", i.baseURL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read the escrow answer: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("the index answered %d: %s", resp.StatusCode,
+			strings.TrimSpace(string(body)))
+	}
+
+	var rows []struct {
+		Slot             uint32 `json:"slot"`
+		Title            string `json:"title"`
+		Description      string `json:"description"`
+		VoteCount        uint32 `json:"vote_count"`
+		ProposalHeight   uint32 `json:"proposal_height"`
+		ActivationHeight uint32 `json:"activation_height"`
+		// A slot with no treasury answers null, which is not the same as one
+		// holding zero sats.
+		Treasury *struct {
+			Txid      string `json:"txid"`
+			Vout      uint32 `json:"vout"`
+			ValueSats int64  `json:"value_sats"`
+		} `json:"treasury"`
+	}
+	if err := json.Unmarshal(body, &rows); err != nil {
+		return nil, fmt.Errorf("decode the escrow answer: %w", err)
+	}
+
+	out := make([]*pb.ListSidechainsResponse_Sidechain, 0, len(rows))
+	for _, r := range rows {
+		chain := &pb.ListSidechainsResponse_Sidechain{
+			Slot:             r.Slot,
+			Title:            r.Title,
+			Description:      r.Description,
+			VoteCount:        r.VoteCount,
+			ProposalHeight:   r.ProposalHeight,
+			ActivationHeight: r.ActivationHeight,
+		}
+		if r.Treasury != nil {
+			chain.BalanceSatoshi = r.Treasury.ValueSats
+			chain.ChaintipTxid = r.Treasury.Txid
+			chain.ChaintipVout = r.Treasury.Vout
+		}
+		out = append(out, chain)
+	}
+	return out, nil
+}

--- a/bitwindow/server/api/drivechain/escrow_index_test.go
+++ b/bitwindow/server/api/drivechain/escrow_index_test.go
@@ -1,0 +1,61 @@
+package api_drivechain
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The index answers the escrow the mainchain holds. A light install reads every
+// sidechain from here, so the shapes must match what the service sends.
+func TestEscrowIndexReadsTheChain(t *testing.T) {
+	var path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		_, _ = w.Write([]byte(`[
+			{"slot":2,"title":"BitNames","description":"names","vote_count":73,
+			 "proposal_height":987283,"activation_height":987402,
+			 "treasury":{"txid":"aa","vout":1,"value_sats":100007100}},
+			{"slot":4,"title":"BitAssets","description":"assets","vote_count":73,
+			 "proposal_height":987283,"activation_height":987402,"treasury":null}]`))
+	}))
+	defer server.Close()
+
+	got, err := newEscrowIndex(server.URL).Sidechains(context.Background())
+	if err != nil {
+		t.Fatalf("read the escrow: %v", err)
+	}
+	if path != "/sidechains" {
+		t.Errorf("read %q, want /sidechains", path)
+	}
+	if len(got) != 2 {
+		t.Fatalf("read %d sidechains, want 2", len(got))
+	}
+
+	first := got[0]
+	if first.Slot != 2 || first.Title != "BitNames" || first.VoteCount != 73 {
+		t.Errorf("first chain = %+v", first)
+	}
+	if first.BalanceSatoshi != 100007100 || first.ChaintipTxid != "aa" || first.ChaintipVout != 1 {
+		t.Errorf("the treasury did not carry through: %+v", first)
+	}
+	// A slot with no treasury reads as zero here, because the wire has no way
+	// to say "none". It must not carry another chain's outpoint.
+	if got[1].BalanceSatoshi != 0 || got[1].ChaintipTxid != "" {
+		t.Errorf("a chain with no treasury carries one: %+v", got[1])
+	}
+}
+
+// A down index must report an error, never an empty list that reads as "no
+// sidechains exist".
+func TestEscrowIndexReportsAFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no enforcer behind me", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	if _, err := newEscrowIndex(server.URL).Sidechains(context.Background()); err == nil {
+		t.Fatal("want an error from a down index, got none")
+	}
+}

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -250,6 +250,21 @@ func EsploraURLsForNetwork(n Network) []string {
 // ThunderEsploraURLForNetwork returns the thunder address index for a network,
 // or an empty string when none is hosted. A thunder node keeps no address
 // history of its own, so a wallet reads it here instead.
+// DrivechainIndexURLForNetwork names the index that reads the sidechain escrow
+// for a network.
+//
+// The escrow belongs to the mainchain, not to any one sidechain, so it does not
+// sit under a chain path. A network with no index answers empty, and a light
+// install there reads no sidechains.
+func DrivechainIndexURLForNetwork(n Network) string {
+	switch n {
+	case NetworkECash:
+		return "https://seed.alpha.ecash.eu.com/drivechain"
+	default:
+		return ""
+	}
+}
+
 func ThunderEsploraURLForNetwork(n Network) string {
 	switch n {
 	case NetworkECash:


### PR DESCRIPTION
Light mode showed "Sidechains need full mode. Switch it on in Settings." and rendered nothing, because one boolean turned the whole page off.

A sidechain lives in the mainchain's hashrate escrow, and only the mainchain knows which slots activated, how they were voted in, or what each treasury holds. A light install runs no enforcer, so it could read none of that.

It now reads the escrow through the hosted index at /drivechain/sidechains, which reads an enforcer on its behalf. Every sidechain comes from the chain: votes, proposal and activation heights, treasury balance, and the CTIP an M5 deposit spends. A network with no index says so, and a down index reports the failure — neither invents a list.

ListSidechainProposals and ListWithdrawals also answer in light mode rather than failing. Without that, the first unreadable call landed in the provider's catch before the list was ever assigned, and the page stayed empty despite a good response.

The page renders that list again. Only the withdrawals view stays gated, and it names the data it is missing instead of telling the user to leave light mode.