### PR TITLE
sail_ui: rename a tab inside a selection area

### DIFF
--- a/bitwindow/test/tab_item_rename_test.dart
+++ b/bitwindow/test/tab_item_rename_test.dart
@@ -15,20 +15,51 @@ void main() {
       WidgetTester tester, {
       required bool selected,
       bool renameable = true,
+      bool selectable = false,
     }) async {
       final renamed = <String>[];
+      final Widget tab = SailTabItem(
+        label: 'Key 1',
+        isSelected: selected,
+        onTap: () {},
+        onLabelChanged: renameable ? renamed.add : null,
+      );
       await tester.pumpSailPage(
-        Center(
-          child: SailTabItem(
-            label: 'Key 1',
-            isSelected: selected,
-            onTap: () {},
-            onLabelChanged: renameable ? renamed.add : null,
-          ),
-        ),
+        Center(child: selectable ? SelectionArea(child: tab) : tab),
       );
       await tester.pumpAndSettle();
       return renamed;
+    }
+
+    // _startEditing focuses the field. Nothing else in the idle state does.
+    bool editing(WidgetTester tester) {
+      return tester.widget<TextField>(find.byType(TextField)).focusNode?.hasFocus ?? false;
+    }
+
+    Future<void> doubleClick(WidgetTester tester) async {
+      await tester.tap(find.text('Key 1'));
+      await tester.pump(kDoubleTapMinTime);
+      await tester.tap(find.text('Key 1'));
+      await tester.pumpAndSettle();
+    }
+
+    // A real user clicks with a mouse, and the pointer drifts a pixel or two.
+    // SelectionArea watches for exactly that, so this is the click that broke.
+    Future<void> mouseDoubleClick(WidgetTester tester) async {
+      final at = tester.getCenter(find.text('Key 1'));
+      for (var click = 0; click < 2; click++) {
+        final gesture = await tester.startGesture(at, kind: PointerDeviceKind.mouse);
+        // A frame passes with the button still down, and the drift lands after
+        // it. That is the order a real mouse produces.
+        await tester.pump();
+        await gesture.moveBy(const Offset(3, 0));
+        await tester.pump();
+        await gesture.up();
+        if (click == 0) {
+          await tester.pump(kDoubleTapMinTime);
+        }
+      }
+      await tester.pumpAndSettle();
     }
 
     testWidgets('a double-click on the selected tab renames it', (tester) async {
@@ -62,6 +93,76 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(renamed, ['Alice ledger']);
+    });
+
+    // enterText focuses the field on its own, so a test that only checks
+    // onSubmitted passes with the gesture broken. This one reads edit mode.
+    testWidgets('a double-click starts edit mode', (tester) async {
+      await pump(tester, selected: true);
+      expect(editing(tester), isFalse, reason: 'the tab starts idle');
+
+      await doubleClick(tester);
+
+      expect(editing(tester), isTrue);
+    });
+
+    // Every rename site in the app sits inside a SelectionArea. Its pan
+    // recognizer wins the gesture arena, which is what broke the rename.
+    testWidgets('a double-click starts edit mode inside a SelectionArea', (tester) async {
+      final renamed = await pump(tester, selected: true, selectable: true);
+
+      await doubleClick(tester);
+      expect(editing(tester), isTrue);
+
+      await tester.enterText(find.byType(TextField), 'Bob cold');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(renamed, ['Bob cold']);
+    });
+
+    testWidgets('a mouse double-click starts edit mode inside a SelectionArea', (tester) async {
+      await pump(tester, selected: true, selectable: true);
+
+      await mouseDoubleClick(tester);
+
+      expect(editing(tester), isTrue);
+    });
+
+    // A drag over the label selects text. A click that lands near the start of
+    // that drag is a second click, not the second half of a double-click.
+    testWidgets('a drag then a click does not rename', (tester) async {
+      await pump(tester, selected: true, selectable: true);
+
+      final at = tester.getCenter(find.text('Key 1'));
+      final drag = await tester.startGesture(at, kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      await drag.moveBy(const Offset(40, 0));
+      await tester.pump();
+      await drag.up();
+      await tester.pump(kDoubleTapMinTime);
+
+      final click = await tester.startGesture(at, kind: PointerDeviceKind.mouse);
+      await click.up();
+      await tester.pumpAndSettle();
+
+      expect(editing(tester), isFalse);
+    });
+
+    // A canceled press never reaches the user, so it cannot count as a click.
+    testWidgets('a canceled second press does not rename', (tester) async {
+      await pump(tester, selected: true, selectable: true);
+
+      final at = tester.getCenter(find.text('Key 1'));
+      final first = await tester.startGesture(at, kind: PointerDeviceKind.mouse);
+      await first.up();
+      await tester.pump(kDoubleTapMinTime);
+
+      final second = await tester.startGesture(at, kind: PointerDeviceKind.mouse);
+      await second.cancel();
+      await tester.pumpAndSettle();
+
+      expect(editing(tester), isFalse);
     });
 
     testWidgets('shows no pencil, since the design has none', (tester) async {

--- a/sail_ui/lib/widgets/core/sail_editable_text.dart
+++ b/sail_ui/lib/widgets/core/sail_editable_text.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' show InputBorder, InputDecoration, TextField, Tooltip;
+import 'package:flutter/gestures.dart' show kDoubleTapSlop, kDoubleTapTimeout, kDoubleTapTouchSlop, kPrimaryButton;
 import 'package:flutter/widgets.dart';
 import 'package:sail_ui/sail_ui.dart';
 
@@ -52,6 +53,13 @@ class _SailEditableTextState extends State<SailEditableText> {
     });
   }
 
+  Duration? _lastTapTime;
+  Offset? _lastTapPosition;
+
+  int? _pressPointer;
+  Offset? _pressPosition;
+  bool _pressDragged = false;
+
   @override
   void didUpdateWidget(SailEditableText old) {
     super.didUpdateWidget(old);
@@ -67,10 +75,88 @@ class _SailEditableTextState extends State<SailEditableText> {
     super.dispose();
   }
 
+  /// An enclosing SelectionArea installs a pan recognizer above this widget.
+  /// That recognizer wins the gesture arena, so a double-tap recognizer here
+  /// never fires. A Listener reads raw pointer events whoever wins the arena,
+  /// so the two clicks are counted here instead.
+  void _onPointerDown(PointerDownEvent event) {
+    if (event.buttons != kPrimaryButton) {
+      return;
+    }
+    _pressPointer = event.pointer;
+    _pressPosition = event.position;
+    _pressDragged = false;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    final from = _pressPosition;
+    if (event.pointer != _pressPointer || _pressDragged || from == null) {
+      return;
+    }
+    if ((event.position - from).distance > kDoubleTapTouchSlop) {
+      _pressDragged = true;
+    }
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    if (event.pointer == _pressPointer) {
+      _forgetPress();
+    }
+  }
+
+  /// A press counts as a click only when it ends where it started. A press that
+  /// drags selects text, and a canceled press never reaches the user at all.
+  /// Two clicks close in time and in place open the rename.
+  void _onPointerUp(PointerUpEvent event) {
+    if (event.pointer != _pressPointer) {
+      return;
+    }
+    final dragged = _pressDragged;
+    _forgetPress();
+    if (dragged) {
+      _lastTapTime = null;
+      _lastTapPosition = null;
+      return;
+    }
+
+    final previousTime = _lastTapTime;
+    final previousPosition = _lastTapPosition;
+    _lastTapTime = event.timeStamp;
+    _lastTapPosition = event.position;
+
+    if (previousTime == null || previousPosition == null) {
+      return;
+    }
+    if (event.timeStamp - previousTime > kDoubleTapTimeout) {
+      return;
+    }
+    if ((event.position - previousPosition).distance > kDoubleTapSlop) {
+      return;
+    }
+
+    _lastTapTime = null;
+    _lastTapPosition = null;
+    _startEditing();
+  }
+
+  void _forgetPress() {
+    _pressPointer = null;
+    _pressPosition = null;
+    _pressDragged = false;
+  }
+
   void _startEditing() {
     setState(() => _editing = true);
-    _focus.requestFocus();
-    _controller.selection = TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
+    // A SelectionArea above this takes focus when its own recognizer wins, which
+    // happens after this click. Commit-on-focus-loss would then close edit mode
+    // again, so the field claims focus once the frame settles.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_editing) {
+        return;
+      }
+      _focus.requestFocus();
+      _controller.selection = TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
+    });
   }
 
   // An empty name would leave the row with nothing to click, so it reverts.
