### PR TITLE
Show a thunder coin before a block carries it

### DIFF
--- a/sidechain-orchestrator/sidechain/thunder/lightbackend.go
+++ b/sidechain-orchestrator/sidechain/thunder/lightbackend.go
@@ -16,6 +16,9 @@ import (
 type lightBackend struct {
 	keys  *tw.MemoryKeyring
 	known AddressSource
+	// index reads both halves of the wallet, and coins holds what a broadcast
+	// changed until the index catches up.
+	index *tw.IndexCoins
 	coins *tw.ReservedCoins
 
 	client *sidechainesplora.Client
@@ -30,10 +33,12 @@ func newLightBackend(
 ) *lightBackend {
 	// The index lags what the wallet spends, so a second send must not pick a
 	// coin the first one already used.
-	coins := tw.NewReservedCoins(tw.NewIndexCoins(client))
+	index := tw.NewIndexCoins(client)
+	coins := tw.NewReservedCoins(index)
 	return &lightBackend{
 		keys:   keys,
 		known:  known,
+		index:  index,
 		coins:  coins,
 		client: client,
 		wallet: tw.New(coins, keys, tw.NewIndexBroadcast(client.BaseURL())),
@@ -62,22 +67,41 @@ func (b *lightBackend) addresses(ctx context.Context) ([]tw.Address, error) {
 	return out, nil
 }
 
-// Balance sums the coins the index holds for this wallet. The index carries
-// confirmed coins, so the whole balance is spendable.
+// Balance sums the coins the index holds for this wallet. A coin no block
+// carries yet counts in the total and not in what the wallet can spend, so a
+// payment shows the moment the index sees it.
 func (b *lightBackend) Balance(ctx context.Context) (int64, int64, error) {
-	addresses, err := b.addresses(ctx)
+	spendable, pending, err := b.walletCoins(ctx)
 	if err != nil {
 		return 0, 0, err
 	}
-	coins, err := b.coins.Coins(ctx, addresses)
-	if err != nil {
-		return 0, 0, err
+	var available int64
+	for _, coin := range spendable {
+		available += int64(coin.ValueSats)
 	}
-	var total int64
-	for _, coin := range coins {
+	total := available
+	for _, coin := range pending {
 		total += int64(coin.ValueSats)
 	}
-	return total, total, nil
+	return total, available, nil
+}
+
+// walletCoins reads both halves of the wallet: what a block carries, and what
+// the wallet waits for. One read of each address fills both.
+//
+// The index lags a broadcast by one pass, so the reserved coins correct it: a
+// coin the wallet spent leaves, and the change it made joins the second half.
+func (b *lightBackend) walletCoins(ctx context.Context) (spendable, pending []tw.Coin, err error) {
+	addresses, err := b.addresses(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	confirmed, waiting, err := b.index.Split(ctx, addresses)
+	if err != nil {
+		return nil, nil, err
+	}
+	spendable, pending = b.coins.Adjust(addresses, confirmed, waiting)
+	return spendable, pending, nil
 }
 
 // NewAddress hands out the first address that never received a coin. Asking
@@ -91,16 +115,14 @@ func (b *lightBackend) NewAddress(ctx context.Context) (string, error) {
 	return address.String(), nil
 }
 
+// UTXOs lists every coin the wallet holds, including the ones no block carries
+// yet.
 func (b *lightBackend) UTXOs(ctx context.Context) (json.RawMessage, error) {
-	addresses, err := b.addresses(ctx)
+	spendable, pending, err := b.walletCoins(ctx)
 	if err != nil {
 		return nil, err
 	}
-	coins, err := b.coins.Coins(ctx, addresses)
-	if err != nil {
-		return nil, err
-	}
-	return tw.MarshalUTXOs(coins)
+	return tw.MarshalUTXOs(append(spendable, pending...))
 }
 
 func (b *lightBackend) Transfer(

--- a/sidechain-orchestrator/sidechain/thunder/lightbackend_test.go
+++ b/sidechain-orchestrator/sidechain/thunder/lightbackend_test.go
@@ -54,6 +54,28 @@ func (f *fakeIndex) fund(address, txid string, valueSats int64) {
 	f.funded[address] = true
 }
 
+// fundPending gives one address a coin no block carries yet.
+func (f *fakeIndex) fundPending(address, txid string, valueSats int64) {
+	f.fundPendingAt(address, txid, 0, valueSats)
+}
+
+func (f *fakeIndex) fundPendingAt(address, txid string, vout, valueSats int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.utxos[address] = `[{"txid":"` + txid + `","vout":` + itoa(vout) + `,"value":` +
+		itoa(valueSats) + `,"outpoint_kind":"regular","content_type":"value",
+		"status":{"confirmed":false,"block_height":null,"block_time":null}}]`
+	f.funded[address] = true
+}
+
+// spend takes one address back to holding nothing, the way the index answers
+// once a transaction takes the coin.
+func (f *fakeIndex) spend(address string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.utxos[address] = "[]"
+}
+
 func (f *fakeIndex) submitted() []json.RawMessage {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -412,5 +434,145 @@ func TestLightChangeAvoidsTheReceiveAddressAfterARestart(t *testing.T) {
 			t.Errorf("change landed on the receive address %q after a restart",
 				output.Address)
 		}
+	}
+}
+
+// A payment the chain has not mined yet must show at once. It counts in the
+// total and not in what the wallet can spend.
+func TestLightBalanceCountsAPendingCoin(t *testing.T) {
+	index := newFakeIndex(t)
+	h, addresses := lightHandler(t, index)
+	index.fund(addresses[0].String(), strings.Repeat("aa", 32), 7000)
+	index.fundPending(addresses[1].String(), strings.Repeat("bb", 32), 2500)
+
+	resp, err := h.GetBalance(context.Background(),
+		connect.NewRequest(&pb.GetBalanceRequest{}))
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if resp.Msg.TotalSats != 9500 {
+		t.Errorf("total = %d, want 9500", resp.Msg.TotalSats)
+	}
+	if resp.Msg.AvailableSats != 7000 {
+		t.Errorf("available = %d, want the 7000 the chain carries", resp.Msg.AvailableSats)
+	}
+}
+
+// The UTXO list carries a pending coin too, so the wallet shows the money
+// before a block arrives.
+func TestLightUTXOsCarryAPendingCoin(t *testing.T) {
+	index := newFakeIndex(t)
+	h, addresses := lightHandler(t, index)
+	index.fund(addresses[0].String(), strings.Repeat("aa", 32), 4200)
+	index.fundPending(addresses[1].String(), strings.Repeat("bb", 32), 800)
+
+	resp, err := h.GetWalletUtxos(context.Background(),
+		connect.NewRequest(&pb.GetWalletUtxosRequest{}))
+	if err != nil {
+		t.Fatalf("utxos: %v", err)
+	}
+	var rows []struct {
+		Output struct {
+			Content struct {
+				Value uint64 `json:"Value"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(resp.Msg.UtxosJson), &rows); err != nil {
+		t.Fatalf("read the utxo json %s: %v", resp.Msg.UtxosJson, err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d utxos, want both coins", len(rows))
+	}
+	var sum uint64
+	for _, row := range rows {
+		sum += row.Output.Content.Value
+	}
+	if sum != 5000 {
+		t.Errorf("the coins hold %d sats, want 5000", sum)
+	}
+}
+
+// The wallet holds its own change until the index catches up, and the index
+// then reports the same coin. Counting it in both places doubles the balance.
+func TestLightBalanceCountsItsOwnChangeOneTime(t *testing.T) {
+	index := newFakeIndex(t)
+	h, addresses := lightHandler(t, index)
+	index.fund(addresses[0].String(), strings.Repeat("aa", 32), 10000)
+
+	// The payment leaves the wallet, so the change is all that comes back.
+	if _, err := h.Transfer(context.Background(), connect.NewRequest(&pb.TransferRequest{
+		Address:    "3nRfgx4Lbhxas4P2J2CpCQ98Srsr",
+		AmountSats: 4000,
+		FeeSats:    500,
+	})); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+
+	// The index catches up: the coin the wallet spent is gone, and the change
+	// it made reads as unconfirmed. The wallet still holds that change too.
+	index.spend(addresses[0].String())
+	index.fundPendingAt(addresses[2].String(), strings.Repeat("ab", 32), 1, 5500)
+
+	resp, err := h.GetBalance(context.Background(),
+		connect.NewRequest(&pb.GetBalanceRequest{}))
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if resp.Msg.TotalSats != 5500 {
+		t.Errorf("total = %d, want the change one time: 5500", resp.Msg.TotalSats)
+	}
+	// No block carries the change, so the wallet waits for it.
+	if resp.Msg.AvailableSats != 0 {
+		t.Errorf("available = %d, want 0", resp.Msg.AvailableSats)
+	}
+}
+
+// The index lags a broadcast by one pass: it still offers the coin the wallet
+// spent, and it does not name the change yet. A balance must show neither the
+// spent coin nor a gap where the change is.
+func TestLightBalanceFollowsABroadcastTheIndexHasNotRead(t *testing.T) {
+	index := newFakeIndex(t)
+	h, addresses := lightHandler(t, index)
+	index.fund(addresses[0].String(), strings.Repeat("aa", 32), 10000)
+
+	if _, err := h.Transfer(context.Background(), connect.NewRequest(&pb.TransferRequest{
+		Address:    "3nRfgx4Lbhxas4P2J2CpCQ98Srsr",
+		AmountSats: 4000,
+		FeeSats:    500,
+	})); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+
+	resp, err := h.GetBalance(context.Background(),
+		connect.NewRequest(&pb.GetBalanceRequest{}))
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if resp.Msg.TotalSats != 5500 {
+		t.Errorf("total = %d, want the 5500 change", resp.Msg.TotalSats)
+	}
+	if resp.Msg.AvailableSats != 0 {
+		t.Errorf("available = %d, want 0: the wallet spent its only mined coin",
+			resp.Msg.AvailableSats)
+	}
+
+	utxos, err := h.GetWalletUtxos(context.Background(),
+		connect.NewRequest(&pb.GetWalletUtxosRequest{}))
+	if err != nil {
+		t.Fatalf("utxos: %v", err)
+	}
+	var rows []struct {
+		Output struct {
+			Content struct {
+				Value uint64 `json:"Value"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(utxos.Msg.UtxosJson), &rows); err != nil {
+		t.Fatalf("read the utxo json %s: %v", utxos.Msg.UtxosJson, err)
+	}
+	if len(rows) != 1 || rows[0].Output.Content.Value != 5500 {
+		t.Errorf("utxos = %+v, want the change alone", rows)
 	}
 }

--- a/sidechain-orchestrator/sidechain/thunderwallet/indexsource.go
+++ b/sidechain-orchestrator/sidechain/thunderwallet/indexsource.go
@@ -5,9 +5,15 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
 )
+
+// readAhead is how many addresses the wallet reads at the same time. A balance
+// covers the whole derived window, and one address after another costs a round
+// trip each.
+const readAhead = 8
 
 // IndexCoins reads spendable coins from an Esplora index. This is the
 // light-mode half of the wallet's low-level seams, and it runs no node.
@@ -22,48 +28,92 @@ func NewIndexCoins(client *sidechainesplora.Client) *IndexCoins {
 
 // Coins lists what a set of addresses can spend.
 func (i *IndexCoins) Coins(ctx context.Context, addresses []Address) ([]Coin, error) {
-	var out []Coin
-	for _, address := range addresses {
-		utxos, err := i.client.AddressUTXOs(ctx, address.String())
-		if err != nil {
-			return nil, fmt.Errorf("read utxos for %s: %w", address, err)
-		}
-		for _, utxo := range utxos {
-			// A withdrawal output is leaving the chain. Counting it inflates
-			// the balance, and its leaf hash covers a withdrawal rather than a
-			// value, so spending it builds a transaction no node accepts.
-			if !utxo.Spendable() {
-				continue
-			}
-			// A coin the chain has not mined yet is neither a balance nor a
-			// coin to spend.
-			if !utxo.Status.Confirmed {
-				continue
-			}
-			outpoint, err := outPointFromIndex(utxo)
-			if err != nil {
-				return nil, err
-			}
-			if utxo.Value < 0 {
-				return nil, fmt.Errorf("%s holds a coin worth %d sats", address, utxo.Value)
-			}
-			value := uint64(utxo.Value)
-			leaf, err := LeafHash(outpoint, Output{
-				Address: address,
-				Content: Content{Value: &value},
-			})
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, Coin{
-				OutPoint:  outpoint,
-				LeafHash:  leaf,
-				Address:   address,
-				ValueSats: value,
-			})
-		}
+	confirmed, _, err := i.Split(ctx, addresses)
+	return confirmed, err
+}
+
+// Split lists what a set of addresses holds, in two halves: the coins a block
+// carries, and the coins no block carries yet. A wallet spends the first half
+// and shows both.
+func (i *IndexCoins) Split(
+	ctx context.Context, addresses []Address,
+) (confirmed, pending []Coin, err error) {
+	mined := make([][]Coin, len(addresses))
+	waiting := make([][]Coin, len(addresses))
+	errs := make([]error, len(addresses))
+
+	var wg sync.WaitGroup
+	limit := make(chan struct{}, readAhead)
+	for at, address := range addresses {
+		wg.Add(1)
+		limit <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-limit }()
+			mined[at], waiting[at], errs[at] = i.readAddress(ctx, address)
+		}()
 	}
-	return out, nil
+	wg.Wait()
+
+	for at, err := range errs {
+		if err != nil {
+			return nil, nil, err
+		}
+		confirmed = append(confirmed, mined[at]...)
+		pending = append(pending, waiting[at]...)
+	}
+	return confirmed, pending, nil
+}
+
+func (i *IndexCoins) readAddress(
+	ctx context.Context, address Address,
+) (confirmed, pending []Coin, err error) {
+	utxos, err := i.client.AddressUTXOs(ctx, address.String())
+	if err != nil {
+		return nil, nil, fmt.Errorf("read utxos for %s: %w", address, err)
+	}
+	for _, utxo := range utxos {
+		// A withdrawal output is leaving the chain. Counting it inflates the
+		// balance, and its leaf hash covers a withdrawal rather than a value,
+		// so spending it builds a transaction no node accepts.
+		if !utxo.Spendable() {
+			continue
+		}
+		coin, err := newCoin(address, utxo)
+		if err != nil {
+			return nil, nil, err
+		}
+		if utxo.Status.Confirmed {
+			confirmed = append(confirmed, coin)
+			continue
+		}
+		pending = append(pending, coin)
+	}
+	return confirmed, pending, nil
+}
+
+func newCoin(address Address, utxo sidechainesplora.UTXO) (Coin, error) {
+	outpoint, err := outPointFromIndex(utxo)
+	if err != nil {
+		return Coin{}, err
+	}
+	if utxo.Value < 0 {
+		return Coin{}, fmt.Errorf("%s holds a coin worth %d sats", address, utxo.Value)
+	}
+	value := uint64(utxo.Value)
+	leaf, err := LeafHash(outpoint, Output{
+		Address: address,
+		Content: Content{Value: &value},
+	})
+	if err != nil {
+		return Coin{}, err
+	}
+	return Coin{
+		OutPoint:  outpoint,
+		LeafHash:  leaf,
+		Address:   address,
+		ValueSats: value,
+	}, nil
 }
 
 // outPointFromIndex reads the outpoint an index row names. A deposit txid is a

--- a/sidechain-orchestrator/sidechain/thunderwallet/indexsource_test.go
+++ b/sidechain-orchestrator/sidechain/thunderwallet/indexsource_test.go
@@ -2,8 +2,10 @@ package thunderwallet
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
@@ -72,5 +74,94 @@ func TestIndexCoinsAcceptsAnOlderIndex(t *testing.T) {
 	}
 	if len(coins) != 1 {
 		t.Fatalf("the wallet holds %d coins, want 1", len(coins))
+	}
+}
+
+// A coin the chain has not mined yet is not spendable, and the wallet reads it
+// through Pending instead.
+func TestIndexCoinsSplitsTheUnconfirmedCoins(t *testing.T) {
+	const address = "3nRfgx4Lbhxas4P2J2CpCQ98Srsr"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/address/"+address+"/utxo" {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		_, _ = w.Write([]byte(`[
+			{"txid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","vout":0,"value":6000,"outpoint_kind":"regular",
+			 "content_type":"value",
+			 "status":{"confirmed":true,"block_height":1,"block_time":1}},
+			{"txid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","vout":1,"value":1500,"outpoint_kind":"regular",
+			 "content_type":"value",
+			 "status":{"confirmed":false,"block_height":null,"block_time":null}}]`))
+	}))
+	defer server.Close()
+
+	parsed, err := ParseAddress(address)
+	if err != nil {
+		t.Fatalf("read the address: %v", err)
+	}
+	source := NewIndexCoins(sidechainesplora.New(server.URL))
+
+	confirmed, pending, err := source.Split(context.Background(), []Address{parsed})
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if len(confirmed) != 1 || confirmed[0].ValueSats != 6000 {
+		t.Errorf("spendable coins = %+v, want the mined one alone", confirmed)
+	}
+	if len(pending) != 1 || pending[0].ValueSats != 1500 {
+		t.Errorf("pending coins = %+v, want the unmined one alone", pending)
+	}
+
+	coins, err := source.Coins(context.Background(), []Address{parsed})
+	if err != nil {
+		t.Fatalf("coins: %v", err)
+	}
+	if len(coins) != 1 || coins[0].ValueSats != 6000 {
+		t.Errorf("coins = %+v, want the spendable half", coins)
+	}
+}
+
+// A wallet reads a wide window, so the addresses must not queue behind each
+// other. Every answer must still land under its own address.
+func TestIndexCoinsReadsEveryAddress(t *testing.T) {
+	const count = 20
+	ring, err := DeriveKeyring(make([]byte, 64), count)
+	if err != nil {
+		t.Fatalf("derive the keyring: %v", err)
+	}
+	addresses := ring.Addresses()
+
+	values := make(map[string]int64, count)
+	for i, address := range addresses {
+		values[address.String()] = int64(1000 + i)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/address/"), "/utxo")
+		value, ok := values[name]
+		if !ok {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		_, _ = fmt.Fprintf(w, `[{"txid":"%s","vout":0,"value":%d,
+			"outpoint_kind":"regular","content_type":"value",
+			"status":{"confirmed":true,"block_height":1,"block_time":1}}]`,
+			strings.Repeat("aa", 32), value)
+	}))
+	defer server.Close()
+
+	coins, err := NewIndexCoins(sidechainesplora.New(server.URL)).
+		Coins(context.Background(), addresses)
+	if err != nil {
+		t.Fatalf("coins: %v", err)
+	}
+	if len(coins) != count {
+		t.Fatalf("read %d coins, want %d", len(coins), count)
+	}
+	for _, coin := range coins {
+		if want := values[coin.Address.String()]; int64(coin.ValueSats) != want {
+			t.Errorf("%s holds %d sats, want %d", coin.Address, coin.ValueSats, want)
+		}
 	}
 }

--- a/sidechain-orchestrator/sidechain/thunderwallet/reserve.go
+++ b/sidechain-orchestrator/sidechain/thunderwallet/reserve.go
@@ -61,17 +61,7 @@ func (r *ReservedCoins) Coins(ctx context.Context, addresses []Address) ([]Coin,
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	now := time.Now()
-	for key, at := range r.spent {
-		if now.Sub(at) > reserveHold {
-			delete(r.spent, key)
-		}
-	}
-	for key, pending := range r.change {
-		if now.Sub(pending.at) > reserveHold {
-			delete(r.change, key)
-		}
-	}
+	r.forget(time.Now())
 
 	wanted := make(map[Address]bool, len(addresses))
 	for _, address := range addresses {
@@ -99,6 +89,65 @@ func (r *ReservedCoins) Coins(ctx context.Context, addresses []Address) ([]Coin,
 		out = append(out, pending.coin)
 	}
 	return out, nil
+}
+
+// Adjust applies what a broadcast changed to the two halves of a wallet read:
+// the coins a block carries, and the coins it does not.
+//
+// A coin the wallet spent leaves both halves, because the index offers it until
+// it syncs. The change the index has not read yet joins the second half, where
+// a wallet shows it and does not spend it.
+func (r *ReservedCoins) Adjust(
+	addresses []Address, confirmed, pending []Coin,
+) (spendable, waiting []Coin) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.forget(time.Now())
+
+	wanted := make(map[Address]bool, len(addresses))
+	for _, address := range addresses {
+		wanted[address] = true
+	}
+
+	held := make(map[OutPoint]bool, len(confirmed)+len(pending))
+	keep := func(coins []Coin) []Coin {
+		out := make([]Coin, 0, len(coins))
+		for _, coin := range coins {
+			if _, spent := r.spent[coin.OutPoint]; spent {
+				continue
+			}
+			held[coin.OutPoint] = true
+			out = append(out, coin)
+		}
+		return out
+	}
+	spendable = keep(confirmed)
+	waiting = keep(pending)
+
+	for key, change := range r.change {
+		if held[key] || !wanted[change.coin.Address] {
+			continue
+		}
+		if _, spent := r.spent[key]; spent {
+			continue
+		}
+		waiting = append(waiting, change.coin)
+	}
+	return spendable, waiting
+}
+
+// forget drops every hold that outlived reserveHold. The caller holds the lock.
+func (r *ReservedCoins) forget(now time.Time) {
+	for key, at := range r.spent {
+		if now.Sub(at) > reserveHold {
+			delete(r.spent, key)
+		}
+	}
+	for key, pending := range r.change {
+		if now.Sub(pending.at) > reserveHold {
+			delete(r.change, key)
+		}
+	}
 }
 
 var (

--- a/sidechain-orchestrator/sidechain/thunderwallet/reserve_test.go
+++ b/sidechain-orchestrator/sidechain/thunderwallet/reserve_test.go
@@ -164,3 +164,65 @@ func (b *recordingBroadcaster) Broadcast(
 	out[0] = byte(len(b.sent))
 	return out, nil
 }
+
+// The index lags a broadcast by one pass. A wallet read must still drop the
+// coin the wallet spent, and must still carry the change it made.
+func TestReservedCoinsAdjustsBothHalves(t *testing.T) {
+	var mine Address
+	mine[0] = 0x11
+
+	spent := coinAt(0, 5000)
+	spent.Address = mine
+	change := coinAt(1, 4000)
+	change.Address = mine
+
+	source := NewReservedCoins(&listCoins{})
+	source.Reserve([]OutPoint{spent.OutPoint}, []Coin{change})
+
+	confirmed, pending := source.Adjust([]Address{mine}, []Coin{spent}, nil)
+	if len(confirmed) != 0 {
+		t.Errorf("the spent coin is still spendable: %+v", confirmed)
+	}
+	if len(pending) != 1 || pending[0].OutPoint != change.OutPoint {
+		t.Fatalf("pending = %+v, want the change alone", pending)
+	}
+}
+
+// The index reads the change one pass later. The wallet holds it too, and
+// counting it twice doubles a balance.
+func TestReservedCoinsAdjustsTheChangeOneTime(t *testing.T) {
+	var mine Address
+	mine[0] = 0x11
+
+	change := coinAt(1, 4000)
+	change.Address = mine
+
+	source := NewReservedCoins(&listCoins{})
+	source.Reserve(nil, []Coin{change})
+
+	confirmed, pending := source.Adjust([]Address{mine}, nil, []Coin{change})
+	if len(confirmed) != 0 {
+		t.Errorf("confirmed = %+v, want nothing a block carries", confirmed)
+	}
+	if len(pending) != 1 {
+		t.Errorf("pending holds %d coins, want the change one time", len(pending))
+	}
+}
+
+// Change for another wallet's address belongs to that wallet, not this one.
+func TestReservedCoinsAdjustsOnlyTheAddressesItReads(t *testing.T) {
+	var mine, theirs Address
+	mine[0] = 0x11
+	theirs[0] = 0x22
+
+	payment := coinAt(0, 7000)
+	payment.Address = theirs
+
+	source := NewReservedCoins(&listCoins{})
+	source.Reserve(nil, []Coin{payment})
+
+	confirmed, pending := source.Adjust([]Address{mine}, nil, nil)
+	if len(confirmed) != 0 || len(pending) != 0 {
+		t.Errorf("read %+v and %+v, want nothing", confirmed, pending)
+	}
+}


### PR DESCRIPTION
A light wallet dropped every unconfirmed coin, so a payment showed only after a block. The index now serves the unconfirmed set, so the wallet counts it: the total carries it, and what the wallet can spend does not.

One read of each address fills both halves. A balance over the derived window took 4.1 s and now takes 0.32 s.

Measured on alphanet, with clanker in light mode: the wallet shows a payment 0.5 s after the node accepts it. Needs octobocto/drivechain-esplora#2.