### PR TITLE
sidechain_core: give every network a colour

### DIFF
--- a/bitwindow/lib/pages/settings/settings_network.dart
+++ b/bitwindow/lib/pages/settings/settings_network.dart
@@ -367,7 +367,15 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
                 value: _confProvider.currentNetworkOptionId,
                 enabled: !_confProvider.hasPrivateBitcoinConf,
                 items: _confProvider.networkOptions
-                    .map((o) => SailDropdownItem<String>(value: o.id, label: o.displayName))
+                    .map(
+                      (o) => SailDropdownItem<String>(
+                        value: o.id,
+                        child: _NetworkOptionLabel(
+                          name: o.displayName,
+                          color: _confProvider.networkFromOption(o).toColor(),
+                        ),
+                      ),
+                    )
                     .toList(),
                 onChanged: (String? id) async {
                   if (id != null && !_confProvider.hasPrivateBitcoinConf) {
@@ -626,4 +634,31 @@ Future<void> swapNetworkWithDatadirPrompt(
       ),
     ),
   );
+}
+
+/// One network in the picker, marked with the colour that network carries.
+/// A network with no colour of its own shows the name alone.
+class _NetworkOptionLabel extends StatelessWidget {
+  final String name;
+  final Color? color;
+
+  const _NetworkOptionLabel({required this.name, this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (color != null) ...[
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 8),
+        ],
+        SailText.primary13(name),
+      ],
+    );
+  }
 }

--- a/sidechain_core/lib/classes/rpc_config.dart
+++ b/sidechain_core/lib/classes/rpc_config.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
@@ -285,6 +286,26 @@ extension NetworkExtensions on BitcoinNetwork {
       case BitcoinNetwork.BITCOIN_NETWORK_UNSPECIFIED || BitcoinNetwork.BITCOIN_NETWORK_UNKNOWN:
       default:
         return 'Unknown';
+    }
+  }
+
+  /// The colour that marks this network, so a user reads at a glance which
+  /// chain the app runs against.
+  ///
+  /// A network with no colour of its own answers null, and a caller then
+  /// renders it in the plain text colour.
+  Color? toColor() {
+    switch (this) {
+      case BitcoinNetwork.BITCOIN_NETWORK_MAINNET:
+        return SailColorScheme.orange;
+      case BitcoinNetwork.BITCOIN_NETWORK_ECASH:
+        return SailColorScheme.red;
+      case BitcoinNetwork.BITCOIN_NETWORK_SIGNET:
+        return SailColorScheme.blue;
+      case BitcoinNetwork.BITCOIN_NETWORK_REGTEST:
+        return SailColorScheme.greyMiddle;
+      default:
+        return null;
     }
   }
 }

--- a/sidechain_core/test/network_color_test.dart
+++ b/sidechain_core/test/network_color_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  test('every network a user picks carries its own colour', () {
+    expect(BitcoinNetwork.BITCOIN_NETWORK_MAINNET.toColor(), SailColorScheme.orange);
+    expect(BitcoinNetwork.BITCOIN_NETWORK_ECASH.toColor(), SailColorScheme.red);
+    expect(BitcoinNetwork.BITCOIN_NETWORK_SIGNET.toColor(), SailColorScheme.blue);
+    expect(BitcoinNetwork.BITCOIN_NETWORK_REGTEST.toColor(), SailColorScheme.greyMiddle);
+  });
+
+  test('no two networks share a colour, or a user cannot tell them apart', () {
+    final coloured = [
+      BitcoinNetwork.BITCOIN_NETWORK_MAINNET,
+      BitcoinNetwork.BITCOIN_NETWORK_ECASH,
+      BitcoinNetwork.BITCOIN_NETWORK_SIGNET,
+      BitcoinNetwork.BITCOIN_NETWORK_REGTEST,
+    ].map((n) => n.toColor()).toSet();
+    expect(coloured.length, 4);
+  });
+
+  test('a network with no colour of its own answers none', () {
+    expect(BitcoinNetwork.BITCOIN_NETWORK_FORKNET.toColor(), isNull);
+    expect(BitcoinNetwork.BITCOIN_NETWORK_TESTNET.toColor(), isNull);
+    expect(BitcoinNetwork.BITCOIN_NETWORK_UNSPECIFIED.toColor(), isNull);
+  });
+}


### PR DESCRIPTION
Chains carry a colour in the config; networks carried none, so nothing marked which chain the app runs against.

Networks now answer one:

| network | colour |
|---|---|
| mainnet | orange |
| alphanet (eCash) | red |
| signet | blue |
| regtest | grey |

The colour sits on the same extension that already names a network, so one place answers both. Forknet and testnet carry none and answer null, and a caller then renders the plain text.

The network picker shows each entry with its colour beside the name. A network with no colour shows the name alone.

Tests pin the four colours, that no two networks share one, and that an uncoloured network answers null.