### PR TITLE
orchestrator: read a sidechain tip from its own index

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.320
+version: 1.0.321
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.320
+version: 1.0.321
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -1938,80 +1938,84 @@ class _DepositModalState extends State<DepositModal> {
           subtitle: 'Slot ${widget.slot}',
           error: fetchError,
           withCloseButton: true,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SailRow(
-                spacing: SailStyleValues.padding08,
-                children: [
-                  Expanded(
-                    child: SailTextField(
-                      label: 'Deposit Address',
-                      loading: LoadingDetails(
-                        enabled: isFetchingAddress,
-                        description: 'Fetching deposit address from ${widget.sidechainName}...',
+          // The card sits inside a fixed share of the window, so a short
+          // window cuts the tail of this form off.
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SailRow(
+                  spacing: SailStyleValues.padding08,
+                  children: [
+                    Expanded(
+                      child: SailTextField(
+                        label: 'Deposit Address',
+                        loading: LoadingDetails(
+                          enabled: isFetchingAddress,
+                          description: 'Fetching deposit address from ${widget.sidechainName}...',
+                        ),
+                        controller: TextEditingController(text: depositAddress ?? ''),
+                        hintText: 's${widget.slot}_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxx',
+                        readOnly: true,
+                        suffixWidget: depositAddress != null ? CopyButton(text: depositAddress!) : null,
                       ),
-                      controller: TextEditingController(text: depositAddress ?? ''),
-                      hintText: 's${widget.slot}_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxx',
-                      readOnly: true,
-                      suffixWidget: depositAddress != null ? CopyButton(text: depositAddress!) : null,
                     ),
-                  ),
-                  SailTooltip(
-                    message: 'Generate new address',
-                    child: SailButton(
-                      variant: ButtonVariant.icon,
-                      icon: SailSVGAsset.iconRestart,
-                      onPressed: isFetchingAddress ? null : _fetchDepositAddress,
+                    SailTooltip(
+                      message: 'Generate new address',
+                      child: SailButton(
+                        variant: ButtonVariant.icon,
+                        icon: SailSVGAsset.iconRestart,
+                        onPressed: isFetchingAddress ? null : _fetchDepositAddress,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SailSpacing(SailStyleValues.padding16),
-              SailRow(
-                spacing: SailStyleValues.padding08,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Expanded(
-                    flex: 2,
-                    child: NumericField(
-                      label: 'Deposit Amount',
-                      controller: amountController,
-                      hintText: '0.00',
+                  ],
+                ),
+                const SailSpacing(SailStyleValues.padding16),
+                SailRow(
+                  spacing: SailStyleValues.padding08,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Expanded(
+                      flex: 2,
+                      child: NumericField(
+                        label: 'Deposit Amount',
+                        controller: amountController,
+                        hintText: '0.00',
+                      ),
                     ),
-                  ),
-                  UnitDropdown(value: Unit.BTC, onChanged: (_) {}, enabled: false),
-                  Expanded(
-                    flex: 2,
-                    child: FromWalletField(
-                      selectedWalletId: fromWalletId,
-                      onChanged: (walletId) => setState(() => selectedWalletId = walletId),
+                    UnitDropdown(value: Unit.BTC, onChanged: (_) {}, enabled: false),
+                    Expanded(
+                      flex: 2,
+                      child: FromWalletField(
+                        selectedWalletId: fromWalletId,
+                        onChanged: (walletId) => setState(() => selectedWalletId = walletId),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SailSpacing(SailStyleValues.padding08),
-              DepositFeeFields(estimate: depositFee, onTargetChanged: _setFeeTarget),
-              const SailSpacing(SailStyleValues.padding08),
-              _LeavesWalletRow(amount: amountController.text, fee: feeController.text),
-              const SailSpacing(SailStyleValues.padding08),
-              SailText.secondary13(
-                '${widget.sidechainName} may deduct its own fee, so the credited amount can be lower.',
-                color: context.sailTheme.colors.textTertiary,
-              ),
-              const SailSpacing(SailStyleValues.padding20),
-              SailButton(
-                label: 'Deposit',
-                loading: isLoading,
-                disabled:
-                    depositAddress == null ||
-                    fromWalletId == null ||
-                    amountController.text.isEmpty ||
-                    feeController.text.isEmpty,
-                onPressed: _deposit,
-              ),
-            ],
+                  ],
+                ),
+                const SailSpacing(SailStyleValues.padding08),
+                DepositFeeFields(estimate: depositFee, onTargetChanged: _setFeeTarget),
+                const SailSpacing(SailStyleValues.padding08),
+                _LeavesWalletRow(amount: amountController.text, fee: feeController.text),
+                const SailSpacing(SailStyleValues.padding08),
+                SailText.secondary13(
+                  '${widget.sidechainName} may deduct its own fee, so the credited amount can be lower.',
+                  color: context.sailTheme.colors.textTertiary,
+                ),
+                const SailSpacing(SailStyleValues.padding20),
+                SailButton(
+                  label: 'Deposit',
+                  loading: isLoading,
+                  disabled:
+                      depositAddress == null ||
+                      fromWalletId == null ||
+                      amountController.text.isEmpty ||
+                      feeController.text.isEmpty,
+                  onPressed: _deposit,
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.190
+version: 0.2.191
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.193
+version: 1.0.194
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/loaders/progress.dart
+++ b/sail_ui/lib/widgets/loaders/progress.dart
@@ -26,14 +26,18 @@ class ProgressBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
     final numberFormat = NumberFormat.decimalPattern('fr_FR');
-    final progress = (goal <= 0 ? 0 : current / goal).toDouble();
+    // A chain whose tip nobody reports has no percentage. Zero would read as
+    // no progress on a chain that holds every block it knows of.
+    final unknownGoal = goal <= 0;
+    final progress = (unknownGoal ? 0 : current / goal).toDouble();
 
-    var textInsideBar = '${numberFormat.format(current)} / ${numberFormat.format(goal)}';
+    var textInsideBar = '${numberFormat.format(current)} / ${unknownGoal ? '?' : numberFormat.format(goal)}';
     if (justPercent) {
       // A chain 4 blocks short of the tip rounds to 100.00% and reads as done.
-      final percent = progress * 100;
+      // A node past the tip its index reports is done, not more than done.
+      final percent = min(progress * 100, 100.0);
       final shown = current < goal ? min(percent, 99.99) : percent;
-      textInsideBar = '${shown.toStringAsFixed(2)}%';
+      textInsideBar = unknownGoal ? 'unknown' : '${shown.toStringAsFixed(2)}%';
     } else if (hideProgressInside) {
       textInsideBar = '';
     }
@@ -114,7 +118,7 @@ class ProgressBar extends StatelessWidget {
             ConstrainedBox(
               constraints: const BoxConstraints(minWidth: 50, maxWidth: 50),
               child: SailText.primary12(
-                '${((progress) * 100).toStringAsFixed(2)}%',
+                unknownGoal ? 'unknown' : '${min(progress * 100, 100.0).toStringAsFixed(2)}%',
                 textAlign: TextAlign.left,
               ),
             ),

--- a/sail_ui/test/progress_unknown_goal_test.dart
+++ b/sail_ui/test/progress_unknown_goal_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+Widget _bar({required int current, required int goal, bool justPercent = false}) {
+  return MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: SizedBox(
+          width: 300,
+          child: ProgressBar(
+            current: current.toDouble(),
+            goal: goal.toDouble(),
+            justPercent: justPercent,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a chain with no reported tip says so, rather than zero', (tester) async {
+    await tester.pumpWidget(_bar(current: 3, goal: 0, justPercent: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('unknown'), findsOneWidget);
+    expect(find.text('0.00%'), findsNothing);
+  });
+
+  testWidgets('a chain with no reported tip hides the goal', (tester) async {
+    await tester.pumpWidget(_bar(current: 3, goal: 0));
+    await tester.pumpAndSettle();
+
+    // The bar carries the count, and the label beside it carries the percent.
+    expect(find.text('3 / ?'), findsOneWidget);
+    expect(find.text('unknown'), findsOneWidget);
+    expect(find.text('0.00%'), findsNothing);
+  });
+
+  testWidgets('a known tip keeps the percent beside the bar', (tester) async {
+    await tester.pumpWidget(_bar(current: 25, goal: 100));
+    await tester.pumpAndSettle();
+
+    expect(find.text('25.00%'), findsOneWidget);
+    expect(find.text('unknown'), findsNothing);
+  });
+
+  // The index trails the node by a block or two, so the node passes the tip
+  // the index reports.
+  testWidgets('a node past the reported tip reads as done, not more', (tester) async {
+    await tester.pumpWidget(_bar(current: 5, goal: 4, justPercent: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('100.00%'), findsOneWidget);
+    expect(find.text('125.00%'), findsNothing);
+  });
+
+  testWidgets('a reported tip still reads as a percentage', (tester) async {
+    await tester.pumpWidget(_bar(current: 50, goal: 100, justPercent: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('50.00%'), findsOneWidget);
+  });
+}

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -265,6 +265,17 @@ func DrivechainIndexURLForNetwork(n Network) string {
 	}
 }
 
+// SidechainEsploraURLForNetwork returns the address index hosted for one
+// sidechain on a network, or an empty string when none is hosted.
+func SidechainEsploraURLForNetwork(chain string, n Network) string {
+	switch chain {
+	case "thunder":
+		return ThunderEsploraURLForNetwork(n)
+	default:
+		return ""
+	}
+}
+
 func ThunderEsploraURLForNetwork(n Network) string {
 	switch n {
 	case NetworkECash:

--- a/sidechain-orchestrator/explorer_heights_test.go
+++ b/sidechain-orchestrator/explorer_heights_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 )
 
-// Networks with no hosted explorer must not dial a hostname that has never
-// existed. ECash is the case that matters: its infrastructure lives on
-// drivechain.dev under a per-generation host and publishes no tip endpoint.
+// A network with no public explorer must not dial a hostname that has never
+// existed. Its sidechains read a hosted address index instead, and a chain
+// with neither reports no tip.
 func TestExplorerHeightsSkipsNetworksWithoutHostedInfra(t *testing.T) {
+	// No public explorer and no chain configured, so nothing reports a tip.
 	for _, network := range []string{"ecash", "mainnet", "regtest", "testnet"} {
 		t.Run(network, func(t *testing.T) {
 			c := &explorerHeightsConnection{o: &Orchestrator{Network: network}}
@@ -18,14 +19,22 @@ func TestExplorerHeightsSkipsNetworksWithoutHostedInfra(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected the fetch to be skipped")
 			}
-			if !strings.Contains(err.Error(), "no public explorer") {
+			if !strings.Contains(err.Error(), "no chain tip") {
 				t.Errorf("err = %v, want the skip reason", err)
 			}
 		})
 	}
 
-	// Signet does have one, so it must not be skipped.
+	// Signet has a public explorer, so it must not be skipped.
 	if !config.PublicExplorerNetwork(config.NetworkSignet) {
 		t.Error("signet is expected to have a public explorer")
+	}
+
+	// eCash has no public explorer, and a hosted index answers for it instead.
+	if config.PublicExplorerNetwork(config.NetworkECash) {
+		t.Error("ecash is not expected to have a public explorer")
+	}
+	if config.SidechainEsploraURLForNetwork("thunder", config.NetworkECash) == "" {
+		t.Error("thunder on ecash is expected to have a hosted index")
 	}
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -3514,6 +3514,8 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		if slot.Error != "" {
 			continue
 		}
+		// Only an index knows the chain's tip. The node's own height would
+		// read as fully synced while it still downloads.
 		if h, ok := heights[name]; ok {
 			slot.Headers = h
 		}
@@ -3560,9 +3562,40 @@ type explorerHeightsConnection struct{ o *Orchestrator }
 
 func (c *explorerHeightsConnection) Fetch(ctx context.Context) (map[string]int64, error) {
 	network := config.NetworkFromString(c.o.Network)
-	if !config.PublicExplorerNetwork(network) {
-		return nil, fmt.Errorf("no public explorer for %s", network)
+	heights := make(map[string]int64)
+
+	if config.PublicExplorerNetwork(network) {
+		if err := c.fetchPublicExplorer(ctx, network, heights); err != nil {
+			return nil, err
+		}
 	}
+	// A network the public explorer does not serve still hosts a per-chain
+	// address index, and a light install reads its chain from that index.
+	for name, cfg := range c.o.Configs() {
+		if cfg.ChainLayer != 2 {
+			continue
+		}
+		if _, ok := heights[name]; ok {
+			continue
+		}
+		height, err := c.o.sidechainIndexHeight(ctx, name, network)
+		if err != nil {
+			c.o.log.Debug().Err(err).Str("chain", name).Msg("sidechain index tip failed")
+			continue
+		}
+		heights[name] = height
+	}
+
+	if len(heights) == 0 {
+		return nil, fmt.Errorf("no chain tip for %s", network)
+	}
+	return heights, nil
+}
+
+// fetchPublicExplorer adds the tips the drivechain.info explorer reports.
+func (c *explorerHeightsConnection) fetchPublicExplorer(
+	ctx context.Context, network config.Network, heights map[string]int64,
+) error {
 	// Readable names match the explorer URL slug directly.
 	url := fmt.Sprintf("https://node.%s.drivechain.info/api/explorer.v1.ExplorerService/GetChainTips", network.ReadableName())
 
@@ -3577,10 +3610,9 @@ func (c *explorerHeightsConnection) Fetch(ctx context.Context) (map[string]int64
 		Height interface{} `json:"height"`
 	}
 	if err := connectJSONPost(rpcCtx, c.o.explorerHTTP(), url, &resp); err != nil {
-		return nil, err
+		return err
 	}
 
-	heights := make(map[string]int64, len(resp))
 	for name, entry := range resp {
 		switch v := entry.Height.(type) {
 		case string:
@@ -3591,7 +3623,7 @@ func (c *explorerHeightsConnection) Fetch(ctx context.Context) (map[string]int64
 			heights[name] = int64(v)
 		}
 	}
-	return heights, nil
+	return nil
 }
 
 // explorerHeightsCached returns the single CachedConnection backing every
@@ -3621,6 +3653,34 @@ func (o *Orchestrator) fetchExplorerHeights(ctx context.Context) map[string]int6
 		o.log.Debug().Err(err).Msg("explorer GetChainTips failed; keeping cached heights")
 	}
 	return heights
+}
+
+// sidechainIndexHeight reads the tip the hosted address index reports for one
+// sidechain.
+func (o *Orchestrator) sidechainIndexHeight(ctx context.Context, chain string, network config.Network) (int64, error) {
+	base := config.SidechainEsploraURLForNetwork(chain, network)
+	if base == "" {
+		return 0, fmt.Errorf("no index for %s on %s", chain, network)
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(rpcCtx, http.MethodGet, base+"/blocks/tip/height", nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := o.explorerHTTP().Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // cleanup
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("index answered %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32))
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(body)), 10, 64)
 }
 
 // connectJSONPost issues a Connect-JSON unary call (POST with empty {} body)

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -38,7 +38,10 @@ class SyncInfo {
   final int verifiedGoal;
 
   double get progress => progressGoal == 0 ? 0 : progressCurrent / progressGoal;
-  bool get isSynced => progressGoal > 0 && progressCurrent == progressGoal;
+
+  /// A node that passed the tip its index reports holds everything anyone
+  /// knows of, so an index one block behind must not read as unsynced.
+  bool get isSynced => progressGoal > 0 && progressCurrent >= progressGoal;
 
   /// True when every height this daemon reports reached the goal. A snapshot
   /// node hits the tip in blocks hours before it verifies the rest, so a card

--- a/sidechain_core/test/sync_info_ahead_of_index_test.dart
+++ b/sidechain_core/test/sync_info_ahead_of_index_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  // The hosted index trails the node it indexes, so a node that passed the
+  // tip the index reports holds everything anyone knows of.
+  test('a node past the reported tip counts as synced', () {
+    final info = SyncInfo(progressCurrent: 5, progressGoal: 4, lastBlockAt: null);
+    expect(info.isSynced, isTrue);
+  });
+
+  test('a node at the reported tip counts as synced', () {
+    final info = SyncInfo(progressCurrent: 4, progressGoal: 4, lastBlockAt: null);
+    expect(info.isSynced, isTrue);
+  });
+
+  test('a node behind the reported tip does not', () {
+    final info = SyncInfo(progressCurrent: 3, progressGoal: 4, lastBlockAt: null);
+    expect(info.isSynced, isFalse);
+  });
+
+  test('an unknown tip does not count as synced', () {
+    final info = SyncInfo(progressCurrent: 3, progressGoal: 0, lastBlockAt: null);
+    expect(info.isSynced, isFalse);
+  });
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.322
+version: 1.0.323
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.193
+version: 1.0.194
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.319
+version: 1.0.320
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The Thunder daemon card reads `3 / 0` and `0.00%`, and the bottom bar reads
`Syncing Thunder blocks 0.00%`, on a node that holds every block the chain has.

## The tip had one source, and it serves two networks

`explorerHeightsConnection.Fetch` asks
`node.<network>.drivechain.info/api/explorer.v1.ExplorerService/GetChainTips`,
behind this gate:

```go
func PublicExplorerNetwork(n Network) bool {
    return n == NetworkSignet || n == NetworkForknet
}
```

On every other network the fetch refuses, so no sidechain gets a tip at all.

A light install already reads its chain from the hosted address index, and that
index answers a tip:

```
$ curl https://seed.alpha.ecash.eu.com/thunder/blocks/tip/height
4
```

The orchestrator reads that for any sidechain the explorer did not answer for,
through a new `SidechainEsploraURLForNetwork`. The read sits inside the same
`CachedConnection` the explorer fetch uses, so its TTL, its single flight and
its last-good value all apply: a 100 ms poll costs one request per half minute,
and an index outage keeps the last known tip rather than dropping it.

## An index trails the node it indexes

A node one block ahead of its index read as unsynced forever, because
`SyncInfo.isSynced` asked for exact equality. That held the 100 ms poll open and
drew a percentage above one hundred. A node at or past the tip its index reports
holds everything anyone knows of, so it counts as caught up.

## What this deliberately does not do

`TestGetSyncStatus_LeavesHeadersZeroWhenExplorerDown` records an earlier
decision: a fallback to the node's own block count made a sidechain look fully
synced while it still downloaded. That decision stands, and that test passes
unchanged. A chain with no index reports no tip, and the interface says
`unknown` rather than inventing `0.00%`.

## Also here

The Deposit modal cut its last line and its button off the bottom of a short
window. Its form scrolls now, and `git diff -w` on that file is the wrapper and
nothing else.

## Tests

- `TestExplorerHeightsSkipsNetworksWithoutHostedInfra` now covers the rule it
  describes: a network with neither a public explorer nor a hosted index reports
  no tip, signet has an explorer, and thunder on eCash has an index.
- Five widget tests cover the bar: an unknown tip as a percentage and as a
  count, a node past the tip, and two known tips.
- Four tests cover `isSynced`: past the tip, at the tip, behind it, and unknown.