### PR TITLE
bmm: replace every bid over the coins it takes

### DIFF
--- a/sail_ui/test/bmm_provider_test.dart
+++ b/sail_ui/test/bmm_provider_test.dart
@@ -18,6 +18,7 @@ class _FakeBmmRPC implements OrchestratorBmmRPC {
   int manualBids = 0;
   int? lastMaxBid;
   String? lastWalletId;
+  bool? lastCapToBlockWorth;
   Object? throwOnStart;
 
   void emit(bmmpb.WatchResponse state) => _controller.add(state);
@@ -30,6 +31,7 @@ class _FakeBmmRPC implements OrchestratorBmmRPC {
     required BinaryType sidechain,
     required int maxBidSats,
     String? walletId,
+    bool capToBlockWorth = false,
   }) async {
     if (throwOnStart != null) {
       throw throwOnStart!;
@@ -37,6 +39,7 @@ class _FakeBmmRPC implements OrchestratorBmmRPC {
     startCalls++;
     lastMaxBid = maxBidSats;
     lastWalletId = walletId;
+    lastCapToBlockWorth = capToBlockWorth;
   }
 
   @override

--- a/sidechain-orchestrator/api/bmm_bid_chain_test.go
+++ b/sidechain-orchestrator/api/bmm_bid_chain_test.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+)
+
+// fakeNode answers the two Core reads the bid walk makes.
+type fakeNode struct {
+	// txs names each transaction the node holds, by txid.
+	txs map[string]fakeTx
+}
+
+type fakeTx struct {
+	// vin names what the transaction spends, as "txid:vout".
+	vin []string
+	// slot marks a bid for that sidechain. A zero slot names no bid.
+	slot int
+	// confirmations above zero says a block carries it.
+	confirmations int
+}
+
+func (n *fakeNode) call(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
+	if method != "getrawtransaction" {
+		return nil, fmt.Errorf("the walk called %s", method)
+	}
+	var params []any
+	if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+		return nil, err
+	}
+	txid, _ := params[0].(string)
+	tx, ok := n.txs[txid]
+	if !ok {
+		return nil, fmt.Errorf("no transaction %s", txid)
+	}
+
+	out := map[string]any{"confirmations": tx.confirmations}
+	vin := make([]map[string]any, 0, len(tx.vin))
+	for _, in := range tx.vin {
+		parts := strings.Split(in, ":")
+		var vout int
+		_, _ = fmt.Sscanf(parts[1], "%d", &vout)
+		vin = append(vin, map[string]any{"txid": parts[0], "vout": vout})
+	}
+	out["vin"] = vin
+
+	if tx.slot > 0 {
+		script, err := orchestrator.M8BmmRequestScript(
+			uint8(tx.slot), strings.Repeat("ab", 32), strings.Repeat("cd", 32))
+		if err != nil {
+			return nil, err
+		}
+		out["vout"] = []map[string]any{{
+			"scriptPubKey": map[string]any{"hex": hex.EncodeToString(script)},
+		}}
+	}
+	return json.Marshal(out)
+}
+
+func handlerOver(node *fakeNode) *BMMHandler {
+	h := &BMMHandler{}
+	h.SetCoreCaller(node.call)
+	return h
+}
+
+// A new bid takes the change of the bid before it. A replacement must respend
+// the coins under the whole chain, or the stranded bids below it hold every
+// later bid out of a block.
+func TestBidInputsWalksToTheConfirmedCoins(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"coin":   {confirmations: 6},
+		"root":   {vin: []string{"coin:1"}, slot: 9},
+		"middle": {vin: []string{"root:1"}, slot: 9},
+		"top":    {vin: []string{"middle:1"}, slot: 9},
+	}}
+
+	got, roots, err := handlerOver(node).bidInputs(context.Background(), 9, "top")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d inputs, want the one confirmed coin", len(got))
+	}
+	if got[0].Txid != "coin" || got[0].Vout != 1 {
+		t.Errorf("input = %s:%d, want coin:1", got[0].Txid, got[0].Vout)
+	}
+	// The mempool counts the fee of the whole chain under the root, and the
+	// replacement must beat all of it.
+	if len(roots) != 1 || roots[0] != "root" {
+		t.Errorf("roots = %v, want the bottom bid", roots)
+	}
+}
+
+// A bid that stands on its own respends its own inputs.
+func TestBidInputsKeepsAConfirmedInput(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"coin": {confirmations: 3},
+		"bid":  {vin: []string{"coin:0"}, slot: 9},
+	}}
+
+	got, roots, err := handlerOver(node).bidInputs(context.Background(), 9, "bid")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	if len(got) != 1 || got[0].Txid != "coin" || got[0].Vout != 0 {
+		t.Errorf("inputs = %+v, want coin:0", got)
+	}
+	if len(roots) != 1 || roots[0] != "bid" {
+		t.Errorf("roots = %v, want the bid itself", roots)
+	}
+}
+
+// An unconfirmed parent that is not a bid of this slot belongs to somebody
+// else. The walk stops there, because the wallet cannot respend it.
+func TestBidInputsStopsAtAnotherSlot(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"coin":    {confirmations: 4},
+		"foreign": {vin: []string{"coin:0"}, slot: 4},
+		"bid":     {vin: []string{"foreign:1"}, slot: 9},
+	}}
+
+	got, _, err := handlerOver(node).bidInputs(context.Background(), 9, "bid")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	if len(got) != 1 || got[0].Txid != "foreign" || got[0].Vout != 1 {
+		t.Errorf("inputs = %+v, want foreign:1", got)
+	}
+}
+
+// A transaction the node cannot read stops the walk, so the replacement keeps
+// the outpoint it already holds.
+func TestBidInputsKeepsAnUnknownParent(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"bid": {vin: []string{"gone:2"}, slot: 9},
+	}}
+
+	got, _, err := handlerOver(node).bidInputs(context.Background(), 9, "bid")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	if len(got) != 1 || got[0].Txid != "gone" {
+		t.Errorf("inputs = %+v, want gone:2", got)
+	}
+}
+
+// Two inputs of one chain can name the same coin. It reaches the replacement
+// one time.
+func TestBidInputsNamesEachCoinOneTime(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"coin": {confirmations: 2},
+		"root": {vin: []string{"coin:0", "coin:0"}, slot: 9},
+		"top":  {vin: []string{"root:0", "root:1"}, slot: 9},
+	}}
+
+	got, _, err := handlerOver(node).bidInputs(context.Background(), 9, "top")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("inputs = %+v, want the coin one time", got)
+	}
+}
+
+// A chain that names itself would walk forever.
+func TestBidInputsRefusesALoop(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"a": {vin: []string{"b:0"}, slot: 9},
+		"b": {vin: []string{"a:0"}, slot: 9},
+	}}
+
+	if _, _, err := handlerOver(node).bidInputs(context.Background(), 9, "a"); err == nil {
+		t.Fatal("want an error for a loop, got none")
+	}
+}
+
+// nodeWithFees answers getmempoolentry as well, so the floor test reads what
+// the chain costs.
+type nodeWithFees struct {
+	*fakeNode
+	// descendant names the fee of a transaction and everything over it, in BTC.
+	descendant map[string]float64
+}
+
+func (n *nodeWithFees) call(ctx context.Context, method, paramsJSON, wallet string) (json.RawMessage, error) {
+	if method != "getmempoolentry" {
+		return n.fakeNode.call(ctx, method, paramsJSON, wallet)
+	}
+	var params []any
+	if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+		return nil, err
+	}
+	txid, _ := params[0].(string)
+	fee, ok := n.descendant[txid]
+	if !ok {
+		return nil, fmt.Errorf("no mempool entry %s", txid)
+	}
+	return json.Marshal(map[string]any{"fees": map[string]any{"descendant": fee}})
+}
+
+// A replacement evicts every bid over the coins it takes, so it must pay more
+// than all of them together.
+func TestReplacementFloorCoversTheWholeChain(t *testing.T) {
+	node := &nodeWithFees{
+		fakeNode: &fakeNode{txs: map[string]fakeTx{
+			"coin":   {confirmations: 6},
+			"root":   {vin: []string{"coin:1"}, slot: 9},
+			"middle": {vin: []string{"root:1"}, slot: 9},
+			"top":    {vin: []string{"middle:1"}, slot: 9},
+		}},
+		// 74799 + 76562 + 1000 sats, the way the live chain read.
+		descendant: map[string]float64{"root": 0.00152361, "top": 0.00001},
+	}
+	h := &BMMHandler{}
+	h.SetCoreCaller(node.call)
+
+	_, roots, err := h.bidInputs(context.Background(), 9, "top")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	floor, err := h.replacementFloorSats(context.Background(), roots)
+	if err != nil {
+		t.Fatalf("floor: %v", err)
+	}
+	if want := int64(152361) + replacementBumpSats; floor != want {
+		t.Errorf("floor = %d, want %d", floor, want)
+	}
+}
+
+// A bid the mempool no longer holds names no floor, so the opening bid stands.
+func TestReplacementFloorOfAGoneBid(t *testing.T) {
+	node := &nodeWithFees{fakeNode: &fakeNode{txs: map[string]fakeTx{}}, descendant: map[string]float64{}}
+	h := &BMMHandler{}
+	h.SetCoreCaller(node.call)
+
+	floor, err := h.replacementFloorSats(context.Background(), []string{"gone"})
+	if err != nil {
+		t.Fatalf("floor: %v", err)
+	}
+	if floor != 0 {
+		t.Errorf("floor = %d, want 0", floor)
+	}
+}
+
+// A node that deprioritised the chain reports a fee under zero. The
+// replacement then beats it at any price, so it names no floor.
+func TestReplacementFloorOfADeprioritisedChain(t *testing.T) {
+	node := &nodeWithFees{
+		fakeNode:   &fakeNode{txs: map[string]fakeTx{}},
+		descendant: map[string]float64{"root": -440999.99},
+	}
+	h := &BMMHandler{}
+	h.SetCoreCaller(node.call)
+
+	floor, err := h.replacementFloorSats(context.Background(), []string{"root"})
+	if err != nil {
+		t.Fatalf("floor: %v", err)
+	}
+	if floor != 0 {
+		t.Errorf("floor = %d, want 0", floor)
+	}
+}

--- a/sidechain-orchestrator/api/bmm_bid_chain_test.go
+++ b/sidechain-orchestrator/api/bmm_bid_chain_test.go
@@ -80,7 +80,7 @@ func TestBidInputsWalksToTheConfirmedCoins(t *testing.T) {
 		"top":    {vin: []string{"middle:1"}, slot: 9},
 	}}
 
-	got, roots, err := handlerOver(node).bidInputs(context.Background(), 9, "top")
+	got, roots, err := handlerOver(node).bidInputs(context.Background(), "top")
 	if err != nil {
 		t.Fatalf("bid inputs: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestBidInputsKeepsAConfirmedInput(t *testing.T) {
 		"bid":  {vin: []string{"coin:0"}, slot: 9},
 	}}
 
