### PR TITLE
sailui: shuffle the entropy keyboard layout

### DIFF
--- a/bitwindow/lib/pages/welcome/wallet_backup_page.dart
+++ b/bitwindow/lib/pages/welcome/wallet_backup_page.dart
@@ -671,7 +671,7 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
                 SailEntropyKeyboard(
                   onType: _type,
                   showKeys: true,
-                  caption: 'Move your mouse over the keys',
+                  caption: 'Move your mouse as randomly as you can across this grid',
                   subCaption: _typed.length == 1 ? '1 character typed' : '${_typed.length} characters typed',
                 ),
               ],

--- a/sail_ui/lib/widgets/components/entropy_keyboard.dart
+++ b/sail_ui/lib/widgets/components/entropy_keyboard.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -16,6 +17,7 @@ const Duration entropyKeyRepeat = Duration(milliseconds: 50);
 
 /// SailEntropyKeyboard turns pointer movement into text. The pointer types the
 /// key it passes over, and that key repeats while the pointer rests on it.
+/// The layout is dealt by the OS CSPRNG at open; Shuffle deals a new one.
 ///
 /// [showKeys] draws the keys. Hidden keys still type, so both modes share one
 /// sampler and one character stream.
@@ -51,6 +53,9 @@ class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
 
   Timer? _repeat;
   String? _hovered;
+  // Random.secure reads the OS CSPRNG, the Dart equal of Go crypto/rand.
+  final Random _random = Random.secure();
+  late final List<String> _layout = entropyKeyboardChars.split('')..shuffle(_random);
 
   int get _rows => (entropyKeyboardChars.length / entropyKeyboardColumns).ceil();
 
@@ -95,10 +100,18 @@ class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
     final column = (x / (width / entropyKeyboardColumns)).floor();
     final row = (y / (height / _rows)).floor();
     final index = row * entropyKeyboardColumns + column;
-    if (index < 0 || index >= entropyKeyboardChars.length) {
+    if (index < 0 || index >= _layout.length) {
       return null;
     }
-    return entropyKeyboardChars[index];
+    return _layout[index];
+  }
+
+  // The pointer sits on the button during a press, so no key is hovered.
+  void _shuffle() {
+    setState(() {
+      _layout.shuffle(_random);
+      _hovered = null;
+    });
   }
 
   void _hover(PointerHoverEvent event, Size size) {
@@ -181,7 +194,23 @@ class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
           ),
         ],
         const SizedBox(height: 6),
-        SailText.secondary12(widget.subCaption ?? widget.caption),
+        Row(
+          children: [
+            Expanded(child: SailText.secondary12(widget.caption)),
+            if (widget.subCaption != null) ...[
+              const SizedBox(width: 12),
+              SailText.secondary12(widget.subCaption!),
+            ],
+            const SizedBox(width: 12),
+            SailButton(
+              label: 'Shuffle',
+              icon: SailSVGAsset.shuffle,
+              variant: ButtonVariant.secondary,
+              small: true,
+              onPressed: () async => _shuffle(),
+            ),
+          ],
+        ),
       ],
     );
   }
@@ -190,7 +219,7 @@ class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
     if (index >= entropyKeyboardChars.length) {
       return const SizedBox.shrink();
     }
-    final char = entropyKeyboardChars[index];
+    final char = _layout[index];
     final hovered = char == _hovered;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: _keyGap / 2),

--- a/sail_ui/test/entropy_keyboard_test.dart
+++ b/sail_ui/test/entropy_keyboard_test.dart
@@ -32,6 +32,16 @@ Future<void> _pump(
   await tester.pumpAndSettle();
 }
 
+List<String> _drawnKeys(WidgetTester tester) {
+  return tester
+      .widgetList<Text>(
+        find.descendant(of: find.byKey(const Key('mouse-entropy-pad')), matching: find.byType(Text)),
+      )
+      .map((t) => t.data ?? '')
+      .where((s) => s.length == 1)
+      .toList();
+}
+
 Future<TestGesture> _enter(WidgetTester tester, Offset at) async {
   final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
   await gesture.addPointer(location: at);
@@ -67,17 +77,41 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('a shown board draws every key and highlights the one under the pointer', (tester) async {
+  testWidgets('a shown board draws every key and types the drawn key under the pointer', (tester) async {
     final typed = <String>[];
     await _pump(tester, typed, showKeys: true);
 
     for (final char in ['!', 'A', 'z', '~']) {
       expect(find.text(char), findsOneWidget, reason: 'the board draws $char');
     }
+    final drawn = _drawnKeys(tester);
+    expect(drawn.toSet(), hasLength(94));
 
     final pad = find.byKey(const Key('mouse-entropy-pad'));
     await _enter(tester, tester.getTopLeft(pad) + const Offset(14, 14));
-    expect(typed, ['!'], reason: 'the first key sits at the top left');
+    expect(typed, [drawn.first], reason: 'the pointer types the key drawn at the top left');
+  });
+
+  testWidgets('the board opens with a shuffled layout', (tester) async {
+    await _pump(tester, <String>[], showKeys: true);
+
+    final drawn = _drawnKeys(tester);
+    expect(drawn.toSet(), hasLength(94));
+    expect(drawn.join(), isNot(entropyKeyboardChars), reason: 'the shuffle moves the keys');
+  });
+
+  testWidgets('the Shuffle button deals a new layout', (tester) async {
+    final typed = <String>[];
+    await _pump(tester, typed, showKeys: true);
+    final before = _drawnKeys(tester).join();
+
+    await tester.tap(find.widgetWithText(SailButton, 'Shuffle').first);
+    await tester.pump();
+
+    final after = _drawnKeys(tester).join();
+    expect(after, isNot(before));
+    expect(after.split('').toSet(), hasLength(94));
+    expect(typed, isEmpty, reason: 'the button types nothing');
   });
 
   testWidgets('a key repeats while the pointer rests on it', (tester) async {


### PR DESCRIPTION
The board deals a crypto-random layout at open, with Random.secure (the OS CSPRNG).
A Shuffle button deals a new layout on demand. The hidden board shuffles too.
Figma: frame 6b on the Create wallet flow page.