### PR TITLE
sailui: square the entropy board at 9x10

### DIFF
--- a/sail_ui/lib/widgets/components/entropy_keyboard.dart
+++ b/sail_ui/lib/widgets/components/entropy_keyboard.dart
@@ -5,12 +5,12 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:sail_ui/sail_ui.dart';
 
-/// The keys the board offers: every printable ASCII character.
+/// The keys the board offers: printable ASCII from ! to z, 90 characters.
 const String entropyKeyboardChars =
-    r"""!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~""";
+    r"""!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz""";
 
 /// How many keys sit in one row.
-const int entropyKeyboardColumns = 12;
+const int entropyKeyboardColumns = 10;
 
 /// How often a key repeats while the pointer rests on it.
 const Duration entropyKeyRepeat = Duration(milliseconds: 50);
@@ -46,8 +46,8 @@ class SailEntropyKeyboard extends StatefulWidget {
 }
 
 class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
-  static const double _keyHeight = 24;
-  static const double _keyGap = 2;
+  static const double _maxKeySize = 44;
+  static const double _keyGap = 4;
   static const double _padding = 8;
   static const double _border = 1;
 
@@ -81,20 +81,37 @@ class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
     }
   }
 
-  double get _keysHeight => _rows * _keyHeight + (_rows - 1) * _keyGap;
+  /// The grid takes its full size when the board is wide, and it scales the
+  /// square keys down inside a narrow board.
+  double _gridWidthFor(double innerWidth) {
+    final full = entropyKeyboardColumns * _maxKeySize + (entropyKeyboardColumns - 1) * _keyGap;
+    return min(full, innerWidth);
+  }
+
+  double _keySizeFor(double gridWidth) =>
+      max(1, (gridWidth - (entropyKeyboardColumns - 1) * _keyGap) / entropyKeyboardColumns);
+
+  double _keysHeightFor(double gridWidth) {
+    final key = _keySizeFor(gridWidth);
+    return _rows * key + (_rows - 1) * _keyGap;
+  }
 
   /// keyAt reads the key under one point. It answers null outside the keys.
   String? keyAt(Offset local, Size size) {
-    final width = size.width - (_padding + _border) * 2;
-    // A visible board types only where the keys are. A hidden one has no
-    // caption to dodge, so its whole face maps to the same grid.
-    final height = widget.showKeys ? _keysHeight : size.height - (_padding + _border) * 2;
-    if (width <= 0 || height <= 0) {
-      return null;
-    }
-    final x = local.dx - _padding - _border;
+    final innerWidth = size.width - (_padding + _border) * 2;
+    var x = local.dx - _padding - _border;
     final y = local.dy - _padding - _border;
-    if (x < 0 || y < 0 || x >= width || y >= height) {
+    var width = innerWidth;
+    // A visible board centers a square grid and types only on it. A hidden
+    // one has no keys to dodge, so its whole face maps to the same grid.
+    var height = size.height - (_padding + _border) * 2;
+    if (widget.showKeys) {
+      final gridWidth = _gridWidthFor(innerWidth);
+      x -= (innerWidth - gridWidth) / 2;
+      width = gridWidth;
+      height = _keysHeightFor(gridWidth);
+    }
+    if (width <= 0 || height <= 0 || x < 0 || y < 0 || x >= width || y >= height) {
       return null;
     }
     final column = (x / (width / entropyKeyboardColumns)).floor();
@@ -176,64 +193,73 @@ class _SailEntropyKeyboardState extends State<SailEntropyKeyboard> {
 
   Widget _keys(BuildContext context) {
     final theme = SailTheme.of(context);
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (var row = 0; row < _rows; row++) ...[
-          if (row > 0) const SizedBox(height: _keyGap),
-          SizedBox(
-            height: _keyHeight,
-            child: Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final gridWidth = _gridWidthFor(constraints.maxWidth);
+        final keySize = _keySizeFor(gridWidth);
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Center(
+              child: SizedBox(
+                width: gridWidth,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (var row = 0; row < _rows; row++) ...[
+                      if (row > 0) const SizedBox(height: _keyGap),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          for (var column = 0; column < entropyKeyboardColumns; column++)
+                            _key(theme, keySize, row * entropyKeyboardColumns + column),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Row(
               children: [
-                for (var column = 0; column < entropyKeyboardColumns; column++)
-                  Expanded(
-                    child: _key(theme, row * entropyKeyboardColumns + column),
-                  ),
+                Expanded(child: SailText.secondary12(widget.caption)),
+                if (widget.subCaption != null) ...[
+                  const SizedBox(width: 12),
+                  SailText.secondary12(widget.subCaption!),
+                ],
+                const SizedBox(width: 12),
+                SailButton(
+                  label: 'Shuffle',
+                  icon: SailSVGAsset.shuffle,
+                  variant: ButtonVariant.secondary,
+                  small: true,
+                  disabled: !widget.enabled,
+                  onPressed: () async => _shuffle(),
+                ),
               ],
             ),
-          ),
-        ],
-        const SizedBox(height: 6),
-        Row(
-          children: [
-            Expanded(child: SailText.secondary12(widget.caption)),
-            if (widget.subCaption != null) ...[
-              const SizedBox(width: 12),
-              SailText.secondary12(widget.subCaption!),
-            ],
-            const SizedBox(width: 12),
-            SailButton(
-              label: 'Shuffle',
-              icon: SailSVGAsset.shuffle,
-              variant: ButtonVariant.secondary,
-              small: true,
-              onPressed: () async => _shuffle(),
-            ),
           ],
-        ),
-      ],
+        );
+      },
     );
   }
 
-  Widget _key(SailThemeData theme, int index) {
-    if (index >= entropyKeyboardChars.length) {
-      return const SizedBox.shrink();
-    }
+  Widget _key(SailThemeData theme, double keySize, int index) {
     final char = _layout[index];
     final hovered = char == _hovered;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: _keyGap / 2),
-      child: Container(
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: hovered ? theme.colors.orange : theme.colors.background,
-          borderRadius: BorderRadius.circular(4),
-        ),
-        child: SailText.primary13(
-          char,
-          monospace: true,
-          color: hovered ? theme.colors.backgroundSecondary : null,
-        ),
+    return Container(
+      width: keySize,
+      height: keySize,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: hovered ? theme.colors.orange : theme.colors.background,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: SailText.primary13(
+        char,
+        monospace: true,
+        color: hovered ? theme.colors.backgroundSecondary : null,
       ),
     );
   }

--- a/sail_ui/test/entropy_keyboard_test.dart
+++ b/sail_ui/test/entropy_keyboard_test.dart
@@ -8,6 +8,7 @@ Future<void> _pump(
   List<String> typed, {
   bool showKeys = false,
   bool enabled = true,
+  double width = 768,
 }) async {
   await tester.binding.setSurfaceSize(const Size(900, 700));
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -17,7 +18,7 @@ Future<void> _pump(
         data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
         child: Scaffold(
           body: SizedBox(
-            width: 768,
+            width: width,
             child: SailEntropyKeyboard(
               onType: typed.add,
               showKeys: showKeys,
@@ -52,10 +53,10 @@ Future<TestGesture> _enter(WidgetTester tester, Offset at) async {
 }
 
 void main() {
-  test('the board offers every printable ASCII character once', () {
-    expect(entropyKeyboardChars, hasLength(94));
-    expect(entropyKeyboardChars.split('').toSet(), hasLength(94));
-    expect(entropyKeyboardChars.codeUnits.every((c) => c >= 0x21 && c <= 0x7e), isTrue);
+  test('the board offers 90 printable ASCII characters once', () {
+    expect(entropyKeyboardChars, hasLength(90));
+    expect(entropyKeyboardChars.split('').toSet(), hasLength(90));
+    expect(entropyKeyboardChars.codeUnits.every((c) => c >= 0x21 && c <= 0x7a), isTrue);
   });
 
   testWidgets('a hidden board types the keys under the pointer', (tester) async {
@@ -81,14 +82,16 @@ void main() {
     final typed = <String>[];
     await _pump(tester, typed, showKeys: true);
 
-    for (final char in ['!', 'A', 'z', '~']) {
+    for (final char in ['!', 'A', 'k', 'z']) {
       expect(find.text(char), findsOneWidget, reason: 'the board draws $char');
     }
     final drawn = _drawnKeys(tester);
-    expect(drawn.toSet(), hasLength(94));
+    expect(drawn.toSet(), hasLength(90));
 
+    // The square grid is 476 wide and centered; aim at the first key.
     final pad = find.byKey(const Key('mouse-entropy-pad'));
-    await _enter(tester, tester.getTopLeft(pad) + const Offset(14, 14));
+    final width = tester.getSize(pad).width;
+    await _enter(tester, tester.getTopLeft(pad) + Offset(width / 2 - 476 / 2 + 22, 9 + 22));
     expect(typed, [drawn.first], reason: 'the pointer types the key drawn at the top left');
   });
 
@@ -96,8 +99,24 @@ void main() {
     await _pump(tester, <String>[], showKeys: true);
 
     final drawn = _drawnKeys(tester);
-    expect(drawn.toSet(), hasLength(94));
+    expect(drawn.toSet(), hasLength(90));
     expect(drawn.join(), isNot(entropyKeyboardChars), reason: 'the shuffle moves the keys');
+  });
+
+  testWidgets('a narrow board scales its keys and still maps them', (tester) async {
+    final typed = <String>[];
+    await _pump(tester, typed, showKeys: true, width: 360);
+
+    final drawn = _drawnKeys(tester);
+    expect(drawn.toSet(), hasLength(90));
+
+    // Inner width 342 gives a 342 grid and 30.6 keys; aim at the first key.
+    const grid = 342.0;
+    const key = (grid - 9 * 4) / 10;
+    final pad = find.byKey(const Key('mouse-entropy-pad'));
+    final width = tester.getSize(pad).width;
+    await _enter(tester, tester.getTopLeft(pad) + Offset(width / 2 - grid / 2 + key / 2, 9 + key / 2));
+    expect(typed, [drawn.first], reason: 'the scaled grid still types the drawn key');
   });
 
   testWidgets('the Shuffle button deals a new layout', (tester) async {
@@ -110,7 +129,7 @@ void main() {
 
     final after = _drawnKeys(tester).join();
     expect(after, isNot(before));
-    expect(after.split('').toSet(), hasLength(94));
+    expect(after.split('').toSet(), hasLength(90));
     expect(typed, isEmpty, reason: 'the button types nothing');
   });
 
@@ -140,5 +159,8 @@ void main() {
     final opacity = tester.widget<Opacity>(find.byType(Opacity).first);
     expect(opacity.opacity, 0.5);
     expect(typed, isEmpty);
+
+    final shuffle = tester.widgetList<SailButton>(find.widgetWithText(SailButton, 'Shuffle')).first;
+    expect(shuffle.disabled, isTrue, reason: 'a disabled board locks its Shuffle button');
   });
 }


### PR DESCRIPTION
The board becomes a centered square grid: 9 rows of 10 square keys.
The character set drops its last four ({, |, }, ~), so 90 keys hold ASCII ! through z.
A disabled board also locks its Shuffle button.