### PR TITLE
orchestrator: deposit and peer with no local enforcer

### DIFF
--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -120,7 +120,11 @@ class BottomNav extends StatelessWidget {
             Expanded(child: Container()),
             Builder(
               builder: (context) => MiningStatus(
-                onTap: () => displayConnectionStatusDialog(context, additionalConnection, onlyShowAdditional),
+                onTap: () => displayConnectionStatusDialog(
+                  context,
+                  additionalConnection,
+                  onlyShowAdditional,
+                ),
               ),
             ),
             const ElectrumScanStatus(),
@@ -239,121 +243,125 @@ class BottomNav extends StatelessWidget {
             initializing: additional.initializingBinary,
           );
 
-          return SailColumn(
-            spacing: SailStyleValues.padding20,
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SailColumn(
-                spacing: SailStyleValues.padding12,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Everything else runs under drivechaind, and a hot start
-                  // adopts one this process never spawned. So it carries no
-                  // start or stop control.
-                  if (model.drivechaind case final orchestrator?)
-                    DaemonConnectionCard(
-                      connection: orchestrator,
-                      syncInfo: null,
-                      infoMessage: null,
-                      navigateToLogs: model.navigateToLogs,
-                    ),
-                  if (showMainchain &&
-                      (!model.mainchain.connected ||
-                          !(model.syncProvider.mainchainSyncInfo?.allSyncsComplete ?? false) ||
-                          (model.syncProvider.mainchainSyncInfo?.offNetwork ?? false) ||
-                          !onlyShowAdditional))
-                    DaemonConnectionCard(
-                      connection: model.mainchain,
-                      syncInfo: model.syncProvider.mainchainSyncInfo,
-                      restartDaemon: () => binaryProvider.restart(
-                        binaryProvider.binaries.firstWhere(
-                          (b) => b.name == BitcoinCore().name,
-                        ),
-                      ),
-                      stopDaemon: () => binaryProvider.stop(
-                        binaryProvider.binaries.firstWhere(
-                          (b) => b.name == BitcoinCore().name,
-                        ),
-                      ),
-                      infoMessage: offNetworkMessage(model.syncProvider.mainchainSyncInfo),
-                      navigateToLogs: model.navigateToLogs,
-                      onOpenConfConfigurator: onOpenConfConfigurator,
-                    ),
-                  if (showEnforcer &&
-                      (!model.enforcer.connected ||
-                          !(model.syncProvider.enforcerSyncInfo?.allSyncsComplete ?? false) ||
-                          !onlyShowAdditional))
-                    DaemonConnectionCard(
-                      connection: model.enforcer,
-                      syncInfo: model.syncProvider.enforcerSyncInfo,
-                      infoMessage: model.mainchain.initializingBinary
-                          ? 'Waiting for mainchain to finish initializing'
-                          : model.syncProvider.inHeaderSync
-                          ? 'Waiting for L1 to sync headers...'
-                          : null,
-                      restartDaemon: () => binaryProvider.restart(
-                        binaryProvider.binaries.firstWhere(
-                          (b) => b.name == Enforcer().name,
-                        ),
-                      ),
-                      stopDaemon: () => binaryProvider.stop(
-                        binaryProvider.binaries.firstWhere(
-                          (b) => b.name == Enforcer().name,
-                        ),
-                      ),
-                      navigateToLogs: model.navigateToLogs,
-                      onOpenConfConfigurator: onOpenEnforcerConfConfigurator,
-                    ),
-                  if (showAdditional)
-                    Builder(
-                      builder: (context) {
-                        // Only sidechains (chainLayer == 2) actually need Core
-                        // header sync — their RPC reports 0/0 until headers
-                        // arrive, which reads as "broken" in the UI. Layer-1
-                        // companions like bitwindowd have their own
-                        // independent connection state and must show it
-                        // unconditionally; gating their card on Core's IBD
-                        // hid the bitwindowd backend status entirely behind
-                        // a misleading "Waiting for Bitcoin Core header sync"
-                        // message even when bitwindowd was healthy.
-                        final isSidechain = additionalConnection.rpc.binary.chainLayer == 2;
-                        final bool coreReady =
-                            !isSidechain ||
-                            (model.mainchain.connected &&
-                                !model.mainchain.initializingBinary &&
-                                model.mainchain.startupError == null &&
-                                !model.syncProvider.inHeaderSync);
-                        final infoMessage = isSidechain && !coreReady ? 'Waiting for Bitcoin Core header sync' : null;
-                        return DaemonConnectionCard(
-                          connection: additionalConnection.rpc,
-                          syncInfo: coreReady ? model.additionalSyncInfo : null,
-                          infoMessage: infoMessage,
-                          restartDaemon: () => binaryProvider.restart(
-                            binaryProvider.binaries.firstWhere(
-                              (b) => b.name == additionalConnection.rpc.binary.name,
-                            ),
+          return SingleChildScrollView(
+            child: SailColumn(
+              spacing: SailStyleValues.padding20,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SailColumn(
+                  spacing: SailStyleValues.padding12,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (showMainchain &&
+                        (!model.mainchain.connected ||
+                            !(model.syncProvider.mainchainSyncInfo?.allSyncsComplete ?? false) ||
+                            (model.syncProvider.mainchainSyncInfo?.offNetwork ?? false) ||
+                            !onlyShowAdditional))
+                      DaemonConnectionCard(
+                        connection: model.mainchain,
+                        syncInfo: model.syncProvider.mainchainSyncInfo,
+                        restartDaemon: () => binaryProvider.restart(
+                          binaryProvider.binaries.firstWhere(
+                            (b) => b.name == BitcoinCore().name,
                           ),
-                          stopDaemon: () => binaryProvider.stop(
-                            binaryProvider.binaries.firstWhere(
-                              (b) => b.name == additionalConnection.rpc.binary.name,
-                            ),
+                        ),
+                        stopDaemon: () => binaryProvider.stop(
+                          binaryProvider.binaries.firstWhere(
+                            (b) => b.name == BitcoinCore().name,
                           ),
-                          navigateToLogs: model.navigateToLogs,
-                          onOpenConfConfigurator: onOpenAdditionalConfConfigurator,
-                        );
-                      },
-                    ),
-                  if (ecashMiningProvider() case final mining?)
-                    MiningStatusCard(
-                      mining: mining,
-                      onOpenSettings: onOpenMiningSettings,
-                      onViewLogs: onViewMiningLogs,
-                    ),
-                ],
-              ),
-            ],
+                        ),
+                        infoMessage: offNetworkMessage(
+                          model.syncProvider.mainchainSyncInfo,
+                        ),
+                        navigateToLogs: model.navigateToLogs,
+                        onOpenConfConfigurator: onOpenConfConfigurator,
+                      ),
+                    if (showEnforcer &&
+                        (!model.enforcer.connected ||
+                            !(model.syncProvider.enforcerSyncInfo?.allSyncsComplete ?? false) ||
+                            !onlyShowAdditional))
+                      DaemonConnectionCard(
+                        connection: model.enforcer,
+                        syncInfo: model.syncProvider.enforcerSyncInfo,
+                        infoMessage: model.mainchain.initializingBinary
+                            ? 'Waiting for mainchain to finish initializing'
+                            : model.syncProvider.inHeaderSync
+                            ? 'Waiting for L1 to sync headers...'
+                            : null,
+                        restartDaemon: () => binaryProvider.restart(
+                          binaryProvider.binaries.firstWhere(
+                            (b) => b.name == Enforcer().name,
+                          ),
+                        ),
+                        stopDaemon: () => binaryProvider.stop(
+                          binaryProvider.binaries.firstWhere(
+                            (b) => b.name == Enforcer().name,
+                          ),
+                        ),
+                        navigateToLogs: model.navigateToLogs,
+                        onOpenConfConfigurator: onOpenEnforcerConfConfigurator,
+                      ),
+                    if (showAdditional)
+                      Builder(
+                        builder: (context) {
+                          // Only sidechains (chainLayer == 2) actually need Core
+                          // header sync — their RPC reports 0/0 until headers
+                          // arrive, which reads as "broken" in the UI. Layer-1
+                          // companions like bitwindowd have their own
+                          // independent connection state and must show it
+                          // unconditionally; gating their card on Core's IBD
+                          // hid the bitwindowd backend status entirely behind
+                          // a misleading "Waiting for Bitcoin Core header sync"
+                          // message even when bitwindowd was healthy.
+                          final isSidechain = additionalConnection.rpc.binary.chainLayer == 2;
+                          final bool coreReady =
+                              !isSidechain ||
+                              (model.mainchain.connected &&
+                                  !model.mainchain.initializingBinary &&
+                                  model.mainchain.startupError == null &&
+                                  !model.syncProvider.inHeaderSync);
+                          final infoMessage = isSidechain && !coreReady ? 'Waiting for Bitcoin Core header sync' : null;
+                          return DaemonConnectionCard(
+                            connection: additionalConnection.rpc,
+                            syncInfo: coreReady ? model.additionalSyncInfo : null,
+                            infoMessage: infoMessage,
+                            restartDaemon: () => binaryProvider.restart(
+                              binaryProvider.binaries.firstWhere(
+                                (b) => b.name == additionalConnection.rpc.binary.name,
+                              ),
+                            ),
+                            stopDaemon: () => binaryProvider.stop(
+                              binaryProvider.binaries.firstWhere(
+                                (b) => b.name == additionalConnection.rpc.binary.name,
+                              ),
+                            ),
+                            navigateToLogs: model.navigateToLogs,
+                            onOpenConfConfigurator: onOpenAdditionalConfConfigurator,
+                          );
+                        },
+                      ),
+                    if (ecashMiningProvider() case final mining?)
+                      MiningStatusCard(
+                        mining: mining,
+                        onOpenSettings: onOpenMiningSettings,
+                        onViewLogs: onViewMiningLogs,
+                      ),
+                    // Everything else runs under drivechaind, and a hot start
+                    // adopts one this process never spawned. So it carries no
+                    // start or stop control.
+                    if (model.drivechaind case final orchestrator?)
+                      DaemonConnectionCard(
+                        connection: orchestrator,
+                        syncInfo: null,
+                        infoMessage: null,
+                        navigateToLogs: model.navigateToLogs,
+                      ),
+                  ],
+                ),
+              ],
+            ),
           );
         }),
       ),
