### PR TITLE
Explorer: read the deposits, and name the bid

### DIFF
--- a/sail_ui/lib/pages/sidechains/explorer/chain_explorer_tab.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/chain_explorer_tab.dart
@@ -100,6 +100,7 @@ class _Overview extends StatelessWidget {
         _RecentActivity(overview: overview, onOpen: onOpen),
         SailRow(
           spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
               child: overview.hasTreasury()
@@ -113,6 +114,7 @@ class _Overview extends StatelessWidget {
             Expanded(child: _PendingWithdrawalsCard(bundle: overview.pendingBundle)),
           ],
         ),
+        DepositsCard(rows: overview.recent.where((r) => r.kind == pb.Kind.KIND_DEPOSIT).toList()),
       ],
     );
   }
@@ -172,10 +174,11 @@ class _BlockStripState extends State<_BlockStrip> {
             mainchain: null,
             mainchainHash: '',
             color: colors.success,
+            amount: blockAmount(context, overview.mempool.feesSats.toInt()),
             lines: [
-              '${overview.mempool.txCount} in the mempool',
-              explorerAmount(context, overview.mempool.feesSats.toInt()),
-              'Not mined yet',
+              transactionCount(overview.mempool.txCount),
+              '',
+              'Waits for a bid',
             ],
           ),
           Container(width: 1, height: 120, color: colors.divider),
@@ -186,10 +189,11 @@ class _BlockStripState extends State<_BlockStrip> {
               mainchainHash: block.mainchainHash,
               color: colors.primary,
               onTap: () => onOpen(ExplorerTarget.block(hash: block.hash)),
+              amount: blockFigure(context, block),
               lines: [
-                '${block.txCount} ${block.txCount == 1 ? 'transaction' : 'transactions'}',
-                block.feesKnown ? explorerAmount(context, block.feesSats.toInt()) : 'Fees unknown',
-                block.sizeBytes != 0 ? '${block.sizeBytes} bytes' : 'Size unknown',
+                transactionCount(block.txCount),
+                block.depositCount != 0 ? '+${blockAmount(context, block.depositValueSats.toInt())} deposited' : '',
+                explorerAge(block.blockTime.toInt()),
               ],
             ),
         ],
@@ -203,6 +207,7 @@ class _BlockCard extends StatelessWidget {
   final String? mainchain;
   final String mainchainHash;
   final Color color;
+  final String amount;
   final List<String> lines;
   final VoidCallback? onTap;
 
@@ -211,6 +216,7 @@ class _BlockCard extends StatelessWidget {
     required this.mainchain,
     this.mainchainHash = '',
     required this.color,
+    required this.amount,
     required this.lines,
     this.onTap,
   });
@@ -239,7 +245,16 @@ class _BlockCard extends StatelessWidget {
                 spacing: 4,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  for (final line in lines) SailText.primary12(line, color: colors.background),
+                  SizedBox(
+                    height: 26,
+                    child: SailText.primary20(amount, bold: true, color: colors.background),
+                  ),
+                  // An empty line holds the slot, so every card reads level.
+                  for (final line in lines)
+                    SizedBox(
+                      height: 16,
+                      child: SailText.primary12(line, color: colors.background),
+                    ),
                 ],
               ),
             ),
@@ -297,7 +312,7 @@ class _RecentActivity extends StatelessWidget {
     final unconfirmed = rows.where((r) => !r.confirmed).length;
     return SailCard(
       title: 'Recent transactions',
-      subtitle: '${rows.length} latest · $unconfirmed unconfirmed',
+      subtitle: 'Latest ${rows.length} · $unconfirmed unconfirmed',
       child: SizedBox(
         height: 360,
         child: SailTable(
@@ -316,7 +331,7 @@ class _RecentActivity extends StatelessWidget {
               SailTableCell(value: '', child: kindBadge(row.kind)),
               SailTableCell(value: explorerAmount(context, row.valueSats.toInt())),
               SailTableCell(value: explorerAmount(context, row.feeSats.toInt())),
-              SailTableCell(value: row.confirmed ? 'Block ${row.blockHeight}' : 'Unconfirmed'),
+              SailTableCell(value: _statusOf(row)),
             ];
           },
           rowCount: rows.length,
@@ -335,6 +350,62 @@ class _RecentActivity extends StatelessWidget {
   }
 }
 
+/// DepositsCard lists what the mainchain paid into the chain. A deposit never
+/// sits in a block body, so a transaction list alone misses it.
+class DepositsCard extends StatelessWidget {
+  final List<pb.Activity> rows;
+  final String subtitle;
+
+  /// compact drops the block and the age, for a card that sits beside another
+  /// one on a page that already names the block.
+  final bool compact;
+
+  const DepositsCard({super.key, required this.rows, this.subtitle = '', this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final total = rows.fold<int>(0, (sum, row) => sum + row.valueSats.toInt());
+    final named = rows.any((row) => row.address.isNotEmpty);
+    return SailCard(
+      title: 'Deposits',
+      subtitle: subtitle.isNotEmpty
+          ? subtitle
+          : rows.isEmpty
+          ? 'None in the newest blocks'
+          : 'Latest ${rows.length} · ${blockAmount(context, total)}',
+      child: SizedBox(
+        height: rows.isEmpty ? 80 : 40.0 * rows.length + 40,
+        child: SailTable(
+          getRowId: (index) => rows[index].id,
+          headerBuilder: (context) => [
+            const SailTableHeaderCell(name: 'Mainchain transaction'),
+            if (named) const SailTableHeaderCell(name: 'Sidechain address'),
+            const SailTableHeaderCell(name: 'Amount'),
+            if (!compact) const SailTableHeaderCell(name: 'Block'),
+            if (!compact) const SailTableHeaderCell(name: 'Age'),
+          ],
+          rowBuilder: (context, index, selected) {
+            final row = rows[index];
+            return [
+              SailTableCell(value: _shorten(row.id), monospace: true),
+              if (named) SailTableCell(value: row.address, monospace: true),
+              SailTableCell(value: blockAmount(context, row.valueSats.toInt())),
+              if (!compact) SailTableCell(value: 'Block ${row.blockHeight}'),
+              if (!compact) SailTableCell(value: explorerAge(row.blockTime.toInt())),
+            ];
+          },
+          rowCount: rows.length,
+          drawGrid: false,
+          onDoubleTap: (rowId) async => launchUrl(
+            Uri.parse(mempoolTxUrl(rowId, GetIt.I.get<BitcoinConfProvider>().network)),
+          ),
+          emptyPlaceholder: 'No deposits yet',
+        ),
+      ),
+    );
+  }
+}
+
 class _TreasuryCard extends StatelessWidget {
   final pb.Treasury treasury;
 
@@ -345,15 +416,27 @@ class _TreasuryCard extends StatelessWidget {
     return SailCard(
       title: 'Treasury',
       subtitle: 'Slot ${treasury.slot} · activated at mainchain ${treasury.activationHeight}',
+      headerValue: blockAmount(context, treasury.balanceSats.toInt()),
       child: SailColumn(
         spacing: SailStyleValues.padding08,
         children: [
-          _Field(label: 'Holds', value: explorerAmount(context, treasury.balanceSats.toInt())),
           _Field(label: 'CTIP', value: '${_shorten(treasury.ctipTxid)} : ${treasury.ctipVout}'),
         ],
       ),
     );
   }
+}
+
+/// _statusOf names the block a row sits in, and how long ago that was.
+String _statusOf(pb.Activity row) {
+  if (!row.confirmed) {
+    return 'Unconfirmed';
+  }
+  final age = explorerAge(row.blockTime.toInt());
+  if (age.isEmpty) {
+    return 'Block ${row.blockHeight}';
+  }
+  return 'Block ${row.blockHeight} · $age';
 }
 
 class _PendingWithdrawalsCard extends StatelessWidget {
@@ -372,14 +455,16 @@ class _PendingWithdrawalsCard extends StatelessWidget {
     }
     return SailCard(
       title: 'Pending withdrawals',
-      subtitle: bundle.heightCreated != 0
-          ? '${bundle.withdrawals.length} withdrawals · created at height ${bundle.heightCreated}'
-          : '${bundle.withdrawals.length} withdrawals',
+      headerValue: blockAmount(context, bundle.totalValueSats.toInt()),
+      subtitle: '${bundle.withdrawals.length} withdrawals · bundle ${bundle.totalWeight} / ${bundle.maxWeight}',
       child: SailColumn(
         spacing: SailStyleValues.padding08,
         children: [
-          _Field(label: 'Total amount', value: explorerAmount(context, bundle.totalValueSats.toInt())),
-          _Field(label: 'Bundle weight', value: '${bundle.totalWeight} / ${bundle.maxWeight}'),
+          _Field(
+            label: 'Total mainchain fees',
+            value: explorerAmount(context, bundle.totalMainFeesSats.toInt()),
+          ),
+          _Field(label: 'Height created', value: '${bundle.heightCreated}'),
         ],
       ),
     );
@@ -423,6 +508,52 @@ String explorerAmount(BuildContext context, int sats) {
     return '—';
   }
   return BitcoinFormatting.formatSatsWithUnit(context, sats);
+}
+
+/// blockAmount reads an amount on a block card, where a zero is a figure of
+/// its own rather than a missing value.
+String blockAmount(BuildContext context, int sats) {
+  return BitcoinFormatting.formatSatsWithUnit(context, sats);
+}
+
+/// blockFigure is what a block card states in large type: what the block
+/// moved, or what it collected. A source states one or the other, never both.
+String blockFigure(BuildContext context, pb.Block block) {
+  if (block.valueKnown) {
+    return blockAmount(context, block.valueSats.toInt());
+  }
+  if (block.feesKnown) {
+    return blockAmount(context, block.feesSats.toInt());
+  }
+  return '';
+}
+
+/// transactionCount names how many transactions a block carried.
+String transactionCount(int count) {
+  return switch (count) {
+    0 => 'No transactions',
+    1 => '1 transaction',
+    _ => '$count transactions',
+  };
+}
+
+/// explorerAge reads how long ago a block arrived. A sidechain header carries
+/// no clock, so the time comes from the mainchain block it names.
+String explorerAge(int unixSeconds) {
+  if (unixSeconds <= 0) {
+    return '';
+  }
+  final age = DateTime.now().difference(DateTime.fromMillisecondsSinceEpoch(unixSeconds * 1000));
+  if (age.inMinutes < 1) {
+    return 'just now';
+  }
+  if (age.inMinutes < 60) {
+    return '${age.inMinutes} ${age.inMinutes == 1 ? 'minute' : 'minutes'} ago';
+  }
+  if (age.inHours < 24) {
+    return '${age.inHours} ${age.inHours == 1 ? 'hour' : 'hours'} ago';
+  }
+  return '${age.inDays} ${age.inDays == 1 ? 'day' : 'days'} ago';
 }
 
 /// kindBadge marks a row as a deposit, a withdrawal or a transfer. A reader

--- a/sail_ui/lib/pages/sidechains/explorer/explorer_detail.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/explorer_detail.dart
@@ -156,6 +156,8 @@ class _BlockView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final block = response.block;
+    final deposits = response.activity.where((r) => r.kind == pb.Kind.KIND_DEPOSIT).toList();
+    final transactions = response.activity.where((r) => r.kind != pb.Kind.KIND_DEPOSIT).toList();
     return SailColumn(
       spacing: SailStyleValues.padding16,
       children: [
@@ -167,65 +169,106 @@ class _BlockView extends StatelessWidget {
             Expanded(
               child: SailCard(
                 title: 'Details',
+                subtitle: explorerAge(block.blockTime.toInt()),
                 child: SailColumn(
                   spacing: SailStyleValues.padding08,
                   children: [
                     _Row(label: 'Transactions', value: '${block.txCount}'),
+                    _Row(label: 'Deposits', value: '${block.depositCount}'),
                     _Row(label: 'Value', value: explorerAmount(context, block.valueSats.toInt())),
+                    if (block.depositCount != 0)
+                      _Row(
+                        label: 'Deposited',
+                        value: explorerAmount(context, block.depositValueSats.toInt()),
+                      ),
                     _Row(
                       label: 'Transaction bytes',
                       value: block.sizeBytes == 0 ? '—' : '${block.sizeBytes}',
                     ),
-                    _Row(
-                      label: 'Fees',
-                      value: block.feesKnown ? explorerAmount(context, block.feesSats.toInt()) : '—',
-                    ),
+                    if (block.feesKnown) _Row(label: 'Fees', value: explorerAmount(context, block.feesSats.toInt())),
                     _Row(label: 'Merkle root', value: shortenId(block.merkleRoot)),
                   ],
                 ),
               ),
             ),
             Expanded(
-              child: SailCard(
-                title: 'Blind merge mine',
-                subtitle: 'The mainchain block that carried the bid',
-                child: SailColumn(
-                  spacing: SailStyleValues.padding08,
-                  children: [
-                    if (block.mainchainHash.isEmpty)
-                      const _Row(label: 'Mainchain block', value: 'Unknown')
-                    else
-                      _LinkRow(
-                        label: 'Mainchain block',
-                        value: block.mainchainHeight != 0 ? '${block.mainchainHeight}' : shortenId(block.mainchainHash),
-                        onTap: () async => launchUrl(
-                          Uri.parse(
-                            mempoolBlockUrl(
-                              block.mainchainHash,
-                              GetIt.I.get<BitcoinConfProvider>().network,
-                            ),
-                          ),
-                        ),
-                      ),
-                    if (block.prevHash.isNotEmpty)
-                      _LinkRow(
-                        label: 'Previous block',
-                        value: shortenId(block.prevHash),
-                        onTap: () async => onOpen(ExplorerTarget.block(hash: block.prevHash)),
-                      ),
-                  ],
-                ),
+              child: _BlindMergeMineCard(block: block, onOpen: onOpen),
+            ),
+          ],
+        ),
+        SailRow(
+          spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: _ActivityTable(
+                title: 'Transactions',
+                subtitle: '${block.txCount} in this block',
+                rows: transactions,
+                onOpen: onOpen,
+              ),
+            ),
+            Expanded(
+              child: DepositsCard(
+                rows: deposits,
+                subtitle: '${block.depositCount} in this block',
+                compact: true,
               ),
             ),
           ],
         ),
-        _ActivityTable(
-          title: 'Transactions',
-          subtitle: '${response.activity.length} in this block',
-          rows: response.activity,
-          onOpen: onOpen,
-        ),
       ],
+    );
+  }
+}
+
+/// _BlindMergeMineCard names the M8 a miner took to mine this block: what it
+/// paid, and the mainchain outpoint that carried it.
+class _BlindMergeMineCard extends StatelessWidget {
+  final pb.Block block;
+  final void Function(ExplorerTarget) onOpen;
+
+  const _BlindMergeMineCard({required this.block, required this.onOpen});
+
+  @override
+  Widget build(BuildContext context) {
+    final network = GetIt.I.get<BitcoinConfProvider>().network;
+    final bid = block.hasBid() ? block.bid : null;
+    return SailCard(
+      title: 'Blind merge mine',
+      headerValue: bid != null ? explorerAmount(context, bid.sats.toInt()) : null,
+      subtitle: bid != null ? 'Winning bid' : 'This install reads no bid for the block',
+      child: SailColumn(
+        spacing: SailStyleValues.padding08,
+        children: [
+          if (bid != null)
+            _LinkRow(
+              label: 'Bid block',
+              value: '${bid.blockHeight}',
+              onTap: () async => launchUrl(Uri.parse(mempoolBlockUrl(bid.blockHash, network))),
+            ),
+          if (bid != null)
+            _LinkRow(
+              label: 'Bid outpoint',
+              value: '${shortenId(bid.txid)} : ${bid.vout}',
+              onTap: () async => launchUrl(Uri.parse(mempoolTxUrl(bid.txid, network))),
+            ),
+          if (block.mainchainHash.isEmpty)
+            const _Row(label: 'Parent block', value: 'Unknown')
+          else
+            _LinkRow(
+              label: 'Parent block',
+              value: block.mainchainHeight != 0 ? '${block.mainchainHeight}' : shortenId(block.mainchainHash),
+              onTap: () async => launchUrl(Uri.parse(mempoolBlockUrl(block.mainchainHash, network))),
+            ),
+          if (block.prevHash.isNotEmpty)
+            _LinkRow(
+              label: 'Previous block',
+              value: shortenId(block.prevHash),
+              onTap: () async => onOpen(ExplorerTarget.block(hash: block.prevHash)),
+            ),
+        ],
+      ),
     );
   }
 }
@@ -469,8 +512,6 @@ class _ActivityTable extends StatelessWidget {
             SailTableHeaderCell(name: 'Transaction'),
             SailTableHeaderCell(name: 'Kind'),
             SailTableHeaderCell(name: 'Value'),
-            SailTableHeaderCell(name: 'Fee'),
-            SailTableHeaderCell(name: 'Size'),
           ],
           rowBuilder: (context, index, selected) {
             final row = rows[index];
@@ -478,8 +519,6 @@ class _ActivityTable extends StatelessWidget {
               SailTableCell(value: shortenId(row.id), monospace: true),
               SailTableCell(value: '', child: kindBadge(row.kind)),
               SailTableCell(value: explorerAmount(context, row.valueSats.toInt())),
-              SailTableCell(value: explorerAmount(context, row.feeSats.toInt())),
-              SailTableCell(value: row.sizeBytes == 0 ? '—' : '${row.sizeBytes} bytes'),
             ];
           },
           rowCount: rows.length,

--- a/sail_ui/lib/pages/sidechains/explorer/explorer_model.dart
+++ b/sail_ui/lib/pages/sidechains/explorer/explorer_model.dart
@@ -9,6 +9,14 @@ import 'package:stacked/stacked.dart';
 /// mainchain block, so this only has to beat a reader's patience.
 const explorerRefreshInterval = Duration(seconds: 3);
 
