### PR TITLE
bitwindow: wear the colour the network carries

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -54,19 +54,12 @@ import 'package:sidechain_core/providers/price_provider.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:window_manager/window_manager.dart';
 
+/// The accent the app wears on a network. It is the colour that network
+/// carries, so the picker and the app agree on what marks a chain.
+///
+/// A network with no colour of its own wears grey.
 Color getNetworkAccentColor(BitcoinNetwork network) {
-  switch (network) {
-    case BitcoinNetwork.BITCOIN_NETWORK_MAINNET:
-      return const Color.fromARGB(255, 255, 153, 0); // Orange (current)
-    case BitcoinNetwork.BITCOIN_NETWORK_TESTNET:
-      return const Color.fromARGB(255, 34, 139, 34); // Green
-    case BitcoinNetwork.BITCOIN_NETWORK_SIGNET:
-      return const Color.fromARGB(255, 65, 105, 225); // Blue
-    case BitcoinNetwork.BITCOIN_NETWORK_REGTEST:
-      return const Color.fromARGB(255, 220, 20, 60); // Red
-    default:
-      return const Color.fromARGB(255, 128, 128, 128); // Gray
-  }
+  return network.toColor() ?? SailColorScheme.greyMiddle;
 }
 
 void main(List<String> args) async {

--- a/bitwindow/test/network_accent_test.dart
+++ b/bitwindow/test/network_accent_test.dart
@@ -1,0 +1,26 @@
+import 'package:bitwindow/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  test('the app accent is the colour the network carries', () {
+    for (final network in [
+      BitcoinNetwork.BITCOIN_NETWORK_MAINNET,
+      BitcoinNetwork.BITCOIN_NETWORK_ECASH,
+      BitcoinNetwork.BITCOIN_NETWORK_SIGNET,
+      BitcoinNetwork.BITCOIN_NETWORK_REGTEST,
+    ]) {
+      expect(getNetworkAccentColor(network), network.toColor(), reason: '$network');
+    }
+  });
+
+  test('alphanet wears red and regtest wears grey, never the other way round', () {
+    expect(getNetworkAccentColor(BitcoinNetwork.BITCOIN_NETWORK_ECASH), SailColorScheme.red);
+    expect(getNetworkAccentColor(BitcoinNetwork.BITCOIN_NETWORK_REGTEST), SailColorScheme.greyMiddle);
+  });
+
+  test('a network with no colour of its own wears grey', () {
+    expect(getNetworkAccentColor(BitcoinNetwork.BITCOIN_NETWORK_TESTNET), SailColorScheme.greyMiddle);
+    expect(getNetworkAccentColor(BitcoinNetwork.BITCOIN_NETWORK_FORKNET), SailColorScheme.greyMiddle);
+  });
+}


### PR DESCRIPTION
Two maps decided a network's colour, and they disagreed. getNetworkAccentColor gave eCash grey and regtest crimson, while the picker gives eCash red and regtest grey. The same network wore two identities depending on where you looked.

The accent now reads the colour the network carries, so one place decides. A network with no colour of its own wears grey, which is what the old default did.

This changes two networks on purpose, to match what was asked: alphanet wears red, regtest wears grey. Testnet loses its green and falls back to grey, since it carries no colour of its own.

Tests pin that the accent equals the network's colour, that alphanet and regtest are not swapped again, and that an uncoloured network wears grey.