### PR TITLE
bmm: abandon a won block the chain left behind

### DIFF
--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -374,7 +374,7 @@ class _HistoricBids extends StatelessWidget {
                   SailTableCell(
                     value: round.hasProfit ? round.profitSats.toString() : '—',
                     monospace: true,
-                    textColor: round.hasProfit ? theme.colors.success : null,
+                    textColor: profitColor(round, theme.colors),
                   ),
                   SailTableCell(value: viewModel.winnerOf(round), monospace: true),
                   SailTableCell(value: '${round.ourBids.length + round.otherBids.length}'),
@@ -394,6 +394,15 @@ class _HistoricBids extends StatelessWidget {
       ],
     );
   }
+}
+
+/// A round the chain left behind pays no fees back, so it returns the bid as a
+/// loss.
+Color? profitColor(bmmpb.Round round, SailColor colors) {
+  if (!round.hasProfit) {
+    return null;
+  }
+  return round.profitSats < 0 ? colors.error : colors.success;
 }
 
 class BMMViewModel extends BaseViewModel {

--- a/sail_ui/test/bmm_profit_color_test.dart
+++ b/sail_ui/test/bmm_profit_color_test.dart
@@ -1,0 +1,28 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/pages/sidechains/bmm_tab.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/bmm/v1/bmm.pb.dart' as bmmpb;
+
+void main() {
+  final colors = SailThemeData.darkTheme(const Color(0xFF000000), false, SailFontValues.inter).colors;
+
+  // The engine gives up on a won block the chain left behind. The miner keeps
+  // the bid, so the row reports a loss and must not read as a win.
+  test('an abandoned round paints its loss', () {
+    final round = bmmpb.Round(result: 'won', hasProfit: true, profitSats: Int64(-1200));
+
+    expect(profitColor(round, colors), colors.error);
+  });
+
+  test('a connected round paints its profit', () {
+    final round = bmmpb.Round(result: 'won', hasProfit: true, profitSats: Int64(3800));
+
+    expect(profitColor(round, colors), colors.success);
+  });
+
+  test('a round with no profit takes the default colour', () {
+    expect(profitColor(bmmpb.Round(result: 'lost'), colors), isNull);
+  });
+}

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -220,13 +220,23 @@ func roundToProto(r bmmstate.Round) *bmmpb.Round {
 		OtherBids:          lo.Map(r.OtherBids, func(b bmmstate.Bid, _ int) *bmmpb.Bid { return bidToProto(b) }),
 	}
 
-	// Profit is only real once the block connects: a bid no miner took is
-	// never paid, so it neither costs nor earns anything.
+	// A bid no miner took is never paid, so it neither costs nor earns. A won
+	// bid is paid, and the block pays its fees back only once it connects.
 	if r.Result == engines.ResultWon {
 		out.HasProfit = true
-		out.ProfitSats = r.BlockWorthSats - r.WinnerBidSats
+		out.ProfitSats = -r.WinnerBidSats
+		if wonBlockConnected(r) {
+			out.ProfitSats = r.BlockWorthSats - r.WinnerBidSats
+		}
 	}
 	return out
+}
+
+// wonBlockConnected reports whether the won block reached the sidechain.
+func wonBlockConnected(r bmmstate.Round) bool {
+	return lo.ContainsBy(r.OurBids, func(b bmmstate.Bid) bool {
+		return b.State == engines.BidConnected
+	})
 }
 
 func bidToProto(b bmmstate.Bid) *bmmpb.Bid {

--- a/sidechain-orchestrator/api/bmm_profit_test.go
+++ b/sidechain-orchestrator/api/bmm_profit_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/engines"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/engines/bmmstate"
+)
+
+func wonRound(bidState string) bmmstate.Round {
+	return bmmstate.Round{
+		Result:         engines.ResultWon,
+		BlockWorthSats: 5000,
+		WinnerBidSats:  1200,
+		OurBids:        []bmmstate.Bid{{BidSats: 1200, IsOurs: true, State: bidState}},
+	}
+}
+
+// A connected block pays its fees, so the round earns what the block is worth
+// less what the bid cost.
+func TestProfitCountsAConnectedBlock(t *testing.T) {
+	out := roundToProto(wonRound(engines.BidConnected))
+
+	require.True(t, out.HasProfit)
+	require.EqualValues(t, 3800, out.ProfitSats)
+}
+
+// The engine abandons a won block the chain left behind. The miner keeps the
+// bid, and the block pays nothing, so the round costs what it bid.
+func TestProfitCountsAnAbandonedBlockAsACost(t *testing.T) {
+	out := roundToProto(wonRound(engines.BidMissed))
+
+	require.True(t, out.HasProfit)
+	require.EqualValues(t, -1200, out.ProfitSats)
+}
+
+// A bid no miner took is never paid.
+func TestALostRoundReportsNoProfit(t *testing.T) {
+	round := wonRound(engines.BidMissed)
+	round.Result = engines.ResultLost
+
+	out := roundToProto(round)
+
+	require.False(t, out.HasProfit)
+	require.Zero(t, out.ProfitSats)
+}

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -24,6 +24,10 @@ const (
 	// bmmConnectAttempts bounds how long a won block is retried, at one attempt
 	// per tick. The fee is already paid, so it is worth waiting minutes.
 	bmmConnectAttempts = 150
+	// bmmConnectHorizon is how far behind the tip a won block can sit and still
+	// connect. Its header names one mainchain block, so the sidechain refuses a
+	// tip older than this and no number of attempts changes that.
+	bmmConnectHorizon = 10
 )
 
 // Round result values.