-	got, roots, err := handlerOver(node).bidInputs(context.Background(), 9, "bid")
+	got, roots, err := handlerOver(node).bidInputs(context.Background(), "bid")
 	if err != nil {
 		t.Fatalf("bid inputs: %v", err)
 	}
@@ -116,21 +116,40 @@ func TestBidInputsKeepsAConfirmedInput(t *testing.T) {
 	}
 }
 
-// An unconfirmed parent that is not a bid of this slot belongs to somebody
-// else. The walk stops there, because the wallet cannot respend it.
-func TestBidInputsStopsAtAnotherSlot(t *testing.T) {
+// One wallet funds the bids of every slot, so a bid for another slot can sit
+// between two of ours. The walk goes through it, or the stranded bid under it
+// holds our chain out of every block.
+func TestBidInputsWalksThroughAnotherSlot(t *testing.T) {
 	node := &fakeNode{txs: map[string]fakeTx{
 		"coin":    {confirmations: 4},
 		"foreign": {vin: []string{"coin:0"}, slot: 4},
 		"bid":     {vin: []string{"foreign:1"}, slot: 9},
 	}}
 
-	got, _, err := handlerOver(node).bidInputs(context.Background(), 9, "bid")
+	got, _, err := handlerOver(node).bidInputs(context.Background(), "bid")
 	if err != nil {
 		t.Fatalf("bid inputs: %v", err)
 	}
-	if len(got) != 1 || got[0].Txid != "foreign" || got[0].Vout != 1 {
-		t.Errorf("inputs = %+v, want foreign:1", got)
+	if len(got) != 1 || got[0].Txid != "coin" || got[0].Vout != 0 {
+		t.Errorf("inputs = %+v, want coin:0", got)
+	}
+}
+
+// An ordinary payment is not a bid. The walk stops there, because a
+// replacement must never undo what a user sent.
+func TestBidInputsStopsAtAPayment(t *testing.T) {
+	node := &fakeNode{txs: map[string]fakeTx{
+		"coin":    {confirmations: 4},
+		"payment": {vin: []string{"coin:0"}},
+		"bid":     {vin: []string{"payment:1"}, slot: 9},
+	}}
+
+	got, _, err := handlerOver(node).bidInputs(context.Background(), "bid")
+	if err != nil {
+		t.Fatalf("bid inputs: %v", err)
+	}
+	if len(got) != 1 || got[0].Txid != "payment" || got[0].Vout != 1 {
+		t.Errorf("inputs = %+v, want payment:1", got)
 	}
 }
 
@@ -141,7 +160,7 @@ func TestBidInputsKeepsAnUnknownParent(t *testing.T) {
 		"bid": {vin: []string{"gone:2"}, slot: 9},
 	}}
 
-	got, _, err := handlerOver(node).bidInputs(context.Background(), 9, "bid")
+	got, _, err := handlerOver(node).bidInputs(context.Background(), "bid")
 	if err != nil {
 		t.Fatalf("bid inputs: %v", err)
 	}
@@ -159,7 +178,7 @@ func TestBidInputsNamesEachCoinOneTime(t *testing.T) {
 		"top":  {vin: []string{"root:0", "root:1"}, slot: 9},
 	}}
 
-	got, _, err := handlerOver(node).bidInputs(context.Background(), 9, "top")
+	got, _, err := handlerOver(node).bidInputs(context.Background(), "top")
 	if err != nil {
 		t.Fatalf("bid inputs: %v", err)
 	}
@@ -175,76 +194,79 @@ func TestBidInputsRefusesALoop(t *testing.T) {
 		"b": {vin: []string{"a:0"}, slot: 9},
 	}}
 
-	if _, _, err := handlerOver(node).bidInputs(context.Background(), 9, "a"); err == nil {
+	if _, _, err := handlerOver(node).bidInputs(context.Background(), "a"); err == nil {
 		t.Fatal("want an error for a loop, got none")
 	}
 }
 
-// nodeWithFees answers getmempoolentry as well, so the floor test reads what
-// the chain costs.
+// nodeWithFees answers the mempool reads the floor makes: what each
+// transaction pays after the node's own deltas, and what sits over it.
 type nodeWithFees struct {
 	*fakeNode
-	// descendant names the fee of a transaction and everything over it, in BTC.
-	descendant map[string]float64
+	// modified names the fee of one transaction in BTC, after the deltas.
+	modified map[string]float64
+	// descendants names what the mempool holds over one transaction.
+	descendants map[string][]string
 }
 
 func (n *nodeWithFees) call(ctx context.Context, method, paramsJSON, wallet string) (json.RawMessage, error) {
-	if method != "getmempoolentry" {
-		return n.fakeNode.call(ctx, method, paramsJSON, wallet)
-	}
 	var params []any
 	if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
 		return nil, err
 	}
 	txid, _ := params[0].(string)
