### PR TITLE
thunder: dial the seed after the enforcer syncs

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.324
+version: 1.0.325
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.324
+version: 1.0.325
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.194
+version: 0.2.195
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.197
+version: 1.0.198
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/dial_thunder_seed_test.go
+++ b/sidechain-orchestrator/dial_thunder_seed_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -41,13 +43,21 @@ func fakeThunder(t *testing.T, calls chan<- seedCall) (string, int) {
 	return host, port
 }
 
+func neverGiveUp() bool { return false }
+
+func testLog(t *testing.T) zerolog.Logger {
+	t.Helper()
+	return zerolog.New(zerolog.NewTestWriter(t))
+}
+
 // Both seeds thunder names are down, so the launcher names one that answers.
 func TestDialThunderSeedAsksTheChain(t *testing.T) {
 	calls := make(chan seedCall, 2)
 	host, port := fakeThunder(t, calls)
 
-	o := &Orchestrator{Network: "ecash", log: zerolog.New(zerolog.NewTestWriter(t))}
-	o.dialThunderSeed(context.Background(), BinaryConfig{Name: "thunder", Host: host, Port: port})
+	dialSeedWhenSynced(context.Background(), testLog(t),
+		BinaryConfig{Name: "thunder", Host: host, Port: port},
+		time.Millisecond, func() bool { return true }, neverGiveUp)
 
 	select {
 	case got := <-calls:
@@ -59,6 +69,48 @@ func TestDialThunderSeedAsksTheChain(t *testing.T) {
 		}
 	default:
 		t.Fatal("the launcher asked thunder nothing")
+	}
+}
+
+// Thunder asks its enforcer for the peer tip's mainchain ancestors on the first
+// exchange, so a dial before the enforcer holds them wastes the peer.
+func TestDialThunderSeedWaitsForTheEnforcer(t *testing.T) {
+	calls := make(chan seedCall, 2)
+	host, port := fakeThunder(t, calls)
+
+	var reads atomic.Int32
+	dialSeedWhenSynced(context.Background(), testLog(t),
+		BinaryConfig{Name: "thunder", Host: host, Port: port},
+		time.Millisecond, func() bool { return reads.Add(1) >= 3 }, neverGiveUp)
+
+	if got := reads.Load(); got != 3 {
+		t.Errorf("read the sync status %d times, want 3", got)
+	}
+	select {
+	case got := <-calls:
+		if got.Method != "connect_peer" {
+			t.Errorf("method = %q, want connect_peer", got.Method)
+		}
+	default:
+		t.Fatal("the launcher never dialled the seed")
+	}
+}
+
+// A shutdown stops the wait, and nothing dials a chain that is going down.
+func TestDialThunderSeedStopsWithTheContext(t *testing.T) {
+	calls := make(chan seedCall, 2)
+	host, port := fakeThunder(t, calls)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dialSeedWhenSynced(ctx, testLog(t),
+		BinaryConfig{Name: "thunder", Host: host, Port: port},
+		time.Millisecond, func() bool { return false }, neverGiveUp)
+
+	select {
+	case got := <-calls:
+		t.Errorf("the launcher asked for %v", got)
+	default:
 	}
 }
 
@@ -77,7 +129,7 @@ func TestDialThunderSeedLeavesEveryOtherChainAlone(t *testing.T) {
 			calls := make(chan seedCall, 2)
 			host, port := fakeThunder(t, calls)
 
-			o := &Orchestrator{Network: test.network, log: zerolog.New(zerolog.NewTestWriter(t))}
+			o := &Orchestrator{Network: test.network, log: testLog(t)}
 			o.dialThunderSeed(context.Background(), BinaryConfig{Name: test.binary, Host: host, Port: port})
 
 			select {
@@ -86,5 +138,56 @@ func TestDialThunderSeedLeavesEveryOtherChainAlone(t *testing.T) {
 			default:
 			}
 		})
