### PR TITLE
sidechain_core: read a chain's up state from its own mode

### DIFF
--- a/sidechain_core/lib/providers/binaries/binary_provider.dart
+++ b/sidechain_core/lib/providers/binaries/binary_provider.dart
@@ -279,7 +279,7 @@ class BinaryProvider extends ChangeNotifier {
 
     // An open window pins the app bundle just as a daemon pins its binary, so
     // the update stops and reopens it too.
-    final wasRunning = isSidechainUp(binary);
+    final wasRunning = holdsItsFiles(binary);
 
     log.i('BinaryProvider: starting update for $name');
 
@@ -510,9 +510,21 @@ class BinaryProvider extends ChangeNotifier {
     return _rpcFor(binary)?.connected ?? false;
   }
 
-  /// True when a chain is up. A light install runs no daemon, so its own open
-  /// window is what up means there.
+  /// True when a chain is up, which is what the start and stop button reads.
+  ///
+  /// A light install runs no daemon of its own, so its window is the only
+  /// thing it can stop. A full install answers for the daemon, because a
+  /// window says nothing about the daemon behind it.
   bool isSidechainUp(Binary binary) {
+    if (!NodeModeProvider.runsLocalBackends) {
+      return _rpcFor(binary)?.windowOpen ?? false;
+    }
+    return isConnected(binary);
+  }
+
+  /// True when a running process holds this chain's files open. An update
+  /// stops it first, whether that is the daemon or the app window.
+  bool holdsItsFiles(Binary binary) {
     return isConnected(binary) || (_rpcFor(binary)?.windowOpen ?? false);
   }
 

--- a/sidechain_core/test/sidechain_up_per_mode_test.dart
+++ b/sidechain_core/test/sidechain_up_per_mode_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sidechain_core/mocks/mocks.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  late MockThunderRPC rpc;
+  late BinaryProvider provider;
+  final thunder = Thunder();
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<Logger>(Logger(level: Level.off));
+    rpc = MockThunderRPC();
+    GetIt.instance.registerSingleton<ThunderRPC>(rpc);
+    provider = BinaryProvider.test(appDir: Directory.systemTemp, binaries: [thunder]);
+  });
+
+  void useMode(wmpb.NodeMode mode) {
+    final nodeMode = NodeModeProvider();
+    nodeMode.mode = mode;
+    GetIt.instance.registerSingleton<NodeModeProvider>(nodeMode);
+  }
+
+  group('light mode', () {
+    // A light install runs no daemon of its own, so its window is the only
+    // thing it can stop.
+    test('an open window is up', () {
+      useMode(wmpb.NodeMode.NODE_MODE_LIGHT);
+      rpc.windowOpen = true;
+      expect(provider.isSidechainUp(thunder), isTrue);
+    });
+
+    test('no window is not up, whatever the daemon answers', () {
+      useMode(wmpb.NodeMode.NODE_MODE_LIGHT);
+      rpc.windowOpen = false;
+      rpc.setConnected(true);
+      expect(provider.isSidechainUp(thunder), isFalse);
+    });
+  });
+
+  group('full mode', () {
+    test('a daemon that answers is up', () {
+      useMode(wmpb.NodeMode.NODE_MODE_FULL);
+      rpc.setConnected(true);
+      expect(provider.isSidechainUp(thunder), isTrue);
+    });
+
+    test('an open window alone is not up', () {
+      useMode(wmpb.NodeMode.NODE_MODE_FULL);
+      rpc.setConnected(false);
+      rpc.windowOpen = true;
+      expect(provider.isSidechainUp(thunder), isFalse);
+    });
+  });
+
+  // An update stops whatever holds the files, in either mode.
+  test('a window holds the files even when the daemon is down', () {
+    useMode(wmpb.NodeMode.NODE_MODE_FULL);
+    rpc.setConnected(false);
+    rpc.windowOpen = true;
+    expect(provider.holdsItsFiles(thunder), isTrue);
+  });
+
+  test('nothing running holds no files', () {
+    useMode(wmpb.NodeMode.NODE_MODE_FULL);
+    rpc.setConnected(false);
+    rpc.windowOpen = false;
+    expect(provider.holdsItsFiles(thunder), isFalse);
+  });
+}


### PR DESCRIPTION
The start and stop button on the sidechains table reads `isSidechainUp`, and
that answered on a daemon **or** a window, whichever said yes:

```dart
bool isSidechainUp(Binary binary) {
  return isConnected(binary) || (_rpcFor(binary)?.windowOpen ?? false);
}
```

Each mode runs one of those two, so the other one lies about it.

- A **light** install runs no sidechain daemon at all. Its window is the only
  thing it can stop. A daemon that answers there belongs to something else, and
  the row still read Stop for it.
- A **full** install runs the daemon. An open window says nothing about the
  daemon behind it, so the row read Stop for a chain whose daemon had exited.

A light install now answers for its window, and a full install answers for its
daemon.

## The update path asks a different question

`update` calls the same predicate to decide whether to stop first, and the
reason is written above the call: an open window pins the app bundle just as a
daemon pins its binary. That caller wants either one, so it gets its own name,
`holdsItsFiles`, rather than a predicate that means something else in each mode.

## Tests

Six tests, four of which fail on master:

- light mode: an open window is up; no window is not up even when a daemon
  answers.
- full mode: a daemon that answers is up; an open window alone is not.
- the update path: a window holds the files with the daemon down, and nothing
  running holds none.