### PR TITLE
wallet: import the BIP47 key one time

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -153,7 +153,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 	// failure here shouldn't break wallet loading — the backend will retry
 	// next time Ensure runs.
 	if targetWallet.WalletType == WalletTypeBitcoinCore && !targetWallet.IsWatchOnly() {
-		if perr := p.ensureBip47NotificationDescriptor(ctx, walletName, targetWallet.Master.SeedHex); perr != nil {
+		if perr := p.ensureBip47NotificationDescriptor(ctx, walletID, walletName, targetWallet.Master.SeedHex); perr != nil {
 			p.log.Warn().Err(perr).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
 			p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
 		}
@@ -1074,18 +1074,32 @@ func (c coreChain) Broadcast(ctx context.Context, rawHex string) (string, error)
 // ============================================================================
 
 // ensureBip47NotificationDescriptor imports the wallet's BIP47 notification
-// P2PKH key (m/47'/0'/0'/0) into Core if not already present. Uses
-// timestamp=0 so the first import rescans the chain from genesis and picks
-// up historic notification txs; subsequent imports are no-ops because Core
-// recognizes the descriptor as already known.
-func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, walletName, seedHex string) error {
+// P2PKH key (m/47'/0'/0'/0) into Core. The import rescans from genesis, which
+// takes hours, so it runs one time for each network.
+//
+// Two signals gate it, and both are necessary. The wallet file names the
+// networks whose import landed, because Core keeps a descriptor whose rescan
+// failed and reports that address as its own with the history unread. Core
+// answers for the datadir in use, because a network switch and a restored
+// wallet file both leave the record standing over a Core wallet that lacks
+// the key.
+func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, walletID, walletName, seedHex string) error {
 	net := p.net()
 	if net == nil {
 		return nil
 	}
-	notifPriv, _, err := bip47.DeriveOwnNotificationKey(seedHex, net)
+	notifPriv, notifAddr, err := bip47.DeriveOwnNotificationKey(seedHex, net)
 	if err != nil {
 		return fmt.Errorf("derive notification key: %w", err)
+	}
+	if w := p.svc.GetWalletByID(walletID); w != nil && w.Bip47NotificationImported[net.Name] {
+		info, err := p.rpc.GetAddressInfo(ctx, walletName, notifAddr.EncodeAddress())
+		if err != nil {
+			return fmt.Errorf("read the notification address: %w", err)
+		}
+		if info.IsMine {
+			return nil
+		}
 	}
 	wif, err := btcutil.NewWIF(notifPriv, net, true)
 	if err != nil {
@@ -1110,7 +1124,7 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 		}
 		return fmt.Errorf("bip47 descriptor %d import failed: %s", i, msg)
 	}
-	return nil
+	return p.svc.MarkBip47NotificationImported(walletID, net.Name)
 }
 
 // importTimestamp is what Core rescans from. A restored seed can have history
@@ -1137,7 +1151,7 @@ func (p *CoreBackend) retryBip47NotificationDescriptor(ctx context.Context, wall
 		delete(p.bip47NotifRetry, walletID)
 		return
 	}
