### PR TITLE
cli: read a thunder address and its transactions

### DIFF
--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -947,10 +947,19 @@ func createSidechainCommands() []*cli.Command {
 		createGenericSidechainCommand("bitnames", newBitnamesClient),
 		createGenericSidechainCommand("coinshift", newCoinshiftClient),
 		createGenericSidechainCommand("photon", newPhotonClient),
-		createGenericSidechainCommand("thunder", newThunderClient),
+		thunderCommand(),
 		createGenericSidechainCommand("truthcoin", newTruthcoinClient),
 		createGenericSidechainCommand("zside", newZsideClient),
 	}
+}
+
+// thunderCommand adds the reads only thunder answers today: an address to
+// receive on, and the transactions that touched the wallet.
+func thunderCommand() *cli.Command {
+	cmd := createGenericSidechainCommand("thunder", newThunderClient)
+	cmd.Subcommands = append(cmd.Subcommands,
+		thunderAddressCommand, thunderTransactionsCommand)
+	return cmd
 }
 
 // SidechainClient interface for all sidechain RPC clients

--- a/sidechain-orchestrator/commands/thunder.go
+++ b/sidechain-orchestrator/commands/thunder.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"fmt"
+	"net/http"
+
+	"connectrpc.com/connect"
+	"github.com/urfave/cli/v2"
+
+	thunderpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/thunder/v1"
+	thunderrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/thunder/v1/thunderv1connect"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/localauth"
+)
+
+// newThunderService talks to the thunder wallet drivechaind serves. Light mode
+// runs no thunder node, so a command reads the wallet here rather than at a
+// node port.
+func newThunderService(cctx *cli.Context) thunderrpc.ThunderServiceClient {
+	return thunderrpc.NewThunderServiceClient(
+		http.DefaultClient,
+		fmt.Sprintf("http://%s", cctx.String("rpcserver")),
+		connect.WithGRPC(),
+		connect.WithInterceptors(localauth.Interceptor(cookieDir(cctx))),
+	)
+}
+
+var thunderAddressCommand = &cli.Command{
+	Name:  "address",
+	Usage: "Show an address to receive on",
+	Action: func(cctx *cli.Context) error {
+		resp, err := newThunderService(cctx).GetNewAddress(
+			cctx.Context, connect.NewRequest(&thunderpb.GetNewAddressRequest{}))
+		if err != nil {
+			return err
+		}
+		fmt.Println(resp.Msg.Address)
+		return nil
+	},
+}
+
+var thunderTransactionsCommand = &cli.Command{
+	Name:    "transactions",
+	Aliases: []string{"txs"},
+	Usage:   "List the transactions that touched this wallet",
+	Action: func(cctx *cli.Context) error {
+		resp, err := newThunderService(cctx).ListWalletTransactions(
+			cctx.Context, connect.NewRequest(&thunderpb.ListWalletTransactionsRequest{}))
+		if err != nil {
+			return err
+		}
+		if len(resp.Msg.Transactions) == 0 {
+			fmt.Println("this wallet holds no transactions")
+			return nil
+		}
+		for _, tx := range resp.Msg.Transactions {
+			fmt.Printf("%s  %s BTC  %s\n",
+				tx.Txid, satsToBtcInt(tx.ValueSats), txState(tx, resp.Msg.TipHeight))
+		}
+		return nil
+	},
+}
+
+// txState says where one transaction sits, and how many blocks cover it.
+//
+// A node keeps no height for a coin it holds, so a full-mode row reads as
+// confirmed at height zero. Such a row names no height and no depth, because
+// both would be invented.
+func txState(tx *thunderpb.SidechainWalletTransaction, tipHeight uint32) string {
+	switch {
+	case !tx.Confirmed:
+		return "pending"
+	case tx.BlockHeight == 0:
+		return "confirmed"
+	}
+	depth := 0
+	if tipHeight >= tx.BlockHeight {
+		depth = int(tipHeight-tx.BlockHeight) + 1
+	}
+	return fmt.Sprintf("height %d (%d confirmations)", tx.BlockHeight, depth)
+}

--- a/sidechain-orchestrator/commands/thunder_test.go
+++ b/sidechain-orchestrator/commands/thunder_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"testing"
+
+	thunderpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/thunder/v1"
+)
+
+func TestTxStateReadsTheChain(t *testing.T) {
+	tests := []struct {
+		name string
+		tx   *thunderpb.SidechainWalletTransaction
+		tip  uint32
+		want string
+	}{
+		{
+			name: "no block carries it",
+			tx:   &thunderpb.SidechainWalletTransaction{},
+			tip:  24,
+			want: "pending",
+		},
+		{
+			name: "the tip carries it",
+			tx:   &thunderpb.SidechainWalletTransaction{Confirmed: true, BlockHeight: 24},
+			tip:  24,
+			want: "height 24 (1 confirmations)",
+		},
+		{
+			name: "three blocks cover it",
+			tx:   &thunderpb.SidechainWalletTransaction{Confirmed: true, BlockHeight: 22},
+			tip:  24,
+			want: "height 22 (3 confirmations)",
+		},
+		{
+			// A node reports no height for the coins it holds, so a full-mode
+			// row carries none. A depth over height zero would be invented.
+			name: "the answer names no height",
+			tx:   &thunderpb.SidechainWalletTransaction{Confirmed: true},
+			tip:  24,
+			want: "confirmed",
+		},
+		{
+			// The index lags the node, so a block can name a height above the
+			// tip the same answer carries.
+			name: "the tip is behind the block",
+			tx:   &thunderpb.SidechainWalletTransaction{Confirmed: true, BlockHeight: 25},
+			tip:  24,
+			want: "height 25 (0 confirmations)",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := txState(test.tx, test.tip); got != test.want {
+				t.Errorf("txState = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The CLI answered a thunder balance and nothing else, so an address and a history needed a hand written curl call.

Two subcommands now read them through drivechaind: 'thunder address' and 'thunder transactions'. Light mode runs no node, so both go to the orchestrator.