### PR TITLE
orchestrator: give the live chain the base sidechain port

### DIFF
--- a/sidechain-orchestrator/config/sidechain_conf.go
+++ b/sidechain-orchestrator/config/sidechain_conf.go
@@ -206,18 +206,32 @@ mainchain-grpc-url=%s
 	}
 }
 
+// networkPortOffset returns what a network adds to a sidechain's base port,
+// following the offsets Bitcoin Core gives its own chains: mainnet 8332,
+// testnet3 18332, signet 38332.
+//
+// The live chain answers at the base port. That is the port a daemon listens
+// on with no arguments, and the port its seed peers name, so a node started by
+// hand and a node started by the launcher reach each other.
+func networkPortOffset(network string) int {
+	switch network {
+	case "regtest":
+		return 10000
+	case "signet":
+		return 30000
+	default: // eCash, the live chain
+		return 0
+	}
+}
+
+// portGroups names every group getNetworkPorts answers with. A value from any
+// of them came from an earlier sync, never from the user.
+var portGroups = []string{"ecash", "regtest", "signet"}
+
 // getNetworkPorts returns port mappings for the given network, derived from BasePort.
 func (m *SidechainConfManager) getNetworkPorts(network string) map[string]string {
 	base := m.Spec.BasePort
-	var offset int
-	switch network {
-	case "regtest":
-		offset = 10000
-	case "mainnet":
-		offset = 20000
-	default: // signet
-		offset = 0
-	}
+	offset := networkPortOffset(network)
 
 	rpcPort := base + offset
 	netPort := base - 2000 + offset
@@ -326,12 +340,16 @@ func (m *SidechainConfManager) isGeneratedEndpoint(key, value string) bool {
 	if value == "" {
 		return true
 	}
-	for _, network := range []string{"signet", "regtest", "mainnet"} {
+	for _, network := range portGroups {
 		if m.getNetworkPorts(network)[key] == value {
 			return true
 		}
 	}
-	return false
+	// A config written before the live chain took the base port names the old
+	// +20000 group, and a sync has to read that as its own too.
+	retired := m.Spec.BasePort + 20000
+	return value == fmt.Sprintf("127.0.0.1:%d", retired) ||
+		value == fmt.Sprintf("0.0.0.0:%d", retired-2000)
 }
 
 func (m *SidechainConfManager) resolveNetwork() string {
@@ -341,8 +359,8 @@ func (m *SidechainConfManager) resolveNetwork() string {
 	switch m.BitcoinConf.Network {
 	case NetworkRegtest:
 		return "regtest"
-	case NetworkForknet, NetworkECash:
-		return "mainnet"
+	case NetworkECash:
+		return "ecash"
 	default:
 		return "signet"
 	}

--- a/sidechain-orchestrator/config/sidechain_conf_network_test.go
+++ b/sidechain-orchestrator/config/sidechain_conf_network_test.go
@@ -140,16 +140,69 @@ func TestGetCliArgsWithholdsNetworkFromUnprovedChains(t *testing.T) {
 	}
 }
 
-// The eCash and forknet boxes both keep the +20000 port group. The daemon name
-// changes; the ports do not.
-func TestNetworkFlagLeavesThePortGroupAlone(t *testing.T) {
-	for _, network := range []Network{NetworkECash, NetworkForknet} {
-		m := sidechainConfFor(t, "thunder", network, nil)
-		if got := m.resolveNetwork(); got != "mainnet" {
-			t.Errorf("resolveNetwork() on %q = %q, want mainnet", network, got)
+// Every network reads its own port group, and the live chain reads the base
+// port a daemon listens on with no arguments.
+func TestEachNetworkReadsItsOwnPortGroup(t *testing.T) {
+	for _, test := range []struct {
+		network Network
+		group   string
+		rpcAddr string
+		netAddr string
+	}{
+		{NetworkECash, "ecash", "127.0.0.1:6009", "0.0.0.0:4009"},
+		{NetworkRegtest, "regtest", "127.0.0.1:16009", "0.0.0.0:14009"},
+		{NetworkSignet, "signet", "127.0.0.1:36009", "0.0.0.0:34009"},
+	} {
+		m := sidechainConfFor(t, "thunder", test.network, nil)
+		if got := m.resolveNetwork(); got != test.group {
+			t.Errorf("resolveNetwork() on %q = %q, want %q", test.network, got, test.group)
 		}
-		if got := m.getNetworkPorts("mainnet")["net-addr"]; got != "0.0.0.0:24009" {
-			t.Errorf("net-addr on %q = %q, want 0.0.0.0:24009", network, got)
+		ports := m.getNetworkPorts(test.group)
+		if got := ports["net-addr"]; got != test.netAddr {
+			t.Errorf("net-addr on %q = %q, want %q", test.network, got, test.netAddr)
+		}
+		if got := ports["rpc-addr"]; got != test.rpcAddr {
+			t.Errorf("rpc-addr on %q = %q, want %q", test.network, got, test.rpcAddr)
+		}
+	}
+}
+
+// The offsets copy the ones Bitcoin Core gives its own chains, so a reader who
+// knows 8332 and 18332 can guess these.
+func TestPortOffsetsFollowBitcoinCore(t *testing.T) {
+	for group, want := range map[string]int{
+		"ecash":   0,
+		"regtest": 10000,
+		"signet":  30000,
+	} {
+		if got := networkPortOffset(group); got != want {
+			t.Errorf("networkPortOffset(%q) = %d, want %d", group, got, want)
+		}
+	}
+}
+
+// A node made before the live chain took the base port holds the retired
+// +20000 value. The next sync moves it, so the node answers where its peers
+// look for it.
+func TestSyncMovesTheLiveChainOffTheRetiredPort(t *testing.T) {
+	SetHomeDir(t.TempDir())
+	t.Cleanup(func() { SetHomeDir("") })
+
+	m := sidechainConfFor(t, "thunder", NetworkECash, map[string]string{
+		"net-addr":           "0.0.0.0:24009",
+		"rpc-addr":           "127.0.0.1:26009",
+		"mainchain-grpc-url": "http://localhost:50051",
+	})
+
+	if err := m.SyncNetworkFromBitcoinConf(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	for key, want := range map[string]string{
+		"net-addr": "0.0.0.0:4009",
+		"rpc-addr": "127.0.0.1:6009",
+	} {
+		if got := m.Config.GetSetting(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
 		}
 	}
 }
@@ -257,8 +310,7 @@ func TestGetNetworkReadsTheMainchainConf(t *testing.T) {
 	for network, want := range map[Network]string{
 		NetworkSignet:  "signet",
 		NetworkRegtest: "regtest",
-		NetworkECash:   "mainnet",
-		NetworkForknet: "mainnet",
+		NetworkECash:   "ecash",
 	} {
 		m := sidechainConfFor(t, "thunder", network, map[string]string{"network": "nonsense"})
 		if got := m.GetNetwork(); got != want {
@@ -275,7 +327,7 @@ func TestSyncKeepsACustomEndpoint(t *testing.T) {
 
 	m := sidechainConfFor(t, "thunder", NetworkSignet, map[string]string{
 		"net-addr":           "0.0.0.0:9999",
-		"rpc-addr":           "127.0.0.1:6009",
+		"rpc-addr":           "127.0.0.1:36009",
 		"mainchain-grpc-url": "https://remote.example/grpc",
 	})
 
@@ -311,8 +363,8 @@ func TestSyncReplacesAnotherNetworksPort(t *testing.T) {
 		t.Fatalf("sync: %v", err)
 	}
 	for key, want := range map[string]string{
-		"net-addr": "0.0.0.0:4009",
-		"rpc-addr": "127.0.0.1:6009",
+		"net-addr": "0.0.0.0:34009",
+		"rpc-addr": "127.0.0.1:36009",
 	} {
 		if got := m.Config.GetSetting(key); got != want {
 			t.Errorf("%s = %q, want %q", key, got, want)

--- a/sidechain-orchestrator/dial_thunder_seed_test.go
+++ b/sidechain-orchestrator/dial_thunder_seed_test.go
@@ -1,0 +1,90 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+type seedCall struct {
+	Method string   `json:"method"`
+	Params []string `json:"params"`
+}
+
+func fakeThunder(t *testing.T, calls chan<- seedCall) (string, int) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got seedCall
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode the request: %v", err)
+		}
+		calls <- got
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split the address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("read the port: %v", err)
+	}
+	return host, port
+}
+
+// Both seeds thunder names are down, so the launcher names one that answers.
+func TestDialThunderSeedAsksTheChain(t *testing.T) {
+	calls := make(chan seedCall, 2)
+	host, port := fakeThunder(t, calls)
+
+	o := &Orchestrator{Network: "ecash", log: zerolog.New(zerolog.NewTestWriter(t))}
+	o.dialThunderSeed(context.Background(), BinaryConfig{Name: "thunder", Host: host, Port: port})
+
+	select {
+	case got := <-calls:
+		if got.Method != "connect_peer" {
+			t.Errorf("method = %q, want connect_peer", got.Method)
+		}
+		if len(got.Params) != 1 || got.Params[0] != alphanetThunderSeed {
+			t.Errorf("params = %v, want [%s]", got.Params, alphanetThunderSeed)
+		}
+	default:
+		t.Fatal("the launcher asked thunder nothing")
+	}
+}
+
+// The seed answers on alphanet alone, and for thunder alone.
+func TestDialThunderSeedLeavesEveryOtherChainAlone(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		network string
+		binary  string
+	}{
+		{name: "another network", network: "signet", binary: "thunder"},
+		{name: "another chain", network: "ecash", binary: "bitnames"},
+		{name: "the mainchain", network: "ecash", binary: "bitcoind"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			calls := make(chan seedCall, 2)
+			host, port := fakeThunder(t, calls)
+
+			o := &Orchestrator{Network: test.network, log: zerolog.New(zerolog.NewTestWriter(t))}
+			o.dialThunderSeed(context.Background(), BinaryConfig{Name: test.binary, Host: host, Port: port})
+
+			select {
+			case got := <-calls:
+				t.Errorf("the launcher asked for %v", got)
+			default:
+			}
+		})
+	}
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1726,7 +1726,30 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 		return
 	}
 
+	o.dialThunderSeed(ctx, config)
+
 	ch <- StartupProgress{Stage: "done", Message: fmt.Sprintf("%s started", config.DisplayName), Done: true}
+}
+
+// alphanetThunderSeed answers on alphanet. Both seeds thunder names are down,
+// so a node that starts reaches nobody without this one.
+const alphanetThunderSeed = "204.168.254.113:4009"
+
+// dialThunderSeed asks thunder to connect to the alphanet seed. The chain
+// answers its RPC by this point.
+//
+// A refused address leaves the chain running: the node keeps the address and
+// retries it on its own.
+func (o *Orchestrator) dialThunderSeed(ctx context.Context, config BinaryConfig) {
+	if config.Name != "thunder" || o.Network != "ecash" {
+		return
+	}
+	proxy := sidechain.NewJSONRPCProxy(config.RPCHost(), config.Port)
+	if err := proxy.Client.Call(ctx, "connect_peer", []any{alphanetThunderSeed}, nil); err != nil {
+		o.log.Warn().Err(err).Str("peer", alphanetThunderSeed).Msg("could not reach the alphanet seed")
+		return
+	}
+	o.log.Info().Str("peer", alphanetThunderSeed).Msg("dialled the alphanet seed")
 }
 
 // RegisterLightWallet records how to ask whether a chain reads a remote index.

--- a/sidechain-orchestrator/orchestrator_sidechain_args_test.go
+++ b/sidechain-orchestrator/orchestrator_sidechain_args_test.go
@@ -58,8 +58,8 @@ func prepareArgs(t *testing.T, orch *Orchestrator, cfg BinaryConfig, opts *Start
 func TestPrepareSidechainArgsPassesTheConf(t *testing.T) {
 	orch := thunderOrchestrator(t, map[string]string{
 		"headless":           "true",
-		"net-addr":           "0.0.0.0:4009",
-		"rpc-addr":           "127.0.0.1:6009",
+		"net-addr":           "0.0.0.0:34009",
+		"rpc-addr":           "127.0.0.1:36009",
 		"mainchain-grpc-url": "http://localhost:50051",
 		"network":            "signet",
 	})
@@ -68,7 +68,7 @@ func TestPrepareSidechainArgsPassesTheConf(t *testing.T) {
 	prepareArgs(t, orch, BinaryConfig{Name: "thunder", ChainLayer: 2}, &opts)
 
 	want := []string{
-		"--net-addr=0.0.0.0:4009",
+		"--net-addr=0.0.0.0:34009",
 		"--mainchain-grpc-url=http://localhost:50051",
 		"--network=signet",
 	}


### PR DESCRIPTION
A thunder node started by hand listens on 4009 and looks for its peers there:

```rust
const DEFAULT_NET_ADDR: SocketAddr =
    ipv4_socket_addr([0, 0, 0, 0], 4000 + THIS_SIDECHAIN as u16);   // 4009
```

The launcher put eCash in the +20000 group, so an app node answered on 24009.
The two could never meet, and full mode on alphanet peers with nobody.

## The offsets now copy Bitcoin Core

| Network | RPC | P2P | Was |
|---|---|---|---|
| eCash | 6009 | **4009** | 26009 / 24009 |
| regtest | 16009 | 14009 | unchanged |
| signet | 36009 | 34009 | 6009 / 4009 |

Core keeps mainnet at 8332, testnet3 at +10000 and signet at +30000. The live
chain answers at the base port for the same reason: it is the port a daemon
takes with no arguments.

## An install that updates moves with it

`SyncNetworkFromBitcoinConf` rewrites an endpoint that an earlier sync
generated, and leaves a value the user typed. The retired +20000 pair now reads
as generated, so an eCash node moves from 24009 to 4009 by itself.

## What this does not do

Both hosts in thunder's alphanet seed list answer on neither port. I dialled
each from a live node:

| Seed | 4009 | 24009 |
|---|---|---|
| 157.180.96.24 | no | no |
| 65.109.148.184 | no | no |

So an updated node uses the right port and still finds nobody on its own. A
live seed has to answer, or the launcher has to dial a known peer after it
starts a chain. That is a separate change.

## Tests

- `TestEachNetworkReadsItsOwnPortGroup` pins the RPC and P2P port of all three.
- `TestPortOffsetsFollowBitcoinCore` pins the offsets against Core's own.
- `TestSyncMovesTheLiveChainOffTheRetiredPort` starts from 24009 and requires
  4009 after a sync.
- `TestSyncKeepsACustomEndpoint` still keeps a hand-typed port.