### PR TITLE
Explorer: read what each node really answers

### DIFF
--- a/sail_ui/lib/pages/sidechains/explorer/chain_explorer_tab.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/chain_explorer_tab.dart
@@ -183,12 +183,13 @@ class _BlockStripState extends State<_BlockStrip> {
             _BlockCard(
               label: '${block.height}',
               mainchain: block.mainchainHeight != 0 ? '${block.mainchainHeight}' : _shorten(block.mainchainHash),
+              mainchainHash: block.mainchainHash,
               color: colors.primary,
               onTap: () => onOpen(ExplorerTarget.block(hash: block.hash)),
               lines: [
                 '${block.txCount} ${block.txCount == 1 ? 'transaction' : 'transactions'}',
-                '${block.feesSats} sats',
-                '${block.sizeBytes} bytes',
+                block.feesKnown ? explorerAmount(context, block.feesSats.toInt()) : 'Fees unknown',
+                block.sizeBytes != 0 ? '${block.sizeBytes} bytes' : 'Size unknown',
               ],
             ),
         ],
@@ -371,7 +372,9 @@ class _PendingWithdrawalsCard extends StatelessWidget {
     }
     return SailCard(
       title: 'Pending withdrawals',
-      subtitle: '${bundle.withdrawals.length} withdrawals · created at height ${bundle.heightCreated}',
+      subtitle: bundle.heightCreated != 0
+          ? '${bundle.withdrawals.length} withdrawals · created at height ${bundle.heightCreated}'
+          : '${bundle.withdrawals.length} withdrawals',
       child: SailColumn(
         spacing: SailStyleValues.padding08,
         children: [

--- a/sail_ui/lib/pages/sidechains/explorer/explorer_detail.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/explorer_detail.dart
@@ -6,6 +6,13 @@ import 'package:sidechain_core/utils/explorer_url.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// What the explorer is looking at.
+/// _paidOut is what a transaction pays out. A withdrawal takes the mainchain
+/// fee as well as the payout.
+int _paidOut(pb.Transaction transaction) => transaction.outputs.fold<int>(
+  0,
+  (sum, o) => sum + o.valueSats.toInt() + (o.contentType == 'withdrawal' ? o.mainFeeSats.toInt() : 0),
+);
+
 enum ExplorerTargetKind { block, transaction, address, search }
 
 /// ExplorerTarget names one thing to read. A search resolves to whichever of
@@ -185,18 +192,21 @@ class _BlockView extends StatelessWidget {
                 child: SailColumn(
                   spacing: SailStyleValues.padding08,
                   children: [
-                    _LinkRow(
-                      label: 'Mainchain block',
-                      value: block.mainchainHeight != 0 ? '${block.mainchainHeight}' : shortenId(block.mainchainHash),
-                      onTap: () async => launchUrl(
-                        Uri.parse(
-                          mempoolBlockUrl(
-                            block.mainchainHash,
-                            GetIt.I.get<BitcoinConfProvider>().network,
+                    if (block.mainchainHash.isEmpty)
+                      const _Row(label: 'Mainchain block', value: 'Unknown')
+                    else
+                      _LinkRow(
+                        label: 'Mainchain block',
+                        value: block.mainchainHeight != 0 ? '${block.mainchainHeight}' : shortenId(block.mainchainHash),
+                        onTap: () async => launchUrl(
+                          Uri.parse(
+                            mempoolBlockUrl(
+                              block.mainchainHash,
+                              GetIt.I.get<BitcoinConfProvider>().network,
+                            ),
                           ),
                         ),
                       ),
-                    ),
                     if (block.prevHash.isNotEmpty)
                       _LinkRow(
                         label: 'Previous block',
@@ -260,10 +270,7 @@ class _TransactionView extends StatelessWidget {
                     _Row(label: 'Fee', value: explorerAmount(context, transaction.feeSats.toInt())),
                     _Row(
                       label: 'Total value',
-                      value: explorerAmount(
-                        context,
-                        transaction.outputs.fold<int>(0, (sum, o) => sum + o.valueSats.toInt()),
-                      ),
+                      value: explorerAmount(context, _paidOut(transaction)),
                     ),
                   ],
                 ),

--- a/sail_ui/lib/pages/sidechains/explorer/explorer_model.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/explorer_model.dart
@@ -39,6 +39,29 @@ class ExplorerModel extends BaseViewModel {
   /// reachedGenesis is true when no block sits below the last page.
   bool get reachedGenesis => _reachedGenesis;
 
+  /// _trimOlderBlocks drops every cached page that no longer continues the
+  /// newest blocks. A new block, or a reorg, breaks that boundary, and the
+  /// pages below it read again.
+  void _trimOlderBlocks(List<pb.Block> head) {
+    if (head.isEmpty) {
+      return;
+    }
+    var next = head.last.height - 1;
+    final keep = <pb.Block>[];
+    for (final block in olderBlocks) {
+      if (block.height != next) {
+        break;
+      }
+      keep.add(block);
+      next--;
+    }
+    olderBlocks
+      ..clear()
+      ..addAll(keep);
+    final last = keep.isNotEmpty ? keep.last : head.last;
+    _reachedGenesis = last.height == 0;
+  }
+
   /// loadOlderBlocks reads the page below the last block a reader can see.
   Future<void> loadOlderBlocks() async {
     if (_readingOlder || _reachedGenesis) {
@@ -84,6 +107,7 @@ class ExplorerModel extends BaseViewModel {
       final next = await _orchestrator.explorer.getOverview(chain);
       if (overview?.writeToJson() != next.writeToJson()) {
         overview = next;
+        _trimOlderBlocks(next.blocks);
         readError = null;
         notifyListeners();
       } else if (readError != null) {

--- a/sail_ui/lib/pages/sidechains/explorer/withdrawals_tab.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/withdrawals_tab.dart
@@ -54,7 +54,9 @@ class _BundleSummary extends StatelessWidget {
     }
     return SailCard(
       title: 'The bundle now',
-      subtitle: '${bundle.withdrawals.length} withdrawals, pending since height ${bundle.heightCreated}',
+      subtitle: bundle.heightCreated != 0
+          ? '${bundle.withdrawals.length} withdrawals, pending since height ${bundle.heightCreated}'
+          : '${bundle.withdrawals.length} withdrawals pending',
       child: SailRow(
         spacing: SailStyleValues.padding16,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/sail_ui/lib/pages/sidechains/explorer/withdrawals_tab.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/withdrawals_tab.dart
@@ -101,16 +101,16 @@ class _BundleTable extends StatelessWidget {
         child: SailTable(
           getRowId: (index) => '${rows[index].mainAddress}:$index',
           headerBuilder: (context) => const [
-            SailTableHeaderCell(name: 'Amount (sats)'),
-            SailTableHeaderCell(name: 'Mainchain fee (sats)'),
+            SailTableHeaderCell(name: 'Amount'),
+            SailTableHeaderCell(name: 'Mainchain fee'),
             SailTableHeaderCell(name: 'Destination address'),
             SailTableHeaderCell(name: 'Bundle weight'),
           ],
           rowBuilder: (context, index, selected) {
             final row = rows[index];
             return [
-              SailTableCell(value: '${row.valueSats}'),
-              SailTableCell(value: '${row.mainFeeSats}'),
+              SailTableCell(value: explorerAmount(context, row.valueSats.toInt())),
+              SailTableCell(value: explorerAmount(context, row.mainFeeSats.toInt())),
               SailTableCell(value: row.mainAddress, monospace: true),
               SailTableCell(value: '${row.cumulativeWeight} / ${bundle.maxWeight}'),
             ];

--- a/sidechain-orchestrator/api/explorer_bundle.go
+++ b/sidechain-orchestrator/api/explorer_bundle.go
@@ -8,17 +8,22 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
 )
 
-// contentWithdrawal is a withdrawal output as a chain writes it. The two
-// spellings both appear on the wire: get_transaction writes the plain pair,
-// and the human readable form renames them.
+// withdrawalPayout is what a withdrawal pays out. The two spellings both
+// appear on the wire: get_transaction writes the plain pair, and the human
+// readable form renames them.
+type withdrawalPayout struct {
+	Value       uint64 `json:"value"`
+	MainFee     uint64 `json:"main_fee"`
+	ValueSats   uint64 `json:"value_sats"`
+	MainFeeSats uint64 `json:"main_fee_sats"`
+	MainAddress string `json:"main_address"`
+}
+
+// contentWithdrawal is a withdrawal output as a chain writes it. A plain
+// output names it Withdrawal, and a filled one names it BitcoinWithdrawal.
 type contentWithdrawal struct {
-	Withdrawal *struct {
-		Value       uint64 `json:"value"`
-		MainFee     uint64 `json:"main_fee"`
-		ValueSats   uint64 `json:"value_sats"`
-		MainFeeSats uint64 `json:"main_fee_sats"`
-		MainAddress string `json:"main_address"`
-	} `json:"Withdrawal"`
+	Withdrawal        *withdrawalPayout `json:"Withdrawal"`
+	BitcoinWithdrawal *withdrawalPayout `json:"BitcoinWithdrawal"`
 }
 
 // nodeBundle is the pending withdrawal bundle as a node writes it.
@@ -89,14 +94,40 @@ func parseBundle(raw json.RawMessage) *pb.WithdrawalBundle {
 // value is not part of the payout, so it answers false.
 func readWithdrawal(raw json.RawMessage) (*pb.Withdrawal, bool) {
 	var content contentWithdrawal
-	if err := json.Unmarshal(raw, &content); err != nil || content.Withdrawal == nil {
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return nil, false
+	}
+	payout := content.Withdrawal
+	if payout == nil {
+		payout = content.BitcoinWithdrawal
+	}
+	if payout == nil {
 		return nil, false
 	}
 	return &pb.Withdrawal{
-		MainAddress: content.Withdrawal.MainAddress,
-		ValueSats:   int64(max(content.Withdrawal.Value, content.Withdrawal.ValueSats)),
-		MainFeeSats: int64(max(content.Withdrawal.MainFee, content.Withdrawal.MainFeeSats)),
+		MainAddress: payout.MainAddress,
+		ValueSats:   int64(max(payout.Value, payout.ValueSats)),
+		MainFeeSats: int64(max(payout.MainFee, payout.MainFeeSats)),
 	}, true
+}
+
+// contentValue reads the sats a plain output holds. A single asset chain
+// names it Value, and a multi asset chain names it BitcoinSats.
+func contentValue(raw json.RawMessage) int64 {
+	var content struct {
+		Value       *int64 `json:"Value"`
+		BitcoinSats *int64 `json:"BitcoinSats"`
+	}
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return 0
+	}
+	switch {
+	case content.Value != nil:
+		return *content.Value
+	case content.BitcoinSats != nil:
+		return *content.BitcoinSats
+	}
+	return 0
 }
 
 // newTransaction reads one indexed transaction into the explorer shape.

--- a/sidechain-orchestrator/api/explorer_bundle.go
+++ b/sidechain-orchestrator/api/explorer_bundle.go
@@ -167,6 +167,9 @@ func newTransaction(tx sidechainesplora.Tx) *pb.Transaction {
 		if w, ok := readWithdrawal(o.Content); ok {
 			coin.MainAddress = w.MainAddress
 			coin.MainFeeSats = w.MainFeeSats
+			// The index stores what the coin cost, which is the payout and
+			// the mainchain fee together. The two read back apart.
+			coin.ValueSats = w.ValueSats
 			out.Kind = pb.Kind_KIND_WITHDRAWAL
 		}
 		out.Outputs = append(out.Outputs, coin)

--- a/sidechain-orchestrator/api/explorer_core.go
+++ b/sidechain-orchestrator/api/explorer_core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"connectrpc.com/connect"
 
@@ -119,6 +120,10 @@ type nodeTx struct {
 			Txid string `json:"txid"`
 			Vout uint32 `json:"vout"`
 		} `json:"Deposit"`
+		Coinbase *struct {
+			MerkleRoot string `json:"merkle_root"`
+			Vout       uint32 `json:"vout"`
+		} `json:"Coinbase"`
 	} `json:"inputs"`
 	Outputs []struct {
 		Address string          `json:"address"`
@@ -165,6 +170,9 @@ func nodeTransaction(ctx context.Context, src source, txid string) (*pb.Transact
 	if envelope.BlockHash != nil {
 		out.Confirmed = true
 		out.BlockHash = *envelope.BlockHash
+		if height, err := nodeHeightOfHash(ctx, src, *envelope.BlockHash); err == nil {
+			out.BlockHeight = height
+		}
 	} else if info, ok := nodeTransactionInfo(ctx, src, txid); ok {
 		out.Confirmed = info.Confirmations != nil && *info.Confirmations > 0
 		out.FeeSats = info.FeeSats
@@ -180,6 +188,10 @@ func nodeTransaction(ctx context.Context, src source, txid string) (*pb.Transact
 			out.Inputs = append(out.Inputs, &pb.Coin{
 				Txid: in.Regular.Txid, Vout: in.Regular.Vout, OutpointKind: "regular",
 			})
+		case in.Coinbase != nil:
+			out.Inputs = append(out.Inputs, &pb.Coin{
+				Txid: in.Coinbase.MerkleRoot, Vout: in.Coinbase.Vout, OutpointKind: "coinbase",
+			})
 		}
 	}
 	for _, o := range tx.Outputs {
@@ -191,12 +203,7 @@ func nodeTransaction(ctx context.Context, src source, txid string) (*pb.Transact
 			coin.MainFeeSats = w.GetMainFeeSats()
 			out.Kind = pb.Kind_KIND_WITHDRAWAL
 		} else {
-			var value struct {
-				Value int64 `json:"Value"`
-			}
-			if err := json.Unmarshal(o.Content, &value); err == nil {
-				coin.ValueSats = value.Value
-			}
+			coin.ValueSats = contentValue(o.Content)
 		}
 		out.Outputs = append(out.Outputs, coin)
 	}
@@ -221,7 +228,16 @@ func nodeTransactionInfo(ctx context.Context, src source, txid string) (nodeTxIn
 func coreTransaction(ctx context.Context, src source, txid string) (*pb.Transaction, error) {
 	raw, err := src.node.CallRaw(ctx, "getrawtransaction", []any{txid, true})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		// Core reads a mined transaction only from the block that carries
+		// it, unless the node runs -txindex. So find that block first.
+		hash, blockErr := coreBlockOf(ctx, src, txid)
+		if blockErr != nil {
+			return nil, blockErr
+		}
+		raw, err = src.node.CallRaw(ctx, "getrawtransaction", []any{txid, true, hash})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
 	}
 	var tx struct {
 		Txid          string `json:"txid"`
@@ -256,10 +272,15 @@ func coreTransaction(ctx context.Context, src source, txid string) (*pb.Transact
 	for _, in := range tx.Vin {
 		out.Inputs = append(out.Inputs, &pb.Coin{Txid: in.Txid, Vout: in.Vout, OutpointKind: "regular"})
 	}
+	if tx.BlockHash != "" {
+		if block, _, err := coreBlockByHash(ctx, src, tx.BlockHash); err == nil {
+			out.BlockHeight = block.GetHeight()
+		}
+	}
 	for _, o := range tx.Vout {
 		out.Outputs = append(out.Outputs, &pb.Coin{
 			Address:     o.ScriptPubKey.Address,
-			ValueSats:   int64(o.Value * 1e8),
+			ValueSats:   int64(math.Round(o.Value * 1e8)),
 			ContentType: "value",
 		})
 	}
@@ -358,11 +379,28 @@ func coinFromContent(address string, content json.RawMessage, tx *pb.Transaction
 		tx.Kind = pb.Kind_KIND_WITHDRAWAL
 		return coin
 	}
-	var value struct {
-		Value int64 `json:"Value"`
-	}
-	if err := json.Unmarshal(content, &value); err == nil {
-		coin.ValueSats = value.Value
-	}
+	coin.ValueSats = contentValue(content)
 	return coin
+}
+
+// coreBlockOf finds the block that carries one transaction. A Core node
+// without -txindex names a transaction only inside its block, so the search
+// walks back from the tip.
+func coreBlockOf(ctx context.Context, src source, txid string) (string, error) {
+	count, err := src.node.GetBlockCount(ctx)
+	if err != nil {
+		return "", connect.NewError(connect.CodeUnavailable, err)
+	}
+	for height := count; height >= 0 && count-height < searchBlockDepth; height-- {
+		block, activity, err := coreBlockAtHeight(ctx, src, uint32(height))
+		if err != nil {
+			return "", err
+		}
+		for _, row := range activity {
+			if row.GetId() == txid {
+				return block.GetHash(), nil
+			}
+		}
+	}
+	return "", notFoundTransaction(src, txid)
 }

--- a/sidechain-orchestrator/api/explorer_handler.go
+++ b/sidechain-orchestrator/api/explorer_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -423,18 +424,24 @@ func (h *ExplorerHandler) GetAddress(
 	if address == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name an address"))
 	}
-	if src.index == nil {
+	// No node holds an address index, so an address always reads the hosted
+	// one, whether the app runs a full node or a light client.
+	index := src.index
+	if index == nil {
+		index = h.addressIndex(src.name)
+	}
+	if index == nil {
 		return nil, connect.NewError(connect.CodeUnimplemented,
 			fmt.Errorf("%s has no index, and a node keeps no address history", src.name))
 	}
 
-	stats, err := src.index.AddressStats(ctx, address)
+	stats, err := index.AddressStats(ctx, address)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 	// The first page already carries the unconfirmed rows, so a separate
 	// mempool read would list every one of them twice.
-	history, err := sidechainesplora.NewWallet(src.index).AddressHistory(ctx, address)
+	history, err := sidechainesplora.NewWallet(index).AddressHistory(ctx, address)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
@@ -453,16 +460,40 @@ func (h *ExplorerHandler) GetAddress(
 	}
 
 	// A deposit creates a coin with no sidechain transaction, so the history
-	// route never carries one. Bo's address view marks deposits, so they come
+	// route never carries one. The address view marks deposits, so they come
 	// from their own route.
-	deposits, err := src.index.AddressDeposits(ctx, address)
+	deposits, err := index.AddressDeposits(ctx, address)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
 	for _, deposit := range deposits {
 		out.Transactions = append(out.Transactions, depositTransaction(address, deposit))
+		out.TxCount++
 	}
+	sortNewestFirst(out.Transactions)
 	return connect.NewResponse(out), nil
+}
+
+// sortNewestFirst orders an address history the way the view reads it: the
+// unconfirmed rows first, then the newest block.
+func sortNewestFirst(rows []*pb.Transaction) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.GetConfirmed() != b.GetConfirmed() {
+			return !a.GetConfirmed()
+		}
+		return a.GetBlockHeight() > b.GetBlockHeight()
+	})
+}
+
+// addressIndex resolves the hosted index for one chain, whatever mode the
+// node runs in.
+func (h *ExplorerHandler) addressIndex(chain string) *sidechainesplora.Client {
+	url := config.SidechainEsploraURLForNetwork(chain, config.NetworkFromString(h.orch.CurrentNetwork()))
+	if url == "" {
+		return nil
+	}
+	return sidechainesplora.New(url)
 }
 
 // depositTransaction reads one mainchain deposit as a row the address view can
@@ -619,12 +650,7 @@ func (t nodeBodyTx) paidOut() int64 {
 			total += w.GetValueSats() + w.GetMainFeeSats()
 			continue
 		}
-		var value struct {
-			Value int64 `json:"Value"`
-		}
-		if err := json.Unmarshal(out.Content, &value); err == nil {
-			total += value.Value
-		}
+		total += contentValue(out.Content)
 	}
 	return total
 }
@@ -655,6 +681,10 @@ func nodeHeader(ctx context.Context, src source, hash string) (nodeHeaderJSON, e
 	raw, err := src.node.CallRaw(ctx, "get_block", []string{hash})
 	if err != nil {
 		return nodeHeaderJSON{}, connect.NewError(connect.CodeUnavailable, err)
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		return nodeHeaderJSON{}, connect.NewError(connect.CodeNotFound,
+			fmt.Errorf("no block on %s hashes to %s", src.name, hash))
 	}
 	var block nodeHeaderJSON
 	if err := json.Unmarshal(raw, &block); err != nil {
@@ -690,11 +720,11 @@ func nodeBlock(ctx context.Context, src source, hash string, height uint32) (*pb
 	// it still answers the header, and the block then lists no transactions.
 	rawIndex, err := src.node.CallRaw(ctx, "get_block_index", []string{hash})
 	if err != nil {
-		return out, nil, nil
+		return blockValueFromBody(out, block), nil, nil
 	}
 	var index nodeBlockIndex
 	if err := json.Unmarshal(rawIndex, &index); err != nil {
-		return out, nil, nil
+		return blockValueFromBody(out, block), nil, nil
 	}
 
 	// The block index names the txids in body order, so a transaction pairs
@@ -725,6 +755,16 @@ func nodeBlock(ctx context.Context, src source, hash string, height uint32) (*pb
 		})
 	}
 	return out, activity, nil
+}
+
+// blockValueFromBody sums what a block paid out. Only get_block_index names
+// the txids, so a chain without it lists no transactions, and the value still
+// reads back.
+func blockValueFromBody(out *pb.Block, block nodeHeaderJSON) *pb.Block {
+	for _, tx := range block.transactions() {
+		out.ValueSats += tx.paidOut()
+	}
+	return out
 }
 
 // depositTxid reads the mainchain txid out of a "txid:vout" outpoint.

--- a/sidechain-orchestrator/api/explorer_test.go
+++ b/sidechain-orchestrator/api/explorer_test.go
@@ -121,6 +121,11 @@ func TestTransactionNamesTheWithdrawalPayout(t *testing.T) {
 	if got := out.GetOutputs()[0].GetMainFeeSats(); got != 1200 {
 		t.Errorf("mainchain fee = %d, want 1200", got)
 	}
+	// The index stores 51200, the cost of the coin. The payout alone is
+	// 50000, and the view adds the fee back for a total.
+	if got := out.GetOutputs()[0].GetValueSats(); got != 50000 {
+		t.Errorf("payout = %d, want 50000", got)
+	}
 	if got := out.GetBlockHeight(); got != 44 {
 		t.Errorf("block height = %d, want 44", got)
 	}

--- a/sidechain-orchestrator/api/explorer_test.go
+++ b/sidechain-orchestrator/api/explorer_test.go
@@ -611,3 +611,162 @@ func TestMinedTransactionComesOutOfItsBlock(t *testing.T) {
 		t.Errorf("size = %d, want 24", out.GetSizeBytes())
 	}
 }
+
+// A multi asset chain names a plain bitcoin output BitcoinSats, and a filled
+// withdrawal BitcoinWithdrawal. Both must read the same as the plain pair.
+func TestMultiAssetOutputNamesReadTheSame(t *testing.T) {
+	if got := contentValue(json.RawMessage(`{"BitcoinSats":40000}`)); got != 40000 {
+		t.Errorf("BitcoinSats reads %d, want 40000", got)
+	}
+	if got := contentValue(json.RawMessage(`{"Value":40000}`)); got != 40000 {
+		t.Errorf("Value reads %d, want 40000", got)
+	}
+	if got := contentValue(json.RawMessage(`{"BitAsset":7}`)); got != 0 {
+		t.Errorf("a non bitcoin output reads %d, want 0", got)
+	}
+
+	raw := json.RawMessage(
+		`{"BitcoinWithdrawal":{"value_sats":100000,"main_fee_sats":1200,"main_address":"bc1q"}}`)
+	w, ok := readWithdrawal(raw)
+	if !ok {
+		t.Fatal("a filled withdrawal reads as a plain output")
+	}
+	if w.GetValueSats() != 100000 || w.GetMainFeeSats() != 1200 {
+		t.Errorf("the payout reads %d and %d, want 100000 and 1200",
+			w.GetValueSats(), w.GetMainFeeSats())
+	}
+}
+
+// A bundle on a multi asset chain pays out through BitcoinWithdrawal, and it
+// must not read as absent.
+func TestParseBundleReadsAFilledWithdrawal(t *testing.T) {
+	raw := json.RawMessage(`{
+		"spend_utxos": [
+			[{"Regular": {"txid": "aa", "vout": 0}},
+			 {"address": "s1", "content": {"BitcoinWithdrawal": {"value_sats": 500000, "main_fee_sats": 900, "main_address": "bc1q"}}}]
+		],
+		"tx": {"vout": []}
+	}`)
+	bundle := parseBundle(raw)
+	if !bundle.GetPresent() {
+		t.Fatal("a filled bundle reads as absent")
+	}
+	if got := bundle.GetTotalValueSats(); got != 500000 {
+		t.Errorf("total value = %d, want 500000", got)
+	}
+}
+
+// A transaction that spends a coinbase output must list that input. The
+// outpoint names a merkle root, not a txid.
+func TestNodeTransactionKeepsACoinbaseInput(t *testing.T) {
+	node := &recordingNode{answers: map[string]string{
+		"get_transaction": `{"inputs":[{"Coinbase":{"merkle_root":"mr","vout":2}}],` +
+			`"outputs":[{"address":"s1","content":{"BitcoinSats":40000}}]}`,
+		"get_transaction_info": `null`,
+	}}
+	src := source{name: "bitnames", node: node}
+
+	tx, err := nodeTransaction(context.Background(), src, "abc")
+	if err != nil {
+		t.Fatalf("read the transaction: %v", err)
+	}
+	if got := len(tx.GetInputs()); got != 1 {
+		t.Fatalf("the transaction holds %d inputs, want 1", got)
+	}
+	if got := tx.GetInputs()[0].GetOutpointKind(); got != "coinbase" {
+		t.Errorf("the input reads as %q, want coinbase", got)
+	}
+	if got := tx.GetOutputs()[0].GetValueSats(); got != 40000 {
+		t.Errorf("the output holds %d sats, want 40000", got)
+	}
+}
+
+// A wrapped transaction names its block. The view reads a height, so the
+// block hash must resolve to one.
+func TestWrappedTransactionResolvesItsHeight(t *testing.T) {
+	node := &recordingNode{
+		count: 2,
+		answers: map[string]string{
+			"get_best_sidechain_block_hash": `"bb"`,
+			"get_transaction":               `{"block_hash":"aa","tx":{"inputs":[],"outputs":[]}}`,
+		},
+		byHash: map[string]string{
+			"bb": `{"header":{"merkle_root":"m2","prev_side_hash":"aa","prev_main_hash":"x2"},"body":{"transactions":[]}}`,
+			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[]}}`,
+		},
+	}
+	src := source{name: "thunder", node: node}
+
+	tx, err := nodeTransaction(context.Background(), src, "abc")
+	if err != nil {
+		t.Fatalf("read the transaction: %v", err)
+	}
+	if !tx.GetConfirmed() {
+		t.Error("a mined transaction reads as unconfirmed")
+	}
+	if got := tx.GetBlockHeight(); got != 0 {
+		t.Errorf("the transaction sits at height %d, want 0", got)
+	}
+	if got := tx.GetBlockHash(); got != "aa" {
+		t.Errorf("the transaction sits in block %q, want aa", got)
+	}
+}
+
+// An unknown hash answers null. A null block must read as NotFound, never as
+// a block at height 0.
+func TestNodeBlockRejectsANullAnswer(t *testing.T) {
+	node := &recordingNode{byHash: map[string]string{"zz": `null`}}
+	src := source{name: "thunder", node: node}
+
+	if _, err := nodeHeader(context.Background(), src, "zz"); err == nil {
+		t.Fatal("a null block reads as found")
+	} else if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("a null block answers %s, want NotFound", connect.CodeOf(err))
+	}
+}
+
+// A chain without get_block_index lists no transactions, and the block still
+// reads back what it paid out.
+func TestBlockWithoutAnIndexKeepsItsValue(t *testing.T) {
+	node := &recordingNode{
+		byHash: map[string]string{
+			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[` +
+				`{"outputs":[{"address":"s1","content":{"BitcoinSats":40000}}]},` +
+				`{"outputs":[{"address":"s2","content":{"Value":2000}}]}]}}`,
+		},
+	}
+	src := source{name: "bitassets", node: node}
+
+	block, activity, err := nodeBlock(context.Background(), src, "aa", 7)
+	if err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+	if got := block.GetValueSats(); got != 42000 {
+		t.Errorf("the block paid out %d, want 42000", got)
+	}
+	if got := block.GetTxCount(); got != 2 {
+		t.Errorf("the block holds %d transactions, want 2", got)
+	}
+	if len(activity) != 0 {
+		t.Errorf("the block lists %d rows, and no node names their txids", len(activity))
+	}
+}
+
+// An address view reads the unconfirmed rows first, then the newest block. A
+// deposit must sort with the rest, not sit below every transaction.
+func TestAddressHistorySortsTheDepositsIn(t *testing.T) {
+	rows := []*pb.Transaction{
+		{Txid: "old", Confirmed: true, BlockHeight: 100},
+		{Txid: "new", Confirmed: true, BlockHeight: 400},
+		{Txid: "pending"},
+		{Txid: "deposit", Confirmed: true, BlockHeight: 300},
+	}
+	sortNewestFirst(rows)
+
+	want := []string{"pending", "new", "deposit", "old"}
+	for i, id := range want {
+		if rows[i].GetTxid() != id {
+			t.Errorf("row %d reads %q, want %q", i, rows[i].GetTxid(), id)
+		}
+	}
+}

--- a/sidechain-orchestrator/gen/explorer/v1/explorer.pb.go
+++ b/sidechain-orchestrator/gen/explorer/v1/explorer.pb.go
@@ -320,9 +320,11 @@ func (x *Activity) GetBlockTime() int64 {
 
 // Coin is one input or one output.
 type Coin struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Address   string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
-	ValueSats int64                  `protobuf:"varint,2,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Address string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	// value_sats is the payout. A withdrawal costs this and main_fee_sats
+	// together.
+	ValueSats int64 `protobuf:"varint,2,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
 	// outpoint_kind reads "regular", "coinbase" or "deposit".
 	OutpointKind string `protobuf:"bytes,3,opt,name=outpoint_kind,json=outpointKind,proto3" json:"outpoint_kind,omitempty"`
 	// content_type reads "value" or "withdrawal".

--- a/sidechain-orchestrator/proto/explorer/v1/explorer.proto
+++ b/sidechain-orchestrator/proto/explorer/v1/explorer.proto
@@ -80,6 +80,8 @@ message Activity {
 // Coin is one input or one output.
 message Coin {
   string address = 1;
+  // value_sats is the payout. A withdrawal costs this and main_fee_sats
+  // together.
   int64 value_sats = 2;
   // outpoint_kind reads "regular", "coinbase" or "deposit".
   string outpoint_kind = 3;

--- a/sidechain_core/lib/gen/explorer/v1/explorer.pb.dart
+++ b/sidechain_core/lib/gen/explorer/v1/explorer.pb.dart
@@ -467,6 +467,8 @@ class Coin extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearAddress() => clearField(1);
 
+  /// value_sats is the payout. A withdrawal costs this and main_fee_sats
+  /// together.
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)


### PR DESCRIPTION
The explorer merged with a set of open review findings on it. This branch closes them.

A multi-asset chain writes its outputs under other names. BitAssets, BitNames and Truthcoin name a plain bitcoin output `BitcoinSats`, and a filled withdrawal `BitcoinWithdrawal`. The explorer read only `Value` and `Withdrawal`, so every such output read as 0 sats, and a real pending bundle read as absent. One pair of decoders now reads both spellings, in every place that reads an output.

Three more node facts came back wrong. A transaction that spends a coinbase output lost that input, because the switch knew only the Regular and Deposit variants. A wrapped transaction named its block but never its height, so the view said Block 0. An unknown hash answers `null`, and a decode of null succeeds, so the explorer built a block at height 0 instead of saying NotFound.

A Core-derived chain has its own two. `getrawtransaction` reads a mined transaction only with -txindex or the block hash, and BBC starts with neither, so a transaction opened from a block was not found; it now finds the block first. An amount converted with a truncation loses a satoshi, so it rounds.

No node holds an address index, which is why the hosted one exists. In full-node mode the explorer had no index to reach and rejected every address lookup. It resolves the hosted index for an address in either mode. The deposits it merges in also sort with the transactions and count toward the total, instead of sitting below the oldest row.

On the Flutter side the block strip claimed values it did not have. It printed `0 sats` in full mode, where no node computes a fee, and `0 bytes` for a chain that serves no block index. It reads `feesKnown` and says so. The mainchain hash never reached the block card, so the link the design asks for did not open; the card gets the hash, and the detail view no longer offers a link when there is no hash to open. A withdrawal costs value plus mainchain fee, so a transaction's total value counts both. A cached page of older blocks broke its boundary when a new block arrived, and dropped a height; the cache trims to what still continues the tip.

Seven tests cover the fixes.