@@ -136,13 +222,18 @@ class _SailEditableTextState extends State<SailEditableText> {
     if (widget.editOnDoubleTap) {
       idle = GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onDoubleTap: _startEditing,
         onSecondaryTapDown: (details) => _showMenu(context, details.globalPosition),
         child: idle,
       );
-      // An enclosing SailCard puts a SelectionArea over this, whose
-      // double-click-to-select wins the gesture arena unless the subtree opts out.
       idle = SelectionContainer.disabled(child: idle);
+      idle = Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: _onPointerDown,
+        onPointerMove: _onPointerMove,
+        onPointerUp: _onPointerUp,
+        onPointerCancel: _onPointerCancel,
+        child: idle,
+      );
     }
 
     final content = _editing ? field : idle;


### PR DESCRIPTION
Double-clicking a selected tab did not rename it. The widget carried a comment naming a `SelectionArea` as the cause, and a `SelectionContainer.disabled` that did not reach it: that call unregisters selectables, and the recognizers stay in the gesture arena.

A probe over four combinations found the trigger. The rename fails only when a mouse pointer drifts a few pixels **and** a `SelectionArea` encloses the tab. Every rename site in the app sits inside one, through `SailSelectionArea` or `SailCard`.

Two things go wrong together, and each fix alone leaves the case failing.

`SelectableRegion` installs a pan recognizer that accepts after a 2 px mouse move, which closes the arena and rejects the descendant double-tap recognizer. A `Listener` never joins the arena, so `SailEditableText` counts the two clicks itself, against `kDoubleTapTimeout` and `kDoubleTapSlop`.

`SelectableRegion` then takes focus while the click is still in flight. The field loses focus at once, and commit-on-focus-loss closes edit mode again. The field now claims focus after the click settles.

The old tests passed with the gesture broken, because `tester.enterText` focuses the field on its own and `onSubmitted` fires whether or not edit mode started. The new tests read edit mode directly, and they fail when either fix is reverted.
