### PR TITLE
orchestrator: trust the replay locktime in the split check

### DIFF
--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -371,6 +371,7 @@ func run(cctx *cli.Context) error {
 	// Chain wallet provider — CoreBackend today; electrum/btcd providers
 	// slot in behind the same wallet.Backend interface.
 	var chainBackend wallet.Backend
+	var localChain wallet.ChainSource
 	if orch.BitcoinConf != nil {
 		// Port and credentials both move with the network.
 		coreEndpoint := func() wallet.CoreEndpoint {
@@ -387,7 +388,9 @@ func run(cctx *cli.Context) error {
 			return endpoint
 		}
 		coreRPC := wallet.NewCoreRPCClient(coreEndpoint)
-		chainBackend = wallet.NewCoreBackend(walletSvc, coreRPC, netParams, log)
+		coreBackend := wallet.NewCoreBackend(walletSvc, coreRPC, netParams, log)
+		chainBackend = coreBackend
+		localChain = coreBackend.Chain()
 		log.Info().Int("rpc_port", coreEndpoint().Port).Msg("core wallet provider initialized")
 	}
 
@@ -466,7 +469,7 @@ func run(cctx *cli.Context) error {
 		if electrumBackend != nil {
 			electrumBackend.OnProxyChange(splitClient.SetProxy)
 		}
-		splitEngine := engines.NewSplitEngine(log, orch, orch, splitClient, walletSvc, currentNetwork)
+		splitEngine := engines.NewSplitEngine(log, orch, orch, splitClient, localChain, walletSvc, currentNetwork)
 		walletEngine.OnNetworkReset(splitEngine.ResetForNetwork)
 		go func() {
 			if err := splitEngine.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/sidechain-orchestrator/engines/split_engine.go
+++ b/sidechain-orchestrator/engines/split_engine.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/fork"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
@@ -40,6 +41,12 @@ type OutspendSource interface {
 	Outspend(ctx context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error)
 }
 
+// LocalChainSource reads a transaction from this chain. wallet.ChainSource
+// satisfies it; nil disables the local locktime check.
+type LocalChainSource interface {
+	GetRawTransaction(ctx context.Context, txid string) (*wallet.RawTransaction, error)
+}
+
 // SplitStore persists the per-outpoint split status.
 type SplitStore interface {
 	SplitStatuses(ctx context.Context) (map[string]bool, error)
@@ -55,6 +62,7 @@ type SplitEngine struct {
 	fork    ForkStateSource
 	coins   UnspentSource
 	btc     OutspendSource
+	local   LocalChainSource
 	store   SplitStore
 	network func() string
 	now     func() time.Time
@@ -66,12 +74,13 @@ type SplitEngine struct {
 	wake chan struct{}
 }
 
-func NewSplitEngine(log zerolog.Logger, forkState ForkStateSource, coins UnspentSource, btc OutspendSource, store SplitStore, network func() string) *SplitEngine {
+func NewSplitEngine(log zerolog.Logger, forkState ForkStateSource, coins UnspentSource, btc OutspendSource, local LocalChainSource, store SplitStore, network func() string) *SplitEngine {
 	return &SplitEngine{
 		log:     log.With().Str("component", "split-engine").Logger(),
 		fork:    forkState,
 		coins:   coins,
 		btc:     btc,
+		local:   local,
 		store:   store,
 		network: network,
 		now:     time.Now,
@@ -137,6 +146,17 @@ func (e *SplitEngine) tick(ctx context.Context) {
 		if _, done := cached[u.Outpoint]; done {
 			continue
 		}
+		// A funding transaction whose magic locktime binds is non-final on
+		// stock Bitcoin forever, so the coin is this chain's alone. No BTC lookup.
+		if e.protectedLocally(ctx, u.Outpoint) {
+			delete(e.absent, u.Outpoint)
+			if err := e.store.SaveSplitStatus(ctx, u.Outpoint, false); err != nil {
+				e.log.Warn().Err(err).Str("outpoint", u.Outpoint).Msg("split: pass stopped")
+				return
+			}
+			e.log.Info().Str("outpoint", u.Outpoint).Msg("split: coin carries the replay locktime")
+			continue
+		}
 		if !dueForRecheck(e.absent[u.Outpoint], e.now()) {
 			continue
 		}
@@ -163,6 +183,27 @@ func (e *SplitEngine) tick(ctx context.Context) {
 		}
 		e.log.Info().Str("outpoint", u.Outpoint).Bool("splittable", status == btcUnspent).Msg("split: outpoint checked")
 	}
+}
+
+// protectedLocally reports whether the coin's funding transaction carries the
+// magic locktime. A local read failure falls back to the BTC lookup.
+func (e *SplitEngine) protectedLocally(ctx context.Context, outpoint string) bool {
+	if e.local == nil {
+		return false
+	}
+	txid, _, ok := parseOutpoint(outpoint)
+	if !ok {
+		return false
+	}
+	raw, err := e.local.GetRawTransaction(ctx, txid)
+	if err != nil || raw == nil {
+		return false
+	}
+	seqs := make([]uint32, 0, len(raw.Vin))
+	for _, in := range raw.Vin {
+		seqs = append(seqs, uint32(in.Sequence))
+	}
+	return replay.Protected(uint32(raw.Locktime), seqs)
 }
 
 // keepLiveAbsences drops the records of coins the wallet no longer holds, so a

--- a/sidechain-orchestrator/engines/split_engine_test.go
+++ b/sidechain-orchestrator/engines/split_engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
@@ -103,8 +104,76 @@ func postFork(outpoints ...string) *fakeCoins {
 	return c
 }
 
+// fakeLocalChain answers locktimes per txid; an unlisted txid errors. Inputs
+// are non-final unless finalSeqs names the txid.
+type fakeLocalChain struct {
+	locktime  map[string]int32
+	finalSeqs map[string]bool
+}
+
+func (f *fakeLocalChain) GetRawTransaction(_ context.Context, txid string) (*wallet.RawTransaction, error) {
+	lt, ok := f.locktime[txid]
+	if !ok {
+		return nil, errors.New("no such tx")
+	}
+	seq := int64(wire.MaxTxInSequenceNum - 1)
+	if f.finalSeqs[txid] {
+		seq = int64(wire.MaxTxInSequenceNum)
+	}
+	return &wallet.RawTransaction{TxID: txid, Locktime: lt, Vin: []wallet.RawTxIn{{Sequence: seq}}}, nil
+}
+
 func newTestSplitEngine(st *fork.ForkState, coins *fakeCoins, btc *fakeOutspend, store *fakeSplitStore, network string) *SplitEngine {
-	return NewSplitEngine(zerolog.Nop(), &fakeForkState{st: st}, coins, btc, store, func() string { return network })
+	return NewSplitEngine(zerolog.Nop(), &fakeForkState{st: st}, coins, btc, nil, store, func() string { return network })
+}
+
+func TestSplitEngineTrustsTheMagicLocktime(t *testing.T) {
+	btc := newFakeOutspend()
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), postFork("aa:0"), btc, store, "ecash")
+	e.local = &fakeLocalChain{locktime: map[string]int32{"aa": 499999999}}
+
+	e.tick(context.Background())
+
+	require.Equal(t, 0, btc.calls["aa:0"])
+	require.Equal(t, map[string]bool{"aa:0": false}, store.statuses)
+}
+
+func TestSplitEngineIgnoresAVoidMagicLocktime(t *testing.T) {
+	btc := newFakeOutspend()
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
+	// Every input is final, so Bitcoin ignores the locktime and a replay can land.
+	e.local = &fakeLocalChain{locktime: map[string]int32{"aa": 499999999}, finalSeqs: map[string]bool{"aa": true}}
+
+	e.tick(context.Background())
+
+	require.Equal(t, 1, btc.calls["aa:0"])
+	require.Equal(t, map[string]bool{"aa:0": true}, store.statuses)
+}
+
+func TestSplitEnginePlainLocktimeStillAsksBitcoin(t *testing.T) {
+	btc := newFakeOutspend()
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
+	e.local = &fakeLocalChain{locktime: map[string]int32{"aa": 0}}
+
+	e.tick(context.Background())
+
+	require.Equal(t, 1, btc.calls["aa:0"])
+	require.Equal(t, map[string]bool{"aa:0": true}, store.statuses)
+}
+
+func TestSplitEngineFallsBackWhenLocalReadFails(t *testing.T) {
+	btc := newFakeOutspend()
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
+	e.local = &fakeLocalChain{locktime: map[string]int32{}}
+
+	e.tick(context.Background())
+
+	require.Equal(t, 1, btc.calls["aa:0"])
+	require.Equal(t, map[string]bool{"aa:0": true}, store.statuses)
 }
 
 func TestSplitEngineChecksEachOutpointOnce(t *testing.T) {

--- a/sidechain-orchestrator/replay/replay.go
+++ b/sidechain-orchestrator/replay/replay.go
@@ -24,6 +24,20 @@ const ReplayLockTime uint32 = 499999999
 // nLockTime take effect.
 const nonFinalSequence uint32 = wire.MaxTxInSequenceNum - 1
 
+// Protected reports whether the stamp binds: the magic locktime plus at least
+// one non-final input. With every input final, Bitcoin ignores nLockTime.
+func Protected(locktime uint32, sequences []uint32) bool {
+	if locktime != ReplayLockTime {
+		return false
+	}
+	for _, s := range sequences {
+		if s != wire.MaxTxInSequenceNum {
+			return true
+		}
+	}
+	return false
+}
+
 // ApplyLockTime stamps the replay locktime and makes every final input
 // non-final so the locktime is actually enforced. Call it before signing.
 func ApplyLockTime(tx *wire.MsgTx) {

--- a/sidechain-orchestrator/replay/replay_test.go
+++ b/sidechain-orchestrator/replay/replay_test.go
@@ -111,3 +111,21 @@ func TestApplyLockTimeHexRejectsBadInput(t *testing.T) {
 		}
 	}
 }
+
+func TestProtectedNeedsANonFinalInput(t *testing.T) {
+	if Protected(ReplayLockTime, []uint32{wire.MaxTxInSequenceNum}) {
+		t.Fatal("a tx with every input final counts as protected")
+	}
+	if !Protected(ReplayLockTime, []uint32{wire.MaxTxInSequenceNum, nonFinalSequence}) {
+		t.Fatal("one non-final input does not count as protected")
+	}
+}
+
+func TestProtectedNeedsTheMagicLocktime(t *testing.T) {
+	if Protected(0, []uint32{nonFinalSequence}) {
+		t.Fatal("a plain locktime counts as protected")
+	}
+	if Protected(ReplayLockTime, nil) {
+		t.Fatal("a tx without inputs counts as protected")
+	}
+}


### PR DESCRIPTION
The split engine reads the local funding tx before it asks Esplora. The magic locktime proves a coin is this-chain-only, so patoshi-claim change no longer reports as on both chains. The dialog stays and only opens for real replay risks.