@@ -636,7 +644,10 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
   ///  3. startupError       -> show it verbatim (orchestrator warmup message)
   ///  4. initializingBinary -> show latest startup log line, or "Initializing [name]…"
   ///  5. else (!connected)  -> "Waiting for [name]"
-  String? _statusLineFor({required RPCConnection rpc, required String binaryLabel}) {
+  String? _statusLineFor({
+    required RPCConnection rpc,
+    required String binaryLabel,
+  }) {
     if (rpc.connectionError != null) {
       return rpc.connectionError;
     }
@@ -671,7 +682,9 @@ class ChainLoaders extends ViewModelWidget<BottomNavViewModel> {
     // Electrum wallets run no L1 daemons, so there are no block-sync bars to
     // show — the chain source reports the only height they have.
     if (!viewModel.needsBackends) {
-      final blocks = chainSourceBlocks(viewModel.syncProvider.chainSourceSyncInfo);
+      final blocks = chainSourceBlocks(
+        viewModel.syncProvider.chainSourceSyncInfo,
+      );
       if (blocks == null) {
         return const SizedBox.shrink();
       }
@@ -846,9 +859,7 @@ class BalanceDisplay extends StatelessWidget {
                         width: SailStyleValues.iconSizeSecondary,
                         height: SailStyleValues.iconSizeSecondary,
                       ),
-                      SailText.secondary12(
-                        formatBitcoin(pendingBalance),
-                      ),
+                      SailText.secondary12(formatBitcoin(pendingBalance)),
                     ],
                   ),
                 ),
@@ -1089,7 +1100,11 @@ class _MiningStatusState extends State<MiningStatus> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  SailSVG.icon(SailSVGAsset.pickaxe, width: 13, color: theme.colors.orange),
+                  SailSVG.icon(
+                    SailSVGAsset.pickaxe,
+                    width: 13,
+                    color: theme.colors.orange,
+                  ),
                   const SizedBox(width: SailStyleValues.padding08),
                   SailText.secondary12('Mining at ${mining.formattedHashRate}'),
                 ],
