### PR TITLE
bmm: refuse a bid rate that is not a number

### DIFF
--- a/sidechain-orchestrator/api/bmm_bid_input_test.go
+++ b/sidechain-orchestrator/api/bmm_bid_input_test.go
@@ -5,6 +5,36 @@ import (
 	"testing"
 )
 
+func TestCheckBidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		bidSats int64
+		rate    float64
+		wantErr bool
+	}{
+		{name: "an exact bid", bidSats: 5_000},
+		{name: "a rate", rate: 2.5},
+		{name: "neither", wantErr: true},
+		{name: "a negative rate", rate: -1, wantErr: true},
+		{name: "not a number", rate: math.NaN(), wantErr: true},
+		{name: "an infinity", rate: math.Inf(1), wantErr: true},
+		{name: "a negative infinity", rate: math.Inf(-1), wantErr: true},
+		{name: "an exact bid beside a bad rate", bidSats: 5_000, rate: math.NaN(), wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkBidInput(test.bidSats, test.rate)
+			if test.wantErr && err == nil {
+				t.Fatalf("checkBidInput(%d, %v) allowed the bid", test.bidSats, test.rate)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("checkBidInput(%d, %v) refused the bid: %v", test.bidSats, test.rate, err)
+			}
+		})
+	}
+}
+
 func TestBidSizing(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/sidechain-orchestrator/api/bmm_bid_sizing.go
+++ b/sidechain-orchestrator/api/bmm_bid_sizing.go
@@ -1,9 +1,25 @@
 package api
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // nominalBidVsize is the size of a one input bid, in vBytes.
 const nominalBidVsize = 188
+
+// checkBidInput reports why a bid names no usable amount. A rate arrives as a
+// double over the wire, so it can carry NaN or an infinity, and both pass a
+// plain comparison.
+func checkBidInput(bidSats int64, rateSatVb float64) error {
+	if math.IsNaN(rateSatVb) || math.IsInf(rateSatVb, 0) {
+		return fmt.Errorf("fee_rate_sat_vb must be a number")
+	}
+	if bidSats <= 0 && rateSatVb <= 0 {
+		return fmt.Errorf("name a bid: bid_sats or fee_rate_sat_vb")
+	}
+	return nil
+}
 
 type bidInput struct {
 	bidSats         int64

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -247,9 +247,8 @@ func bidToProto(b bmmstate.Bid) *bmmpb.Bid {
 func (h *BMMHandler) CreateBid(
 	ctx context.Context, req *connect.Request[bmmpb.CreateBidRequest],
 ) (*connect.Response[bmmpb.CreateBidResponse], error) {
-	if req.Msg.BidSats <= 0 && req.Msg.FeeRateSatVb <= 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument,
-			fmt.Errorf("name a bid: bid_sats or fee_rate_sat_vb"))
+	if err := checkBidInput(req.Msg.BidSats, req.Msg.FeeRateSatVb); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if err := h.requireEnforcerSynced(ctx); err != nil {
 		return nil, err
@@ -333,19 +332,20 @@ func (h *BMMHandler) CreateBid(
 		return nil, err
 	}
 
-	// The wallet decided the amount, so the chain is the only place that knows
-	// what the bid cost. The fee is spent by now, so a lookup that misses —
-	// an electrum broadcast the local node has not seen, or a block that
-	// already took it — reports the rate's nominal cost rather than losing
-	// the bid.
-	if byRate {
-		if paid, err := h.bidFeeSats(ctx, send.Msg.Txid); err == nil {
-			bidSats = paid
-		} else {
+	// The chain is the only place that knows what the bid cost. A rate lets
+	// the wallet size the fee, and a fixed fee still grows when coin selection
+	// leaves change below the dust threshold and pays the remainder instead.
+	// The fee is spent by now, so a lookup that misses — an electrum broadcast
+	// the local node has not seen, or a block that already took it — reports
+	// the asking price rather than losing the bid.
+	if paid, err := h.bidFeeSats(ctx, send.Msg.Txid); err == nil {
+		bidSats = paid
+	} else {
+		if byRate {
 			bidSats = int64(math.Ceil(req.Msg.FeeRateSatVb * nominalBidVsize))
-			zerolog.Ctx(ctx).Warn().Err(err).Str("txid", send.Msg.Txid).
-				Msg("could not read what the bid paid, reporting the rate's nominal cost")
 		}
+		zerolog.Ctx(ctx).Warn().Err(err).Str("txid", send.Msg.Txid).
+			Msg("could not read what the bid paid, reporting what it asked for")
 	}
 
 	return connect.NewResponse(&bmmpb.CreateBidResponse{


### PR DESCRIPTION
Two findings from the review of #2164, which merged before I pushed them.

## A rate that is not a number

`fee_rate_sat_vb` crosses the wire as a double, so a client can send `NaN` or an
infinity. Both pass `rate <= 0`, so the bid went on to `math.Ceil` and an
integer conversion, which yields a fee of zero. `SendTransaction` then falls
back to the wallet's own fee policy, and `CreateBid` still broadcasts and
reports a nonsense amount.

`checkBidInput` holds the rule and rejects a non-finite rate before anything
spends. `TestCheckBidInput` covers eight inputs: an exact bid, a rate, neither,
a negative rate, `NaN`, both infinities, and an exact bid beside a bad rate.

## What the bid actually paid

Both wallet backends drop a change output below the dust threshold and pay the
remainder as fee (`wallet/core_backend.go`, `wallet/electrum_backend.go`). A
fixed-fee bid therefore pays a little more than it asked for, and the answer
reported only the asking price, which overstates the round's profit.

The fee lookup already ran for a rate-sized bid. It now runs for every bid, so
the answer carries what the chain says the transaction paid. A lookup that
misses still reports the asking price rather than losing the bid.

The overspend itself stays. It is bounded by the dust threshold, and predicting
it would mean running coin selection before the wallet does.