+/// How often a quiet chain still redraws. Every page reads relative times, and
+/// those follow the clock rather than the chain.
+const explorerAgeInterval = Duration(minutes: 1);
+
+/// ageRefreshDue is true when the page must redraw to keep its relative times
+/// true, whatever the chain did.
+bool ageRefreshDue(DateTime last, DateTime now) => now.difference(last) >= explorerAgeInterval;
+
 /// ExplorerModel reads the chain through the orchestrator. A light client
 /// answers from a hosted index, a full node from its own chain.
 class ExplorerModel extends BaseViewModel {
@@ -32,6 +40,8 @@ class ExplorerModel extends BaseViewModel {
   bool _reading = false;
   bool _readingOlder = false;
   bool _reachedGenesis = false;
+
+  DateTime _lastDraw = DateTime.now();
 
   /// blocks are the newest blocks, then every page a reader scrolled back to.
   List<pb.Block> get blocks => [...?overview?.blocks, ...olderBlocks];
@@ -109,10 +119,12 @@ class ExplorerModel extends BaseViewModel {
         overview = next;
         _trimOlderBlocks(next.blocks);
         readError = null;
-        notifyListeners();
+        _draw();
       } else if (readError != null) {
         readError = null;
-        notifyListeners();
+        _draw();
+      } else if (ageRefreshDue(_lastDraw, DateTime.now())) {
+        _draw();
       }
     } catch (e) {
       readError = e.toString();
@@ -120,6 +132,11 @@ class ExplorerModel extends BaseViewModel {
     } finally {
       _reading = false;
     }
+  }
+
+  void _draw() {
+    _lastDraw = DateTime.now();
+    notifyListeners();
   }
 
   Future<pb.GetBlockResponse> block({String? hash, int? height}) {

--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -98,6 +98,24 @@ class _SailTableState extends State<SailTable> {
     _sortColumnIndex = widget.sortColumnIndex;
     _sortAscending = widget.sortAscending ?? true;
 
+    // A caller can add or drop a column between builds. Every width reads by
+    // column index, so the list must follow the header count.
+    final headers = widget.headerBuilder(context);
+    if (headers.length != _numColumns) {
+      _numColumns = headers.length;
+      _widths
+        ..clear()
+        ..addAll(List.filled(_numColumns!, defaultMinColumnWidth));
+      if (_currentConstraints != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            _resizeColumns(_currentConstraints!.maxWidth, force: true);
+          }
+        });
+      }
+      return;
+    }
+
     // Recalculate column widths when row count changes
     if (oldWidget.rowCount != widget.rowCount) {
       if (_currentConstraints != null && mounted) {

--- a/sail_ui/lib/widgets/containers/sail_card.dart
+++ b/sail_ui/lib/widgets/containers/sail_card.dart
@@ -21,6 +21,10 @@ class SailCard extends StatelessWidget {
   final String? titleTooltip;
   final String? subtitle;
   final String? error;
+
+  /// headerValue is the one figure the card is about, in large type under the
+  /// title.
+  final String? headerValue;
   final VoidCallback? onPressed;
   final bool padding;
   final bool bottomPadding;
@@ -44,6 +48,7 @@ class SailCard extends StatelessWidget {
     this.titleTooltip,
     this.subtitle,
     this.error,
+    this.headerValue,
     this.onPressed,
     this.padding = true,
     this.bottomPadding = true,
@@ -70,7 +75,12 @@ class SailCard extends StatelessWidget {
     );
   }
 
-  Widget _build(BuildContext context, SailThemeData theme, BorderRadius radius, bool boundedHeight) {
+  Widget _build(
+    BuildContext context,
+    SailThemeData theme,
+    BorderRadius radius,
+    bool boundedHeight,
+  ) {
     return SelectionArea(
       child: SailShadow(
         shadowSize: shadowSize,
@@ -84,7 +94,10 @@ class SailCard extends StatelessWidget {
                     border: Border(
                       top: BorderSide(color: theme.colors.border, width: 1.0),
                       right: BorderSide(color: theme.colors.border, width: 1.0),
-                      bottom: BorderSide(color: theme.colors.border, width: 1.0),
+                      bottom: BorderSide(
+                        color: theme.colors.border,
+                        width: 1.0,
+                      ),
                       left: BorderSide(
                         color: selected ? theme.colors.primary : theme.colors.border,
                         width: selected ? 2.0 : 1.0,
@@ -159,6 +172,8 @@ class SailCard extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisSize: MainAxisSize.min,
                         children: [
+                          if (theme.chrome.beveled && title != null && headerValue != null)
+                            SailText.primary22(headerValue!, bold: true),
                           if (theme.chrome.beveled && title != null && (subtitle != null || error != null))
                             SailText.primary12(
                               error ?? subtitle!,
@@ -179,6 +194,7 @@ class SailCard extends StatelessWidget {
                                       titleTooltip: titleTooltip,
                                       subtitle: subtitle,
                                       error: error,
+                                      headerValue: headerValue,
                                     ),
                                   ),
                                   SailRow(
@@ -193,7 +209,9 @@ class SailCard extends StatelessWidget {
                                             icon: SailSVGAsset.iconNewWindow,
                                             onPressed: () async {
                                               final windowProvider = GetIt.I.get<WindowProvider>();
-                                              await windowProvider.open(newWindow!);
+                                              await windowProvider.open(
+                                                newWindow!,
+                                              );
                                             },
                                           ),
                                         ),

--- a/sail_ui/lib/widgets/containers/sail_dialogs.dart
+++ b/sail_ui/lib/widgets/containers/sail_dialogs.dart
@@ -118,12 +118,17 @@ class CardHeader extends StatelessWidget {
   final String? subtitle;
   final String? error;
 
+  /// headerValue is the one figure the card is about. It reads between the
+  /// title and the subtitle, in large type.
+  final String? headerValue;
+
   const CardHeader({
     super.key,
     required this.title,
     this.titleTooltip,
     this.subtitle,
     this.error,
+    this.headerValue,
   });
 
   @override
@@ -142,6 +147,7 @@ class CardHeader extends StatelessWidget {
           )
         else
           SailText.primary16(title, bold: true),
+        if (headerValue != null) SailText.primary22(headerValue!, bold: true),
         if (error != null || subtitle != null)
           SailText.primary13(
             error ?? subtitle!,
@@ -219,7 +225,12 @@ class SailModal extends StatelessWidget {
   final Color? backgroundColor;
   final BoxConstraints? constraints;
 
-  const SailModal({super.key, required this.child, this.backgroundColor, this.constraints});
+  const SailModal({
+    super.key,
+    required this.child,
+    this.backgroundColor,
+    this.constraints,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/sail_ui/test/explorer_block_card_test.dart
+++ b/sail_ui/test/explorer_block_card_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  group('transactionCount', () {
+    test('names an empty block, one transaction, and many', () {
+      expect(transactionCount(0), 'No transactions');
+      expect(transactionCount(1), '1 transaction');
+      expect(transactionCount(4), '4 transactions');
+    });
+  });
+
+  group('explorerAge', () {
+    int agoBy(Duration back) => DateTime.now().subtract(back).millisecondsSinceEpoch ~/ 1000;
+
+    test('a block with no time reads empty', () {
+      expect(explorerAge(0), '');
+      expect(explorerAge(-1), '');
+    });
+
+    test('reads minutes, hours and days', () {
+      expect(explorerAge(agoBy(const Duration(seconds: 20))), 'just now');
+      expect(explorerAge(agoBy(const Duration(minutes: 1, seconds: 5))), '1 minute ago');
+      expect(explorerAge(agoBy(const Duration(minutes: 34))), '34 minutes ago');
+      expect(explorerAge(agoBy(const Duration(hours: 1, minutes: 2))), '1 hour ago');
+      expect(explorerAge(agoBy(const Duration(hours: 9))), '9 hours ago');
+      expect(explorerAge(agoBy(const Duration(days: 2, hours: 3))), '2 days ago');
+    });
+  });
+
+  group('ageRefreshDue', () {
+    final now = DateTime(2026, 9, 5, 12, 0);
+
+    test('a quiet chain redraws once a minute', () {
+      expect(ageRefreshDue(now.subtract(const Duration(seconds: 30)), now), isFalse);
+      expect(ageRefreshDue(now.subtract(const Duration(minutes: 1)), now), isTrue);
+      expect(ageRefreshDue(now.subtract(const Duration(hours: 2)), now), isTrue);
+    });
+  });
+}

--- a/sail_ui/test/sail_table_columns_test.dart
+++ b/sail_ui/test/sail_table_columns_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+Widget _table({required bool withAddress}) {
+  return MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: SizedBox(
+          width: 800,
+          height: 400,
+          child: SailTable(
+            getRowId: (index) => 'row$index',
+            headerBuilder: (context) => [
+              const SailTableHeaderCell(name: 'Transaction'),
+              if (withAddress) const SailTableHeaderCell(name: 'Address'),
+              const SailTableHeaderCell(name: 'Amount'),
+            ],
+            rowBuilder: (context, index, selected) => [
+              const SailTableCell(value: 'd1'),
+              if (withAddress) const SailTableCell(value: 'sc1'),
+              const SailTableCell(value: '12300 sats'),
+            ],
+            rowCount: 1,
+            drawGrid: false,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  // A source that names no address drops that column. A refresh can add it
+  // back, and the table reads every width by column index.
+  testWidgets('a changed column count keeps the table alive', (tester) async {
+    await tester.pumpWidget(_table(withAddress: false));
+    await tester.pumpAndSettle();
+    expect(find.text('Address'), findsNothing);
+
+    await tester.pumpWidget(_table(withAddress: true));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(find.text('Address'), findsOneWidget);
+
+    await tester.pumpWidget(_table(withAddress: false));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(find.text('Address'), findsNothing);
+  });
+}

--- a/sidechain-orchestrator/api/explorer_bid.go
+++ b/sidechain-orchestrator/api/explorer_bid.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
+)
+
+// mainchainBlock is a mainchain block at verbosity 3. Core computes the fee
+// there, so no input walk is necessary.
+type mainchainBlock struct {
+	Hash   string `json:"hash"`
+	Height uint32 `json:"height"`
+	Tx     []struct {
+		Txid string  `json:"txid"`
+		Fee  float64 `json:"fee"`
+		Vout []struct {
+			N            uint32  `json:"n"`
+			Value        float64 `json:"value"`
+			ScriptPubKey struct {
+				Hex string `json:"hex"`
+			} `json:"scriptPubKey"`
+		} `json:"vout"`
+	} `json:"tx"`
+}
+
+// SetCoreCaller wires the bitcoind seam the bid lookup reads.
+func (h *ExplorerHandler) SetCoreCaller(c CoreRawCaller) { h.core = c }
+
+func (h *ExplorerHandler) coreCall(ctx context.Context, method, paramsJSON string) (json.RawMessage, error) {
+	if h.core == nil {
+		return nil, fmt.Errorf("no bitcoind seam")
+	}
+	return h.core(ctx, method, paramsJSON, "")
+}
+
+// resolveBid names the winning BMM bid for one sidechain block: the M8
+// outpoint on the mainchain, and the fee it paid.
+//
+// A header names the mainchain block the bid was built on. A miner takes that
+// bid in the very next block, so the M8 sits one block later.
+func (h *ExplorerHandler) resolveBid(ctx context.Context, slot uint32, block *pb.Block) {
+	if block == nil || block.GetBid() != nil || block.GetMainchainHash() == "" {
+		return
+	}
+	parent, err := h.mainchainHeader(ctx, block.GetMainchainHash())
+	if err != nil || parent.NextBlockHash == "" {
+		return
+	}
+	carrier := parent.NextBlockHash
+	raw, err := h.coreCall(ctx, "getblock", fmt.Sprintf("[%q,3]", carrier))
+	if err != nil {
+		return
+	}
+	var mined mainchainBlock
+	if err := json.Unmarshal(raw, &mined); err != nil {
+		return
+	}
+	block.Bid = findBid(mined, uint8(slot), block.GetHash(), block.GetMainchainHash())
+}
+
+// mainchainHeaderJSON is what getblockheader answers.
+type mainchainHeaderJSON struct {
+	Height        uint32 `json:"height"`
+	Time          int64  `json:"time"`
+	NextBlockHash string `json:"nextblockhash"`
+}
+
+// mainchainHeader reads one mainchain block header.
+func (h *ExplorerHandler) mainchainHeader(ctx context.Context, hash string) (mainchainHeaderJSON, error) {
+	raw, err := h.coreCall(ctx, "getblockheader", fmt.Sprintf("[%q]", hash))
+	if err != nil {
+		return mainchainHeaderJSON{}, err
+	}
+	var header mainchainHeaderJSON
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return mainchainHeaderJSON{}, fmt.Errorf("read the mainchain header %s: %w", hash, err)
+	}
+	return header, nil
+}
+
+// findBid picks the M8 in a mainchain block that commits to one sidechain
+// block. A valid M8 sits at output zero, so a copy anywhere else is not a bid.
+// It also names the parent it was built on, and only that parent can mine it.
+func findBid(mined mainchainBlock, slot uint8, criticalHash, prevMainHash string) *pb.Bid {
+	for _, tx := range mined.Tx {
+		// The fee is the bid, so the M8 output itself pays nothing.
+		if len(tx.Vout) == 0 || tx.Vout[0].N != 0 || tx.Vout[0].Value != 0 {
+			continue
+		}
+		script, err := hex.DecodeString(tx.Vout[0].ScriptPubKey.Hex)
+		if err != nil {
+			continue
+		}
+		request := orchestrator.ParseM8BmmRequestScript(script)
+		if request == nil || request.Slot != slot || request.CriticalHash != criticalHash {
+			continue
+		}
+		if request.PrevMainHash != prevMainHash {
+			continue
+		}
+		return &pb.Bid{
+			Txid:        tx.Txid,
+			Sats:        int64(math.Round(tx.Fee * 1e8)),
+			BlockHash:   mined.Hash,
+			BlockHeight: mined.Height,
+		}
+	}
+	return nil
+}

--- a/sidechain-orchestrator/api/explorer_bid_test.go
+++ b/sidechain-orchestrator/api/explorer_bid_test.go
@@ -1,0 +1,259 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
+)
+
+// This is the M8 a live mainchain block carried for thunder, slot 9. The
+// script holds the tag, the slot, the sidechain block hash, then the parent
+// mainchain hash in reverse byte order.
+const liveBidScript = "6a4400bf00094d6adc93a9b0f528d6625b9990c765255947b0c06eb1cbda33cc0adc0eb69322" +
+	"065e35407b1ff889317a733d36f7b71104618f0ffa6552c70000000000000000"
+
+const liveSidechainHash = "4d6adc93a9b0f528d6625b9990c765255947b0c06eb1cbda33cc0adc0eb69322"
+
+const liveParentHash = "0000000000000000c75265fa0f8f610411b7f7363d737a3189f81f7b40355e06"
+
+// The winning bid is the M8 that commits to this sidechain block. Core states
+// the fee, so the bid reads back with no input walk.
+func TestFindBidPicksTheM8ForOneBlock(t *testing.T) {
+	mined := mainchainBlock{
+		Hash:   "00000000000000009563c32a953b8a55ed4e6bc23ab4f0078d04651142442497",
+		Height: 996817,
+	}
+	if err := json.Unmarshal(json.RawMessage(fmt.Sprintf(`[
+		{"txid":"a2b2e63d","fee":0,"vout":[{"n":0,"scriptPubKey":{"hex":"6a25d6e1c5df"}}]},
+		{"txid":"61d66813","fee":0.00003,"vout":[{"n":0,"scriptPubKey":{"hex":%q}}]},
+		{"txid":"c8e5d438","fee":0.000013,"vout":[{"n":0,"scriptPubKey":{"hex":"6a33300deb25"}}]}
+	]`, liveBidScript)), &mined.Tx); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+
+	bid := findBid(mined, 9, liveSidechainHash, liveParentHash)
+	if bid == nil {
+		t.Fatal("no bid matched, and one M8 commits to this block")
+	}
+	if bid.GetTxid() != "61d66813" {
+		t.Errorf("the bid is %s, want 61d66813", bid.GetTxid())
+	}
+	if bid.GetVout() != 0 {
+		t.Errorf("the M8 sits at output %d, want 0", bid.GetVout())
+	}
+	if bid.GetSats() != 3000 {
+		t.Errorf("the bid paid %d sats, want 3000", bid.GetSats())
+	}
+	if bid.GetBlockHeight() != 996817 {
+		t.Errorf("the carrier block is %d, want 996817", bid.GetBlockHeight())
+	}
+}
+
+// An M8 for another slot, or for another block, is not this block's bid.
+func TestFindBidIgnoresAnotherSlotAndAnotherBlock(t *testing.T) {
+	mined := mainchainBlock{Hash: "mm", Height: 1}
+	if err := json.Unmarshal(json.RawMessage(fmt.Sprintf(
+		`[{"txid":"61d66813","fee":0.00003,"vout":[{"n":0,"scriptPubKey":{"hex":%q}}]}]`,
+		liveBidScript,
+	)), &mined.Tx); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+
+	if bid := findBid(mined, 8, liveSidechainHash, liveParentHash); bid != nil {
+		t.Errorf("slot 8 matched a slot 9 bid: %s", bid.GetTxid())
+	}
+	if bid := findBid(mined, 9, "ff", liveParentHash); bid != nil {
+		t.Errorf("another block matched: %s", bid.GetTxid())
+	}
+}
+
+// A miner takes a bid in the block after the one the header names, so the
+// lookup reads that child block.
+func TestResolveBidReadsTheBlockAfterTheHeader(t *testing.T) {
+	const parent = liveParentHash
+	const carrier = "00000000000000009563c32a953b8a55ed4e6bc23ab4f0078d04651142442497"
+
+	var asked []string
+	handler := &ExplorerHandler{}
+	handler.SetCoreCaller(func(_ context.Context, method, params, _ string) (json.RawMessage, error) {
+		asked = append(asked, method+" "+params)
+		switch method {
+		case "getblockheader":
+			return json.RawMessage(fmt.Sprintf(`{"nextblockhash":%q}`, carrier)), nil
+		case "getblock":
+			return json.RawMessage(fmt.Sprintf(
+				`{"hash":%q,"height":996817,"tx":[
+					{"txid":"61d66813","fee":0.00003,"vout":[{"n":0,"scriptPubKey":{"hex":%q}}]}
+				]}`, carrier, liveBidScript)), nil
+		}
+		return nil, fmt.Errorf("no answer for %s", method)
+	})
+
+	block := &pb.Block{Hash: liveSidechainHash, MainchainHash: parent}
+	handler.resolveBid(context.Background(), 9, block)
+
+	if block.GetBid() == nil {
+		t.Fatal("the block names no bid")
+	}
+	if got := block.GetBid().GetSats(); got != 3000 {
+		t.Errorf("the bid paid %d sats, want 3000", got)
+	}
+	if len(asked) != 2 || asked[0] != fmt.Sprintf("getblockheader [%q]", parent) {
+		t.Errorf("the lookup asked %v", asked)
+	}
+}
+
+// A block with no mainchain hash, and a chain with no bitcoind, both answer
+// without a bid rather than an error.
+func TestResolveBidStaysQuietWithoutASource(t *testing.T) {
+	handler := &ExplorerHandler{}
+	block := &pb.Block{Hash: liveSidechainHash}
+	handler.resolveBid(context.Background(), 9, block)
+	if block.GetBid() != nil {
+		t.Error("a header with no mainchain hash named a bid")
+	}
+
+	block = &pb.Block{Hash: liveSidechainHash, MainchainHash: "aa"}
+	handler.resolveBid(context.Background(), 9, block)
+	if block.GetBid() != nil {
+		t.Error("an install with no bitcoind named a bid")
+	}
+}
+
+// A valid M8 sits at output zero. A copy of the payload anywhere else is not
+// a bid, and it must not carry that transaction's fee onto the page.
+func TestFindBidIgnoresAnM8AwayFromOutputZero(t *testing.T) {
+	mined := mainchainBlock{Hash: "mm", Height: 1}
+	if err := json.Unmarshal(json.RawMessage(fmt.Sprintf(`[
+		{"txid":"c0p1ed","fee":0.01,"vout":[
+			{"n":0,"scriptPubKey":{"hex":"6a0500"}},
+			{"n":1,"scriptPubKey":{"hex":%q}}
+		]},
+		{"txid":"61d66813","fee":0.00003,"vout":[{"n":0,"scriptPubKey":{"hex":%q}}]}
+	]`, liveBidScript, liveBidScript)), &mined.Tx); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+
+	bid := findBid(mined, 9, liveSidechainHash, liveParentHash)
+	if bid == nil {
+		t.Fatal("no bid matched, and one M8 sits at output zero")
+	}
+	if bid.GetTxid() != "61d66813" {
+		t.Errorf("the bid is %s, want 61d66813", bid.GetTxid())
+	}
+	if bid.GetSats() != 3000 {
+		t.Errorf("the bid paid %d sats, want 3000", bid.GetSats())
+	}
+}
+
+// An M8 that names another parent could never mine this block, whatever else
+// it commits to.
+func TestFindBidIgnoresAnotherParent(t *testing.T) {
+	mined := mainchainBlock{Hash: "mm", Height: 1}
+	if err := json.Unmarshal(json.RawMessage(fmt.Sprintf(
+		`[{"txid":"61d66813","fee":0.00003,"vout":[{"n":0,"scriptPubKey":{"hex":%q}}]}]`,
+		liveBidScript,
+	)), &mined.Tx); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+
+	other := "00000000000000000000000000000000000000000000000000000000000000ff"
+	if bid := findBid(mined, 9, liveSidechainHash, other); bid != nil {
+		t.Errorf("a bid built on another parent matched: %s", bid.GetTxid())
+	}
+}
+
+// The fee is the bid, so a valid M8 output pays nothing. A burn that carries
+// the same bytes is not a bid.
+func TestFindBidIgnoresAValueBearingM8(t *testing.T) {
+	mined := mainchainBlock{Hash: "mm", Height: 1}
+	if err := json.Unmarshal(json.RawMessage(fmt.Sprintf(`[
+		{"txid":"burn","fee":0.5,"vout":[{"n":0,"value":0.25,"scriptPubKey":{"hex":%q}}]},
+		{"txid":"61d66813","fee":0.00003,"vout":[{"n":0,"value":0,"scriptPubKey":{"hex":%q}}]}
+	]`, liveBidScript, liveBidScript)), &mined.Tx); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+
+	bid := findBid(mined, 9, liveSidechainHash, liveParentHash)
+	if bid == nil {
+		t.Fatal("no bid matched, and one M8 pays nothing")
+	}
+	if bid.GetTxid() != "61d66813" {
+		t.Errorf("the bid is %s, want 61d66813", bid.GetTxid())
+	}
+}
+
+// A sidechain block connects when a miner takes its M8, which is the block
+// after the one the header names. Those two can be hours apart, so the age
+// reads from the carrier.
+func TestResolveMainchainReadsTheCarrierTime(t *testing.T) {
+	const parent = "0000000000000000c75265fa0f8f610411b7f7363d737a3189f81f7b40355e06"
+	const carrier = "00000000000000009563c32a953b8a55ed4e6bc23ab4f0078d04651142442497"
+
+	var asked int
+	handler := &ExplorerHandler{mainchain: newMainchainCache()}
+	handler.SetCoreCaller(func(_ context.Context, method, params, _ string) (json.RawMessage, error) {
+		if method != "getblockheader" {
+			return nil, fmt.Errorf("no answer for %s", method)
+		}
+		asked++
+		if strings.Contains(params, parent) {
+			return json.RawMessage(fmt.Sprintf(
+				`{"height":996816,"time":1000,"nextblockhash":%q}`, carrier)), nil
+		}
+		return json.RawMessage(`{"height":996817,"time":9581}`), nil
+	})
+
+	block := &pb.Block{Hash: liveSidechainHash, MainchainHash: parent}
+	handler.resolveMainchain(context.Background(), block)
+
+	if got := block.GetMainchainHeight(); got != 996816 {
+		t.Errorf("the header names block %d, want 996816", got)
+	}
+	if got := block.GetBlockTime(); got != 9581 {
+		t.Errorf("the block connected at %d, want the carrier time 9581", got)
+	}
+
+	// A second block on the same parent answers from the cache.
+	asked = 0
+	again := &pb.Block{Hash: "bb", MainchainHash: parent}
+	handler.resolveMainchain(context.Background(), again)
+	if asked != 0 {
+		t.Errorf("the second read asked bitcoind %d times, want 0", asked)
+	}
+	if again.GetBlockTime() != 9581 {
+		t.Errorf("the cached time reads %d, want 9581", again.GetBlockTime())
+	}
+}
+
+// A parent with no block after it carries no M8 yet, so the page reads it
+// again rather than holding a time of zero.
+func TestResolveMainchainRetriesAParentWithNoCarrier(t *testing.T) {
+	const parent = "0000000000000000c75265fa0f8f610411b7f7363d737a3189f81f7b40355e06"
+
+	var asked int
+	handler := &ExplorerHandler{mainchain: newMainchainCache()}
+	handler.SetCoreCaller(func(_ context.Context, method, params, _ string) (json.RawMessage, error) {
+		asked++
+		return json.RawMessage(`{"height":996816,"time":1000}`), nil
+	})
+
+	block := &pb.Block{Hash: liveSidechainHash, MainchainHash: parent}
+	handler.resolveMainchain(context.Background(), block)
+	if block.GetMainchainHeight() != 996816 {
+		t.Errorf("the header names block %d, want 996816", block.GetMainchainHeight())
+	}
+	if block.GetBlockTime() != 0 {
+		t.Errorf("a block with no carrier states a time of %d", block.GetBlockTime())
+	}
+
+	asked = 0
+	handler.resolveMainchain(context.Background(), &pb.Block{Hash: "bb", MainchainHash: parent})
+	if asked == 0 {
+		t.Error("the page cached a parent that carries no M8 yet")
+	}
+}

--- a/sidechain-orchestrator/api/explorer_blocks.go
+++ b/sidechain-orchestrator/api/explorer_blocks.go
@@ -32,6 +32,10 @@ func (h *ExplorerHandler) ListBlocks(
 			return nil, connect.NewError(connect.CodeUnavailable, err)
 		}
 		out.Blocks = blockList(rows)
+		if len(out.Blocks) > limit {
+			out.Blocks = out.Blocks[:limit]
+		}
+		fillIndexBlockDeposits(ctx, src, out.Blocks)
 	} else {
 		out.Blocks, err = nodeBlocksBefore(ctx, src, req.Msg.GetBeforeHeight(), limit)
 		if err != nil {
@@ -41,7 +45,7 @@ func (h *ExplorerHandler) ListBlocks(
 	if len(out.Blocks) > limit {
 		out.Blocks = out.Blocks[:limit]
 	}
-	h.resolveMainchainHeights(ctx, out.GetBlocks())
+	h.resolveMainchain(ctx, out.GetBlocks()...)
 	return connect.NewResponse(out), nil
 }
 

--- a/sidechain-orchestrator/api/explorer_cache.go
+++ b/sidechain-orchestrator/api/explorer_cache.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"context"
+	"sync"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
+	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
+)
+
+// blockCacheSize bounds both caches. A block body never changes, so the walk
+// for the newest rows reads each block one time.
+const blockCacheSize = 8192
+
+// blockCache holds what one sidechain block carried.
+type blockCache struct {
+	mu    sync.Mutex
+	rows  map[string]cachedBlock
+	order []string
+}
+
+type cachedBlock struct {
+	block    *pb.Block
+	activity []*pb.Activity
+	// ownHeight is true when the node named the height itself. A node that
+	// names none takes the walk's height, and that one is not cacheable.
+	ownHeight bool
+}
+
+func newBlockCache() *blockCache {
+	return &blockCache{rows: map[string]cachedBlock{}}
+}
+
+// get answers a copy, so a caller can stamp a row without touching the cache.
+// It answers false for ownHeight when the caller must stamp the height too.
+func (c *blockCache) get(key string) (*pb.Block, []*pb.Activity, bool, bool) {
+	if c == nil {
+		return nil, nil, false, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	held, ok := c.rows[key]
+	if !ok {
+		return nil, nil, false, false
+	}
+	block, rows := copyBlock(held)
+	return block, rows, held.ownHeight, true
+}
+
+// put stores a copy and answers another one. A caller keeps writing to the
+// block it gave, so the cache never holds that one.
+func (c *blockCache) put(
+	key string, block *pb.Block, activity []*pb.Activity, ownHeight bool,
+) (*pb.Block, []*pb.Activity) {
+	if c == nil {
+		return block, activity
+	}
+	held, rows := copyBlock(cachedBlock{block: block, activity: activity})
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.rows[key]; !ok {
+		c.order = append(c.order, key)
+		for len(c.order) > blockCacheSize {
+			delete(c.rows, c.order[0])
+			c.order = c.order[1:]
+		}
+	}
+	c.rows[key] = cachedBlock{block: held, activity: rows, ownHeight: ownHeight}
+	return copyBlock(c.rows[key])
+}
+
+func copyBlock(held cachedBlock) (*pb.Block, []*pb.Activity) {
+	rows := make([]*pb.Activity, 0, len(held.activity))
+	for _, row := range held.activity {
+		rows = append(rows, proto.Clone(row).(*pb.Activity))
+	}
+	return proto.Clone(held.block).(*pb.Block), rows
+}
+
+// mainchainAnchor is what the mainchain says about one sidechain header.
+type mainchainAnchor struct {
+	// parentHeight is the block the header names, which a bid was built on.
+	parentHeight uint32
+	// minedAt is the time of the block after that one. A miner takes the M8
+	// there, so that is when the sidechain block connected.
+	minedAt int64
+}
+
+// mainchainCache holds those, because a mainchain header never changes.
+type mainchainCache struct {
+	mu    sync.Mutex
+	rows  map[string]mainchainAnchor
+	order []string
+}
+
+func newMainchainCache() *mainchainCache {
+	return &mainchainCache{rows: map[string]mainchainAnchor{}}
+}
+
+func (c *mainchainCache) get(hash string) (mainchainAnchor, bool) {
+	if c == nil {
+		return mainchainAnchor{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	held, ok := c.rows[hash]
+	return held, ok
+}
+
+func (c *mainchainCache) put(hash string, held mainchainAnchor) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.rows[hash]; !ok {
+		c.order = append(c.order, hash)
+		for len(c.order) > blockCacheSize {
+			delete(c.rows, c.order[0])
+			c.order = c.order[1:]
+		}
+	}
+	c.rows[hash] = held
+}
+
+// anchorFor names the mainchain block a sidechain header points at, and the
+// time the block after it connected the sidechain block. A sidechain header
+// carries no clock of its own.
+func (h *ExplorerHandler) anchorFor(ctx context.Context, hash string) (mainchainAnchor, bool) {
+	if hash == "" {
+		return mainchainAnchor{}, false
+	}
+	if held, ok := h.mainchain.get(hash); ok {
+		return held, true
+	}
+	held, ok := h.anchorFromCore(ctx, hash)
+	if !ok {
+		held, ok = h.anchorFromEnforcer(ctx, hash)
+	}
+	if !ok {
+		return mainchainAnchor{}, false
+	}
+	// A parent with no block after it carries no M8 yet, so read it again.
+	if held.minedAt != 0 {
+		h.mainchain.put(hash, held)
+	}
+	return held, true
+}
+
+// anchorFromCore reads the parent and the block that followed it.
+func (h *ExplorerHandler) anchorFromCore(ctx context.Context, hash string) (mainchainAnchor, bool) {
+	parent, err := h.mainchainHeader(ctx, hash)
+	if err != nil {
+		return mainchainAnchor{}, false
+	}
+	out := mainchainAnchor{parentHeight: parent.Height}
+	if parent.NextBlockHash == "" {
+		return out, true
+	}
+	carrier, err := h.mainchainHeader(ctx, parent.NextBlockHash)
+	if err != nil {
+		return out, true
+	}
+	out.minedAt = carrier.Time
+	return out, true
+}
+
+// anchorFromEnforcer answers for an install that runs no bitcoind. It names
+// the parent's own time, which is the earliest the block can have connected.
+func (h *ExplorerHandler) anchorFromEnforcer(ctx context.Context, hash string) (mainchainAnchor, bool) {
+	validator, err := h.orch.EnforcerValidator()
+	if err != nil {
+		return mainchainAnchor{}, false
+	}
+	resp, err := validator.GetBlockHeaderInfo(ctx, connect.NewRequest(
+		&enforcerpb.GetBlockHeaderInfoRequest{
+			BlockHash: &commonv1.ReverseHex{Hex: wrapperspb.String(hash)},
+		}))
+	if err != nil {
+		return mainchainAnchor{}, false
+	}
+	for _, info := range resp.Msg.GetHeaderInfos() {
+		return mainchainAnchor{parentHeight: info.GetHeight(), minedAt: int64(info.GetTimestamp())}, true
+	}
+	return mainchainAnchor{}, false
+}
+
+// resolveMainchain fills in the block a header names, and when it connected.
+func (h *ExplorerHandler) resolveMainchain(ctx context.Context, blocks ...*pb.Block) {
+	for _, block := range blocks {
+		if block == nil || block.GetMainchainHash() == "" {
+			continue
+		}
+		if block.GetMainchainHeight() != 0 && block.GetBlockTime() != 0 {
+			continue
+		}
+		held, ok := h.anchorFor(ctx, block.GetMainchainHash())
+		if !ok {
+			continue
+		}
+		block.MainchainHeight = held.parentHeight
+		block.BlockTime = held.minedAt
+	}
+}

--- a/sidechain-orchestrator/api/explorer_core.go
+++ b/sidechain-orchestrator/api/explorer_core.go
@@ -35,12 +35,21 @@ func coreOverview(ctx context.Context, src source) (*pb.GetOverviewResponse, err
 	}
 	out.TipHeight = uint32(count)
 
-	for height := count; height >= 0 && len(out.Blocks) < blockListSize; height-- {
+	for walked := 0; walked < activityScanDepth; walked++ {
+		if len(out.Blocks) >= blockListSize && len(out.Recent) >= activityListSize {
+			break
+		}
+		height := count - int64(walked)
+		if height < 0 {
+			break
+		}
 		block, activity, err := coreBlockAtHeight(ctx, src, uint32(height))
 		if err != nil {
 			return nil, err
 		}
-		out.Blocks = append(out.Blocks, block)
+		if len(out.Blocks) < blockListSize {
+			out.Blocks = append(out.Blocks, block)
+		}
 		for _, row := range activity {
 			if len(out.Recent) >= activityListSize {
 				break
@@ -67,6 +76,20 @@ func coreBlockAtHeight(ctx context.Context, src source, height uint32) (*pb.Bloc
 
 // coreBlockByHash reads one block from a Core derived node by its hash.
 func coreBlockByHash(ctx context.Context, src source, hash string) (*pb.Block, []*pb.Activity, error) {
+	key := src.cacheKey(hash)
+	if block, activity, _, ok := src.cache.get(key); ok {
+		return block, activity, nil
+	}
+	block, activity, err := readCoreBlock(ctx, src, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, rows := src.cache.put(key, block, activity, true)
+	return out, rows, nil
+}
+
+// readCoreBlock asks the node for one block and what it carried.
+func readCoreBlock(ctx context.Context, src source, hash string) (*pb.Block, []*pb.Activity, error) {
 	raw, err := src.node.CallRaw(ctx, "getblock", []any{hash, 1})
 	if err != nil {
 		return nil, nil, connect.NewError(connect.CodeUnavailable, err)

--- a/sidechain-orchestrator/api/explorer_deposit_test.go
+++ b/sidechain-orchestrator/api/explorer_deposit_test.go
@@ -1,0 +1,391 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
+)
+
+// A node writes a deposit as a pair: the mainchain outpoint, then the
+// sidechain output it created. This is the shape a live thunder node sends.
+func TestBlockIndexReadsTheDepositPair(t *testing.T) {
+	raw := json.RawMessage(`{
+		"txs": [],
+		"deposits": [
+			[{"Deposit": "7215d16ed52a4f26b4ed5cbef066dd2aedc9336ad5c2069942f1e36c9973b0c4:0"},
+			 {"address": "hbpj5v1raA6qHnJKjab8Wh9NDW2", "content": {"Value": 12300}}],
+			[{"Deposit": "d9f0a85ccd0205a5fee36c6afad63a8704c5b0339f2e8b8cb8431d5d458e3e61:0"},
+			 {"address": "2fPNxpAMPdBL6KyzYt7ZuzvgPkUM", "content": {"Value": 200000000}}]
+		],
+		"bundle_spends": []
+	}`)
+
+	var index nodeBlockIndex
+	if err := json.Unmarshal(raw, &index); err != nil {
+		t.Fatalf("read the block index: %v", err)
+	}
+	if got := len(index.Deposits); got != 2 {
+		t.Fatalf("the block holds %d deposits, want 2", got)
+	}
+	first := index.Deposits[0]
+	if first.Address != "hbpj5v1raA6qHnJKjab8Wh9NDW2" {
+		t.Errorf("the first deposit paid %s", first.Address)
+	}
+	if first.ValueSats != 12300 {
+		t.Errorf("the first deposit is worth %d sats, want 12300", first.ValueSats)
+	}
+	want := "7215d16ed52a4f26b4ed5cbef066dd2aedc9336ad5c2069942f1e36c9973b0c4"
+	if got := depositTxid(first.Outpoint); got != want {
+		t.Errorf("the first outpoint names %s, want %s", got, want)
+	}
+	if index.Deposits[1].ValueSats != 200000000 {
+		t.Errorf("the second deposit is worth %d sats", index.Deposits[1].ValueSats)
+	}
+}
+
+// A block that holds a deposit reports it, both as a row and as a count. A
+// deposit never sits in the block body, so the body count alone reads zero.
+func TestNodeBlockReportsWhatWasDeposited(t *testing.T) {
+	node := &recordingNode{
+		count: 1,
+		answers: map[string]string{
+			"get_best_sidechain_block_hash": `"aa"`,
+		},
+		byHash: map[string]string{
+			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[]}}`,
+		},
+		index: map[string]string{
+			"aa": `{"txs":[],"deposits":[
+				[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}],
+				[{"Deposit":"d9f0a85c:0"},{"address":"sc2","content":{"Value":200000000}}]
+			]}`,
+		},
+	}
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+
+	block, activity, err := nodeBlock(context.Background(), src, "aa", 0)
+	if err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+	if got := block.GetDepositCount(); got != 2 {
+		t.Errorf("deposit count = %d, want 2", got)
+	}
+	if got := block.GetDepositValueSats(); got != 200012300 {
+		t.Errorf("deposited = %d sats, want 200012300", got)
+	}
+	if got := len(activity); got != 2 {
+		t.Fatalf("the block lists %d rows, want 2", got)
+	}
+	if activity[0].GetKind() != pb.Kind_KIND_DEPOSIT {
+		t.Errorf("the first row reads %s, want a deposit", activity[0].GetKind())
+	}
+	if got := activity[0].GetAddress(); got != "sc1" {
+		t.Errorf("the first row paid %s, want sc1", got)
+	}
+	if got := activity[0].GetValueSats(); got != 12300 {
+		t.Errorf("the first row is worth %d sats, want 12300", got)
+	}
+}
+
+// A block index that answers a shape no reader knows is an error, not an
+// empty block. A silent fallback hid every deposit.
+func TestNodeBlockRefusesABlockIndexItCannotRead(t *testing.T) {
+	node := &recordingNode{
+		byHash: map[string]string{
+			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[]}}`,
+		},
+		index: map[string]string{"aa": `{"txs":[],"deposits":[{"outpoint":"7215d16e:0"}]}`},
+	}
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+
+	if _, _, err := nodeBlock(context.Background(), src, "aa", 0); err == nil {
+		t.Fatal("the read passed, and it must refuse a shape it cannot read")
+	}
+}
+
+// The overview lists the newest transactions whatever their age. A chain that
+// saw nothing for weeks still names what it did last.
+func TestOverviewWalksPastTheBlockWindowForRows(t *testing.T) {
+	// The chain holds 40 blocks. Only the oldest one carries a transaction,
+	// so a walk that stops at the block window lists nothing.
+	const tip = 39
+	node := &recordingNode{
+		count: tip + 1,
+		answers: map[string]string{
+			"get_best_sidechain_block_hash": `"b39"`,
+		},
+		byHash: map[string]string{},
+		index:  map[string]string{},
+	}
+	for height := 0; height <= tip; height++ {
+		hash := fmt.Sprintf("b%d", height)
+		prev := ""
+		if height > 0 {
+			prev = fmt.Sprintf(`"prev_side_hash":"b%d",`, height-1)
+		}
+		node.byHash[hash] = fmt.Sprintf(
+			`{"header":{%s"merkle_root":"m%d","prev_main_hash":"x%d"},"body":{"transactions":[]}}`,
+			prev, height, height,
+		)
+		node.index[hash] = `{"txs":[],"deposits":[]}`
+	}
+	node.index["b0"] = `{"txs":[],"deposits":[
+		[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+	]}`
+
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+	out, err := nodeOverview(context.Background(), src)
+	if err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	if got := len(out.GetBlocks()); got != blockListSize {
+		t.Errorf("the strip holds %d blocks, want %d", got, blockListSize)
+	}
+	if got := len(out.GetRecent()); got != 1 {
+		t.Fatalf("the overview lists %d rows, want 1", got)
+	}
+	if got := out.GetRecent()[0].GetAddress(); got != "sc1" {
+		t.Errorf("the row paid %s, want sc1", got)
+	}
+}
+
+// The walk stops at the scan depth, so an empty chain never reads forever.
+func TestOverviewStopsAtTheScanDepth(t *testing.T) {
+	const height = activityScanDepth + 50
+	node := &recordingNode{
+		count: height + 1,
+		answers: map[string]string{
+			"get_best_sidechain_block_hash": `"b0"`,
+		},
+		byHash: map[string]string{},
+		index:  map[string]string{},
+	}
+	// Every block names the same parent, so the walk only stops on its cap.
+	node.byHash["b0"] = `{"header":{"prev_side_hash":"b0","merkle_root":"m","prev_main_hash":"x"},"body":{"transactions":[]}}`
+	node.index["b0"] = `{"txs":[],"deposits":[]}`
+
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+	if _, err := nodeOverview(context.Background(), src); err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	var reads int
+	for _, method := range node.called {
+		if method == "get_block" {
+			reads++
+		}
+	}
+	if reads > activityScanDepth {
+		t.Errorf("the walk read %d blocks, and the cap is %d", reads, activityScanDepth)
+	}
+}
+
+// The cache answers a copy. A caller that stamps a row must never write into
+// what the next reader gets.
+func TestBlockCacheAnswersACopy(t *testing.T) {
+	cache := newBlockCache()
+	block, rows := cache.put("thunder:aa",
+		&pb.Block{Hash: "aa", Height: 3},
+		[]*pb.Activity{{Id: "tx1"}},
+		true,
+	)
+	block.Height = 99
+	rows[0].BlockTime = 12345
+
+	again, rowsAgain, _, ok := cache.get("thunder:aa")
+	if !ok {
+		t.Fatal("the cache holds no block")
+	}
+	if again.GetHeight() != 3 {
+		t.Errorf("the cached height reads %d, want 3", again.GetHeight())
+	}
+	if rowsAgain[0].GetBlockTime() != 0 {
+		t.Errorf("the cached row reads a time of %d, want 0", rowsAgain[0].GetBlockTime())
+	}
+}
+
+// A node that failed to answer the block index named no row. The cache must
+// hold none of that, or the block stays empty after the node recovers.
+func TestNodeBlockCachesNoIncompleteRead(t *testing.T) {
+	node := &recordingNode{
+		byHash: map[string]string{
+			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[]}}`,
+		},
+		index: map[string]string{},
+	}
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+	ctx := context.Background()
+
+	if _, _, err := nodeBlock(ctx, src, "aa", 0); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+	if _, _, _, ok := src.cache.get(src.cacheKey("aa")); ok {
+		t.Fatal("the cache holds a block the node never named the rows of")
+	}
+
+	node.index["aa"] = `{"txs":[],"deposits":[
+		[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+	]}`
+	_, activity, err := nodeBlock(ctx, src, "aa", 0)
+	if err != nil {
+		t.Fatalf("read the block again: %v", err)
+	}
+	if len(activity) != 1 {
+		t.Fatalf("the second read lists %d rows, want 1", len(activity))
+	}
+	if _, _, _, ok := src.cache.get(src.cacheKey("aa")); !ok {
+		t.Error("the cache holds no block after a complete read")
+	}
+}
+
+// A hosted index lists the deposit rows and states no total. The block reads
+// the total back from those rows, so the page never says zero over a list.
+func TestCountDepositsFillsWhatAnIndexLeavesEmpty(t *testing.T) {
+	block := &pb.Block{Hash: "aa"}
+	rows := []*pb.Activity{
+		{Kind: pb.Kind_KIND_TRANSFER, Id: "tx1", ValueSats: 500},
+		{Kind: pb.Kind_KIND_DEPOSIT, Id: "d1", ValueSats: 12300},
+		{Kind: pb.Kind_KIND_DEPOSIT, Id: "d2", ValueSats: 200000000},
+	}
+	countDeposits(block, rows)
+
+	if got := block.GetDepositCount(); got != 2 {
+		t.Errorf("deposit count = %d, want 2", got)
+	}
+	if got := block.GetDepositValueSats(); got != 200012300 {
+		t.Errorf("deposited = %d sats, want 200012300", got)
+	}
+
+	// A source that states its own total keeps it.
+	stated := &pb.Block{Hash: "bb", DepositCount: 1, DepositValueSats: 7}
+	countDeposits(stated, rows)
+	if stated.GetDepositCount() != 1 || stated.GetDepositValueSats() != 7 {
+		t.Errorf("the stated total changed to %d / %d", stated.GetDepositCount(), stated.GetDepositValueSats())
+	}
+}
+
+// The walk reads up to the scan depth, and only a kept block or one that
+// carried a row costs a mainchain lookup.
+func TestOverviewResolvesOnlyTheBlocksThePageUses(t *testing.T) {
+	const tip = 39
+	node := &recordingNode{
+		count:   tip + 1,
+		answers: map[string]string{"get_best_sidechain_block_hash": `"b39"`},
+		byHash:  map[string]string{},
+		index:   map[string]string{},
+	}
+	for height := 0; height <= tip; height++ {
+		hash := fmt.Sprintf("b%d", height)
+		prev := ""
+		if height > 0 {
+			prev = fmt.Sprintf(`"prev_side_hash":"b%d",`, height-1)
+		}
+		node.byHash[hash] = fmt.Sprintf(
+			`{"header":{%s"merkle_root":"m%d","prev_main_hash":"x%d"},"body":{"transactions":[]}}`,
+			prev, height, height,
+		)
+		node.index[hash] = `{"txs":[],"deposits":[]}`
+	}
+	node.index["b0"] = `{"txs":[],"deposits":[
+		[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+	]}`
+
+	var asked []string
+	src := source{
+		name:  "thunder",
+		node:  node,
+		cache: newBlockCache(),
+		resolve: func(_ context.Context, blocks ...*pb.Block) {
+			for _, block := range blocks {
+				asked = append(asked, block.GetMainchainHash())
+				block.BlockTime = 1700000000
+			}
+		},
+	}
+	out, err := nodeOverview(context.Background(), src)
+	if err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	// Six kept blocks, plus the one block that carried the deposit.
+	if len(asked) != blockListSize+1 {
+		t.Errorf("the page resolved %d blocks, want %d", len(asked), blockListSize+1)
+	}
+	if len(out.GetRecent()) != 1 {
+		t.Fatalf("the overview lists %d rows, want 1", len(out.GetRecent()))
+	}
+	if out.GetRecent()[0].GetBlockTime() != 1700000000 {
+		t.Error("the row carries no block time")
+	}
+}
+
+// A node that names no height takes the one the walk counted. That count can
+// move between two calls, so the cache must never hold it.
+func TestNodeBlockRestampsAHeightTheNodeNeverNamed(t *testing.T) {
+	node := &recordingNode{
+		byHash: map[string]string{
+			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[]}}`,
+		},
+		index: map[string]string{"aa": `{"txs":[],"deposits":[
+			[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+		]}`},
+	}
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+	ctx := context.Background()
+
+	if _, _, err := nodeBlock(ctx, src, "aa", 41); err != nil {
+		t.Fatalf("read the block: %v", err)
+	}
+	block, activity, err := nodeBlock(ctx, src, "aa", 42)
+	if err != nil {
+		t.Fatalf("read the block again: %v", err)
+	}
+	if block.GetHeight() != 42 {
+		t.Errorf("the cached block reads height %d, want 42", block.GetHeight())
+	}
+	if len(activity) != 1 || activity[0].GetBlockHeight() != 42 {
+		t.Errorf("the row names height %d, want 42", activity[0].GetBlockHeight())
+	}
+}
+
+// A node that serves no block index names no row, whatever the walk reads.
+// The page reads the strip and stops, rather than the whole scan depth on
+// every refresh.
+func TestOverviewStopsAtTheStripWithoutABlockIndex(t *testing.T) {
+	const tip = 99
+	node := &recordingNode{
+		count:   tip + 1,
+		answers: map[string]string{"get_best_sidechain_block_hash": `"b99"`},
+		byHash:  map[string]string{},
+		index:   map[string]string{},
+	}
+	for height := 0; height <= tip; height++ {
+		prev := ""
+		if height > 0 {
+			prev = fmt.Sprintf(`"prev_side_hash":"b%d",`, height-1)
+		}
+		node.byHash[fmt.Sprintf("b%d", height)] = fmt.Sprintf(
+			`{"header":{%s"merkle_root":"m%d","prev_main_hash":"x%d"},"body":{"transactions":[]}}`,
+			prev, height, height,
+		)
+	}
+
+	src := source{name: "thunder", node: node, cache: newBlockCache()}
+	out, err := nodeOverview(context.Background(), src)
+	if err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	if len(out.GetBlocks()) != blockListSize {
+		t.Errorf("the strip holds %d blocks, want %d", len(out.GetBlocks()), blockListSize)
+	}
+	var reads int
+	for _, method := range node.called {
+		if method == "get_block" {
+			reads++
+		}
+	}
+	if reads != blockListSize {
+		t.Errorf("the walk read %d blocks, want %d", reads, blockListSize)
+	}
+}

--- a/sidechain-orchestrator/api/explorer_handler.go
+++ b/sidechain-orchestrator/api/explorer_handler.go
@@ -12,7 +12,6 @@ import (
 
 	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
-	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
 	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
@@ -23,7 +22,11 @@ import (
 const blockListSize = 6
 
 // activityListSize is how many rows the overview carries.
-const activityListSize = 12
+const activityListSize = 10
+
+// activityScanDepth is how far down the chain the overview walks for those
+// rows. A chain that saw nothing lately still lists what it did last.
+const activityScanDepth = 500
 
 // Bundle weights, as the chain sizes a withdrawal bundle.
 const (
@@ -38,12 +41,20 @@ const (
 // from its own chain. No sidechain node keeps an address history, so the
 // address call needs an index either way.
 type ExplorerHandler struct {
-	orch *orchestrator.Orchestrator
+	orch      *orchestrator.Orchestrator
+	blocks    *blockCache
+	mainchain *mainchainCache
+	// core reads bitcoind, for the BMM bid a block was mined by.
+	core CoreRawCaller
 }
 
 // NewExplorerHandler builds the handler.
 func NewExplorerHandler(orch *orchestrator.Orchestrator) *ExplorerHandler {
-	return &ExplorerHandler{orch: orch}
+	return &ExplorerHandler{
+		orch:      orch,
+		blocks:    newBlockCache(),
+		mainchain: newMainchainCache(),
+	}
 }
 
 // source is where one chain's explorer reads from. Exactly one of index and
@@ -56,7 +67,17 @@ type source struct {
 	// core is true for a chain built on Bitcoin Core. Such a node speaks
 	// Core's own method names, not the CUSF ones this file reads.
 	core bool
+	// cache holds the blocks already read. An index and a node answer
+	// different shapes for one block, so each keeps its own entries.
+	cache *blockCache
+	// origin names the chain, the network and what answered for them.
+	origin string
+	// resolve names the mainchain block a header points at.
+	resolve func(ctx context.Context, blocks ...*pb.Block)
 }
+
+// cacheKey names one block, as one source answered for it.
+func (s source) cacheKey(hash string) string { return s.origin + ":" + hash }
 
 // sourceFor picks the index when one is hosted, and the local node otherwise.
 func (h *ExplorerHandler) sourceFor(chain string) (source, error) {
@@ -76,7 +97,13 @@ func (h *ExplorerHandler) sourceFor(chain string) (source, error) {
 	}
 	network := config.NetworkFromString(h.orch.CurrentNetwork())
 
-	out := source{name: chain, core: cfg.IsBitcoinCore}
+	out := source{
+		name:    chain,
+		core:    cfg.IsBitcoinCore,
+		cache:   h.blocks,
+		resolve: h.resolveMainchain,
+		origin:  chain + ":node:" + string(network),
+	}
 	if cfg.Slot >= 0 && cfg.Slot <= 255 {
 		out.slot = uint32(cfg.Slot)
 	}
@@ -86,6 +113,7 @@ func (h *ExplorerHandler) sourceFor(chain string) (source, error) {
 	if h.orch.NodeMode() == orchestrator.NodeModeLight {
 		if url := config.SidechainEsploraURLForNetwork(chain, network); url != "" {
 			out.index = sidechainesplora.New(url)
+			out.origin = chain + ":index:" + string(network)
 			return out, nil
 		}
 	}
@@ -119,7 +147,7 @@ func (h *ExplorerHandler) GetOverview(
 	if out.GetTreasury() == nil {
 		out.Treasury = h.enforcerTreasury(ctx, src.slot)
 	}
-	h.resolveMainchainHeights(ctx, out.GetBlocks())
+	h.resolveMainchain(ctx, out.GetBlocks()...)
 	return connect.NewResponse(out), nil
 }
 
@@ -162,7 +190,33 @@ func indexOverview(ctx context.Context, src source) (*pb.GetOverviewResponse, er
 	if state, err := src.index.Withdrawals(ctx); err == nil {
 		out.PendingBundle = parseBundle(state.Bundle)
 	}
+	fillIndexDeposits(ctx, src, out)
 	return out, nil
+}
+
+// fillIndexDeposits states what each block on the strip took from the
+// mainchain. An index gives no per block total, so the page reads the block's
+// own rows. A block never changes, so it costs one read ever.
+func fillIndexDeposits(ctx context.Context, src source, out *pb.GetOverviewResponse) {
+	fillIndexBlockDeposits(ctx, src, out.GetBlocks())
+}
+
+// fillIndexBlockDeposits states what each block took from the mainchain.
+func fillIndexBlockDeposits(ctx context.Context, src source, blocks []*pb.Block) {
+	for _, block := range blocks {
+		key := src.cacheKey(block.GetHash())
+		if held, _, _, ok := src.cache.get(key); ok {
+			block.DepositCount = held.GetDepositCount()
+			block.DepositValueSats = held.GetDepositValueSats()
+			continue
+		}
+		rows, err := src.index.BlockActivity(ctx, block.GetHash())
+		if err != nil {
+			continue
+		}
+		countDeposits(block, activityList(rows))
+		src.cache.put(key, block, activityList(rows), true)
+	}
 }
 
 func nodeOverview(ctx context.Context, src source) (*pb.GetOverviewResponse, error) {
@@ -187,19 +241,59 @@ func nodeOverview(ctx context.Context, src source) (*pb.GetOverviewResponse, err
 			fmt.Errorf("read the tip hash: %w", err))
 	}
 
-	for height := int64(tip); height >= 0 && next != "" && len(out.Blocks) < blockListSize; height-- {
-		block, activity, err := nodeBlock(ctx, src, next, uint32(height))
+	// The walk reads far more blocks than the page keeps. Only a kept block,
+	// or one that carried a row, costs a mainchain lookup.
+	type carried struct {
+		block *pb.Block
+		rows  []*pb.Activity
+	}
+	var contributors []carried
+
+	deep := true
+	for walked := 0; walked < activityScanDepth && next != ""; walked++ {
+		if len(out.Blocks) >= blockListSize && (!deep || len(out.Recent) >= activityListSize) {
+			break
+		}
+		height := int64(tip) - int64(walked)
+		if height < 0 {
+			break
+		}
+		block, activity, named, err := walkBlock(ctx, src, next, uint32(height))
 		if err != nil {
 			return nil, err
 		}
-		out.Blocks = append(out.Blocks, block)
+		// A node that serves no block index names no row, whatever the walk
+		// reads. The strip is all such a chain can answer.
+		if !named {
+			deep = false
+		}
+		kept := len(out.Blocks) < blockListSize
+		if kept {
+			out.Blocks = append(out.Blocks, block)
+		}
+		var taken []*pb.Activity
 		for _, row := range activity {
 			if len(out.Recent) >= activityListSize {
 				break
 			}
 			out.Recent = append(out.Recent, row)
+			taken = append(taken, row)
+		}
+		if kept || len(taken) != 0 {
+			contributors = append(contributors, carried{block: block, rows: taken})
 		}
 		next = block.GetPrevHash()
+	}
+
+	if src.resolve != nil {
+		blocks := make([]*pb.Block, 0, len(contributors))
+		for _, one := range contributors {
+			blocks = append(blocks, one.block)
+		}
+		src.resolve(ctx, blocks...)
+		for _, one := range contributors {
+			stampRows(one.block, one.rows)
+		}
 	}
 
 	// The template is what the node would mine next, so its body is the
@@ -254,33 +348,6 @@ func (h *ExplorerHandler) enforcerTreasury(ctx context.Context, slot uint32) *pb
 	return out
 }
 
-// resolveMainchainHeights names the mainchain block each header points at. A
-// hash alone tells a reader nothing, and only the enforcer holds the height.
-func (h *ExplorerHandler) resolveMainchainHeights(ctx context.Context, blocks []*pb.Block) {
-	validator, err := h.orch.EnforcerValidator()
-	if err != nil {
-		return
-	}
-	for _, block := range blocks {
-		if block.GetMainchainHeight() != 0 || block.GetMainchainHash() == "" {
-			continue
-		}
-		resp, err := validator.GetBlockHeaderInfo(ctx, connect.NewRequest(
-			&enforcerpb.GetBlockHeaderInfoRequest{
-				BlockHash: &commonv1.ReverseHex{
-					Hex: wrapperspb.String(block.GetMainchainHash()),
-				},
-			}))
-		if err != nil {
-			return
-		}
-		for _, info := range resp.Msg.GetHeaderInfos() {
-			block.MainchainHeight = info.GetHeight()
-			break
-		}
-	}
-}
-
 // GetBlock reads one block and what it carried.
 func (h *ExplorerHandler) GetBlock(
 	ctx context.Context, req *connect.Request[pb.GetBlockRequest],
@@ -307,9 +374,10 @@ func (h *ExplorerHandler) GetBlock(
 		if err != nil {
 			return nil, connect.NewError(connect.CodeUnavailable, err)
 		}
-		return connect.NewResponse(&pb.GetBlockResponse{
-			Block: newBlock(block), Activity: activityList(rows),
-		}), nil
+		out := &pb.GetBlockResponse{Block: newBlock(block), Activity: activityList(rows)}
+		countDeposits(out.Block, out.Activity)
+		h.resolveBid(ctx, src.slot, out.Block)
+		return connect.NewResponse(out), nil
 	}
 
 	if src.core {
@@ -344,8 +412,25 @@ func (h *ExplorerHandler) GetBlock(
 	if err != nil {
 		return nil, err
 	}
-	h.resolveMainchainHeights(ctx, []*pb.Block{block})
+	h.resolveMainchain(ctx, block)
+	stampRows(block, activity)
+	h.resolveBid(ctx, src.slot, block)
 	return connect.NewResponse(&pb.GetBlockResponse{Block: block, Activity: activity}), nil
+}
+
+// countDeposits fills in what a block took from the mainchain, for a source
+// that lists the rows but states no total.
+func countDeposits(block *pb.Block, rows []*pb.Activity) {
+	if block == nil || block.GetDepositCount() != 0 {
+		return
+	}
+	for _, row := range rows {
+		if row.GetKind() != pb.Kind_KIND_DEPOSIT {
+			continue
+		}
+		block.DepositCount++
+		block.DepositValueSats += row.GetValueSats()
+	}
 }
 
 // GetTransaction reads one transaction.
@@ -669,9 +754,43 @@ type nodeBlockIndex struct {
 		Txid string `json:"txid"`
 		Size uint64 `json:"size"`
 	} `json:"txs"`
-	Deposits []struct {
-		Outpoint string `json:"outpoint"`
-	} `json:"deposits"`
+	Deposits []nodeDeposit `json:"deposits"`
+}
+
+// nodeDeposit is one deposit the mainchain paid into a block.
+type nodeDeposit struct {
+	Outpoint  string
+	Address   string
+	ValueSats int64
+}
+
+// UnmarshalJSON reads the pair a node writes: the mainchain outpoint, then the
+// sidechain output it created.
+func (d *nodeDeposit) UnmarshalJSON(raw []byte) error {
+	var pair []json.RawMessage
+	if err := json.Unmarshal(raw, &pair); err != nil {
+		return fmt.Errorf("read the deposit pair: %w", err)
+	}
+	if len(pair) != 2 {
+		return fmt.Errorf("a deposit holds an outpoint and an output, got %d parts", len(pair))
+	}
+	var outpoint struct {
+		Deposit string `json:"Deposit"`
+	}
+	if err := json.Unmarshal(pair[0], &outpoint); err != nil {
+		return fmt.Errorf("read the deposit outpoint: %w", err)
+	}
+	var output struct {
+		Address string          `json:"address"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(pair[1], &output); err != nil {
+		return fmt.Errorf("read the deposit output: %w", err)
+	}
+	d.Outpoint = outpoint.Deposit
+	d.Address = output.Address
+	d.ValueSats = contentValue(output.Content)
+	return nil
 }
 
 // nodeHeader reads one block header from the node.
@@ -697,11 +816,67 @@ func nodeHeader(ctx context.Context, src source, hash string) (nodeHeaderJSON, e
 // nodeBlock reads one block from the node, with the rows it carried. A node
 // computes no fees, so every fee reads zero.
 func nodeBlock(ctx context.Context, src source, hash string, height uint32) (*pb.Block, []*pb.Activity, error) {
+	block, activity, _, err := walkBlock(ctx, src, hash, height)
+	return block, activity, err
+}
+
+// walkBlock reads one block, and says whether the node named the rows. A node
+// that serves no block index names none, and no deeper walk finds any.
+func walkBlock(
+	ctx context.Context, src source, hash string, height uint32,
+) (*pb.Block, []*pb.Activity, bool, error) {
+	key := src.cacheKey(hash)
+	out, activity, ownHeight, ok := src.cache.get(key)
+	if !ok {
+		read, rows, state, err := readNodeBlock(ctx, src, hash, height)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		// A node that failed to answer the index named no row. Caching that
+		// leaves the block empty even after the node recovers.
+		if !state.complete {
+			return read, rows, false, nil
+		}
+		ownHeight = state.ownHeight
+		out, activity = src.cache.put(key, read, rows, state.ownHeight)
+	}
+	// A node that names no height takes the caller's. That one comes from the
+	// tip count, which can move between two calls, so it is never cacheable.
+	if !ownHeight {
+		out.Height = height
+		for _, row := range activity {
+			row.BlockHeight = height
+		}
+	}
+	return out, activity, true, nil
+}
+
+// stampRows gives every row the time of the block that carried it. A
+// sidechain header holds no clock, so that time comes from the mainchain.
+func stampRows(block *pb.Block, rows []*pb.Activity) {
+	for _, row := range rows {
+		row.BlockTime = block.GetBlockTime()
+	}
+}
+
+// nodeRead says what a node answered for one block.
+type nodeRead struct {
+	// complete is true when the node named the rows the block carried.
+	complete bool
+	// ownHeight is true when the node named the height itself.
+	ownHeight bool
+}
+
+// readNodeBlock asks the node for one block and what it carried.
+func readNodeBlock(
+	ctx context.Context, src source, hash string, height uint32,
+) (*pb.Block, []*pb.Activity, nodeRead, error) {
 	block, err := nodeHeader(ctx, src, hash)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nodeRead{}, err
 	}
 
+	state := nodeRead{ownHeight: block.Height != nil}
 	if block.Height != nil {
 		height = *block.Height
 	}
@@ -711,6 +886,7 @@ func nodeBlock(ctx context.Context, src source, hash string, height uint32) (*pb
 		MerkleRoot:    block.merkleRoot(),
 		MainchainHash: block.prevMainHash(),
 		TxCount:       uint32(len(block.transactions())),
+		ValueKnown:    true,
 	}
 	if prev := block.prevSideHash(); prev != nil {
 		out.PrevHash = *prev
@@ -720,11 +896,12 @@ func nodeBlock(ctx context.Context, src source, hash string, height uint32) (*pb
 	// it still answers the header, and the block then lists no transactions.
 	rawIndex, err := src.node.CallRaw(ctx, "get_block_index", []string{hash})
 	if err != nil {
-		return blockValueFromBody(out, block), nil, nil
+		return blockValueFromBody(out, block), nil, state, nil
 	}
 	var index nodeBlockIndex
 	if err := json.Unmarshal(rawIndex, &index); err != nil {
-		return blockValueFromBody(out, block), nil, nil
+		return nil, nil, state, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("read the block index of %s: %w", hash, err))
 	}
 
 	// The block index names the txids in body order, so a transaction pairs
@@ -747,14 +924,19 @@ func nodeBlock(ctx context.Context, src source, hash string, height uint32) (*pb
 		activity = append(activity, row)
 	}
 	for _, deposit := range index.Deposits {
+		out.DepositCount++
+		out.DepositValueSats += deposit.ValueSats
 		activity = append(activity, &pb.Activity{
 			Kind:        pb.Kind_KIND_DEPOSIT,
 			Id:          depositTxid(deposit.Outpoint),
+			Address:     deposit.Address,
+			ValueSats:   deposit.ValueSats,
 			Confirmed:   true,
 			BlockHeight: height,
 		})
 	}
-	return out, activity, nil
+	state.complete = true
+	return out, activity, state, nil
 }
 
 // blockValueFromBody sums what a block paid out. Only get_block_index names

--- a/sidechain-orchestrator/api/explorer_index_test.go
+++ b/sidechain-orchestrator/api/explorer_index_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
+)
+
+// A hosted index states no per block deposit total. The page reads each
+// block's own rows, so a deposit shows even when ten newer transfers pushed
+// it out of the recent list. A block never changes, so it costs one read.
+func TestIndexOverviewStatesWhatEachBlockTook(t *testing.T) {
+	var asked []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/blocks":
+			_, _ = w.Write([]byte(`[
+				{"id":"b43","height":43,"tx_count":0,"fees":0,"mainchain_blockhash":"x43"},
+				{"id":"b42","height":42,"tx_count":0,"fees":0,"mainchain_blockhash":"x42"}
+			]`))
+		case r.URL.Path == "/txs/recent":
+			// Newer transfers pushed every deposit out of this list.
+			_, _ = w.Write([]byte(`[
+				{"kind":"transfer","id":"t1","value":5,"status":{"confirmed":true,"block_height":43}}
+			]`))
+		case r.URL.Path == "/mempool":
+			_, _ = w.Write([]byte(`{"count":0,"vsize":0,"total_fee":0}`))
+		case r.URL.Path == "/block/b43/activity":
+			_, _ = w.Write([]byte(`[
+				{"kind":"deposit","id":"d1","value":12300,"status":{"confirmed":true,"block_height":43}},
+				{"kind":"deposit","id":"d2","value":200000000,"status":{"confirmed":true,"block_height":43}}
+			]`))
+		case strings.HasSuffix(r.URL.Path, "/activity"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	src := source{name: "thunder", index: sidechainesplora.New(server.URL), cache: newBlockCache()}
+	out, err := indexOverview(context.Background(), src)
+	if err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	if len(out.GetBlocks()) != 2 {
+		t.Fatalf("the strip holds %d blocks, want 2", len(out.GetBlocks()))
+	}
+
+	took := out.GetBlocks()[0]
+	if took.GetDepositCount() != 2 {
+		t.Errorf("block 43 took %d deposits, want 2", took.GetDepositCount())
+	}
+	if took.GetDepositValueSats() != 200012300 {
+		t.Errorf("block 43 took %d sats, want 200012300", took.GetDepositValueSats())
+	}
+	if quiet := out.GetBlocks()[1]; quiet.GetDepositCount() != 0 {
+		t.Errorf("block 42 took %d deposits, want none", quiet.GetDepositCount())
+	}
+
+	// A hosted index never states the value a block moved.
+	if took.GetValueKnown() {
+		t.Error("an index block claims to know the value it moved")
+	}
+
+	var reads int
+	for _, path := range asked {
+		if strings.HasSuffix(path, "/activity") {
+			reads++
+		}
+	}
+	if reads != 2 {
+		t.Errorf("the page read %d block activities, want 2", reads)
+	}
+
+	// A second read answers from the cache, so the refresh costs nothing.
+	asked = nil
+	again, err := indexOverview(context.Background(), src)
+	if err != nil {
+		t.Fatalf("read the overview again: %v", err)
+	}
+	if again.GetBlocks()[0].GetDepositValueSats() != 200012300 {
+		t.Errorf("the second read states %d sats", again.GetBlocks()[0].GetDepositValueSats())
+	}
+	for _, path := range asked {
+		if strings.HasSuffix(path, "/activity") {
+			t.Errorf("the second read asked for %s, and the cache holds it", path)
+		}
+	}
+}
+
+// A block that took nothing states nothing.
+func TestIndexOverviewLeavesAQuietChainAlone(t *testing.T) {
+	var asked []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/blocks":
+			_, _ = w.Write([]byte(`[{"id":"b43","height":43,"tx_count":1,"fees":900}]`))
+		case "/txs/recent":
+			_, _ = w.Write([]byte(`[{"kind":"transfer","id":"t1","value":5,"status":{"confirmed":true,"block_height":43}}]`))
+		case "/block/b43/activity":
+			_, _ = w.Write([]byte(`[{"kind":"transfer","id":"t1","value":5,"status":{"confirmed":true,"block_height":43}}]`))
+		case "/mempool":
+			_, _ = w.Write([]byte(`{"count":0,"vsize":0,"total_fee":0}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	src := source{name: "thunder", index: sidechainesplora.New(server.URL), cache: newBlockCache()}
+	out, err := indexOverview(context.Background(), src)
+	if err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	if out.GetBlocks()[0].GetDepositCount() != 0 {
+		t.Error("a chain with no deposit states one")
+	}
+	if out.GetRecent()[0].GetKind() != pb.Kind_KIND_TRANSFER {
+		t.Error("the row reads as something other than a transfer")
+	}
+}
+
+// An index and a node answer different shapes for one block. A user who
+// switches mode must never read one shape out of the other's entry.
+func TestBlockCacheKeepsEachSourceApart(t *testing.T) {
+	hash := "b43"
+	cache := newBlockCache()
+
+	light := source{name: "thunder", origin: "thunder:index:signet", cache: cache}
+	full := source{name: "thunder", origin: "thunder:node:signet", cache: cache}
+	other := source{name: "thunder", origin: "thunder:node:ecash", cache: cache}
+
+	cache.put(light.cacheKey(hash), &pb.Block{Hash: hash, FeesSats: 900, FeesKnown: true}, nil, true)
+
+	if _, _, _, ok := cache.get(full.cacheKey(hash)); ok {
+		t.Error("the node read an index block")
+	}
+	if _, _, _, ok := cache.get(other.cacheKey(hash)); ok {
+		t.Error("one network read another network's block")
+	}
+	held, _, _, ok := cache.get(light.cacheKey(hash))
+	if !ok {
+		t.Fatal("the index holds no block of its own")
+	}
+	if !held.GetFeesKnown() || held.GetFeesSats() != 900 {
+		t.Errorf("the index block reads %d sats, known %v", held.GetFeesSats(), held.GetFeesKnown())
+	}
+}
+
+// A caller keeps writing to the block it gave the cache. The cache holds its
+// own copy, so a later write never reaches the next reader.
+func TestBlockCacheHoldsNoCallerPointer(t *testing.T) {
+	cache := newBlockCache()
+	mine := &pb.Block{Hash: "aa", Height: 3}
+	rows := []*pb.Activity{{Id: "d1"}}
+	cache.put("thunder:index:signet:aa", mine, rows, true)
+
+	// The overview stamps the mainchain fields after the cache read.
+	mine.MainchainHeight = 996816
+	mine.BlockTime = 9581
+	rows[0].BlockTime = 9581
+
+	held, heldRows, _, ok := cache.get("thunder:index:signet:aa")
+	if !ok {
+		t.Fatal("the cache holds no block")
+	}
+	if held.GetMainchainHeight() != 0 || held.GetBlockTime() != 0 {
+		t.Errorf("the cached block took a later write: %d / %d",
+			held.GetMainchainHeight(), held.GetBlockTime())
+	}
+	if heldRows[0].GetBlockTime() != 0 {
+		t.Errorf("the cached row took a later write: %d", heldRows[0].GetBlockTime())
+	}
+}

--- a/sidechain-orchestrator/api/explorer_node_live_test.go
+++ b/sidechain-orchestrator/api/explorer_node_live_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+// A live node answers the overview in the shape the page reads, deposits
+// included. Set EXPLORER_NODE_TEST to the node's RPC port to run it.
+func TestExplorerReadsALiveNode(t *testing.T) {
+	port := os.Getenv("EXPLORER_NODE_TEST")
+	if port == "" {
+		t.Skip("set EXPLORER_NODE_TEST to a sidechain RPC port")
+	}
+	number, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("read the port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	src := source{
+		name:  "thunder",
+		node:  sidechain.NewJSONRPCProxy("127.0.0.1", number),
+		cache: newBlockCache(),
+	}
+	out, err := nodeOverview(ctx, src)
+	if err != nil {
+		t.Fatalf("read the overview: %v", err)
+	}
+	if len(out.GetBlocks()) == 0 {
+		t.Fatal("the node holds no blocks")
+	}
+	t.Logf("tip %d, %d blocks, %d rows", out.GetTipHeight(), len(out.GetBlocks()), len(out.GetRecent()))
+
+	var deposits int
+	for _, row := range out.GetRecent() {
+		if row.GetKind() != pb.Kind_KIND_DEPOSIT {
+			continue
+		}
+		deposits++
+		if row.GetAddress() == "" {
+			t.Errorf("deposit %s names no address", row.GetId())
+		}
+		if row.GetValueSats() == 0 {
+			t.Errorf("deposit %s is worth nothing", row.GetId())
+		}
+		t.Logf("deposit %s paid %d sats to %s in block %d",
+			row.GetId(), row.GetValueSats(), row.GetAddress(), row.GetBlockHeight())
+	}
+	if len(out.GetRecent()) == 0 {
+		t.Error("the overview lists no rows, and the chain saw transactions")
+	}
+}

--- a/sidechain-orchestrator/api/explorer_test.go
+++ b/sidechain-orchestrator/api/explorer_test.go
@@ -238,6 +238,16 @@ func (n *recordingNode) GetBlockCount(context.Context) (int64, error) {
 	return n.count, nil
 }
 
+// This node mines nothing and proposes nothing, so the overview reads an empty
+// mempool and no bundle.
+func (n *recordingNode) GetBlockTemplate(context.Context) (*sidechain.BlockTemplate, error) {
+	return nil, fmt.Errorf("this node builds no template")
+}
+
+func (n *recordingNode) GetPendingWithdrawalBundle(context.Context) (json.RawMessage, error) {
+	return nil, fmt.Errorf("this node proposes no bundle")
+}
+
 func (n *recordingNode) CallRaw(_ context.Context, method string, params any) (json.RawMessage, error) {
 	n.called = append(n.called, method)
 	if method == "get_block" || method == "get_block_index" {

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -523,6 +523,7 @@ func run(cctx *cli.Context) error {
 	mux.Handle(bmmPath, bmmH)
 
 	explorerHandler := api.NewExplorerHandler(orch)
+	explorerHandler.SetCoreCaller(handler.RawCoreCall)
 	explorerPath, explorerH := explorerrpc.NewExplorerServiceHandler(explorerHandler, connect.WithInterceptors(authIC))
 	mux.Handle(explorerPath, explorerH)
 

--- a/sidechain-orchestrator/gen/explorer/v1/explorer.pb.go
+++ b/sidechain-orchestrator/gen/explorer/v1/explorer.pb.go
@@ -97,7 +97,17 @@ type Block struct {
 	// no previous outputs, so it never knows what a mined block collected.
 	FeesKnown bool `protobuf:"varint,11,opt,name=fees_known,json=feesKnown,proto3" json:"fees_known,omitempty"`
 	// value_sats is what the block's transactions paid out together.
-	ValueSats     int64 `protobuf:"varint,12,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
+	ValueSats int64 `protobuf:"varint,12,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
+	// value_known is false when the source cannot compute it. A hosted index
+	// states the fees a block collected, and never the value it moved.
+	ValueKnown bool `protobuf:"varint,20,opt,name=value_known,json=valueKnown,proto3" json:"value_known,omitempty"`
+	// deposit_count and deposit_value_sats name what the mainchain paid into
+	// this block. A deposit never sits in the block body.
+	DepositCount     uint32 `protobuf:"varint,13,opt,name=deposit_count,json=depositCount,proto3" json:"deposit_count,omitempty"`
+	DepositValueSats int64  `protobuf:"varint,14,opt,name=deposit_value_sats,json=depositValueSats,proto3" json:"deposit_value_sats,omitempty"`
+	// bid names the winning BMM bid on the mainchain: the outpoint that carried
+	// the M8, and what it paid.
+	Bid           *Bid `protobuf:"bytes,15,opt,name=bid,proto3" json:"bid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -216,25 +226,136 @@ func (x *Block) GetValueSats() int64 {
 	return 0
 }
 
+func (x *Block) GetValueKnown() bool {
+	if x != nil {
+		return x.ValueKnown
+	}
+	return false
+}
+
+func (x *Block) GetDepositCount() uint32 {
+	if x != nil {
+		return x.DepositCount
+	}
+	return 0
+}
+
+func (x *Block) GetDepositValueSats() int64 {
+	if x != nil {
+		return x.DepositValueSats
+	}
+	return 0
+}
+
+func (x *Block) GetBid() *Bid {
+	if x != nil {
+		return x.Bid
+	}
+	return nil
+}
+
+// Bid is the M8 a miner took to mine one sidechain block.
+type Bid struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Txid  string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	Vout  uint32                 `protobuf:"varint,2,opt,name=vout,proto3" json:"vout,omitempty"`
+	// sats is the fee the bid paid.
+	Sats int64 `protobuf:"varint,3,opt,name=sats,proto3" json:"sats,omitempty"`
+	// block_hash and block_height name the mainchain block that carried the M8.
+	// That block is the child of the block the header names.
+	BlockHash     string `protobuf:"bytes,4,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"`
+	BlockHeight   uint32 `protobuf:"varint,5,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Bid) Reset() {
+	*x = Bid{}
+	mi := &file_explorer_v1_explorer_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Bid) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Bid) ProtoMessage() {}
+
+func (x *Bid) ProtoReflect() protoreflect.Message {
+	mi := &file_explorer_v1_explorer_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Bid.ProtoReflect.Descriptor instead.
+func (*Bid) Descriptor() ([]byte, []int) {
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Bid) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *Bid) GetVout() uint32 {
+	if x != nil {
+		return x.Vout
+	}
+	return 0
+}
+
+func (x *Bid) GetSats() int64 {
+	if x != nil {
+		return x.Sats
+	}
+	return 0
+}
+
+func (x *Bid) GetBlockHash() string {
+	if x != nil {
+		return x.BlockHash
+	}
+	return ""
+}
+
+func (x *Bid) GetBlockHeight() uint32 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
 // Activity is one thing that happened on the chain.
 type Activity struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Kind  Kind                   `protobuf:"varint,1,opt,name=kind,proto3,enum=explorer.v1.Kind" json:"kind,omitempty"`
 	// id is the txid. A deposit carries its mainchain txid.
-	Id            string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
-	ValueSats     int64  `protobuf:"varint,3,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
-	FeeSats       int64  `protobuf:"varint,4,opt,name=fee_sats,json=feeSats,proto3" json:"fee_sats,omitempty"`
-	SizeBytes     int64  `protobuf:"varint,5,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
-	Confirmed     bool   `protobuf:"varint,6,opt,name=confirmed,proto3" json:"confirmed,omitempty"`
-	BlockHeight   uint32 `protobuf:"varint,7,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
-	BlockTime     int64  `protobuf:"varint,8,opt,name=block_time,json=blockTime,proto3" json:"block_time,omitempty"`
+	Id          string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	ValueSats   int64  `protobuf:"varint,3,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
+	FeeSats     int64  `protobuf:"varint,4,opt,name=fee_sats,json=feeSats,proto3" json:"fee_sats,omitempty"`
+	SizeBytes   int64  `protobuf:"varint,5,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Confirmed   bool   `protobuf:"varint,6,opt,name=confirmed,proto3" json:"confirmed,omitempty"`
+	BlockHeight uint32 `protobuf:"varint,7,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
+	BlockTime   int64  `protobuf:"varint,8,opt,name=block_time,json=blockTime,proto3" json:"block_time,omitempty"`
+	// address is the sidechain address a deposit paid. It is empty on every
+	// other kind.
+	Address       string `protobuf:"bytes,9,opt,name=address,proto3" json:"address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Activity) Reset() {
 	*x = Activity{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[1]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +367,7 @@ func (x *Activity) String() string {
 func (*Activity) ProtoMessage() {}
 
 func (x *Activity) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[1]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -259,7 +380,7 @@ func (x *Activity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Activity.ProtoReflect.Descriptor instead.
 func (*Activity) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{1}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Activity) GetKind() Kind {
@@ -318,6 +439,13 @@ func (x *Activity) GetBlockTime() int64 {
 	return 0
 }
 
+func (x *Activity) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
 // Coin is one input or one output.
 type Coin struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
@@ -341,7 +469,7 @@ type Coin struct {
 
 func (x *Coin) Reset() {
 	*x = Coin{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[2]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -353,7 +481,7 @@ func (x *Coin) String() string {
 func (*Coin) ProtoMessage() {}
 
 func (x *Coin) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[2]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -366,7 +494,7 @@ func (x *Coin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Coin.ProtoReflect.Descriptor instead.
 func (*Coin) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{2}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Coin) GetAddress() string {
@@ -444,7 +572,7 @@ type Transaction struct {
 
 func (x *Transaction) Reset() {
 	*x = Transaction{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[3]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -456,7 +584,7 @@ func (x *Transaction) String() string {
 func (*Transaction) ProtoMessage() {}
 
 func (x *Transaction) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[3]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -469,7 +597,7 @@ func (x *Transaction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Transaction.ProtoReflect.Descriptor instead.
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{3}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Transaction) GetTxid() string {
@@ -556,7 +684,7 @@ type Treasury struct {
 
 func (x *Treasury) Reset() {
 	*x = Treasury{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[4]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -568,7 +696,7 @@ func (x *Treasury) String() string {
 func (*Treasury) ProtoMessage() {}
 
 func (x *Treasury) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[4]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -581,7 +709,7 @@ func (x *Treasury) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Treasury.ProtoReflect.Descriptor instead.
 func (*Treasury) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{4}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Treasury) GetSlot() uint32 {
@@ -631,7 +759,7 @@ type Mempool struct {
 
 func (x *Mempool) Reset() {
 	*x = Mempool{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[5]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -643,7 +771,7 @@ func (x *Mempool) String() string {
 func (*Mempool) ProtoMessage() {}
 
 func (x *Mempool) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[5]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -656,7 +784,7 @@ func (x *Mempool) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Mempool.ProtoReflect.Descriptor instead.
 func (*Mempool) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{5}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Mempool) GetTxCount() uint32 {
@@ -690,7 +818,7 @@ type GetOverviewRequest struct {
 
 func (x *GetOverviewRequest) Reset() {
 	*x = GetOverviewRequest{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[6]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -702,7 +830,7 @@ func (x *GetOverviewRequest) String() string {
 func (*GetOverviewRequest) ProtoMessage() {}
 
 func (x *GetOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[6]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -715,7 +843,7 @@ func (x *GetOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOverviewRequest.ProtoReflect.Descriptor instead.
 func (*GetOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{6}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetOverviewRequest) GetChain() string {
@@ -743,7 +871,7 @@ type GetOverviewResponse struct {
 
 func (x *GetOverviewResponse) Reset() {
 	*x = GetOverviewResponse{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[7]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -755,7 +883,7 @@ func (x *GetOverviewResponse) String() string {
 func (*GetOverviewResponse) ProtoMessage() {}
 
 func (x *GetOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[7]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -768,7 +896,7 @@ func (x *GetOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOverviewResponse.ProtoReflect.Descriptor instead.
 func (*GetOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{7}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetOverviewResponse) GetBlocks() []*Block {
@@ -833,7 +961,7 @@ type ListBlocksRequest struct {
 
 func (x *ListBlocksRequest) Reset() {
 	*x = ListBlocksRequest{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[8]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -845,7 +973,7 @@ func (x *ListBlocksRequest) String() string {
 func (*ListBlocksRequest) ProtoMessage() {}
 
 func (x *ListBlocksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[8]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -858,7 +986,7 @@ func (x *ListBlocksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBlocksRequest.ProtoReflect.Descriptor instead.
 func (*ListBlocksRequest) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{8}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListBlocksRequest) GetChain() string {
@@ -892,7 +1020,7 @@ type ListBlocksResponse struct {
 
 func (x *ListBlocksResponse) Reset() {
 	*x = ListBlocksResponse{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[9]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -904,7 +1032,7 @@ func (x *ListBlocksResponse) String() string {
 func (*ListBlocksResponse) ProtoMessage() {}
 
 func (x *ListBlocksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[9]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -917,7 +1045,7 @@ func (x *ListBlocksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBlocksResponse.ProtoReflect.Descriptor instead.
 func (*ListBlocksResponse) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{9}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListBlocksResponse) GetBlocks() []*Block {
@@ -939,7 +1067,7 @@ type GetBlockRequest struct {
 
 func (x *GetBlockRequest) Reset() {
 	*x = GetBlockRequest{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[10]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -951,7 +1079,7 @@ func (x *GetBlockRequest) String() string {
 func (*GetBlockRequest) ProtoMessage() {}
 
 func (x *GetBlockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[10]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -964,7 +1092,7 @@ func (x *GetBlockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlockRequest.ProtoReflect.Descriptor instead.
 func (*GetBlockRequest) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{10}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetBlockRequest) GetChain() string {
@@ -998,7 +1126,7 @@ type GetBlockResponse struct {
 
 func (x *GetBlockResponse) Reset() {
 	*x = GetBlockResponse{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[11]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1010,7 +1138,7 @@ func (x *GetBlockResponse) String() string {
 func (*GetBlockResponse) ProtoMessage() {}
 
 func (x *GetBlockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[11]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1023,7 +1151,7 @@ func (x *GetBlockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlockResponse.ProtoReflect.Descriptor instead.
 func (*GetBlockResponse) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{11}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GetBlockResponse) GetBlock() *Block {
@@ -1050,7 +1178,7 @@ type GetTransactionRequest struct {
 
 func (x *GetTransactionRequest) Reset() {
 	*x = GetTransactionRequest{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[12]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1062,7 +1190,7 @@ func (x *GetTransactionRequest) String() string {
 func (*GetTransactionRequest) ProtoMessage() {}
 
 func (x *GetTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[12]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1075,7 +1203,7 @@ func (x *GetTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{12}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetTransactionRequest) GetChain() string {
@@ -1101,7 +1229,7 @@ type GetTransactionResponse struct {
 
 func (x *GetTransactionResponse) Reset() {
 	*x = GetTransactionResponse{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[13]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +1241,7 @@ func (x *GetTransactionResponse) String() string {
 func (*GetTransactionResponse) ProtoMessage() {}
 
 func (x *GetTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[13]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +1254,7 @@ func (x *GetTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{13}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetTransactionResponse) GetTransaction() *Transaction {
@@ -1146,7 +1274,7 @@ type GetAddressRequest struct {
 
 func (x *GetAddressRequest) Reset() {
 	*x = GetAddressRequest{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[14]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1158,7 +1286,7 @@ func (x *GetAddressRequest) String() string {
 func (*GetAddressRequest) ProtoMessage() {}
 
 func (x *GetAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[14]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1171,7 +1299,7 @@ func (x *GetAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAddressRequest.ProtoReflect.Descriptor instead.
 func (*GetAddressRequest) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{14}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetAddressRequest) GetChain() string {
@@ -1205,7 +1333,7 @@ type GetAddressResponse struct {
 
 func (x *GetAddressResponse) Reset() {
 	*x = GetAddressResponse{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[15]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1217,7 +1345,7 @@ func (x *GetAddressResponse) String() string {
 func (*GetAddressResponse) ProtoMessage() {}
 
 func (x *GetAddressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[15]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1230,7 +1358,7 @@ func (x *GetAddressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAddressResponse.ProtoReflect.Descriptor instead.
 func (*GetAddressResponse) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{15}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetAddressResponse) GetAddress() string {
@@ -1304,7 +1432,7 @@ type Withdrawal struct {
 
 func (x *Withdrawal) Reset() {
 	*x = Withdrawal{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[16]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1316,7 +1444,7 @@ func (x *Withdrawal) String() string {
 func (*Withdrawal) ProtoMessage() {}
 
 func (x *Withdrawal) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[16]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1329,7 +1457,7 @@ func (x *Withdrawal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Withdrawal.ProtoReflect.Descriptor instead.
 func (*Withdrawal) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{16}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Withdrawal) GetMainAddress() string {
@@ -1377,7 +1505,7 @@ type WithdrawalBundle struct {
 
 func (x *WithdrawalBundle) Reset() {
 	*x = WithdrawalBundle{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[17]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1389,7 +1517,7 @@ func (x *WithdrawalBundle) String() string {
 func (*WithdrawalBundle) ProtoMessage() {}
 
 func (x *WithdrawalBundle) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[17]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1402,7 +1530,7 @@ func (x *WithdrawalBundle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawalBundle.ProtoReflect.Descriptor instead.
 func (*WithdrawalBundle) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{17}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *WithdrawalBundle) GetPresent() bool {
@@ -1470,7 +1598,7 @@ type GetWithdrawalsRequest struct {
 
 func (x *GetWithdrawalsRequest) Reset() {
 	*x = GetWithdrawalsRequest{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[18]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1482,7 +1610,7 @@ func (x *GetWithdrawalsRequest) String() string {
 func (*GetWithdrawalsRequest) ProtoMessage() {}
 
 func (x *GetWithdrawalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[18]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1495,7 +1623,7 @@ func (x *GetWithdrawalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWithdrawalsRequest.ProtoReflect.Descriptor instead.
 func (*GetWithdrawalsRequest) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{18}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetWithdrawalsRequest) GetChain() string {
@@ -1517,7 +1645,7 @@ type GetWithdrawalsResponse struct {
 
 func (x *GetWithdrawalsResponse) Reset() {
 	*x = GetWithdrawalsResponse{}
-	mi := &file_explorer_v1_explorer_proto_msgTypes[19]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1529,7 +1657,7 @@ func (x *GetWithdrawalsResponse) String() string {
 func (*GetWithdrawalsResponse) ProtoMessage() {}
 
 func (x *GetWithdrawalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_explorer_v1_explorer_proto_msgTypes[19]
+	mi := &file_explorer_v1_explorer_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1542,7 +1670,7 @@ func (x *GetWithdrawalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWithdrawalsResponse.ProtoReflect.Descriptor instead.
 func (*GetWithdrawalsResponse) Descriptor() ([]byte, []int) {
-	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{19}
+	return file_explorer_v1_explorer_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetWithdrawalsResponse) GetBundle() *WithdrawalBundle {
@@ -1563,7 +1691,7 @@ var File_explorer_v1_explorer_proto protoreflect.FileDescriptor
 
 const file_explorer_v1_explorer_proto_rawDesc = "" +
 	"\n" +
-	"\x1aexplorer/v1/explorer.proto\x12\vexplorer.v1\"\xf7\x02\n" +
+	"\x1aexplorer/v1/explorer.proto\x12\vexplorer.v1\"\x8f\x04\n" +
 	"\x05Block\x12\x16\n" +
 	"\x06height\x18\x01 \x01(\rR\x06height\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1b\n" +
@@ -1582,7 +1710,19 @@ const file_explorer_v1_explorer_proto_rawDesc = "" +
 	"\n" +
 	"fees_known\x18\v \x01(\bR\tfeesKnown\x12\x1d\n" +
 	"\n" +
-	"value_sats\x18\f \x01(\x03R\tvalueSats\"\xfa\x01\n" +
+	"value_sats\x18\f \x01(\x03R\tvalueSats\x12\x1f\n" +
+	"\vvalue_known\x18\x14 \x01(\bR\n" +
+	"valueKnown\x12#\n" +
+	"\rdeposit_count\x18\r \x01(\rR\fdepositCount\x12,\n" +
+	"\x12deposit_value_sats\x18\x0e \x01(\x03R\x10depositValueSats\x12\"\n" +
+	"\x03bid\x18\x0f \x01(\v2\x10.explorer.v1.BidR\x03bid\"\x83\x01\n" +
+	"\x03Bid\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
+	"\x04vout\x18\x02 \x01(\rR\x04vout\x12\x12\n" +
+	"\x04sats\x18\x03 \x01(\x03R\x04sats\x12\x1d\n" +
+	"\n" +
+	"block_hash\x18\x04 \x01(\tR\tblockHash\x12!\n" +
+	"\fblock_height\x18\x05 \x01(\rR\vblockHeight\"\x94\x02\n" +
 	"\bActivity\x12%\n" +
 	"\x04kind\x18\x01 \x01(\x0e2\x11.explorer.v1.KindR\x04kind\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x1d\n" +
@@ -1594,7 +1734,8 @@ const file_explorer_v1_explorer_proto_rawDesc = "" +
 	"\tconfirmed\x18\x06 \x01(\bR\tconfirmed\x12!\n" +
 	"\fblock_height\x18\a \x01(\rR\vblockHeight\x12\x1d\n" +
 	"\n" +
-	"block_time\x18\b \x01(\x03R\tblockTime\"\xf6\x01\n" +
+	"block_time\x18\b \x01(\x03R\tblockTime\x12\x18\n" +
+	"\aaddress\x18\t \x01(\tR\aaddress\"\xf6\x01\n" +
 	"\x04Coin\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1d\n" +
 	"\n" +
@@ -1723,64 +1864,66 @@ func file_explorer_v1_explorer_proto_rawDescGZIP() []byte {
 }
 
 var file_explorer_v1_explorer_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_explorer_v1_explorer_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_explorer_v1_explorer_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_explorer_v1_explorer_proto_goTypes = []any{
 	(Kind)(0),                      // 0: explorer.v1.Kind
 	(*Block)(nil),                  // 1: explorer.v1.Block
-	(*Activity)(nil),               // 2: explorer.v1.Activity
-	(*Coin)(nil),                   // 3: explorer.v1.Coin
-	(*Transaction)(nil),            // 4: explorer.v1.Transaction
-	(*Treasury)(nil),               // 5: explorer.v1.Treasury
-	(*Mempool)(nil),                // 6: explorer.v1.Mempool
-	(*GetOverviewRequest)(nil),     // 7: explorer.v1.GetOverviewRequest
-	(*GetOverviewResponse)(nil),    // 8: explorer.v1.GetOverviewResponse
-	(*ListBlocksRequest)(nil),      // 9: explorer.v1.ListBlocksRequest
-	(*ListBlocksResponse)(nil),     // 10: explorer.v1.ListBlocksResponse
-	(*GetBlockRequest)(nil),        // 11: explorer.v1.GetBlockRequest
-	(*GetBlockResponse)(nil),       // 12: explorer.v1.GetBlockResponse
-	(*GetTransactionRequest)(nil),  // 13: explorer.v1.GetTransactionRequest
-	(*GetTransactionResponse)(nil), // 14: explorer.v1.GetTransactionResponse
-	(*GetAddressRequest)(nil),      // 15: explorer.v1.GetAddressRequest
-	(*GetAddressResponse)(nil),     // 16: explorer.v1.GetAddressResponse
-	(*Withdrawal)(nil),             // 17: explorer.v1.Withdrawal
-	(*WithdrawalBundle)(nil),       // 18: explorer.v1.WithdrawalBundle
-	(*GetWithdrawalsRequest)(nil),  // 19: explorer.v1.GetWithdrawalsRequest
-	(*GetWithdrawalsResponse)(nil), // 20: explorer.v1.GetWithdrawalsResponse
+	(*Bid)(nil),                    // 2: explorer.v1.Bid
+	(*Activity)(nil),               // 3: explorer.v1.Activity
+	(*Coin)(nil),                   // 4: explorer.v1.Coin
+	(*Transaction)(nil),            // 5: explorer.v1.Transaction
+	(*Treasury)(nil),               // 6: explorer.v1.Treasury
+	(*Mempool)(nil),                // 7: explorer.v1.Mempool
+	(*GetOverviewRequest)(nil),     // 8: explorer.v1.GetOverviewRequest
+	(*GetOverviewResponse)(nil),    // 9: explorer.v1.GetOverviewResponse
+	(*ListBlocksRequest)(nil),      // 10: explorer.v1.ListBlocksRequest
+	(*ListBlocksResponse)(nil),     // 11: explorer.v1.ListBlocksResponse
+	(*GetBlockRequest)(nil),        // 12: explorer.v1.GetBlockRequest
+	(*GetBlockResponse)(nil),       // 13: explorer.v1.GetBlockResponse
+	(*GetTransactionRequest)(nil),  // 14: explorer.v1.GetTransactionRequest
+	(*GetTransactionResponse)(nil), // 15: explorer.v1.GetTransactionResponse
+	(*GetAddressRequest)(nil),      // 16: explorer.v1.GetAddressRequest
+	(*GetAddressResponse)(nil),     // 17: explorer.v1.GetAddressResponse
+	(*Withdrawal)(nil),             // 18: explorer.v1.Withdrawal
+	(*WithdrawalBundle)(nil),       // 19: explorer.v1.WithdrawalBundle
+	(*GetWithdrawalsRequest)(nil),  // 20: explorer.v1.GetWithdrawalsRequest
+	(*GetWithdrawalsResponse)(nil), // 21: explorer.v1.GetWithdrawalsResponse
 }
 var file_explorer_v1_explorer_proto_depIdxs = []int32{
-	0,  // 0: explorer.v1.Activity.kind:type_name -> explorer.v1.Kind
-	0,  // 1: explorer.v1.Transaction.kind:type_name -> explorer.v1.Kind
-	3,  // 2: explorer.v1.Transaction.inputs:type_name -> explorer.v1.Coin
-	3,  // 3: explorer.v1.Transaction.outputs:type_name -> explorer.v1.Coin
-	1,  // 4: explorer.v1.GetOverviewResponse.blocks:type_name -> explorer.v1.Block
-	2,  // 5: explorer.v1.GetOverviewResponse.recent:type_name -> explorer.v1.Activity
-	6,  // 6: explorer.v1.GetOverviewResponse.mempool:type_name -> explorer.v1.Mempool
-	5,  // 7: explorer.v1.GetOverviewResponse.treasury:type_name -> explorer.v1.Treasury
-	18, // 8: explorer.v1.GetOverviewResponse.pending_bundle:type_name -> explorer.v1.WithdrawalBundle
-	1,  // 9: explorer.v1.ListBlocksResponse.blocks:type_name -> explorer.v1.Block
-	1,  // 10: explorer.v1.GetBlockResponse.block:type_name -> explorer.v1.Block
-	2,  // 11: explorer.v1.GetBlockResponse.activity:type_name -> explorer.v1.Activity
-	4,  // 12: explorer.v1.GetTransactionResponse.transaction:type_name -> explorer.v1.Transaction
-	4,  // 13: explorer.v1.GetAddressResponse.transactions:type_name -> explorer.v1.Transaction
-	17, // 14: explorer.v1.WithdrawalBundle.withdrawals:type_name -> explorer.v1.Withdrawal
-	18, // 15: explorer.v1.GetWithdrawalsResponse.bundle:type_name -> explorer.v1.WithdrawalBundle
-	7,  // 16: explorer.v1.ExplorerService.GetOverview:input_type -> explorer.v1.GetOverviewRequest
-	11, // 17: explorer.v1.ExplorerService.GetBlock:input_type -> explorer.v1.GetBlockRequest
-	9,  // 18: explorer.v1.ExplorerService.ListBlocks:input_type -> explorer.v1.ListBlocksRequest
-	13, // 19: explorer.v1.ExplorerService.GetTransaction:input_type -> explorer.v1.GetTransactionRequest
-	15, // 20: explorer.v1.ExplorerService.GetAddress:input_type -> explorer.v1.GetAddressRequest
-	19, // 21: explorer.v1.ExplorerService.GetWithdrawals:input_type -> explorer.v1.GetWithdrawalsRequest
-	8,  // 22: explorer.v1.ExplorerService.GetOverview:output_type -> explorer.v1.GetOverviewResponse
-	12, // 23: explorer.v1.ExplorerService.GetBlock:output_type -> explorer.v1.GetBlockResponse
-	10, // 24: explorer.v1.ExplorerService.ListBlocks:output_type -> explorer.v1.ListBlocksResponse
-	14, // 25: explorer.v1.ExplorerService.GetTransaction:output_type -> explorer.v1.GetTransactionResponse
-	16, // 26: explorer.v1.ExplorerService.GetAddress:output_type -> explorer.v1.GetAddressResponse
-	20, // 27: explorer.v1.ExplorerService.GetWithdrawals:output_type -> explorer.v1.GetWithdrawalsResponse
-	22, // [22:28] is the sub-list for method output_type
-	16, // [16:22] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	2,  // 0: explorer.v1.Block.bid:type_name -> explorer.v1.Bid
+	0,  // 1: explorer.v1.Activity.kind:type_name -> explorer.v1.Kind
+	0,  // 2: explorer.v1.Transaction.kind:type_name -> explorer.v1.Kind
+	4,  // 3: explorer.v1.Transaction.inputs:type_name -> explorer.v1.Coin
+	4,  // 4: explorer.v1.Transaction.outputs:type_name -> explorer.v1.Coin
+	1,  // 5: explorer.v1.GetOverviewResponse.blocks:type_name -> explorer.v1.Block
+	3,  // 6: explorer.v1.GetOverviewResponse.recent:type_name -> explorer.v1.Activity
+	7,  // 7: explorer.v1.GetOverviewResponse.mempool:type_name -> explorer.v1.Mempool
+	6,  // 8: explorer.v1.GetOverviewResponse.treasury:type_name -> explorer.v1.Treasury
+	19, // 9: explorer.v1.GetOverviewResponse.pending_bundle:type_name -> explorer.v1.WithdrawalBundle
+	1,  // 10: explorer.v1.ListBlocksResponse.blocks:type_name -> explorer.v1.Block
+	1,  // 11: explorer.v1.GetBlockResponse.block:type_name -> explorer.v1.Block
+	3,  // 12: explorer.v1.GetBlockResponse.activity:type_name -> explorer.v1.Activity
+	5,  // 13: explorer.v1.GetTransactionResponse.transaction:type_name -> explorer.v1.Transaction
+	5,  // 14: explorer.v1.GetAddressResponse.transactions:type_name -> explorer.v1.Transaction
+	18, // 15: explorer.v1.WithdrawalBundle.withdrawals:type_name -> explorer.v1.Withdrawal
+	19, // 16: explorer.v1.GetWithdrawalsResponse.bundle:type_name -> explorer.v1.WithdrawalBundle
+	8,  // 17: explorer.v1.ExplorerService.GetOverview:input_type -> explorer.v1.GetOverviewRequest
+	12, // 18: explorer.v1.ExplorerService.GetBlock:input_type -> explorer.v1.GetBlockRequest
+	10, // 19: explorer.v1.ExplorerService.ListBlocks:input_type -> explorer.v1.ListBlocksRequest
+	14, // 20: explorer.v1.ExplorerService.GetTransaction:input_type -> explorer.v1.GetTransactionRequest
+	16, // 21: explorer.v1.ExplorerService.GetAddress:input_type -> explorer.v1.GetAddressRequest
+	20, // 22: explorer.v1.ExplorerService.GetWithdrawals:input_type -> explorer.v1.GetWithdrawalsRequest
+	9,  // 23: explorer.v1.ExplorerService.GetOverview:output_type -> explorer.v1.GetOverviewResponse
+	13, // 24: explorer.v1.ExplorerService.GetBlock:output_type -> explorer.v1.GetBlockResponse
+	11, // 25: explorer.v1.ExplorerService.ListBlocks:output_type -> explorer.v1.ListBlocksResponse
+	15, // 26: explorer.v1.ExplorerService.GetTransaction:output_type -> explorer.v1.GetTransactionResponse
+	17, // 27: explorer.v1.ExplorerService.GetAddress:output_type -> explorer.v1.GetAddressResponse
+	21, // 28: explorer.v1.ExplorerService.GetWithdrawals:output_type -> explorer.v1.GetWithdrawalsResponse
+	23, // [23:29] is the sub-list for method output_type
+	17, // [17:23] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_explorer_v1_explorer_proto_init() }
@@ -1794,7 +1937,7 @@ func file_explorer_v1_explorer_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_explorer_v1_explorer_proto_rawDesc), len(file_explorer_v1_explorer_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/proto/explorer/v1/explorer.proto
+++ b/sidechain-orchestrator/proto/explorer/v1/explorer.proto
@@ -62,6 +62,28 @@ message Block {
   bool fees_known = 11;
   // value_sats is what the block's transactions paid out together.
   int64 value_sats = 12;
+  // value_known is false when the source cannot compute it. A hosted index
+  // states the fees a block collected, and never the value it moved.
+  bool value_known = 20;
+  // deposit_count and deposit_value_sats name what the mainchain paid into
+  // this block. A deposit never sits in the block body.
+  uint32 deposit_count = 13;
+  int64 deposit_value_sats = 14;
+  // bid names the winning BMM bid on the mainchain: the outpoint that carried
+  // the M8, and what it paid.
+  Bid bid = 15;
+}
+
+// Bid is the M8 a miner took to mine one sidechain block.
+message Bid {
+  string txid = 1;
+  uint32 vout = 2;
+  // sats is the fee the bid paid.
+  int64 sats = 3;
+  // block_hash and block_height name the mainchain block that carried the M8.
+  // That block is the child of the block the header names.
+  string block_hash = 4;
+  uint32 block_height = 5;
 }
 
 // Activity is one thing that happened on the chain.
@@ -75,6 +97,9 @@ message Activity {
   bool confirmed = 6;
   uint32 block_height = 7;
   int64 block_time = 8;
+  // address is the sidechain address a deposit paid. It is empty on every
+  // other kind.
+  string address = 9;
 }
 
 // Coin is one input or one output.

--- a/sidechain_core/lib/gen/explorer/v1/explorer.pb.dart
+++ b/sidechain_core/lib/gen/explorer/v1/explorer.pb.dart
@@ -34,6 +34,10 @@ class Block extends $pb.GeneratedMessage {
     $fixnum.Int64? sizeBytes,
     $core.bool? feesKnown,
     $fixnum.Int64? valueSats,
+    $core.int? depositCount,
+    $fixnum.Int64? depositValueSats,
+    Bid? bid,
+    $core.bool? valueKnown,
   }) {
     final $result = create();
     if (height != null) {
@@ -72,6 +76,18 @@ class Block extends $pb.GeneratedMessage {
     if (valueSats != null) {
       $result.valueSats = valueSats;
     }
+    if (depositCount != null) {
+      $result.depositCount = depositCount;
+    }
+    if (depositValueSats != null) {
+      $result.depositValueSats = depositValueSats;
+    }
+    if (bid != null) {
+      $result.bid = bid;
+    }
+    if (valueKnown != null) {
+      $result.valueKnown = valueKnown;
+    }
     return $result;
   }
   Block._() : super();
@@ -91,6 +107,10 @@ class Block extends $pb.GeneratedMessage {
     ..aInt64(10, _omitFieldNames ? '' : 'sizeBytes')
     ..aOB(11, _omitFieldNames ? '' : 'feesKnown')
     ..aInt64(12, _omitFieldNames ? '' : 'valueSats')
+    ..a<$core.int>(13, _omitFieldNames ? '' : 'depositCount', $pb.PbFieldType.OU3)
+    ..aInt64(14, _omitFieldNames ? '' : 'depositValueSats')
+    ..aOM<Bid>(15, _omitFieldNames ? '' : 'bid', subBuilder: Bid.create)
+    ..aOB(20, _omitFieldNames ? '' : 'valueKnown')
     ..hasRequiredFields = false
   ;
 
@@ -230,6 +250,160 @@ class Block extends $pb.GeneratedMessage {
   $core.bool hasValueSats() => $_has(11);
   @$pb.TagNumber(12)
   void clearValueSats() => clearField(12);
+
+  /// deposit_count and deposit_value_sats name what the mainchain paid into
+  /// this block. A deposit never sits in the block body.
+  @$pb.TagNumber(13)
+  $core.int get depositCount => $_getIZ(12);
+  @$pb.TagNumber(13)
+  set depositCount($core.int v) { $_setUnsignedInt32(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasDepositCount() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearDepositCount() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $fixnum.Int64 get depositValueSats => $_getI64(13);
+  @$pb.TagNumber(14)
+  set depositValueSats($fixnum.Int64 v) { $_setInt64(13, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasDepositValueSats() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearDepositValueSats() => clearField(14);
+
+  /// bid names the winning BMM bid on the mainchain: the outpoint that carried
+  /// the M8, and what it paid.
+  @$pb.TagNumber(15)
+  Bid get bid => $_getN(14);
+  @$pb.TagNumber(15)
+  set bid(Bid v) { setField(15, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasBid() => $_has(14);
+  @$pb.TagNumber(15)
+  void clearBid() => clearField(15);
+  @$pb.TagNumber(15)
+  Bid ensureBid() => $_ensure(14);
+
+  /// value_known is false when the source cannot compute it. A hosted index
+  /// states the fees a block collected, and never the value it moved.
+  @$pb.TagNumber(20)
+  $core.bool get valueKnown => $_getBF(15);
+  @$pb.TagNumber(20)
+  set valueKnown($core.bool v) { $_setBool(15, v); }
+  @$pb.TagNumber(20)
+  $core.bool hasValueKnown() => $_has(15);
+  @$pb.TagNumber(20)
+  void clearValueKnown() => clearField(20);
+}
+
+/// Bid is the M8 a miner took to mine one sidechain block.
+class Bid extends $pb.GeneratedMessage {
+  factory Bid({
+    $core.String? txid,
+    $core.int? vout,
+    $fixnum.Int64? sats,
+    $core.String? blockHash,
+    $core.int? blockHeight,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (vout != null) {
+      $result.vout = vout;
+    }
+    if (sats != null) {
+      $result.sats = sats;
+    }
+    if (blockHash != null) {
+      $result.blockHash = blockHash;
+    }
+    if (blockHeight != null) {
+      $result.blockHeight = blockHeight;
+    }
+    return $result;
+  }
+  Bid._() : super();
+  factory Bid.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Bid.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Bid', package: const $pb.PackageName(_omitMessageNames ? '' : 'explorer.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.OU3)
+    ..aInt64(3, _omitFieldNames ? '' : 'sats')
+    ..aOS(4, _omitFieldNames ? '' : 'blockHash')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'blockHeight', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Bid clone() => Bid()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Bid copyWith(void Function(Bid) updates) => super.copyWith((message) => updates(message as Bid)) as Bid;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Bid create() => Bid._();
+  Bid createEmptyInstance() => create();
+  static $pb.PbList<Bid> createRepeated() => $pb.PbList<Bid>();
+  @$core.pragma('dart2js:noInline')
+  static Bid getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Bid>(create);
+  static Bid? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get vout => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set vout($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVout() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVout() => clearField(2);
+
+  /// sats is the fee the bid paid.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get sats => $_getI64(2);
+  @$pb.TagNumber(3)
+  set sats($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSats() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSats() => clearField(3);
+
+  /// block_hash and block_height name the mainchain block that carried the M8.
+  /// That block is the child of the block the header names.
+  @$pb.TagNumber(4)
+  $core.String get blockHash => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set blockHash($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasBlockHash() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearBlockHash() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get blockHeight => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set blockHeight($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasBlockHeight() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearBlockHeight() => clearField(5);
 }
 
 /// Activity is one thing that happened on the chain.
@@ -243,6 +417,7 @@ class Activity extends $pb.GeneratedMessage {
     $core.bool? confirmed,
     $core.int? blockHeight,
     $fixnum.Int64? blockTime,
+    $core.String? address,
   }) {
     final $result = create();
     if (kind != null) {
@@ -269,6 +444,9 @@ class Activity extends $pb.GeneratedMessage {
     if (blockTime != null) {
       $result.blockTime = blockTime;
     }
+    if (address != null) {
+      $result.address = address;
+    }
     return $result;
   }
   Activity._() : super();
@@ -284,6 +462,7 @@ class Activity extends $pb.GeneratedMessage {
     ..aOB(6, _omitFieldNames ? '' : 'confirmed')
     ..a<$core.int>(7, _omitFieldNames ? '' : 'blockHeight', $pb.PbFieldType.OU3)
     ..aInt64(8, _omitFieldNames ? '' : 'blockTime')
+    ..aOS(9, _omitFieldNames ? '' : 'address')
     ..hasRequiredFields = false
   ;
 
@@ -380,6 +559,17 @@ class Activity extends $pb.GeneratedMessage {
   $core.bool hasBlockTime() => $_has(7);
   @$pb.TagNumber(8)
   void clearBlockTime() => clearField(8);
+
+  /// address is the sidechain address a deposit paid. It is empty on every
+  /// other kind.
+  @$pb.TagNumber(9)
+  $core.String get address => $_getSZ(8);
+  @$pb.TagNumber(9)
+  set address($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasAddress() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearAddress() => clearField(9);
 }
 
 /// Coin is one input or one output.

--- a/sidechain_core/lib/gen/explorer/v1/explorer.pbjson.dart
+++ b/sidechain_core/lib/gen/explorer/v1/explorer.pbjson.dart
@@ -45,6 +45,10 @@ const Block$json = {
     {'1': 'size_bytes', '3': 10, '4': 1, '5': 3, '10': 'sizeBytes'},
     {'1': 'fees_known', '3': 11, '4': 1, '5': 8, '10': 'feesKnown'},
     {'1': 'value_sats', '3': 12, '4': 1, '5': 3, '10': 'valueSats'},
+    {'1': 'value_known', '3': 20, '4': 1, '5': 8, '10': 'valueKnown'},
+    {'1': 'deposit_count', '3': 13, '4': 1, '5': 13, '10': 'depositCount'},
+    {'1': 'deposit_value_sats', '3': 14, '4': 1, '5': 3, '10': 'depositValueSats'},
+    {'1': 'bid', '3': 15, '4': 1, '5': 11, '6': '.explorer.v1.Bid', '10': 'bid'},
   ],
 };
 
@@ -56,7 +60,28 @@ final $typed_data.Uint8List blockDescriptor = $convert.base64Decode(
     'hlaWdodBgGIAEoDVIPbWFpbmNoYWluSGVpZ2h0Eh0KCmJsb2NrX3RpbWUYByABKANSCWJsb2Nr'
     'VGltZRIZCgh0eF9jb3VudBgIIAEoDVIHdHhDb3VudBIbCglmZWVzX3NhdHMYCSABKANSCGZlZX'
     'NTYXRzEh0KCnNpemVfYnl0ZXMYCiABKANSCXNpemVCeXRlcxIdCgpmZWVzX2tub3duGAsgASgI'
-    'UglmZWVzS25vd24SHQoKdmFsdWVfc2F0cxgMIAEoA1IJdmFsdWVTYXRz');
+    'UglmZWVzS25vd24SHQoKdmFsdWVfc2F0cxgMIAEoA1IJdmFsdWVTYXRzEh8KC3ZhbHVlX2tub3'
+    'duGBQgASgIUgp2YWx1ZUtub3duEiMKDWRlcG9zaXRfY291bnQYDSABKA1SDGRlcG9zaXRDb3Vu'
+    'dBIsChJkZXBvc2l0X3ZhbHVlX3NhdHMYDiABKANSEGRlcG9zaXRWYWx1ZVNhdHMSIgoDYmlkGA'
+    '8gASgLMhAuZXhwbG9yZXIudjEuQmlkUgNiaWQ=');
+
+@$core.Deprecated('Use bidDescriptor instead')
+const Bid$json = {
+  '1': 'Bid',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'vout', '3': 2, '4': 1, '5': 13, '10': 'vout'},
+    {'1': 'sats', '3': 3, '4': 1, '5': 3, '10': 'sats'},
+    {'1': 'block_hash', '3': 4, '4': 1, '5': 9, '10': 'blockHash'},
+    {'1': 'block_height', '3': 5, '4': 1, '5': 13, '10': 'blockHeight'},
+  ],
+};
+
+/// Descriptor for `Bid`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bidDescriptor = $convert.base64Decode(
+    'CgNCaWQSEgoEdHhpZBgBIAEoCVIEdHhpZBISCgR2b3V0GAIgASgNUgR2b3V0EhIKBHNhdHMYAy'
+    'ABKANSBHNhdHMSHQoKYmxvY2tfaGFzaBgEIAEoCVIJYmxvY2tIYXNoEiEKDGJsb2NrX2hlaWdo'
+    'dBgFIAEoDVILYmxvY2tIZWlnaHQ=');
 
 @$core.Deprecated('Use activityDescriptor instead')
 const Activity$json = {
@@ -70,6 +95,7 @@ const Activity$json = {
     {'1': 'confirmed', '3': 6, '4': 1, '5': 8, '10': 'confirmed'},
     {'1': 'block_height', '3': 7, '4': 1, '5': 13, '10': 'blockHeight'},
     {'1': 'block_time', '3': 8, '4': 1, '5': 3, '10': 'blockTime'},
+    {'1': 'address', '3': 9, '4': 1, '5': 9, '10': 'address'},
   ],
 };
 
@@ -79,7 +105,7 @@ final $typed_data.Uint8List activityDescriptor = $convert.base64Decode(
     'gCIAEoCVICaWQSHQoKdmFsdWVfc2F0cxgDIAEoA1IJdmFsdWVTYXRzEhkKCGZlZV9zYXRzGAQg'
     'ASgDUgdmZWVTYXRzEh0KCnNpemVfYnl0ZXMYBSABKANSCXNpemVCeXRlcxIcCgljb25maXJtZW'
     'QYBiABKAhSCWNvbmZpcm1lZBIhCgxibG9ja19oZWlnaHQYByABKA1SC2Jsb2NrSGVpZ2h0Eh0K'
-    'CmJsb2NrX3RpbWUYCCABKANSCWJsb2NrVGltZQ==');
+    'CmJsb2NrX3RpbWUYCCABKANSCWJsb2NrVGltZRIYCgdhZGRyZXNzGAkgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use coinDescriptor instead')
 const Coin$json = {
@@ -410,6 +436,7 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> ExplorerSe
   '.explorer.v1.GetOverviewRequest': GetOverviewRequest$json,
   '.explorer.v1.GetOverviewResponse': GetOverviewResponse$json,
   '.explorer.v1.Block': Block$json,
+  '.explorer.v1.Bid': Bid$json,
   '.explorer.v1.Activity': Activity$json,
   '.explorer.v1.Mempool': Mempool$json,
   '.explorer.v1.Treasury': Treasury$json,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,47 @@
+# Explorer: deposits, BMM detail, and a recent list that never runs empty
+
+## What is wrong today
+
+1. `explorer_handler.go:672` declares `Deposits []struct{ Outpoint string }`. The node
+   returns a two-element array `[outpoint, output]`. The parse fails, so `nodeBlock`
+   takes the fallback path and returns no rows and no size for every block that holds
+   a deposit.
+2. `blockListSize = 6` caps the activity walk at six blocks. A chain with no recent
+   transaction lists nothing.
+3. The block card writes "Fees unknown" and "Size unknown".
+4. No deposit list exists.
+5. The block screen shows no BMM bid and no outpoint.
+
+## Design
+
+Figma page `Explorer flow`, file `Uvj2xZiMJsOt3nDaSxDGLQ`:
+
+- `1 · Explorer · overview` (`757:315`) — a deposit line on each block card, and a new
+  full width `deposits` card.
+- `2 · Explorer · block` (`763:371`) — the BMM card gains `Mainchain block` and
+  `Bid outpoint`; the bottom row holds `transactions` and `deposits` side by side.
+
+## Plan
+
+- [x] Read the node and find the real deposit shape
+- [x] Figma: deposit line on the block cards
+- [x] Figma: deposit list on the overview
+- [x] Figma: BMM outpoint and the two bottom tables on the block screen
+- [x] Proto: `Activity.address`, `Block.deposit_count`, `Block.deposit_value_sats`,
+      and a `Bid` message
+- [x] Go: parse the deposit pair, and fill the address and the value
+- [x] Go: walk down until the activity list holds 10 rows, with a per-block cache
+- [x] Go: read the block time from the enforcer header
+- [x] Go: read the winning bid out of the mainchain block
+- [x] Dart: drop the unknown lines, add the deposit line to the block card
+- [x] Dart: deposit list on the overview
+- [x] Dart: BMM fields and the two tables on the block screen
+- [x] Tests, lint, PR
+
+## Result
+
+The bid sits one mainchain block later than the header names. A header names
+the parent the M8 was built on, and a miner takes that M8 in the next block.
+
+A live thunder node reads back five deposits, from block 43 down to block 21.
+Every one of those sits below the old six block window.


### PR DESCRIPTION
A node writes a deposit as a two-element array, and the reader expected an object. Every block that held a deposit parsed as nothing, so the page showed no deposit, no transaction row, and no size. The overview also read six blocks only, so a chain with nothing recent listed nothing at all.

The overview now walks down until it holds ten rows, whatever their age, and caches each block it reads. The block page names the M8 a miner took: the mainchain outpoint that carried it, and the fee it paid.

Tested against a live thunder node on alphanet.