@@ -1132,14 +1147,24 @@ class _BalanceRefreshButtonState extends State<_BalanceRefreshButton> {
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: SailStyleValues.padding04),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SailStyleValues.padding04,
+      ),
       child: _busy
-          ? const SizedBox(width: 12, height: 12, child: CircularProgressIndicator(strokeWidth: 2))
+          ? const SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
           : SailTappable(
               onTap: _refresh,
               child: Tooltip(
                 message: 'Refresh balance',
-                child: SailSVG.icon(SailSVGAsset.iconRestart, width: 14, color: theme.colors.textSecondary),
+                child: SailSVG.icon(
+                  SailSVGAsset.iconRestart,
+                  width: 14,
+                  color: theme.colors.textSecondary,
+                ),
               ),
             ),
     );

--- a/sidechain-orchestrator/api/ctip_index.go
+++ b/sidechain-orchestrator/api/ctip_index.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ctipReadTimeout bounds one read of the hosted index. A deposit waits on this,
+// so it stays short.
+const ctipReadTimeout = 8 * time.Second
+
+// indexCtip is a sidechain's treasury outpoint, as the hosted index reports it.
+type indexCtip struct {
+	Txid  string
+	Vout  uint32
+	Value uint64
+}
+
+// readIndexCtip reads a slot's treasury outpoint from a hosted Esplora index.
+// baseURL already carries the escrow path, so only the slot is appended.
+//
+// A light install runs no enforcer, and the index reads the escrow on its
+// behalf. The treasury it reports is the outpoint an M5 deposit spends.
+func readIndexCtip(ctx context.Context, baseURL string, slot uint32) (*indexCtip, error) {
+	base := strings.TrimRight(baseURL, "/")
+	url := fmt.Sprintf("%s/sidechain/%d", base, slot)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build the treasury request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ctipReadTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("read the treasury from %s: %w", base, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read the treasury answer: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("the index answered %d: %s", resp.StatusCode,
+			strings.TrimSpace(string(body)))
+	}
+
+	var row struct {
+		Treasury *struct {
+			Txid      string `json:"txid"`
+			Vout      uint32 `json:"vout"`
+			ValueSats uint64 `json:"value_sats"`
+		} `json:"treasury"`
+	}
+	if err := json.Unmarshal(body, &row); err != nil {
+		return nil, fmt.Errorf("decode the treasury answer: %w", err)
+	}
+
+	// A slot that took no deposit yet holds no treasury, and the first deposit
+	// creates one. That is not a fault.
+	if row.Treasury == nil {
+		return nil, nil
+	}
+
+	return &indexCtip{
+		Txid:  row.Treasury.Txid,
+		Vout:  row.Treasury.Vout,
+		Value: row.Treasury.ValueSats,
+	}, nil
+}