-	if err := p.ensureBip47NotificationDescriptor(ctx, walletName, w.Master.SeedHex); err != nil {
+	if err := p.ensureBip47NotificationDescriptor(ctx, walletID, walletName, w.Master.SeedHex); err != nil {
 		p.log.Warn().Err(err).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
 		p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
 		return

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -235,6 +236,139 @@ func TestCoreBackendEnsureTransientBackoff(t *testing.T) {
 
 // A failed BIP47 notification import doesn't break wallet loading, but the
 // wallet must not be cached as fully provisioned: later calls retry it.
+// notificationImports counts the imports of the BIP47 notification key, which
+// is the only single descriptor import that carries a bare pkh().
+func notificationImports(t *testing.T, fake *fakeBitcoind) int {
+	t.Helper()
+	n := 0
+	for _, call := range fake.callsFor("importdescriptors") {
+		var descs []ImportDescriptor
+		require.NoError(t, json.Unmarshal(call.Params[0], &descs))
+		if len(descs) == 1 && strings.HasPrefix(descs[0].Desc, "pkh(") {
+			n++
+		}
+	}
+	return n
+}
+
+// The notification import rescans from genesis, which costs hours. A landed
+// import is what stops the next one, and the wallet file records it.
+func TestCoreBackendImportsBip47NotificationKeyOnce(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.Equal(t, 1, notificationImports(t, fake))
+	require.True(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
+
+	_, err = backend.walletName(ctx, coreID)
+	require.NoError(t, err)
+	_, err = backend.walletName(ctx, coreID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, notificationImports(t, fake))
+}
+
+// A network switch points Core at another datadir, where the new wallet holds
+// no notification key. The record in wallet.json must not speak for it.
+func TestCoreBackendImportsBip47NotificationKeyPerNetwork(t *testing.T) {
+	svc := newTestService(t)
+	_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+	require.NoError(t, err)
+	core, err := svc.GenerateWallet("Core", "", "", testSlots)
+	require.NoError(t, err)
+
+	fake := newFakeBitcoind(t)
+	fake.stubEnsureFlow()
+	params := &chaincfg.RegressionNetParams
+	backend := NewCoreBackend(
+		svc, fake.client(t),
+		ParamsFunc(func() *chaincfg.Params { return params }),
+		zerolog.New(zerolog.NewTestWriter(t)),
+	)
+	ctx := context.Background()
+
+	_, err = backend.Ensure(ctx, core.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, notificationImports(t, fake))
+	require.True(t, svc.GetWalletByID(core.ID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
+
+	params = &chaincfg.SigNetParams
+	backend.ResetNetworkState()
+	_, err = backend.Ensure(ctx, core.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, notificationImports(t, fake))
+	assert.True(t, svc.GetWalletByID(core.ID).Bip47NotificationImported[chaincfg.SigNetParams.Name])
+}
+
+// A wallet file restored onto a fresh Core datadir names an import that this
+// Core never took, so Core has the last word.
+func TestCoreBackendImportsBip47NotificationKeyCoreLacksIt(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.Equal(t, 1, notificationImports(t, fake))
+
+	// A fresh Core datadir: the wallet exists, and owns none of its addresses.
+	fake.handle("getaddressinfo", func(c bitcoindCall) (any, string) {
+		var address string
+		_ = json.Unmarshal(c.Params[0], &address)
+		return map[string]any{"address": address, "hdkeypath": "m/84'/1'/0'/0/0", "ismine": false}, ""
+	})
+	backend.ResetNetworkState()
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, notificationImports(t, fake))
+}
+
+// Core keeps the descriptor when the import's rescan fails, so it answers
+// ismine for an address whose history it never read. Only a repeat import
+// reads that history, so the failed import must not count as landed.
+func TestCoreBackendRetriesBip47ImportCoreAlreadyOwns(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	var mu sync.Mutex
+	failNotif := true
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		mu.Lock()
+		fail := failNotif && len(descs) == 1 && strings.HasPrefix(descs[0].Desc, "pkh(")
+		mu.Unlock()
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": !fail}
+			if fail {
+				results[i]["error"] = map[string]any{"code": -1, "message": "rescan timed out"}
+			}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.Equal(t, 1, notificationImports(t, fake))
+	require.False(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
+
+	mu.Lock()
+	failNotif = false
+	mu.Unlock()
+	backend.mu.Lock()
+	backend.bip47NotifRetry[coreID] = time.Time{} // backoff elapsed
+	backend.mu.Unlock()
+
+	_, err = backend.walletName(ctx, coreID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, notificationImports(t, fake))
+	assert.True(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
+}
+
 func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()
@@ -1593,4 +1727,21 @@ func TestCoreBackendPreviewBumpFeeAddsInputsForTheChangePath(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, preview.AddsInputs)
+}
+
+// A marker that reaches no disk still stops the next import, and the import
+// after a restart then rescans from genesis again.
+func TestMarkBip47NotificationImportedRollsBackOnSaveFailure(t *testing.T) {
+	svc := newTestService(t)
+	w, err := svc.GenerateWallet("Core", "", "", testSlots)
+	require.NoError(t, err)
+
+	// A directory at the wallet file's path fails the write on every platform.
+	path := svc.walletFilePath()
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	err = svc.MarkBip47NotificationImported(w.ID, chaincfg.RegressionNetParams.Name)
+	require.Error(t, err)
+	assert.False(t, svc.GetWalletByID(w.ID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 }

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -980,6 +980,36 @@ func (s *Service) SetWalletHardwareDevice(walletID, deviceType, fingerprint stri
 	return fmt.Errorf("wallet %s not found", walletID)
 }
 
+// MarkBip47NotificationImported records that this network's Core wallet took
+// the wallet's BIP47 notification key, so no later start imports it again.
+func (s *Service) MarkBip47NotificationImported(walletID, network string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.locked() {
+		return fmt.Errorf("wallet is locked")
+	}
+	for i := range s.wallets {
+		if s.wallets[i].ID != walletID {
+			continue
+		}
+		if s.wallets[i].Bip47NotificationImported[network] {
+			return nil
+		}
+		if s.wallets[i].Bip47NotificationImported == nil {
+			s.wallets[i].Bip47NotificationImported = map[string]bool{}
+		}
+		s.wallets[i].Bip47NotificationImported[network] = true
+		if err := s.saveWalletFile(); err != nil {
+			// A marker that reaches no disk still stops the next import, and
+			// the import after a restart then rescans from genesis again.
+			delete(s.wallets[i].Bip47NotificationImported, network)
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("wallet %s not found", walletID)
+}
+
 // UpdateWallet updates or adds a wallet and saves to file.
 // Dart: WalletReaderProvider.updateWallet (L570-591)
 func (s *Service) UpdateWallet(wallet WalletData) error {

--- a/sidechain-orchestrator/wallet/types.go
+++ b/sidechain-orchestrator/wallet/types.go
@@ -58,6 +58,10 @@ type WalletData struct {
 	// descriptors with a rescan from genesis; a freshly generated seed scans
 	// from the tip.
 	Imported bool `json:"imported,omitempty"`
+	// Bip47NotificationImported names the networks whose Core wallet took the
+	// BIP47 notification key. Each network has its own bitcoind datadir, and
+	// the import rescans from genesis, so it runs one time for each.
+	Bip47NotificationImported map[string]bool `json:"bip47_notification_imported,omitempty"`
 	// Multisig, when set, makes this an m-of-n multisig wallet. Cosigners that
 	// carry a mnemonic or xprv are held on disk and can sign; the rest are
 	// watch-only legs.


### PR DESCRIPTION
`ensureBip47NotificationDescriptor` imports the BIP47 notification key with
`Timestamp: 0`, which makes Core rescan the chain from the genesis block. It ran
on every wallet load. Its comment claimed a repeat import is a no-op:

> subsequent imports are no-ops because Core recognizes the descriptor as
> already known

Core's own log on the alphanet server says otherwise:

```
09-01T09:42:13Z RescanFromTime: Rescanning last 996689 blocks
09-01T11:24:23Z RescanFromTime: Rescanning last 996692 blocks
09-01T13:07:47Z RescanFromTime: Rescanning last 996694 blocks
09-01T14:49:19Z RescanFromTime: Rescanning last 996701 blocks
```

136 starts in that log, each from genesis, each about 1h42m — which is how long
one full rescan takes. The wallet rescanned without pause.

## What it costs the user

Core reports no balance while a wallet rescans:

```json
{"balance": null, "scanning": {"duration": 259, "progress": 0.0223}}
```

So the wallet reads as empty. The BMM engine on that server refused to bid with
`insufficient funds: need 1000 sats, have 0 sats`, while the same wallet held
1.0001 BTC.

## The change

The wallet file records a landed import, and only that record stops the next
one. `MarkBip47NotificationImported` writes it after Core reports every
descriptor imported.

Core reporting the address as its own is a weaker signal, and not the one to
use: an import whose rescan fails leaves the descriptor in place with the
history unread, and only a repeat import reads that history. The retry path
therefore still runs in that case.

The field is optional, so an existing wallet file loads unchanged. Such a wallet
imports one more time, records it, and never rescans again.

## Tests

- `TestCoreBackendImportsBip47NotificationKeyOnce` requires exactly one
  notification import across three loads, and requires the record on the wallet.
- `TestCoreBackendRetriesBip47ImportCoreAlreadyOwns` fails the first import the
  way a timed-out rescan does, requires no record, then requires the retry to
  import again and record it.
- `TestCoreBackendRetriesFailedBip47NotificationImport` covers the backoff, as
  before.