-	fee, ok := n.descendant[txid]
-	if !ok {
-		return nil, fmt.Errorf("no mempool entry %s", txid)
+
+	switch method {
+	case "getmempoolentry":
+		fee, ok := n.modified[txid]
+		if !ok {
+			return nil, fmt.Errorf("no mempool entry %s", txid)
+		}
+		return json.Marshal(map[string]any{"fees": map[string]any{"modified": fee}})
+	case "getmempooldescendants":
+		return json.Marshal(n.descendants[txid])
+	default:
+		return n.fakeNode.call(ctx, method, paramsJSON, wallet)
 	}
-	return json.Marshal(map[string]any{"fees": map[string]any{"descendant": fee}})
+}
+
+func floorOver(t *testing.T, node *nodeWithFees, roots []string) int64 {
+	t.Helper()
+	h := &BMMHandler{}
+	h.SetCoreCaller(node.call)
+	floor, err := h.replacementFloorSats(context.Background(), roots)
+	if err != nil {
+		t.Fatalf("floor: %v", err)
+	}
+	return floor
 }
 
 // A replacement evicts every bid over the coins it takes, so it must pay more
 // than all of them together.
 func TestReplacementFloorCoversTheWholeChain(t *testing.T) {
 	node := &nodeWithFees{
-		fakeNode: &fakeNode{txs: map[string]fakeTx{
-			"coin":   {confirmations: 6},
-			"root":   {vin: []string{"coin:1"}, slot: 9},
-			"middle": {vin: []string{"root:1"}, slot: 9},
-			"top":    {vin: []string{"middle:1"}, slot: 9},
-		}},
+		fakeNode: &fakeNode{txs: map[string]fakeTx{}},
 		// 74799 + 76562 + 1000 sats, the way the live chain read.
-		descendant: map[string]float64{"root": 0.00152361, "top": 0.00001},
+		modified:    map[string]float64{"root": 0.00074799, "middle": 0.00076562, "top": 0.00001},
+		descendants: map[string][]string{"root": {"middle", "top"}},
 	}
-	h := &BMMHandler{}
-	h.SetCoreCaller(node.call)
 
-	_, roots, err := h.bidInputs(context.Background(), 9, "top")
-	if err != nil {
-		t.Fatalf("bid inputs: %v", err)
-	}
-	floor, err := h.replacementFloorSats(context.Background(), roots)
-	if err != nil {
-		t.Fatalf("floor: %v", err)
-	}
-	if want := int64(152361) + replacementBumpSats; floor != want {
-		t.Errorf("floor = %d, want %d", floor, want)
+	if want := int64(152361) + replacementBumpSats; floorOver(t, node, []string{"root"}) != want {
+		t.Errorf("floor = %d, want %d", floorOver(t, node, []string{"root"}), want)
 	}
 }
 
-// A bid the mempool no longer holds names no floor, so the opening bid stands.
-func TestReplacementFloorOfAGoneBid(t *testing.T) {
-	node := &nodeWithFees{fakeNode: &fakeNode{txs: map[string]fakeTx{}}, descendant: map[string]float64{}}
-	h := &BMMHandler{}
-	h.SetCoreCaller(node.call)
-
-	floor, err := h.replacementFloorSats(context.Background(), []string{"gone"})
-	if err != nil {
-		t.Fatalf("floor: %v", err)
+// One chain can name two roots, and a bid over both belongs to each root's
+// descendants. Counting it twice asks for a fee no ceiling allows.
+func TestReplacementFloorCountsEachTransactionOneTime(t *testing.T) {
+	node := &nodeWithFees{
+		fakeNode:    &fakeNode{txs: map[string]fakeTx{}},
+		modified:    map[string]float64{"root": 0.00001, "top": 0.00002},
+		descendants: map[string][]string{"root": {"top"}},
 	}
-	if floor != 0 {
-		t.Errorf("floor = %d, want 0", floor)
+
+	if want := int64(3000) + replacementBumpSats; floorOver(t, node, []string{"root", "top"}) != want {
+		t.Errorf("floor = %d, want %d", floorOver(t, node, []string{"root", "top"}), want)
 	}
 }
 
@@ -252,17 +274,25 @@ func TestReplacementFloorOfAGoneBid(t *testing.T) {
 // replacement then beats it at any price, so it names no floor.
 func TestReplacementFloorOfADeprioritisedChain(t *testing.T) {
 	node := &nodeWithFees{
-		fakeNode:   &fakeNode{txs: map[string]fakeTx{}},
-		descendant: map[string]float64{"root": -440999.99},
+		fakeNode:    &fakeNode{txs: map[string]fakeTx{}},
+		modified:    map[string]float64{"root": -210000.0},
+		descendants: map[string][]string{},
 	}
-	h := &BMMHandler{}
-	h.SetCoreCaller(node.call)
 
-	floor, err := h.replacementFloorSats(context.Background(), []string{"root"})
-	if err != nil {
-		t.Fatalf("floor: %v", err)
+	if floorOver(t, node, []string{"root"}) != 0 {
+		t.Errorf("floor = %d, want 0", floorOver(t, node, []string{"root"}))
 	}
-	if floor != 0 {
-		t.Errorf("floor = %d, want 0", floor)
+}
+
+// A bid the mempool no longer holds names no floor, so the opening bid stands.
+func TestReplacementFloorOfAGoneBid(t *testing.T) {
+	node := &nodeWithFees{
+		fakeNode:    &fakeNode{txs: map[string]fakeTx{}},
+		modified:    map[string]float64{},
+		descendants: map[string][]string{},
+	}
+
+	if floorOver(t, node, []string{"gone"}) != 0 {
+		t.Errorf("floor = %d, want 0", floorOver(t, node, []string{"gone"}))
 	}
 }

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -38,11 +38,16 @@ type BMMHandler struct {
 	orch   *orchestrator.Orchestrator
 	wallet *WalletHandler
 	engine *engines.BmmEngine
+	// core reads bitcoind. A test supplies its own through SetCoreCaller.
+	core CoreRawCaller
 }
 
 func NewBMMHandler(orch *orchestrator.Orchestrator, wallet *WalletHandler) *BMMHandler {
 	return &BMMHandler{orch: orch, wallet: wallet}
 }
+
+// SetCoreCaller replaces the bitcoind seam.
+func (h *BMMHandler) SetCoreCaller(c CoreRawCaller) { h.core = c }
 
 // SetEngine wires the background bidder, which calls back into this handler.
 func (h *BMMHandler) SetEngine(engine *engines.BmmEngine) {
@@ -310,11 +315,14 @@ func (h *BMMHandler) CreateBid(
 	// bidding against it: only one M8 per slot can be accepted.
 	var requiredInputs []*wpb.UnspentOutput
 	if req.Msg.ReplaceTxid != "" {
-		requiredInputs, err = h.bidInputs(ctx, req.Msg.ReplaceTxid)
+		var roots []string
+		requiredInputs, roots, err = h.bidInputs(ctx, cfg.Slot, req.Msg.ReplaceTxid)
 		if err != nil {
 			return nil, err
 		}
-		floorSats, err := h.replacementFloorSats(ctx, req.Msg.ReplaceTxid)
+		// The replacement evicts every bid over those coins, so it pays more
+		// than all of them together.
+		floorSats, err := h.replacementFloorSats(ctx, roots)
 		if err != nil {
 			return nil, err
 		}
@@ -604,24 +612,96 @@ func (h *BMMHandler) sidechainConfig(binary pb.BinaryType) (orchestrator.BinaryC
 // stranded bids costs the sum of all of them.
 //
 // A transaction the mempool no longer holds needs no floor at all.
-func (h *BMMHandler) replacementFloorSats(ctx context.Context, txid string) (int64, error) {
-	raw, err := h.coreCall(ctx, "getmempoolentry", fmt.Sprintf("[%q]", txid))
-	if err != nil {
+func (h *BMMHandler) replacementFloorSats(ctx context.Context, roots []string) (int64, error) {
+	var total int64
+	for _, txid := range roots {
+		raw, err := h.coreCall(ctx, "getmempoolentry", fmt.Sprintf("[%q]", txid))
+		if err != nil {
+			continue
+		}
+		var entry struct {
+			Fees struct {
+				Descendant float64 `json:"descendant"`
+			} `json:"fees"`
+		}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return 0, connect.NewError(connect.CodeInternal,
+				fmt.Errorf("decode mempool entry %s: %w", txid, err))
+		}
+		total += int64(math.Round(entry.Fees.Descendant * 1e8))
+	}
+	// A node that deprioritised the chain reports a fee far below zero, and a
+	// replacement then beats it at any price.
+	if total <= 0 {
 		return 0, nil
 	}
-	var entry struct {
-		Fees struct {
-			Descendant float64 `json:"descendant"`
-		} `json:"fees"`
-	}
-	if err := json.Unmarshal(raw, &entry); err != nil {
-		return 0, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("decode mempool entry %s: %w", txid, err))
-	}
-	return int64(math.Round(entry.Fees.Descendant*1e8)) + replacementBumpSats, nil
+	return total + replacementBumpSats, nil
 }
 
-func (h *BMMHandler) bidInputs(ctx context.Context, txid string) ([]*wpb.UnspentOutput, error) {
+// maxBidChain bounds the walk down a chain of stranded bids. A wallet that
+// stacks more than this names a loop, not a chain.
+const maxBidChain = 50
+
+// bidInputs names the coins a replacement respends to evict a stranded bid.
+//
+// A new bid takes the change of the bid before it, so one stranded bid can
+// carry a whole chain of stranded bids under it. Respending the top one leaves
+// the rest, and every one of them holds the chain unminable. So the walk goes
+// down while a parent is another bid for this slot, and it returns the coins a
+// block already carries. Spending those evicts the whole chain at one time.
+func (h *BMMHandler) bidInputs(
+	ctx context.Context, slot int, txid string,
+) (inputs []*wpb.UnspentOutput, roots []string, err error) {
+	var (
+		seen     = make(map[string]bool)
+		rootSeen = make(map[string]bool)
+	)
+
+	var walk func(txid string, depth int) error
+	walk = func(txid string, depth int) error {
+		if depth > maxBidChain {
+			return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+				"bid %s sits over more than %d unconfirmed bids", txid, maxBidChain))
+		}
+		spends, err := h.txInputs(ctx, txid)
+		if err != nil {
+			return err
+		}
+		for _, in := range spends {
+			key := fmt.Sprintf("%s:%d", in.Txid, in.Vout)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			if h.pendingBid(ctx, slot, in.Txid) {
+				if err := walk(in.Txid, depth+1); err != nil {
+					return err
+				}
+				continue
+			}
+			inputs = append(inputs, in)
+			// This bid holds a coin under the chain, so the mempool counts
+			// every bid above it as its descendant.
+			if !rootSeen[txid] {
+				rootSeen[txid] = true
+				roots = append(roots, txid)
+			}
+		}
+		return nil
+	}
+
+	if err := walk(txid, 0); err != nil {
+		return nil, nil, err
+	}
+	if len(inputs) == 0 {
+		return nil, nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("bid %s has no inputs to reuse", txid))
+	}
+	return inputs, roots, nil
+}
+
+// txInputs names the outpoints one transaction spends.
+func (h *BMMHandler) txInputs(ctx context.Context, txid string) ([]*wpb.UnspentOutput, error) {
 	raw, err := h.coreCall(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("read bid %s: %w", txid, err))
@@ -646,7 +726,37 @@ func (h *BMMHandler) bidInputs(ctx context.Context, txid string) ([]*wpb.Unspent
 	}), nil
 }
 
+// pendingBid says whether one transaction is an unconfirmed bid for this slot.
+// A read that fails stops the walk, because a coin the node cannot name is one
+// the replacement keeps.
+func (h *BMMHandler) pendingBid(ctx context.Context, slot int, txid string) bool {
+	raw, err := h.coreCall(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
+	if err != nil {
+		return false
+	}
+	var tx struct {
+		Confirmations int `json:"confirmations"`
+		Vout          []struct {
+			ScriptPubKey struct {
+				Hex string `json:"hex"`
+			} `json:"scriptPubKey"`
+		} `json:"vout"`
+	}
+	if err := json.Unmarshal(raw, &tx); err != nil || tx.Confirmations > 0 || len(tx.Vout) == 0 {
+		return false
+	}
+	script, err := hex.DecodeString(tx.Vout[0].ScriptPubKey.Hex)
+	if err != nil {
+		return false
+	}
+	request := orchestrator.ParseM8BmmRequestScript(script)
+	return request != nil && int(request.Slot) == slot
+}
+
 func (h *BMMHandler) coreCall(ctx context.Context, method, paramsJSON string) (json.RawMessage, error) {
+	if h.core != nil {
+		return h.core(ctx, method, paramsJSON, "")
+	}
 	handler := NewHandler(h.orch)
 	return handler.RawCoreCall(ctx, method, paramsJSON, "")
 }

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -102,7 +102,8 @@ func (h *BMMHandler) Start(
 	if err := h.requireEnforcerSynced(ctx); err != nil {
 		return nil, err
 	}
-	if err := h.engine.Start(req.Msg.Sidechain, req.Msg.WalletId, req.Msg.MaxBidSats); err != nil {
+	if err := h.engine.Start(req.Msg.Sidechain, req.Msg.WalletId,
+		req.Msg.MaxBidSats, req.Msg.CapToBlockWorth); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	return connect.NewResponse(&bmmpb.StartResponse{}), nil

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -317,7 +317,7 @@ func (h *BMMHandler) CreateBid(
 	var requiredInputs []*wpb.UnspentOutput
 	if req.Msg.ReplaceTxid != "" {
 		var roots []string
-		requiredInputs, roots, err = h.bidInputs(ctx, cfg.Slot, req.Msg.ReplaceTxid)
+		requiredInputs, roots, err = h.bidInputs(ctx, req.Msg.ReplaceTxid)
 		if err != nil {
 			return nil, err
 		}
@@ -614,29 +614,66 @@ func (h *BMMHandler) sidechainConfig(binary pb.BinaryType) (orchestrator.BinaryC
 //
 // A transaction the mempool no longer holds needs no floor at all.
 func (h *BMMHandler) replacementFloorSats(ctx context.Context, roots []string) (int64, error) {
+	// One chain can carry two roots, and a bid over both of them belongs to
+	// each root's descendants. So each transaction counts one time, by txid.
+	counted := make(map[string]bool)
 	var total int64
-	for _, txid := range roots {
-		raw, err := h.coreCall(ctx, "getmempoolentry", fmt.Sprintf("[%q]", txid))
-		if err != nil {
-			continue
+	for _, root := range roots {
+		for _, txid := range append([]string{root}, h.mempoolDescendants(ctx, root)...) {
+			if counted[txid] {
+				continue
+			}
+			counted[txid] = true
+			fee, ok, err := h.modifiedFeeSats(ctx, txid)
+			if err != nil {
+				return 0, err
+			}
+			if ok {
+				total += fee
+			}
 		}
-		var entry struct {
-			Fees struct {
-				Descendant float64 `json:"descendant"`
-			} `json:"fees"`
-		}
-		if err := json.Unmarshal(raw, &entry); err != nil {
-			return 0, connect.NewError(connect.CodeInternal,
-				fmt.Errorf("decode mempool entry %s: %w", txid, err))
-		}
-		total += int64(math.Round(entry.Fees.Descendant * 1e8))
 	}
 	// A node that deprioritised the chain reports a fee far below zero, and a
-	// replacement then beats it at any price.
+	// replacement then beats it at any price. Core compares the same modified
+	// fees, so this is the number its own rule reads.
 	if total <= 0 {
 		return 0, nil
 	}
 	return total + replacementBumpSats, nil
+}
+
+// mempoolDescendants names every transaction the mempool holds over one
+// transaction. A read that fails names none, and the floor then counts the
+// transactions it does know.
+func (h *BMMHandler) mempoolDescendants(ctx context.Context, txid string) []string {
+	raw, err := h.coreCall(ctx, "getmempooldescendants", fmt.Sprintf("[%q]", txid))
+	if err != nil {
+		return nil
+	}
+	var txids []string
+	if err := json.Unmarshal(raw, &txids); err != nil {
+		return nil
+	}
+	return txids
+}
+
+// modifiedFeeSats reads what one mempool transaction pays after the deltas a
+// node applied. It reports false for a transaction the mempool no longer holds.
+func (h *BMMHandler) modifiedFeeSats(ctx context.Context, txid string) (int64, bool, error) {
+	raw, err := h.coreCall(ctx, "getmempoolentry", fmt.Sprintf("[%q]", txid))
+	if err != nil {
+		return 0, false, nil
+	}
+	var entry struct {
+		Fees struct {
+			Modified float64 `json:"modified"`
+		} `json:"fees"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return 0, false, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("decode mempool entry %s: %w", txid, err))
+	}
+	return int64(math.Round(entry.Fees.Modified * 1e8)), true, nil
 }
 
 // maxBidChain bounds the walk down a chain of stranded bids. A wallet that
@@ -651,7 +688,7 @@ const maxBidChain = 50
 // down while a parent is another bid for this slot, and it returns the coins a
 // block already carries. Spending those evicts the whole chain at one time.
 func (h *BMMHandler) bidInputs(
-	ctx context.Context, slot int, txid string,
+	ctx context.Context, txid string,
 ) (inputs []*wpb.UnspentOutput, roots []string, err error) {
 	var (
 		seen     = make(map[string]bool)
@@ -674,7 +711,7 @@ func (h *BMMHandler) bidInputs(
 				continue
 			}
 			seen[key] = true
-			if h.pendingBid(ctx, slot, in.Txid) {
+			if h.pendingBid(ctx, in.Txid) {
 				if err := walk(in.Txid, depth+1); err != nil {
 					return err
 				}
@@ -727,10 +764,15 @@ func (h *BMMHandler) txInputs(ctx context.Context, txid string) ([]*wpb.UnspentO
 	}), nil
 }
 
-// pendingBid says whether one transaction is an unconfirmed bid for this slot.
-// A read that fails stops the walk, because a coin the node cannot name is one
-// the replacement keeps.
-func (h *BMMHandler) pendingBid(ctx context.Context, slot int, txid string) bool {
+// pendingBid says whether one transaction is an unconfirmed BMM request. The
+// slot does not matter: one wallet funds the bids of every slot, so a bid for
+// another slot can sit between two of ours, and stopping there would leave the
+// stranded bid under it in place. A replacement evicts that other bid, and its
+// own engine bids again on the next tip.
+//
+// Everything else stops the walk. A read that fails stops it too, because a
+// coin the node cannot name is one the replacement keeps.
+func (h *BMMHandler) pendingBid(ctx context.Context, txid string) bool {
 	raw, err := h.coreCall(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
 	if err != nil {
 		return false
@@ -750,8 +792,7 @@ func (h *BMMHandler) pendingBid(ctx context.Context, slot int, txid string) bool
 	if err != nil {
 		return false
 	}
-	request := orchestrator.ParseM8BmmRequestScript(script)
-	return request != nil && int(request.Slot) == slot
+	return orchestrator.ParseM8BmmRequestScript(script) != nil
 }
 
 func (h *BMMHandler) coreCall(ctx context.Context, method, paramsJSON string) (json.RawMessage, error) {

--- a/sidechain-orchestrator/commands/bmm.go
+++ b/sidechain-orchestrator/commands/bmm.go
@@ -141,6 +141,11 @@ var bmmStartCommand = &cli.Command{
 	ArgsUsage: "<sidechain>",
 	Flags: []cli.Flag{
 		&cli.Int64Flag{Name: "max-bid", Value: 100000, Usage: "highest sats to bid"},
+		&cli.BoolFlag{
+			Name: "cap-to-block-worth",
+			Usage: "hold every bid at or under what the sidechain block collects in fees; " +
+				"a chain with cheap blocks then loses every round",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
@@ -151,8 +156,9 @@ var bmmStartCommand = &cli.Command{
 			return err
 		}
 		if _, err := newBMMClient(cctx).Start(cctx.Context, connect.NewRequest(&bmmpb.StartRequest{
-			Sidechain:  sidechain,
-			MaxBidSats: cctx.Int64("max-bid"),
+			Sidechain:       sidechain,
+			MaxBidSats:      cctx.Int64("max-bid"),
+			CapToBlockWorth: cctx.Bool("cap-to-block-worth"),
 		})); err != nil {
 			return err
 		}

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -239,6 +239,21 @@ func EsploraURLsForNetwork(n Network) []string {
 	}
 }
 
+// FeeExplorerURLForNetwork names a mempool.space style explorer that reports
+// what the next blocks pay, or an empty string when a network hosts none.
+//
+// Core's own estimator reads the mempool it holds, and a chain whose mempool
+// carries transactions no miner takes pushes that estimate far over what the
+// blocks really pay. The explorer reads the blocks, so it answers the market.
+func FeeExplorerURLForNetwork(n Network) string {
+	switch n {
+	case NetworkECash:
+		return "https://explorer.alpha.ecash.ninja"
+	default:
+		return ""
+	}
+}
+
 // ThunderEsploraURLForNetwork returns the thunder address index for a network,
 // or an empty string when none is hosted. A thunder node keeps no address
 // history of its own, so a wallet reads it here instead.

--- a/sidechain-orchestrator/config/network_test.go
+++ b/sidechain-orchestrator/config/network_test.go
@@ -1,0 +1,16 @@
+package config
+
+import "testing"
+
+// Core's estimator reads a mempool that carries transactions no miner takes,
+// so the eCash network reads its own explorer instead.
+func TestFeeExplorerURLForNetwork(t *testing.T) {
+	if got := FeeExplorerURLForNetwork(NetworkECash); got != "https://explorer.alpha.ecash.ninja" {
+		t.Errorf("ecash explorer = %q", got)
+	}
+	for _, n := range []Network{NetworkMainnet, NetworkSignet, NetworkRegtest} {
+		if got := FeeExplorerURLForNetwork(n); got != "" {
+			t.Errorf("%s explorer = %q, want none", n, got)
+		}
+	}
+}

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -80,6 +80,10 @@ type bmmTarget struct {
 	maxBidSats int64
 	// walletID funds every bid. Empty spends from the active wallet.
 	walletID string
+	// capToBlockWorth holds a bid at or under what the block collects in fees.
+	// A chain with cheap blocks then loses every round, so an operator turns it
+	// on by choice.
+	capToBlockWorth bool
 	// lastTip is the tip this sidechain last opened a round on. Per sidechain,
 	// so starting one does not have to wait out another's round.
 	lastTip string
@@ -122,13 +126,19 @@ func NewBmmEngine(log zerolog.Logger, backend BmmBackend, tip MainchainTip, fee 
 
 // Start bids for sidechain on every new mainchain tip until Stop, raising
 // toward maxBidSats when outbid. walletID funds every bid.
-func (e *BmmEngine) Start(sidechain pb.BinaryType, walletID string, maxBidSats int64) error {
+func (e *BmmEngine) Start(
+	sidechain pb.BinaryType, walletID string, maxBidSats int64, capToBlockWorth bool,
+) error {
 	if maxBidSats <= 0 {
 		return fmt.Errorf("max_bid_sats must be positive")
 	}
 
 	e.mu.Lock()
-	target := bmmTarget{maxBidSats: maxBidSats, walletID: walletID}
+	target := bmmTarget{
+		maxBidSats:      maxBidSats,
+		walletID:        walletID,
+		capToBlockWorth: capToBlockWorth,
+	}
 	if existing, ok := e.targets[sidechain]; ok {
 		target.lastTip = existing.lastTip
 	} else if round, ok := e.current[sidechain]; ok {
@@ -138,7 +148,8 @@ func (e *BmmEngine) Start(sidechain pb.BinaryType, walletID string, maxBidSats i
 	e.mu.Unlock()
 
 	e.log.Info().Stringer("sidechain", sidechain).
-		Int64("max_bid_sats", maxBidSats).Msg("bmm started")
+		Int64("max_bid_sats", maxBidSats).
+		Bool("cap_to_block_worth", capToBlockWorth).Msg("bmm started")
 	e.notify()
 	e.poke()
 	return nil
@@ -413,7 +424,8 @@ func (e *BmmEngine) openRound(
 	e.current[sidechain] = round
 	e.mu.Unlock()
 
-	if err := e.placeBid(ctx, sidechain, round, walletID, 0, e.NextBlockRate(ctx), target.maxBidSats, replaceTxid); err != nil {
+	if err := e.placeBid(ctx, sidechain, round, walletID, 0, e.NextBlockRate(ctx),
+		target.maxBidSats, replaceTxid, target.capToBlockWorth); err != nil {
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
 			e.log.Info().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid refused, retrying next tick")
 			e.retryTip(sidechain, tip)
@@ -585,6 +597,7 @@ func (e *BmmEngine) ourTxids(sidechain pb.BinaryType) map[string]bool {
 func (e *BmmEngine) placeBid(
 	ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round,
 	walletID string, bidSats int64, feeRateSatVb float64, maxBidSats int64, replaceTxid string,
+	capToBlockWorth bool,
 ) error {
 	resp, err := e.backend.CreateBid(ctx, connect.NewRequest(&bmmpb.CreateBidRequest{
 		Sidechain:          sidechain,
@@ -594,7 +607,7 @@ func (e *BmmEngine) placeBid(
 		MaxBidSats:         maxBidSats,
 		ReplaceTxid:        replaceTxid,
 		ExpectPrevMainHash: round.PrevMainHash,
-		CapToBlockWorth:    true,
+		CapToBlockWorth:    capToBlockWorth,
 	}))
 
 	e.mu.Lock()
@@ -661,7 +674,7 @@ func (e *BmmEngine) NextBlockRate(ctx context.Context) float64 {
 }
 
 // maybeRaise replaces our live bid when a competitor has overtaken it, never
-// going above the ceiling or above what the block is worth.
+// going above the ceiling the operator set.
 func (e *BmmEngine) maybeRaise(ctx context.Context, sidechain pb.BinaryType, target bmmTarget) {
 	e.mu.Lock()
 	round, ok := e.current[sidechain]
@@ -693,7 +706,7 @@ func (e *BmmEngine) maybeRaise(ctx context.Context, sidechain pb.BinaryType, tar
 	}
 
 	ceiling := target.maxBidSats
-	if worth > 0 && worth < ceiling {
+	if target.capToBlockWorth && worth > 0 && worth < ceiling {
 		ceiling = worth
 	}
 	next := top + bmmRaiseBumpSats
@@ -712,7 +725,8 @@ func (e *BmmEngine) maybeRaise(ctx context.Context, sidechain pb.BinaryType, tar
 		Int64("from_sats", live.BidSats).Int64("to_sats", next).Msg("raising bmm bid")
 	// The live bid stands when a raise is refused, so the round carries on at
 	// its current price rather than being unwound.
-	if err := e.placeBid(ctx, sidechain, round, walletID, next, 0, target.maxBidSats, live.Txid); err != nil {
+	if err := e.placeBid(ctx, sidechain, round, walletID, next, 0,
+		target.maxBidSats, live.Txid, target.capToBlockWorth); err != nil {
 		e.log.Warn().Err(err).Stringer("sidechain", sidechain).
 			Int64("to_sats", next).Msg("raising bmm bid failed, keeping the live bid")
 	}

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/engines/bmmstate"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/feerate"
 	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
 )
@@ -66,12 +67,6 @@ type MainchainTip interface {
 	ChainTip(context.Context) (hash string, height int32, err error)
 }
 
-// NextBlockFee reports what Core expects a transaction to pay per vByte to
-// enter the next block.
-type NextBlockFee interface {
-	NextBlockFeeRate(ctx context.Context) (satsPerVByte float64, err error)
-}
-
 // relayMinimumRate is the last resort rate, in sats per vByte, for when Core
 // reports neither an estimate nor a relay floor.
 const relayMinimumRate = 1.0
@@ -95,7 +90,7 @@ type BmmEngine struct {
 	log     zerolog.Logger
 	backend BmmBackend
 	tip     MainchainTip
-	fee     NextBlockFee
+	fee     feerate.FeeEstimator
 	store   *bmmstate.Store
 
 	mu      sync.Mutex
@@ -109,7 +104,10 @@ type BmmEngine struct {
 	wake chan struct{}
 }
 
-func NewBmmEngine(log zerolog.Logger, backend BmmBackend, tip MainchainTip, fee NextBlockFee, store *bmmstate.Store) *BmmEngine {
+func NewBmmEngine(
+	log zerolog.Logger, backend BmmBackend, tip MainchainTip,
+	fee feerate.FeeEstimator, store *bmmstate.Store,
+) *BmmEngine {
 	return &BmmEngine{
 		log:         log.With().Str("component", "bmm").Logger(),
 		backend:     backend,
@@ -662,7 +660,7 @@ func (e *BmmEngine) NextBlockRate(ctx context.Context) float64 {
 	if e.fee == nil {
 		return relayMinimumRate
 	}
-	rate, err := e.fee.NextBlockFeeRate(ctx)
+	rate, err := e.fee.EstimateFee(ctx)
 	if err != nil {
 		e.log.Debug().Err(err).Msg("core reports no fee rate, opening at the relay minimum")
 		return relayMinimumRate

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -124,7 +124,7 @@ type fakeFee struct {
 	err  error
 }
 
-func (f *fakeFee) NextBlockFeeRate(context.Context) (float64, error) {
+func (f *fakeFee) EstimateFee(context.Context) (float64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.rate, f.err

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -192,7 +192,7 @@ func TestBmmEngineIdleUntilStarted(t *testing.T) {
 // Only a new tip opens a round, so a repeated tip must not bid again.
 func TestBmmEngineOpensOneRoundPerTip(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000))
+	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -209,12 +209,12 @@ func TestBmmEngineBidsForASidechainStartedMidBlock(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	ctx := context.Background()
 
-	require.NoError(t, engine.Start(testSidechain, "", 20_000))
+	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
 	engine.tick(ctx)
 	require.Equal(t, 1, backend.bids)
 
 	const other = pb.BinaryType_BINARY_TYPE_BITNAMES
-	require.NoError(t, engine.Start(other, "", 20_000))
+	require.NoError(t, engine.Start(other, "", 20_000, false))
 	engine.tick(ctx)
 
 	assert.Equal(t, 2, backend.bids, "the newly started sidechain bids on the current tip")
@@ -226,7 +226,7 @@ func TestBmmEngineBidsForASidechainStartedMidBlock(t *testing.T) {
 func TestBmmEngineKeepsCompetitorsAfterTheRoundCloses(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	backend.others = []*bmmpb.Bid{{Txid: "rival", CriticalHash: "rival-h", BidSats: 9000}}
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -245,7 +245,7 @@ func TestBmmEngineKeepsCompetitorsAfterTheRoundCloses(t *testing.T) {
 
 func TestBmmEngineSettlesAWonRound(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -268,7 +268,7 @@ func TestBmmEngineSettlesAWonRound(t *testing.T) {
 func TestBmmEngineSettlesALostRound(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	backend.others = []*bmmpb.Bid{{Txid: "rival", CriticalHash: "rival-h", BidSats: 30_000}}
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -290,7 +290,7 @@ func TestBmmEngineSettlesALostRound(t *testing.T) {
 func TestBmmEngineRaisesWhenOutbid(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "", 30_000))
+	require.NoError(t, engine.Start(testSidechain, "", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -314,7 +314,7 @@ func TestBmmEngineRaisesWhenOutbid(t *testing.T) {
 func TestBmmEngineBidsFromTheNamedWallet(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "wallet-b", 30_000))
+	require.NoError(t, engine.Start(testSidechain, "wallet-b", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -336,12 +336,12 @@ func TestBmmEngineBidsFromTheNamedWallet(t *testing.T) {
 func TestBmmEngineRaisesFromTheWalletThatFundedTheBid(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "wallet-b", 30_000))
+	require.NoError(t, engine.Start(testSidechain, "wallet-b", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
 
-	require.NoError(t, engine.Start(testSidechain, "wallet-c", 30_000))
+	require.NoError(t, engine.Start(testSidechain, "wallet-c", 30_000, false))
 	backend.others = []*bmmpb.Bid{{Txid: "rival", BidSats: 12_000}}
 	engine.tick(ctx)
 
@@ -353,7 +353,7 @@ func TestBmmEngineRaisesFromTheWalletThatFundedTheBid(t *testing.T) {
 func TestBmmEngineNeverRaisesAboveMax(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 90_000
-	require.NoError(t, engine.Start(testSidechain, "", 12_000))
+	require.NoError(t, engine.Start(testSidechain, "", 12_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -364,11 +364,12 @@ func TestBmmEngineNeverRaisesAboveMax(t *testing.T) {
 	assert.Equal(t, 1, backend.bids, "a raise above max is not worth making")
 }
 
-// A bid above what the block collects loses money even when max allows it.
-func TestBmmEngineNeverRaisesAboveBlockWorth(t *testing.T) {
+// An operator who asks for the cap keeps every bid at or under what the block
+// collects.
+func TestBmmEngineHoldsTheCapWhenTheOperatorAsks(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 12_500
-	require.NoError(t, engine.Start(testSidechain, "", 100_000))
+	require.NoError(t, engine.Start(testSidechain, "", 100_000, true))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -379,10 +380,26 @@ func TestBmmEngineNeverRaisesAboveBlockWorth(t *testing.T) {
 	assert.Equal(t, 1, backend.bids, "13 000 would exceed the 12 500 the block is worth")
 }
 
+// A chain whose blocks carry few fees loses every round under the cap. So the
+// raise answers the ceiling alone unless the operator asks for the cap.
+func TestBmmEngineRaisesPastTheBlockWorth(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.feesSats = 1_000
+	require.NoError(t, engine.Start(testSidechain, "", 100_000, false))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+
+	backend.others = []*bmmpb.Bid{{Txid: "rival", BidSats: 12_000}}
+	engine.tick(ctx)
+
+	assert.Equal(t, 2, backend.bids, "the raise beats the rival, over the 1 000 the block is worth")
+}
+
 func TestBmmEngineRecordsAFailedBid(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.bidErr = errors.New("no block template")
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
@@ -394,7 +411,7 @@ func TestBmmEngineRecordsAFailedBid(t *testing.T) {
 
 func TestBmmEngineStopEndsBidding(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -411,8 +428,8 @@ func TestBmmEngineStopEndsBidding(t *testing.T) {
 
 func TestBmmEngineRejectsBadBounds(t *testing.T) {
 	engine, _, _, _ := newEngine(t)
-	require.Error(t, engine.Start(testSidechain, "", 0), "a ceiling of zero bids nothing")
-	require.Error(t, engine.Start(testSidechain, "", -1), "a negative ceiling is not a bid")
+	require.Error(t, engine.Start(testSidechain, "", 0, false), "a ceiling of zero bids nothing")
+	require.Error(t, engine.Start(testSidechain, "", -1, false), "a negative ceiling is not a bid")
 }
 
 // Core names the rate, so a caller that wants a cheaper bid cannot have one.
@@ -440,7 +457,7 @@ func TestBmmEngineOpensAtTheRelayMinimumWithoutAnEstimate(t *testing.T) {
 func TestBmmEngineOpensByRateNotByAmount(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	engine.fee.(*fakeFee).set(42)
-	require.NoError(t, engine.Start(testSidechain, "", 100_000))
+	require.NoError(t, engine.Start(testSidechain, "", 100_000, false))
 	tip.set("main-1")
 
 	engine.tick(context.Background())
@@ -454,7 +471,7 @@ func TestBmmEngineOpensByRateNotByAmount(t *testing.T) {
 // mainchain block carried the commitment. We must name that block.
 func TestBmmEngineNamesTheMainBlockOnConnect(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -472,7 +489,7 @@ func TestBmmEngineNamesTheMainBlockOnConnect(t *testing.T) {
 // connect on that block, not on the tip.
 func TestBmmEngineWinsARoundTheTipOutran(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -495,7 +512,7 @@ func TestBmmEngineWinsARoundTheTipOutran(t *testing.T) {
 // written down, so a restart can still resume it.
 func TestBmmEngineHoldsAnUndecidableRound(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -516,7 +533,7 @@ func TestBmmEngineHoldsAnUndecidableRound(t *testing.T) {
 // the bid, not connected blind on whatever the tip is by then.
 func TestBmmEngineDecidesAParkedRoundOnRetry(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -541,7 +558,7 @@ func TestBmmEngineDecidesAParkedRoundOnRetry(t *testing.T) {
 // must never be written down as a loss.
 func TestBmmEngineNeverCallsAnUndecidableRoundLost(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -562,7 +579,7 @@ func TestBmmEngineNeverCallsAnUndecidableRoundLost(t *testing.T) {
 // History is on disk, so a restart keeps what past rounds cost and earned.
 func TestBmmEngineHistorySurvivesRestart(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -583,7 +600,7 @@ func TestBmmEngineHistorySurvivesRestart(t *testing.T) {
 
 func TestBmmEngineClearHistory(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -608,7 +625,7 @@ func mustHistory(t *testing.T, engine *BmmEngine) []bmmstate.Round {
 // the connect back up rather than forfeit it.
 func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -635,7 +652,7 @@ func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 
 func TestBmmEngineRecordsBlockHeights(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -659,7 +676,7 @@ func TestBmmEngineIgnoresBidsFromAnotherRound(t *testing.T) {
 	backend.others = []*bmmpb.Bid{
 		{Txid: "stale", CriticalHash: "stale-h", BidSats: 80_000, PrevMainHash: "block-0"},
 	}
-	require.NoError(t, engine.Start(testSidechain, "", 50_000))
+	require.NoError(t, engine.Start(testSidechain, "", 50_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -673,18 +690,19 @@ func TestBmmEngineIgnoresBidsFromAnotherRound(t *testing.T) {
 // not caught up cannot spend on an already-dead round.
 func TestBmmEngineNamesTheTipItExpects(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
 	assert.Equal(t, "block-1", backend.lastExpectTip)
 }
 
-// An opening bid above what the block collects is a guaranteed loss.
+// The cap holds an opening bid at what the block collects, when the operator
+// asks for it.
 func TestBmmEngineCapsTheOpeningBidToBlockWorth(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 8_000
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, true))
 
 	engine.tick(context.Background())
 
@@ -692,10 +710,21 @@ func TestBmmEngineCapsTheOpeningBidToBlockWorth(t *testing.T) {
 	assert.Equal(t, int64(8_000), engine.Current(testSidechain).OurBids[0].BidSats)
 }
 
+// With no cap the opening bid answers the ceiling, whatever the block collects.
+func TestBmmEngineOpensAtTheCeilingWithNoCap(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.feesSats = 8_000
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+
+	engine.tick(context.Background())
+
+	assert.Equal(t, int64(10_000), backend.lastBidSats)
+}
+
 // Stop ends bidding, but a bid already broadcast still has to settle.
 func TestBmmEngineSettlesAfterStop(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -715,14 +744,14 @@ func TestBmmEngineSettlesAfterStop(t *testing.T) {
 // Restarting must not re-open a round already in play and double-bid it.
 func TestBmmEngineRestartDoesNotDoubleBidTheSameRound(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
 	require.Equal(t, 1, backend.bids)
 
 	engine.Stop(testSidechain)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 	engine.tick(ctx)
 
 	assert.Equal(t, 1, backend.bids, "same tip, still one bid")
@@ -732,7 +761,7 @@ func TestBmmEngineRestartDoesNotDoubleBidTheSameRound(t *testing.T) {
 // stop us connecting a block we may already have paid for.
 func TestBmmEngineKeepsRoundPendingWhenTheCommitmentCannotBeRead(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -760,7 +789,7 @@ func TestBmmEngineKeepsRoundPendingWhenTheCommitmentCannotBeRead(t *testing.T) {
 func TestBmmEngineCurrentIsADeepCopy(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.others = []*bmmpb.Bid{{Txid: "rival", BidSats: 5_000, PrevMainHash: "block-1"}}
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
@@ -775,7 +804,7 @@ func TestBmmEngineCurrentIsADeepCopy(t *testing.T) {
 // the bid we already broadcast can still win.
 func TestBmmEngineDoesNotSettleAnOpenRoundOnStop(t *testing.T) {
 	engine, _, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -797,7 +826,7 @@ func TestBmmEngineDoesNotSettleAnOpenRoundOnStop(t *testing.T) {
 func TestBmmEngineRetriesAfterAPreconditionRefusal(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.bidErr = connect.NewError(connect.CodeFailedPrecondition, errors.New("enforcer is still syncing"))
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -817,7 +846,7 @@ func TestBmmEngineRetriesAfterAPreconditionRefusal(t *testing.T) {
 func TestBmmEngineDoesNotRetryOtherFailures(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.bidErr = errors.New("no block template")
-	require.NoError(t, engine.Start(testSidechain, "", 10_000))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -835,7 +864,7 @@ func TestBmmEngineDoesNotRetryOtherFailures(t *testing.T) {
 // spends its change inherits that. The next opening bid must replace it.
 func TestBmmEngineReplacesAStrandedBid(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000))
+	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -860,7 +889,7 @@ func TestBmmEngineReplacesWithTheFundingWallet(t *testing.T) {
 	for _, walletID := range []string{"core-wallet", "electrum-wallet"} {
 		t.Run(walletID, func(t *testing.T) {
 			engine, backend, tip, _ := newEngine(t)
-			require.NoError(t, engine.Start(testSidechain, walletID, 20_000))
+			require.NoError(t, engine.Start(testSidechain, walletID, 20_000, false))
 
 			ctx := context.Background()
 			engine.tick(ctx)
@@ -883,7 +912,7 @@ func TestBmmEngineReplacesWithTheFundingWallet(t *testing.T) {
 // rather than respend inputs that are already gone.
 func TestBmmEngineOpensFreelyWhenNoBidIsStranded(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000))
+	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -901,7 +930,7 @@ func TestBmmEngineOpensFreelyWhenNoBidIsStranded(t *testing.T) {
 // leave it looking live.
 func TestBmmEngineRecordsAStrandedBidAsReplaced(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000))
+	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -934,7 +963,7 @@ func TestBmmEngineRecordsAStrandedBidAsReplaced(t *testing.T) {
 // which evicts every bid chained to it.
 func TestBmmEngineReplacesAStrandedBidAfterRestart(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "core-wallet", 20_000))
+	require.NoError(t, engine.Start(testSidechain, "core-wallet", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -955,7 +984,7 @@ func TestBmmEngineReplacesAStrandedBidAfterRestart(t *testing.T) {
 	backend.mu.Unlock()
 
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
-	require.NoError(t, restarted.Start(testSidechain, "core-wallet", 20_000))
+	require.NoError(t, restarted.Start(testSidechain, "core-wallet", 20_000, false))
 
 	tip.set("block-4")
 	restarted.tick(ctx)

--- a/sidechain-orchestrator/feerate/feerate.go
+++ b/sidechain-orchestrator/feerate/feerate.go
@@ -1,10 +1,10 @@
-// Package feerate reads what the next block pays, from a mempool.space style
-// explorer.
+// Package feerate answers what a transaction pays to enter the next block.
 package feerate
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -13,6 +13,46 @@ import (
 
 // timeout bounds one read. A bid waits on this answer, so it stays short.
 const timeout = 5 * time.Second
+
+// FeeEstimator answers what a transaction pays per vByte to enter the next
+// block.
+type FeeEstimator interface {
+	EstimateFee(ctx context.Context) (satsPerVByte float64, err error)
+}
+
+// Func adapts a plain function to a FeeEstimator.
+type Func func(ctx context.Context) (float64, error)
+
+// EstimateFee calls the function.
+func (f Func) EstimateFee(ctx context.Context) (float64, error) { return f(ctx) }
+
+// Fallback asks each source in order and takes the first rate it gets. A
+// caller lists the sources it trusts most first.
+type Fallback struct {
+	sources []FeeEstimator
+}
+
+// NewFallback reads the sources in the order given.
+func NewFallback(sources ...FeeEstimator) *Fallback {
+	return &Fallback{sources: sources}
+}
+
+// EstimateFee answers with the first rate a source reports. It names every
+// failure when no source answers, so a caller sees why.
+func (f *Fallback) EstimateFee(ctx context.Context) (float64, error) {
+	if len(f.sources) == 0 {
+		return 0, errors.New("no fee source")
+	}
+	var failures []error
+	for _, source := range f.sources {
+		rate, err := source.EstimateFee(ctx)
+		if err == nil {
+			return rate, nil
+		}
+		failures = append(failures, err)
+	}
+	return 0, errors.Join(failures...)
+}
 
 // Explorer reads the recommended rates of one mempool.space style server.
 type Explorer struct {
@@ -40,9 +80,10 @@ type recommended struct {
 	MinimumFee  float64 `json:"minimumFee"`
 }
 
-// NextBlockFeeRate is what a transaction pays per vByte to enter the next
-// block.
-func (e *Explorer) NextBlockFeeRate(ctx context.Context) (float64, error) {
+// EstimateFee is what a transaction pays per vByte to enter the next block.
+// The explorer reads the blocks a miner made, so it answers the market rather
+// than the mempool a node happens to hold.
+func (e *Explorer) EstimateFee(ctx context.Context) (float64, error) {
 	url := e.baseURL + "/api/v1/fees/recommended"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -66,3 +107,9 @@ func (e *Explorer) NextBlockFeeRate(ctx context.Context) (float64, error) {
 	}
 	return rates.FastestFee, nil
 }
+
+var (
+	_ FeeEstimator = (*Explorer)(nil)
+	_ FeeEstimator = (*Fallback)(nil)
+	_ FeeEstimator = Func(nil)
+)

--- a/sidechain-orchestrator/feerate/feerate.go
+++ b/sidechain-orchestrator/feerate/feerate.go
@@ -1,0 +1,68 @@
+// Package feerate reads what the next block pays, from a mempool.space style
+// explorer.
+package feerate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// timeout bounds one read. A bid waits on this answer, so it stays short.
+const timeout = 5 * time.Second
+
+// Explorer reads the recommended rates of one mempool.space style server.
+type Explorer struct {
+	baseURL string
+	http    *http.Client
+}
+
+// NewExplorer points a reader at a server, such as
+// https://explorer.alpha.ecash.ninja.
+func NewExplorer(baseURL string) *Explorer {
+	return &Explorer{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: timeout},
+	}
+}
+
+// URL is the server this reader asks.
+func (e *Explorer) URL() string { return e.baseURL }
+
+// recommended is what /api/v1/fees/recommended answers, in sats per vByte.
+type recommended struct {
+	FastestFee  float64 `json:"fastestFee"`
+	HalfHourFee float64 `json:"halfHourFee"`
+	HourFee     float64 `json:"hourFee"`
+	MinimumFee  float64 `json:"minimumFee"`
+}
+
+// NextBlockFeeRate is what a transaction pays per vByte to enter the next
+// block.
+func (e *Explorer) NextBlockFeeRate(ctx context.Context) (float64, error) {
+	url := e.baseURL + "/api/v1/fees/recommended"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build the request for %s: %w", url, err)
+	}
+	resp, err := e.http.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("%s answered %d", url, resp.StatusCode)
+	}
+	var rates recommended
+	if err := json.NewDecoder(resp.Body).Decode(&rates); err != nil {
+		return 0, fmt.Errorf("decode %s: %w", url, err)
+	}
+	if rates.FastestFee <= 0 {
+		return 0, fmt.Errorf("%s reports no rate for the next block", url)
+	}
+	return rates.FastestFee, nil
+}

--- a/sidechain-orchestrator/feerate/feerate_test.go
+++ b/sidechain-orchestrator/feerate/feerate_test.go
@@ -2,6 +2,7 @@ package feerate
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,11 +23,11 @@ func explorerOver(t *testing.T, status int, body string) *Explorer {
 }
 
 // The next block pays the fastest rate the explorer reports.
-func TestNextBlockFeeRateReadsTheFastestRate(t *testing.T) {
+func TestEstimateFeeReadsTheFastestRate(t *testing.T) {
 	e := explorerOver(t, http.StatusOK,
 		`{"fastestFee":4,"halfHourFee":1,"hourFee":1,"economyFee":1,"minimumFee":1}`)
 
-	rate, err := e.NextBlockFeeRate(context.Background())
+	rate, err := e.EstimateFee(context.Background())
 	if err != nil {
 		t.Fatalf("read the rate: %v", err)
 	}
@@ -43,23 +44,58 @@ func TestNewExplorerTrimsTheSlash(t *testing.T) {
 	}
 }
 
-func TestNextBlockFeeRateRefusesAZeroRate(t *testing.T) {
+func TestEstimateFeeRefusesAZeroRate(t *testing.T) {
 	e := explorerOver(t, http.StatusOK, `{"fastestFee":0}`)
-	if _, err := e.NextBlockFeeRate(context.Background()); err == nil {
+	if _, err := e.EstimateFee(context.Background()); err == nil {
 		t.Fatal("want an error for a zero rate, got none")
 	}
 }
 
-func TestNextBlockFeeRateRefusesABadStatus(t *testing.T) {
+func TestEstimateFeeRefusesABadStatus(t *testing.T) {
 	e := explorerOver(t, http.StatusBadGateway, "")
-	if _, err := e.NextBlockFeeRate(context.Background()); err == nil {
+	if _, err := e.EstimateFee(context.Background()); err == nil {
 		t.Fatal("want an error for a 502, got none")
 	}
 }
 
-func TestNextBlockFeeRateRefusesJunk(t *testing.T) {
+func TestEstimateFeeRefusesJunk(t *testing.T) {
 	e := explorerOver(t, http.StatusOK, "not json")
-	if _, err := e.NextBlockFeeRate(context.Background()); err == nil {
+	if _, err := e.EstimateFee(context.Background()); err == nil {
 		t.Fatal("want an error for a body it cannot read, got none")
 	}
 }
+
+// The fallback answers with the first source that reports a rate.
+func TestFallbackTakesTheFirstAnswer(t *testing.T) {
+	broken := Func(func(context.Context) (float64, error) { return 0, errUnavailable })
+	steady := Func(func(context.Context) (float64, error) { return 7, nil })
+
+	rate, err := NewFallback(broken, steady).EstimateFee(context.Background())
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	if rate != 7 {
+		t.Errorf("rate = %v, want 7", rate)
+	}
+}
+
+// A caller sees why no source answered.
+func TestFallbackNamesEveryFailure(t *testing.T) {
+	broken := Func(func(context.Context) (float64, error) { return 0, errUnavailable })
+
+	_, err := NewFallback(broken, broken).EstimateFee(context.Background())
+	if err == nil {
+		t.Fatal("want an error when no source answers, got none")
+	}
+	if !errors.Is(err, errUnavailable) {
+		t.Errorf("error = %v, want the source failure", err)
+	}
+}
+
+func TestFallbackWithNoSource(t *testing.T) {
+	if _, err := NewFallback().EstimateFee(context.Background()); err == nil {
+		t.Fatal("want an error with no source, got none")
+	}
+}
+
+var errUnavailable = errors.New("the source is down")

--- a/sidechain-orchestrator/feerate/feerate_test.go
+++ b/sidechain-orchestrator/feerate/feerate_test.go
@@ -1,0 +1,65 @@
+package feerate
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func explorerOver(t *testing.T, status int, body string) *Explorer {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/fees/recommended" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return NewExplorer(server.URL)
+}
+
+// The next block pays the fastest rate the explorer reports.
+func TestNextBlockFeeRateReadsTheFastestRate(t *testing.T) {
+	e := explorerOver(t, http.StatusOK,
+		`{"fastestFee":4,"halfHourFee":1,"hourFee":1,"economyFee":1,"minimumFee":1}`)
+
+	rate, err := e.NextBlockFeeRate(context.Background())
+	if err != nil {
+		t.Fatalf("read the rate: %v", err)
+	}
+	if rate != 4 {
+		t.Errorf("rate = %v, want 4", rate)
+	}
+}
+
+// A trailing slash in the address names the same server.
+func TestNewExplorerTrimsTheSlash(t *testing.T) {
+	e := NewExplorer("https://explorer.example.com/")
+	if e.URL() != "https://explorer.example.com" {
+		t.Errorf("url = %q", e.URL())
+	}
+}
+
+func TestNextBlockFeeRateRefusesAZeroRate(t *testing.T) {
+	e := explorerOver(t, http.StatusOK, `{"fastestFee":0}`)
+	if _, err := e.NextBlockFeeRate(context.Background()); err == nil {
+		t.Fatal("want an error for a zero rate, got none")
+	}
+}
+
+func TestNextBlockFeeRateRefusesABadStatus(t *testing.T) {
+	e := explorerOver(t, http.StatusBadGateway, "")
+	if _, err := e.NextBlockFeeRate(context.Background()); err == nil {
+		t.Fatal("want an error for a 502, got none")
+	}
+}
+
+func TestNextBlockFeeRateRefusesJunk(t *testing.T) {
+	e := explorerOver(t, http.StatusOK, "not json")
+	if _, err := e.NextBlockFeeRate(context.Background()); err == nil {
+		t.Fatal("want an error for a body it cannot read, got none")
+	}
+}

--- a/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
+++ b/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
@@ -25,13 +25,16 @@ const (
 type StartRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	Sidechain v1.BinaryType          `protobuf:"varint,1,opt,name=sidechain,proto3,enum=orchestrator.v1.BinaryType" json:"sidechain,omitempty"`
-	// Ceiling for raises. A bid is never raised above this, nor above what the
-	// block is worth, since either loses money.
+	// Ceiling for raises. A bid never goes above this.
 	MaxBidSats int64 `protobuf:"varint,3,opt,name=max_bid_sats,json=maxBidSats,proto3" json:"max_bid_sats,omitempty"`
 	// Wallet that funds every bid. Empty uses the active wallet.
-	WalletId      string `protobuf:"bytes,4,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	WalletId string `protobuf:"bytes,4,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	// Hold every bid at or under what the block collects in fees. A chain whose
+	// blocks carry few fees then bids almost nothing, and every competitor wins,
+	// so this is off unless the operator asks for it.
+	CapToBlockWorth bool `protobuf:"varint,5,opt,name=cap_to_block_worth,json=capToBlockWorth,proto3" json:"cap_to_block_worth,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *StartRequest) Reset() {
@@ -83,6 +86,13 @@ func (x *StartRequest) GetWalletId() string {
 		return x.WalletId
 	}
 	return ""
+}
+
+func (x *StartRequest) GetCapToBlockWorth() bool {
+	if x != nil {
+		return x.CapToBlockWorth
+	}
+	return false
 }
 
 type StartResponse struct {
@@ -1196,12 +1206,13 @@ var File_bmm_v1_bmm_proto protoreflect.FileDescriptor
 
 const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\n" +
-	"\x10bmm/v1/bmm.proto\x12\x06bmm.v1\x1a\"orchestrator/v1/orchestrator.proto\"\x8e\x01\n" +
+	"\x10bmm/v1/bmm.proto\x12\x06bmm.v1\x1a\"orchestrator/v1/orchestrator.proto\"\xbb\x01\n" +
 	"\fStartRequest\x129\n" +
 	"\tsidechain\x18\x01 \x01(\x0e2\x1b.orchestrator.v1.BinaryTypeR\tsidechain\x12 \n" +
 	"\fmax_bid_sats\x18\x03 \x01(\x03R\n" +
 	"maxBidSats\x12\x1b\n" +
-	"\twallet_id\x18\x04 \x01(\tR\bwalletIdJ\x04\b\x02\x10\x03\"\x0f\n" +
+	"\twallet_id\x18\x04 \x01(\tR\bwalletId\x12+\n" +
+	"\x12cap_to_block_worth\x18\x05 \x01(\bR\x0fcapToBlockWorthJ\x04\b\x02\x10\x03\"\x0f\n" +
 	"\rStartResponse\"H\n" +
 	"\vStopRequest\x129\n" +
 	"\tsidechain\x18\x01 \x01(\x0e2\x1b.orchestrator.v1.BinaryTypeR\tsidechain\"\x0e\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1075,21 +1075,50 @@ func (o *Orchestrator) EstimateFee(ctx context.Context) (float64, error) {
 		sources = append(sources, feerate.NewExplorer(url))
 	}
 	sources = append(sources, feerate.Func(o.coreFeeRate))
-	return feerate.NewFallback(sources...).EstimateFee(ctx)
+
+	rate, err := feerate.NewFallback(sources...).EstimateFee(ctx)
+	if err != nil {
+		return 0, err
+	}
+	// The node refuses a transaction under what it relays, so an explorer that
+	// reads another node's market never takes the bid below this floor.
+	floor, floorErr := o.relayFloorRate(ctx)
+	if floorErr != nil {
+		o.log.Debug().Err(floorErr).Msg("core reports no relay floor")
+		return rate, nil
+	}
+	return highestFeeRate(rate, floor), nil
+}
+
+// relayFloorRate is the least a transaction pays for this node to relay it.
+func (o *Orchestrator) relayFloorRate(ctx context.Context) (float64, error) {
+	rpc, err := o.coreRPC()
+	if err != nil {
+		return 0, err
+	}
+	return rpc.MempoolMinFeeRate(ctx)
+}
+
+// coreRPC dials the node this install runs.
+func (o *Orchestrator) coreRPC() (*wallet.CoreRPCClient, error) {
+	if o.BitcoinConf == nil {
+		return nil, fmt.Errorf("no bitcoin config")
+	}
+	user, password, err := o.BitcoinConf.GetRPCCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("core rpc credentials: %w", err)
+	}
+	return wallet.NewCoreRPCClient(wallet.StaticCoreEndpoint(
+		o.BitcoinConf.GetRPCHost(), o.BitcoinConf.GetRPCPort(), user, password,
+	)), nil
 }
 
 // coreFeeRate asks Core itself.
 func (o *Orchestrator) coreFeeRate(ctx context.Context) (float64, error) {
-	if o.BitcoinConf == nil {
-		return 0, fmt.Errorf("no bitcoin config")
-	}
-	user, password, err := o.BitcoinConf.GetRPCCredentials()
+	rpc, err := o.coreRPC()
 	if err != nil {
-		return 0, fmt.Errorf("core rpc credentials: %w", err)
+		return 0, err
 	}
-	rpc := wallet.NewCoreRPCClient(wallet.StaticCoreEndpoint(
-		o.BitcoinConf.GetRPCHost(), o.BitcoinConf.GetRPCPort(), user, password,
-	))
 	estimate, estimateErr := rpc.EstimateSmartFee(ctx, 1)
 	relay, relayErr := rpc.MempoolMinFeeRate(ctx)
 	if estimateErr != nil && relayErr != nil {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/datasource"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/feerate"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/fork"
 	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	enforcerrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
@@ -1061,10 +1062,27 @@ func (o *Orchestrator) ensureCoreSidechainWallet(ctx context.Context, cfg Binary
 	)
 }
 
-// NextBlockFeeRate asks Core what a transaction pays per vByte to enter the
-// next block. It is the floor a BMM bid opens at, because a miner leaves a
-// cheaper bid in the mempool and the engine raises only against a competitor.
+// NextBlockFeeRate is what a transaction pays per vByte to enter the next
+// block. It is the floor a BMM bid opens at, because a miner leaves a cheaper
+// bid in the mempool and the engine raises only against a competitor.
+//
+// A network with an explorer answers from the blocks it reads. Core's own
+// estimator reads the mempool it holds, and a chain whose mempool carries
+// transactions no miner takes pushes that estimate far over the market.
 func (o *Orchestrator) NextBlockFeeRate(ctx context.Context) (float64, error) {
+	if url := config.FeeExplorerURLForNetwork(config.Network(o.CurrentNetwork())); url != "" {
+		rate, err := feerate.NewExplorer(url).NextBlockFeeRate(ctx)
+		if err == nil {
+			return rate, nil
+		}
+		o.log.Debug().Err(err).Str("explorer", url).
+			Msg("the explorer reports no fee rate, asking core")
+	}
+	return o.coreFeeRate(ctx)
+}
+
+// coreFeeRate asks Core itself, for a network with no explorer.
+func (o *Orchestrator) coreFeeRate(ctx context.Context) (float64, error) {
 	if o.BitcoinConf == nil {
 		return 0, fmt.Errorf("no bitcoin config")
 	}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1062,26 +1062,23 @@ func (o *Orchestrator) ensureCoreSidechainWallet(ctx context.Context, cfg Binary
 	)
 }
 
-// NextBlockFeeRate is what a transaction pays per vByte to enter the next
-// block. It is the floor a BMM bid opens at, because a miner leaves a cheaper
-// bid in the mempool and the engine raises only against a competitor.
+// EstimateFee is what a transaction pays per vByte to enter the next block. It
+// is the floor a BMM bid opens at, because a miner leaves a cheaper bid in the
+// mempool and the engine raises only against a competitor.
 //
-// A network with an explorer answers from the blocks it reads. Core's own
-// estimator reads the mempool it holds, and a chain whose mempool carries
-// transactions no miner takes pushes that estimate far over the market.
-func (o *Orchestrator) NextBlockFeeRate(ctx context.Context) (float64, error) {
+// The explorer of the network answers first, because it reads the blocks a
+// miner made. Core reads the mempool it holds, and a chain whose mempool
+// carries transactions no miner takes pushes that estimate far over the market.
+func (o *Orchestrator) EstimateFee(ctx context.Context) (float64, error) {
+	sources := make([]feerate.FeeEstimator, 0, 2)
 	if url := config.FeeExplorerURLForNetwork(config.Network(o.CurrentNetwork())); url != "" {
-		rate, err := feerate.NewExplorer(url).NextBlockFeeRate(ctx)
-		if err == nil {
-			return rate, nil
-		}
-		o.log.Debug().Err(err).Str("explorer", url).
-			Msg("the explorer reports no fee rate, asking core")
+		sources = append(sources, feerate.NewExplorer(url))
 	}
-	return o.coreFeeRate(ctx)
+	sources = append(sources, feerate.Func(o.coreFeeRate))
+	return feerate.NewFallback(sources...).EstimateFee(ctx)
 }
 
-// coreFeeRate asks Core itself, for a network with no explorer.
+// coreFeeRate asks Core itself.
 func (o *Orchestrator) coreFeeRate(ctx context.Context) (float64, error) {
 	if o.BitcoinConf == nil {
 		return 0, fmt.Errorf("no bitcoin config")

--- a/sidechain-orchestrator/orphan_drain_test.go
+++ b/sidechain-orchestrator/orphan_drain_test.go
@@ -7,12 +7,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// sleeperExit names the channel that closes when one sleeper exits, by pid. A
+// dead child stays a zombie until its parent reaps it, and a signal 0 to a
+// zombie still succeeds, so a poll alone reads a dead process as alive.
+var sleeperExit sync.Map
 
 // startSleeper runs a real child this test can watch die. A PID from exec is a
 // live process, so the drain has something it must actually signal.
@@ -21,11 +27,17 @@ func startSleeper(t *testing.T) int {
 	cmd := exec.Command("sleep", "300")
 	require.NoError(t, cmd.Start())
 	pid := cmd.Process.Pid
+
+	exited := make(chan struct{})
+	sleeperExit.Store(pid, exited)
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(exited)
+	}()
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
+		sleeperExit.Delete(pid)
 	})
-	go func() { _, _ = cmd.Process.Wait() }()
 	return pid
 }
 
@@ -38,6 +50,15 @@ func alive(t *testing.T, pid int) bool {
 
 func waitGone(t *testing.T, pid int, timeout time.Duration) bool {
 	t.Helper()
+	if value, ok := sleeperExit.Load(pid); ok {
+		select {
+		case <-value.(chan struct{}):
+			return true
+		case <-time.After(timeout):
+			return false
+		}
+	}
+
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if !alive(t, pid) {

--- a/sidechain-orchestrator/proto/bmm/v1/bmm.proto
+++ b/sidechain-orchestrator/proto/bmm/v1/bmm.proto
@@ -44,11 +44,14 @@ message StartRequest {
   // The opening bid comes from Core's next block estimate, so the caller
   // sets no floor of its own.
   reserved 2;
-  // Ceiling for raises. A bid is never raised above this, nor above what the
-  // block is worth, since either loses money.
+  // Ceiling for raises. A bid never goes above this.
   int64 max_bid_sats = 3;
   // Wallet that funds every bid. Empty uses the active wallet.
   string wallet_id = 4;
+  // Hold every bid at or under what the block collects in fees. A chain whose
+  // blocks carry few fees then bids almost nothing, and every competitor wins,
+  // so this is off unless the operator asks for it.
+  bool cap_to_block_worth = 5;
 }
 
 message StartResponse {}

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pb.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pb.dart
@@ -22,6 +22,7 @@ class StartRequest extends $pb.GeneratedMessage {
     $3.BinaryType? sidechain,
     $fixnum.Int64? maxBidSats,
     $core.String? walletId,
+    $core.bool? capToBlockWorth,
   }) {
     final $result = create();
     if (sidechain != null) {
@@ -33,6 +34,9 @@ class StartRequest extends $pb.GeneratedMessage {
     if (walletId != null) {
       $result.walletId = walletId;
     }
+    if (capToBlockWorth != null) {
+      $result.capToBlockWorth = capToBlockWorth;
+    }
     return $result;
   }
   StartRequest._() : super();
@@ -43,6 +47,7 @@ class StartRequest extends $pb.GeneratedMessage {
     ..e<$3.BinaryType>(1, _omitFieldNames ? '' : 'sidechain', $pb.PbFieldType.OE, defaultOrMaker: $3.BinaryType.BINARY_TYPE_UNSPECIFIED, valueOf: $3.BinaryType.valueOf, enumValues: $3.BinaryType.values)
     ..aInt64(3, _omitFieldNames ? '' : 'maxBidSats')
     ..aOS(4, _omitFieldNames ? '' : 'walletId')
+    ..aOB(5, _omitFieldNames ? '' : 'capToBlockWorth')
     ..hasRequiredFields = false
   ;
 
@@ -76,8 +81,7 @@ class StartRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearSidechain() => clearField(1);
 
-  /// Ceiling for raises. A bid is never raised above this, nor above what the
-  /// block is worth, since either loses money.
+  /// Ceiling for raises. A bid never goes above this.
   @$pb.TagNumber(3)
   $fixnum.Int64 get maxBidSats => $_getI64(1);
   @$pb.TagNumber(3)
@@ -96,6 +100,18 @@ class StartRequest extends $pb.GeneratedMessage {
   $core.bool hasWalletId() => $_has(2);
   @$pb.TagNumber(4)
   void clearWalletId() => clearField(4);
+
+  /// Hold every bid at or under what the block collects in fees. A chain whose
+  /// blocks carry few fees then bids almost nothing, and every competitor wins,
+  /// so this is off unless the operator asks for it.
+  @$pb.TagNumber(5)
+  $core.bool get capToBlockWorth => $_getBF(3);
+  @$pb.TagNumber(5)
+  set capToBlockWorth($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasCapToBlockWorth() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearCapToBlockWorth() => clearField(5);
 }
 
 class StartResponse extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pbjson.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pbjson.dart
@@ -20,6 +20,7 @@ const StartRequest$json = {
     {'1': 'sidechain', '3': 1, '4': 1, '5': 14, '6': '.orchestrator.v1.BinaryType', '10': 'sidechain'},
     {'1': 'max_bid_sats', '3': 3, '4': 1, '5': 3, '10': 'maxBidSats'},
     {'1': 'wallet_id', '3': 4, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'cap_to_block_worth', '3': 5, '4': 1, '5': 8, '10': 'capToBlockWorth'},
   ],
   '9': [
     {'1': 2, '2': 3},
@@ -30,7 +31,8 @@ const StartRequest$json = {
 final $typed_data.Uint8List startRequestDescriptor = $convert.base64Decode(
     'CgxTdGFydFJlcXVlc3QSOQoJc2lkZWNoYWluGAEgASgOMhsub3JjaGVzdHJhdG9yLnYxLkJpbm'
     'FyeVR5cGVSCXNpZGVjaGFpbhIgCgxtYXhfYmlkX3NhdHMYAyABKANSCm1heEJpZFNhdHMSGwoJ'
-    'd2FsbGV0X2lkGAQgASgJUgh3YWxsZXRJZEoECAIQAw==');
+    'd2FsbGV0X2lkGAQgASgJUgh3YWxsZXRJZBIrChJjYXBfdG9fYmxvY2tfd29ydGgYBSABKAhSD2'
+    'NhcFRvQmxvY2tXb3J0aEoECAIQAw==');
 
 @$core.Deprecated('Use startResponseDescriptor instead')
 const StartResponse$json = {

--- a/sidechain_core/lib/rpcs/orchestrator_bmm_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_bmm_rpc.dart
@@ -20,16 +20,21 @@ class OrchestratorBmmRPC {
 
   /// Bid on every new mainchain tip until [stop], raising toward [maxBidSats]
   /// when a competitor outbids us.
+  ///
+  /// [capToBlockWorth] holds every bid at or under what the block collects in
+  /// fees. A chain with cheap blocks then loses every round, so it is off.
   Future<void> start({
     required BinaryType sidechain,
     required int maxBidSats,
     String? walletId,
+    bool capToBlockWorth = false,
   }) async {
     await _unaryClient.start(
       bmmpb.StartRequest(
         sidechain: sidechain,
         walletId: walletId ?? '',
         maxBidSats: Int64(maxBidSats),
+        capToBlockWorth: capToBlockWorth,
       ),
     );
   }


### PR DESCRIPTION
Two faults kept the alphanet chain still for five hours.

A bid takes the change of the bid before it, so a stranded bid carries a chain of stranded bids under it. A replacement respent the top one alone, so the dead root stayed and held every later bid out of a block. A replacement now walks down while a parent is another bid for the slot, and respends the coins a block already carries. The fee floor comes from the same roots.

The engine also held every bid at or under what the block collects in fees. On a chain with cheap blocks that ceiling sits at a few hundred sats, and every competitor wins. The cap is now a setting on Start, and it is off unless the operator asks for it.