--- a/sidechain-orchestrator/api/ctip_index_test.go
+++ b/sidechain-orchestrator/api/ctip_index_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReadIndexCtipReadsTheTreasury(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"slot":9,"treasury":{"txid":"be01","vout":2,"value_sats":10403007000}}`))
+	}))
+	defer srv.Close()
+
+	ctip, err := readIndexCtip(context.Background(), srv.URL+"/drivechain", 9)
+	if err != nil {
+		t.Fatalf("read the treasury: %v", err)
+	}
+	if gotPath != "/drivechain/sidechain/9" {
+		t.Errorf("asked for %q, want /drivechain/sidechain/9", gotPath)
+	}
+	if ctip == nil {
+		t.Fatal("a slot with a treasury must report one")
+	}
+	if ctip.Txid != "be01" || ctip.Vout != 2 || ctip.Value != 10403007000 {
+		t.Errorf("read %+v, want txid be01 vout 2 value 10403007000", *ctip)
+	}
+}
+
+// A slot that took no deposit yet holds no treasury. The first deposit starts
+// one, so that is not a fault.
+func TestReadIndexCtipAllowsAnEmptyTreasury(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"slot":13}`))
+	}))
+	defer srv.Close()
+
+	ctip, err := readIndexCtip(context.Background(), srv.URL, 13)
+	if err != nil {
+		t.Fatalf("read the treasury: %v", err)
+	}
+	if ctip != nil {
+		t.Errorf("read %+v, want no treasury", *ctip)
+	}
+}
+
+func TestReadIndexCtipReportsABadAnswer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("404 page not found"))
+	}))
+	defer srv.Close()
+
+	if _, err := readIndexCtip(context.Background(), srv.URL, 9); err == nil {
+		t.Error("a 404 must report an error, not an empty treasury")
+	}
+}

--- a/sidechain-orchestrator/api/deposit.go
+++ b/sidechain-orchestrator/api/deposit.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
 	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 )