@@ -864,6 +868,9 @@ func (e *BmmEngine) retryConnects(ctx context.Context, sidechain pb.BinaryType, 
 
 	var stillPending []*bmmstate.Round
 	for _, round := range pending {
+		if e.abandonBehindTip(sidechain, round, tipHeight) {
+			continue
+		}
 		if e.retryRound(ctx, sidechain, round, tip, tipHeight) {
 			continue
 		}
@@ -883,6 +890,33 @@ func (e *BmmEngine) retryConnects(ctx context.Context, sidechain pb.BinaryType, 
 	e.mu.Lock()
 	e.unconnected[sidechain] = append(e.unconnected[sidechain], stillPending...)
 	e.mu.Unlock()
+}
+
+// abandonBehindTip gives up on a won block the chain has left too far behind.
+//
+// Every attempt submits the block through the sidechain's network task. A block
+// that can never connect therefore takes that task away from the peers it
+// serves, and the node stops answering them. Clearing the live bid also keeps a
+// restart from resuming the round, which would otherwise hand it a fresh
+// attempt budget every time.
+// retryConnects owns the round by the time it calls this, so the fields below
+// take no lock. save must not run under one: it notifies, and that locks.
+func (e *BmmEngine) abandonBehindTip(
+	sidechain pb.BinaryType, round *bmmstate.Round, tipHeight int32,
+) bool {
+	if round.IncludedInHeight <= 0 || tipHeight-round.IncludedInHeight <= bmmConnectHorizon {
+		return false
+	}
+	e.log.Warn().Stringer("sidechain", sidechain).
+		Str("round", round.PrevMainHash).
+		Int32("included_height", round.IncludedInHeight).
+		Int32("tip_height", tipHeight).
+		Msg("abandoning a won block the chain left behind")
+	if live := liveBid(round); live != nil {
+		live.State = BidMissed
+	}
+	e.save(round)
+	return true
 }
 
 // retryRound settles a round still waiting: one whose deciding block was never

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -964,3 +964,65 @@ func TestBmmEngineReplacesAStrandedBidAfterRestart(t *testing.T) {
 		"the oldest stranded bid is the root of the chain, so replacing it evicts them all")
 	assert.Equal(t, "core-wallet", backend.lastWalletID)
 }
+
+// A won block the chain left far behind can never connect, because its header
+// names one mainchain block. Retrying it submits through the sidechain's
+// network task, which then stops answering its peers.
+func TestBmmEngineAbandonsAWonBlockBehindTheTip(t *testing.T) {
+	engine, backend, _, store := newEngine(t)
+
+	round := &bmmstate.Round{
+		Sidechain:        int32(testSidechain),
+		PrevMainHash:     "old-round",
+		PrevMainHeight:   996693,
+		IncludedInHeight: 996694,
+		Result:           ResultWon,
+		OurBids: []bmmstate.Bid{{
+			Txid: "won-txid", CriticalHash: "critical", IsOurs: true, State: BidLive,
+		}},
+	}
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	// The tip has moved 79 blocks past the block that decided the round.
+	engine.retryConnects(context.Background(), testSidechain, "tip", 996773)
+
+	assert.Zero(t, backend.connects, "a block this far behind must not be submitted")
+
+	engine.mu.Lock()
+	left := len(engine.unconnected[testSidechain])
+	engine.mu.Unlock()
+	assert.Zero(t, left, "the round leaves the retry list")
+
+	// A restart must not resume it, or it gets a fresh attempt budget and the
+	// node starves again.
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, &fakeTip{}, newFakeFee(), store)
+	restarted.mu.Lock()
+	resumed := len(restarted.unconnected[testSidechain])
+	restarted.mu.Unlock()
+	assert.Zero(t, resumed, "a restart leaves the abandoned round alone")
+}
+
+// A won block within the horizon is still worth retrying: the fee is paid.
+func TestBmmEngineKeepsRetryingARecentWonBlock(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+
+	round := &bmmstate.Round{
+		Sidechain:        int32(testSidechain),
+		PrevMainHash:     "recent-round",
+		PrevMainHeight:   996770,
+		IncludedInHeight: 996771,
+		Result:           ResultWon,
+		OurBids: []bmmstate.Bid{{
+			Txid: "won-txid", CriticalHash: "critical", IsOurs: true, State: BidLive,
+		}},
+	}
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	engine.retryConnects(context.Background(), testSidechain, "tip", 996773)
+
+	assert.Positive(t, backend.connects, "a recent won block is still submitted")
+}


### PR DESCRIPTION
A won round whose mainchain block falls far behind the tip can never connect, because the block header names one mainchain block. The engine retried it every tick anyway, and each attempt went through the sidechain's network task. Thunder then stopped answering its peers, so a node that dialled it timed out.

retryConnects never saved the attempt count, so every restart handed the same round a fresh budget of 150 attempts. This happened on the alphanet server today and stopped the chain from peering.

The engine now drops a won round more than 10 blocks behind the tip, and clears its live bid so a restart does not resume it.