+	}
+}
+
+func TestEnforcerAtTip(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		result *ChainSyncResult
+		want   bool
+	}{
+		{name: "at the tip", result: &ChainSyncResult{Blocks: 100, Headers: 100}, want: true},
+		{name: "behind", result: &ChainSyncResult{Blocks: 99, Headers: 100}},
+		{name: "no headers", result: &ChainSyncResult{}},
+		{name: "an error", result: &ChainSyncResult{Blocks: 100, Headers: 100, Error: "down"}},
+		{name: "no result", result: nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := enforcerAtTip(test.result); got != test.want {
+				t.Errorf("enforcerAtTip = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// A drain must end the wait, or the goroutine outlives the daemon it serves.
+func TestDialThunderSeedStopsWhenTheDrainBegins(t *testing.T) {
+	calls := make(chan seedCall, 2)
+	host, port := fakeThunder(t, calls)
+
+	var reads atomic.Int32
+	dialSeedWhenSynced(context.Background(), testLog(t),
+		BinaryConfig{Name: "thunder", Host: host, Port: port},
+		time.Millisecond,
+		func() bool { reads.Add(1); return false },
+		func() bool { return reads.Load() >= 2 })
+
+	select {
+	case got := <-calls:
+		t.Errorf("the launcher asked for %v", got)
+	default:
+	}
+}
+
+// A reset cancels each item's context as soon as the binary answers, so the
+// dial must not take that context.
+func TestSeedDialContextOutlivesTheCaller(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dialCtx := seedDialContext(ctx)
+	cancel()
+
+	if dialCtx.Err() != nil {
+		t.Errorf("the dial context ended with the caller: %v", dialCtx.Err())
 	}
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1770,7 +1770,7 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 		return
 	}
 
-	o.dialThunderSeed(ctx, config)
+	go o.dialThunderSeed(ctx, config)
 
 	ch <- StartupProgress{Stage: "done", Message: fmt.Sprintf("%s started", config.DisplayName), Done: true}
 }
@@ -1779,8 +1779,10 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 // so a node that starts reaches nobody without this one.
 const alphanetThunderSeed = "204.168.254.113:4009"
 
-// dialThunderSeed asks thunder to connect to the alphanet seed. The chain
-// answers its RPC by this point.
+// enforcerSyncPoll is how often the seed dial re-reads the sync status.
+const enforcerSyncPoll = 5 * time.Second
+
+// dialThunderSeed asks thunder to connect to the alphanet seed.
 //
 // A refused address leaves the chain running: the node keeps the address and
 // retries it on its own.
@@ -1788,12 +1790,63 @@ func (o *Orchestrator) dialThunderSeed(ctx context.Context, config BinaryConfig)
 	if config.Name != "thunder" || o.Network != "ecash" {
 		return
 	}
-	proxy := sidechain.NewJSONRPCProxy(config.RPCHost(), config.Port)
-	if err := proxy.Client.Call(ctx, "connect_peer", []any{alphanetThunderSeed}, nil); err != nil {
-		o.log.Warn().Err(err).Str("peer", alphanetThunderSeed).Msg("could not reach the alphanet seed")
+	gen := o.shutdownGen.Load()
+	dialCtx := seedDialContext(ctx)
+	dialSeedWhenSynced(dialCtx, o.log, config, enforcerSyncPoll,
+		func() bool {
+			status, err := o.GetSyncStatus(dialCtx)
+			return err == nil && enforcerAtTip(status.Enforcer)
+		},
+		func() bool { return o.shutdownGen.Load() != gen },
+	)
+}
+
+// seedDialContext detaches the dial from the call that started the chain. A
+// data reset cancels each item's context as soon as the binary answers, and the
+// enforcer reaches its tip after that. The next drain ends the wait instead.
+func seedDialContext(ctx context.Context) context.Context {
+	return context.WithoutCancel(ctx)
+}
+
+// dialSeedWhenSynced holds the dial until synced answers true. Thunder asks its
+// enforcer for the mainchain ancestors of the peer's tip on the first exchange.
+// A peer that gets no answer stays connected and asks for nothing more.
+func dialSeedWhenSynced(
+	ctx context.Context, log zerolog.Logger, config BinaryConfig, every time.Duration, synced, giveUp func() bool,
+) {
+	if !waitUntil(ctx, every, synced, giveUp) {
+		log.Warn().Str("peer", alphanetThunderSeed).Msg("the enforcer never reached the tip, so nothing dialled the alphanet seed")
 		return
 	}
-	o.log.Info().Str("peer", alphanetThunderSeed).Msg("dialled the alphanet seed")
+	proxy := sidechain.NewJSONRPCProxy(config.RPCHost(), config.Port)
+	if err := proxy.Client.Call(ctx, "connect_peer", []any{alphanetThunderSeed}, nil); err != nil {
+		log.Warn().Err(err).Str("peer", alphanetThunderSeed).Msg("could not reach the alphanet seed")
+		return
+	}
+	log.Info().Str("peer", alphanetThunderSeed).Msg("dialled the alphanet seed")
+}
+
+// waitUntil calls ready every interval until it answers true. It stops when ctx
+// ends, or when giveUp answers true.
+func waitUntil(ctx context.Context, every time.Duration, ready, giveUp func() bool) bool {
+	for {
+		if giveUp() {
+			return false
+		}
+		if ready() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(every):
+		}
+	}
+}
+
+// enforcerAtTip reports whether the enforcer holds every block it knows about.
+func enforcerAtTip(r *ChainSyncResult) bool {
+	return r != nil && r.Error == "" && r.Headers > 0 && r.Blocks == r.Headers
 }
 
 // RegisterLightWallet records how to ask whether a chain reads a remote index.

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.326
+version: 1.0.327
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.197
+version: 1.0.198
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.323
+version: 1.0.324
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Thunder asks its enforcer for the mainchain ancestors of the peer tip on the first exchange. The launcher dialled the seed as soon as thunder answered RPC, so the enforcer was still on its initial sync. The peer task failed, kept the connection, and asked for nothing more. The chain stayed at height 0.

The dial now waits for the enforcer to reach its own headers, and it runs off the boot path so the start message is not held back.