@@ -58,6 +60,11 @@ func (h *WalletHandler) CreateDeposit(
 
 	treasurySats := oldTreasurySats + req.Msg.AmountSats
 
+	h.svc.Log().Info().Uint8("slot", slot).Str("destination", req.Msg.Destination).
+		Int64("amount_sats", req.Msg.AmountSats).Int64("fee_sats", req.Msg.FeeSats).
+		Int64("old_treasury_sats", oldTreasurySats).Int64("new_treasury_sats", treasurySats).
+		Int("external_inputs", len(externalInputs)).Msg("building the deposit")
+
 	// The enforcer wallet takes no raw outputs, but it builds the whole M5
 	// itself from the slot and the destination.
 	if err := h.requireEngine(); err != nil {
@@ -77,6 +84,9 @@ func (h *WalletHandler) CreateDeposit(
 	if err != nil {
 		return nil, err
 	}
+
+	h.svc.Log().Info().Str("txid", send.Msg.Txid).Uint8("slot", slot).
+		Int64("amount_sats", req.Msg.AmountSats).Msg("broadcast the deposit")
 
 	// An M5 is an ordinary transaction on the wire, so nothing later can tell
 	// it apart from a normal send. Record it while we still know.
@@ -107,6 +117,13 @@ func (h *WalletHandler) sidechainCtip(
 	if h.orch == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("orchestrator not wired"))
 	}
+
+	// A light install runs no enforcer. The hosted index reads the escrow on
+	// its behalf, and the treasury it reports is the outpoint an M5 spends.
+	if h.orch.NodeMode() == orchestrator.NodeModeLight {
+		return h.indexCtip(ctx, slot)
+	}
+
 	validator, err := h.orch.EnforcerValidator()
 	if err != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
@@ -118,6 +135,38 @@ func (h *WalletHandler) sidechainCtip(
 		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get ctip: %w", err))
 	}
 	return resp.Msg.GetCtip(), nil
+}
+
+// indexCtip reads the treasury outpoint from the hosted index, for an install
+// that runs no enforcer of its own.
+func (h *WalletHandler) indexCtip(
+	ctx context.Context, slot uint32,
+) (*enforcerpb.GetCtipResponse_Ctip, error) {
+	url := config.DrivechainIndexURLForNetwork(config.Network(h.orch.CurrentNetwork()))
+	if url == "" {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("this network serves no escrow index, so a deposit needs full mode"))
+	}
+
+	ctip, err := readIndexCtip(ctx, url, slot)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get ctip: %w", err))
+	}
+	if ctip == nil {
+		h.svc.Log().Info().Uint32("slot", slot).Str("index", url).
+			Msg("the index reports no treasury yet, so this deposit starts one")
+		return nil, nil
+	}
+
+	h.svc.Log().Info().Uint32("slot", slot).Str("index", url).
+		Str("txid", ctip.Txid).Uint32("vout", ctip.Vout).Uint64("value_sats", ctip.Value).
+		Msg("read the treasury from the index, with no enforcer")
+
+	return &enforcerpb.GetCtipResponse_Ctip{
+		Txid:  &commonv1.ReverseHex{Hex: wrapperspb.String(ctip.Txid)},
+		Vout:  ctip.Vout,
+		Value: ctip.Value,
+	}, nil
 }
 
 // ListSidechainDeposits reports the deposits this install made to a slot. The

--- a/sidechain-orchestrator/sidechain/thunder/handler.go
+++ b/sidechain-orchestrator/sidechain/thunder/handler.go
@@ -234,7 +234,9 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	// The node takes positional params. A bare string reads as neither, and it
+	// answers "Invalid params".
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil


### PR DESCRIPTION
Three faults, all found by depositing 1 ECX to Thunder on alphanet in light mode and watching it land.

A deposit spends the sidechain's treasury outpoint, and the orchestrator asked the enforcer for it. A light install runs no enforcer, so every deposit died with `get ctip: dial tcp 127.0.0.1:50051: connection refused`. The button was reachable and the transaction could never be built. Light mode now reads the treasury from the hosted index, which already serves the escrow, and logs the outpoint it used.

`ConnectPeer` sent the address as a bare string, and the node answered `Invalid params`. Positional params work, which is why `thunder-cli` connected and the API route did not. That call is how a frontend peers two nodes.

Daemon Status overflowed its dialog by 230 pixels once a fourth card appeared, and the Drivechaind card sat at the top. The list scrolls now, and that card ends it.

The deposit is live on alphanet: txid `015ea7a563cbd0f084a070110cd561b98eaad2226be43c70c463acaf40b2821e`, confirmed in block 996690, and the enforcer records it as slot 9's treasury at sequence 7.
