### PR TITLE
bitwindow: add date filter to wallet/utxo table

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_overview.dart
+++ b/bitwindow/lib/pages/wallet/wallet_overview.dart
@@ -227,8 +227,7 @@ class _TransactionTableState extends State<TransactionTable> {
       builder: (BuildContext context, BoxConstraints constraints) {
         return SailCard(
           title: 'Wallet Transaction History',
-          titleTooltip:
-              'This transaction list contains all your wallet transactions. Sends, receives, and sidechain-interaction transactions.',
+          titleTooltip: 'This transaction list contains all your wallet transactions. Sends, receives, and sidechain-interaction transactions.',
           bottomPadding: false,
           widgetHeaderEnd: SailButton(
             label: 'Export CSV',
@@ -264,7 +263,7 @@ class _TransactionTableState extends State<TransactionTable> {
                           onSort: () => onSort('date'),
                           filterWidget: SailTooltip(
                             message: 'Filter by date range',
-                            child: DateFilter(model: widget.model),
+                            child: DateFilter(onPickedRange: (dateRange) => widget.model.addFilter(dateRange)),
                           ),
                         ),
                         SailTableHeaderCell(
@@ -411,7 +410,7 @@ class _TransactionTableState extends State<TransactionTable> {
                         }
                         onSort(column);
                       },
-                      onDoubleTap: (rowId) => showTransactionDetails(context, rowId),
+                      onDoubleTap: (rowId) async => await showTransactionDetails(context, rowId),
                     ),
                   ),
                 ),
@@ -554,13 +553,8 @@ class OverviewViewModel extends BaseViewModel with ChangeTrackingMixin {
     notifyIfChanged();
   }
 
-  void setDateRange(({DateTime start, DateTime end})? range) {
+  void addFilter(({DateTime start, DateTime end})? range) {
     dateRange = range;
-    notifyListeners();
-  }
-
-  void clearDateFilter() {
-    dateRange = null;
     notifyListeners();
   }
 
@@ -797,105 +791,6 @@ class WalletStats extends ViewModelWidget<OverviewViewModel> {
       loading: LoadingDetails(
         enabled: viewModel.loading,
         description: 'Waiting for enforcer to boot and wallet to sync..',
-      ),
-    );
-  }
-}
-
-class DateRangeFilterWidget extends StatelessWidget {
-  final OverviewViewModel model;
-
-  const DateRangeFilterWidget({
-    super.key,
-    required this.model,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        final pickedRange = await showSailDateRangePicker(
-          context: context,
-          firstDate: DateTime(2009, 1, 3),
-          lastDate: DateTime.now().add(const Duration(days: 365)),
-          initialRange: model.dateRange,
-        );
-
-        if (pickedRange != null) {
-          model.setDateRange(pickedRange);
-        }
-      },
-      child: Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: SailStyleValues.padding16,
-          vertical: SailStyleValues.padding12,
-        ),
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: context.sailTheme.colors.divider,
-            width: 1,
-          ),
-          borderRadius: BorderRadius.circular(4),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SailSVG.icon(SailSVGAsset.iconCalendar, width: 16),
-            const SizedBox(width: SailStyleValues.padding08),
-            SailText.primary13(
-              model.dateRange == null
-                  ? 'Select date range'
-                  : '${DateFormat('MMM dd, yyyy').format(model.dateRange!.start)} - ${DateFormat('MMM dd, yyyy').format(model.dateRange!.end)}',
-            ),
-            if (model.dateRange != null) ...[
-              const SizedBox(width: SailStyleValues.padding08),
-              SailTappable(
-                onTap: () async => model.clearDateFilter(),
-                child: SailSVG.fromAsset(
-                  SailSVGAsset.x,
-                  width: 16,
-                  color: context.sailTheme.colors.text,
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class DateFilter extends StatelessWidget {
-  final OverviewViewModel model;
-
-  const DateFilter({
-    super.key,
-    required this.model,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        if (model.dateRange != null) {
-          model.setDateRange(null);
-          return;
-        }
-        final pickedRange = await showSailDateRangePicker(
-          context: context,
-          firstDate: DateTime(2009, 1, 3),
-          lastDate: DateTime.now().add(const Duration(days: 365)),
-          initialRange: model.dateRange,
-        );
-
-        if (pickedRange != null) {
-          model.setDateRange(pickedRange);
-        }
-      },
-      child: SailSVG.icon(
-        width: 16,
-        model.dateRange == null ? SailSVGAsset.filter : SailSVGAsset.filterX,
-        color: model.dateRange == null ? context.sailTheme.colors.textSecondary : context.sailTheme.colors.orange,
       ),
     );
   }

--- a/bitwindow/lib/pages/wallet/wallet_overview.dart
+++ b/bitwindow/lib/pages/wallet/wallet_overview.dart
@@ -227,7 +227,8 @@ class _TransactionTableState extends State<TransactionTable> {
       builder: (BuildContext context, BoxConstraints constraints) {
         return SailCard(
           title: 'Wallet Transaction History',
-          titleTooltip: 'This transaction list contains all your wallet transactions. Sends, receives, and sidechain-interaction transactions.',
+          titleTooltip:
+              'This transaction list contains all your wallet transactions. Sends, receives, and sidechain-interaction transactions.',
           bottomPadding: false,
           widgetHeaderEnd: SailButton(
             label: 'Export CSV',

--- a/bitwindow/lib/pages/wallet/wallet_utxos.dart
+++ b/bitwindow/lib/pages/wallet/wallet_utxos.dart
@@ -460,7 +460,6 @@ class _UTXOTableState extends State<UTXOTable> {
                           SailSVGAsset.snowflake,
                           width: 14,
                           color: theme.colors.info,
-                          alignment: Alignment.center,
                         )
                       : const SizedBox(width: 14),
                 ),

--- a/bitwindow/lib/pages/wallet/wallet_utxos.dart
+++ b/bitwindow/lib/pages/wallet/wallet_utxos.dart
@@ -433,7 +433,11 @@ class _UTXOTableState extends State<UTXOTable> {
             getRowId: (index) => sortedEntries[index].output,
             headerBuilder: (context) => [
               SailTableHeaderCell(name: '', onSort: () => onSort('frozen')),
-              SailTableHeaderCell(name: 'Date', onSort: () => onSort('date')),
+              SailTableHeaderCell(
+                name: 'Date',
+                onSort: () => onSort('date'),
+                filterWidget: DateFilter(onPickedRange: (dateRange) => widget.model.addFilter(dateRange)),
+              ),
               SailTableHeaderCell(name: 'Output', onSort: () => onSort('output')),
               SailTableHeaderCell(name: 'Address', onSort: () => onSort('address')),
               SailTableHeaderCell(name: 'Path', onSort: () => onSort('path')),
@@ -546,6 +550,14 @@ class _UTXOTableState extends State<UTXOTable> {
 class LatestUTXOsViewModel extends BaseViewModel with ChangeTrackingMixin {
   final TransactionProvider _txProvider = GetIt.I<TransactionProvider>();
   final EnforcerRPC _enforcerRPC = GetIt.I<EnforcerRPC>();
+  String sortColumn = 'date';
+  bool sortAscending = true;
+  ({DateTime end, DateTime start})? dateFilter;
+
+  LatestUTXOsViewModel() {
+    initChangeTracker();
+    _txProvider.addListener(_onChange);
+  }
 
   List<UnspentOutput> get entries {
     if (loading) {
@@ -567,16 +579,16 @@ class LatestUTXOsViewModel extends BaseViewModel with ChangeTrackingMixin {
         ),
       ];
     }
-
-    return _txProvider.utxos.toList();
-  }
-
-  String sortColumn = 'date';
-  bool sortAscending = true;
-
-  LatestUTXOsViewModel() {
-    initChangeTracker();
-    _txProvider.addListener(_onChange);
+    var utxos = _txProvider.utxos.where((utxo) {
+      if (dateFilter != null) {
+        final receivedAt = utxo.receivedAt.toDateTime();
+        if (receivedAt.isBefore(dateFilter!.start) || receivedAt.isAfter(dateFilter!.end)) {
+          return false;
+        }
+      }
+      return true;
+    }).toList();
+    return utxos;
   }
 
   void _onChange() {
@@ -591,6 +603,11 @@ class LatestUTXOsViewModel extends BaseViewModel with ChangeTrackingMixin {
   void dispose() {
     _txProvider.removeListener(_onChange);
     super.dispose();
+  }
+
+  void addFilter(({DateTime end, DateTime start})? range) {
+    dateFilter = range;
+    notifyListeners();
   }
 }
 

--- a/bitwindow/lib/pages/wallet/wallet_utxos.dart
+++ b/bitwindow/lib/pages/wallet/wallet_utxos.dart
@@ -453,17 +453,24 @@ class _UTXOTableState extends State<UTXOTable> {
 
               return [
                 SailTableCell(
+                  width: 14,
                   value: '',
                   child: isFrozen
-                      ? SailSVG.fromAsset(SailSVGAsset.snowflake, width: 14, color: theme.colors.info)
+                      ? SailSVG.icon(
+                          SailSVGAsset.snowflake,
+                          width: 14,
+                          color: theme.colors.info,
+                          alignment: Alignment.center,
+                        )
                       : const SizedBox(width: 14),
                 ),
                 SailTableCell(
                   value: utxo.hasReceivedAt() ? formatDate(utxo.receivedAt.toDateTime().toLocal()) : '—',
                 ),
                 SailTableCell(
-                  value: '${utxo.output.substring(0, 6)}..:${utxo.output.split(':').last}',
+                  value: '',
                   copyValue: utxo.output,
+                  child: UTXO.toView(utxo),
                 ),
                 SailTableCell(
                   value: utxo.address,

--- a/bitwindow/lib/pages/wallet/wallet_utxos.dart
+++ b/bitwindow/lib/pages/wallet/wallet_utxos.dart
@@ -587,8 +587,11 @@ class LatestUTXOsViewModel extends BaseViewModel with ChangeTrackingMixin {
     }
     var utxos = _txProvider.utxos.where((utxo) {
       if (dateFilter != null) {
+        final start = DateTime(dateFilter!.start.year, dateFilter!.start.month, dateFilter!.start.day);
+        final end = DateTime(dateFilter!.end.year, dateFilter!.end.month, dateFilter!.end.day, 23, 59, 59);
+
         final receivedAt = utxo.receivedAt.toDateTime();
-        if (receivedAt.isBefore(dateFilter!.start) || receivedAt.isAfter(dateFilter!.end)) {
+        if (receivedAt.isBefore(start) || receivedAt.isAfter(end)) {
           return false;
         }
       }

--- a/sail_ui/lib/widgets/components/utxo.dart
+++ b/sail_ui/lib/widgets/components/utxo.dart
@@ -1,5 +1,9 @@
 import 'dart:convert';
 
+import 'package:flutter/widgets.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+import 'package:sail_ui/widgets/core/sail_text.dart';
+
 class UTXO {
   final String txid;
   final int vout;
@@ -79,4 +83,14 @@ class UTXO {
     'time': time,
     'raw': raw,
   };
+
+  static Widget toView(UnspentOutput utxo) {
+    final oPoint = utxo.output.split(':');
+    return Row(
+      children: [
+        Expanded(child: SailText.secondary12(oPoint[0], overflow: TextOverflow.ellipsis)),
+        Text(':${oPoint[1]}'),
+      ],
+    );
+  }
 }

--- a/sail_ui/lib/widgets/containers/sail_date_picker.dart
+++ b/sail_ui/lib/widgets/containers/sail_date_picker.dart
@@ -61,3 +61,46 @@ Widget _themedPickerBuilder(BuildContext context, Widget? child) {
     child: child!,
   );
 }
+
+class DateFilter extends StatefulWidget {
+  final Function(({DateTime start, DateTime end})? range) onPickedRange;
+
+  const DateFilter({super.key, required this.onPickedRange});
+
+  @override
+  State<StatefulWidget> createState() => _DateFilterState();
+}
+
+class _DateFilterState extends State<DateFilter> {
+  ({DateTime end, DateTime start})? _pickedRange;
+  bool filterActive = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () async {
+        if (filterActive) {
+          filterActive = false;
+          widget.onPickedRange.call(null);
+          return;
+        }
+        _pickedRange = await showSailDateRangePicker(
+          context: context,
+          firstDate: DateTime(2009, 1, 3),
+          lastDate: DateTime.now().add(const Duration(days: 365)),
+          initialRange: _pickedRange,
+        );
+
+        if (_pickedRange != null) {
+          widget.onPickedRange.call(_pickedRange);
+          filterActive = true;
+        }
+      },
+      child: SailSVG.icon(
+        filterActive ? SailSVGAsset.filterX : SailSVGAsset.filter,
+        color: filterActive ? context.sailTheme.colors.orange : context.sailTheme.colors.textSecondary,
+        width: 16,
+      ),
+    );
+  }
+}

--- a/sail_ui/lib/widgets/core/sail_svg.dart
+++ b/sail_ui/lib/widgets/core/sail_svg.dart
@@ -1611,11 +1611,7 @@ class SailSVG {
           alignment: alignment,
           child: SailSVG.fromAsset(
             asset,
-            color:
-                color ??
-                (coloredAssets.contains(asset)
-                    ? null
-                    : (isHighlighted ? colors.primary : colors.icon)),
+            color: color ?? (coloredAssets.contains(asset) ? null : (isHighlighted ? colors.primary : colors.icon)),
             width: width ?? SailStyleValues.iconSizePrimary,
             height: height ?? SailStyleValues.iconSizePrimary,
           ),
@@ -1637,9 +1633,7 @@ class SailSVG {
         asset.toAssetPath(),
         package: 'sail_ui',
         width: width,
-        colorFilter: color != null
-            ? ColorFilter.mode(color, BlendMode.srcIn)
-            : null,
+        colorFilter: color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
         height: height,
       ),
     );

--- a/sail_ui/lib/widgets/core/sail_svg.dart
+++ b/sail_ui/lib/widgets/core/sail_svg.dart
@@ -1601,33 +1601,47 @@ class SailSVG {
     double? width,
     double? height,
     Color? color,
+    Alignment alignment = Alignment.center,
   }) {
     return Builder(
       builder: (context) {
         final colors = SailTheme.of(context).colors;
 
-        return SailSVG.fromAsset(
-          asset,
-          color: color ?? (coloredAssets.contains(asset) ? null : (isHighlighted ? colors.primary : colors.icon)),
-          width: width ?? SailStyleValues.iconSizePrimary,
-          height: height ?? SailStyleValues.iconSizePrimary,
+        return Align(
+          alignment: alignment,
+          child: SailSVG.fromAsset(
+            asset,
+            color:
+                color ??
+                (coloredAssets.contains(asset)
+                    ? null
+                    : (isHighlighted ? colors.primary : colors.icon)),
+            width: width ?? SailStyleValues.iconSizePrimary,
+            height: height ?? SailStyleValues.iconSizePrimary,
+          ),
         );
       },
     );
   }
 
-  static SvgPicture fromAsset(
+  static Widget fromAsset(
     SailSVGAsset asset, {
     double? height,
     double? width,
     Color? color,
+    Alignment alignment = Alignment.center,
   }) {
-    return SvgPicture.asset(
-      asset.toAssetPath(),
-      package: 'sail_ui',
-      width: width,
-      colorFilter: color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
-      height: height,
+    return Align(
+      alignment: alignment,
+      child: SvgPicture.asset(
+        asset.toAssetPath(),
+        package: 'sail_ui',
+        width: width,
+        colorFilter: color != null
+            ? ColorFilter.mode(color, BlendMode.srcIn)
+            : null,
+        height: height,
+      ),
     );
   }
 
@@ -1636,13 +1650,17 @@ class SailSVG {
     double? width,
     double? height,
     BoxFit? fit,
+    Alignment alignment = Alignment.center,
   }) {
-    return Image.asset(
-      asset.toAssetPath(),
-      package: 'sail_ui',
-      width: width,
-      height: height,
-      fit: fit ?? BoxFit.contain,
+    return Align(
+      alignment: alignment,
+      child: Image.asset(
+        asset.toAssetPath(),
+        package: 'sail_ui',
+        width: width,
+        height: height,
+        fit: fit ?? BoxFit.contain,
+      ),
     );
   }
 }


### PR DESCRIPTION
Adds same filter from overview to utxo table

- creates a datefilter component
- makes `Output` expandable
- adds alignment to icons

screenshot example below:
<img width="959" height="250" alt="image" src="https://github.com/user-attachments/assets/3e6d0666-cc8e-496e-a95a-e301028a9b4e" />
