### PR TITLE
Keep BMM bidding after a restart

### DIFF
--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -145,6 +145,17 @@ func (e *BmmEngine) Start(
 	e.targets[sidechain] = target
 	e.mu.Unlock()
 
+	// A restart must resume bidding. Without the target the engine wakes with
+	// nothing to bid for, and it says nothing about it.
+	if err := e.store.SaveTarget(bmmstate.Target{
+		Sidechain:       int32(sidechain),
+		WalletID:        walletID,
+		MaxBidSats:      maxBidSats,
+		CapToBlockWorth: capToBlockWorth,
+	}); err != nil {
+		e.log.Warn().Err(err).Stringer("sidechain", sidechain).Msg("store the bmm target")
+	}
+
 	e.log.Info().Stringer("sidechain", sidechain).
 		Int64("max_bid_sats", maxBidSats).
 		Bool("cap_to_block_worth", capToBlockWorth).Msg("bmm started")
@@ -158,6 +169,9 @@ func (e *BmmEngine) Stop(sidechain pb.BinaryType) {
 	e.mu.Lock()
 	delete(e.targets, sidechain)
 	e.mu.Unlock()
+	if err := e.store.DeleteTarget(int32(sidechain)); err != nil {
+		e.log.Warn().Err(err).Stringer("sidechain", sidechain).Msg("drop the bmm target")
+	}
 	e.log.Info().Stringer("sidechain", sidechain).Msg("bmm stopped")
 	e.notify()
 }
@@ -256,6 +270,7 @@ func (e *BmmEngine) Run(ctx context.Context) error {
 	ticker := time.NewTicker(bmmTickInterval)
 	defer ticker.Stop()
 
+	e.resumeTargets()
 	e.resumeUnconnected()
 	e.log.Info().Dur("interval", bmmTickInterval).Msg("bmm engine started")
 
@@ -267,6 +282,32 @@ func (e *BmmEngine) Run(ctx context.Context) error {
 		case <-ticker.C:
 		case <-e.wake:
 		}
+	}
+}
+
+// resumeTargets reloads what the engine bids for, so a restart carries on
+// rather than stopping without a word.
+func (e *BmmEngine) resumeTargets() {
+	targets, err := e.store.Targets()
+	if err != nil {
+		e.log.Warn().Err(err).Msg("read stored bmm targets")
+		return
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, t := range targets {
+		if t.MaxBidSats <= 0 {
+			continue
+		}
+		sidechain := pb.BinaryType(t.Sidechain)
+		e.targets[sidechain] = bmmTarget{
+			maxBidSats:      t.MaxBidSats,
+			walletID:        t.WalletID,
+			capToBlockWorth: t.CapToBlockWorth,
+		}
+		e.log.Info().Stringer("sidechain", sidechain).
+			Int64("max_bid_sats", t.MaxBidSats).Msg("resuming bmm")
 	}
 }
 

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -595,7 +595,42 @@ func TestBmmEngineHistorySurvivesRestart(t *testing.T) {
 	assert.Equal(t, ResultWon, history[len(history)-1].Result)
 
 	running, _, _ := restarted.Running(testSidechain)
-	assert.False(t, running, "a restart must never resume spending on its own")
+	assert.False(t, running, "a fresh engine bids for nothing until it runs")
+}
+
+// The operator starts bidding once. A restart must carry on, or the chain
+// stalls until somebody notices and starts it by hand.
+func TestBmmEngineResumesItsTargetAfterRestart(t *testing.T) {
+	engine, backend, tip, store := newEngine(t)
+	require.NoError(t, engine.Start(testSidechain, "spender", 10_000, true))
+
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
+	running, _, _ := restarted.Running(testSidechain)
+	require.False(t, running, "the target loads when the engine runs")
+
+	restarted.resumeTargets()
+	running, wallet, max := restarted.Running(testSidechain)
+	assert.True(t, running)
+	assert.Equal(t, "spender", wallet)
+	assert.Equal(t, int64(10_000), max)
+
+	restarted.tick(context.Background())
+	assert.Positive(t, backend.bids, "a resumed target bids on the next tip")
+}
+
+// Stop is a decision, so it must outlive the process too.
+func TestBmmEngineForgetsAStoppedTargetAfterRestart(t *testing.T) {
+	engine, backend, tip, store := newEngine(t)
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	engine.Stop(testSidechain)
+
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
+	restarted.resumeTargets()
+
+	running, _, _ := restarted.Running(testSidechain)
+	assert.False(t, running)
+	restarted.tick(context.Background())
+	assert.Zero(t, backend.bids, "a stopped engine spends nothing")
 }
 
 func TestBmmEngineClearHistory(t *testing.T) {

--- a/sidechain-orchestrator/engines/bmmstate/store.go
+++ b/sidechain-orchestrator/engines/bmmstate/store.go
@@ -13,6 +13,8 @@ import (
 
 const fileName = "bmm_rounds.json"
 
+const targetsFileName = "bmm_targets.json"
+
 // Bid is one M8 broadcast for a round.
 type Bid struct {
 	Txid           string `json:"txid"`
@@ -47,21 +49,38 @@ type Round struct {
 	BlocksWaited       int    `json:"blocks_waited,omitempty"`
 }
 
-// Store keeps rounds in a JSON file, newest first, capped at limit.
-type Store struct {
-	path  string
-	limit int
+// Target is what the engine bids for on one sidechain. It outlives the
+// process, so a restart resumes bidding rather than stopping it silently.
+type Target struct {
+	Sidechain       int32  `json:"sidechain"`
+	WalletID        string `json:"wallet_id,omitempty"`
+	MaxBidSats      int64  `json:"max_bid_sats"`
+	CapToBlockWorth bool   `json:"cap_to_block_worth,omitempty"`
+}
 
-	mu     sync.Mutex
-	loaded bool
-	rounds []Round
+// Store keeps rounds in a JSON file, newest first, capped at limit. It keeps
+// the bidding targets in a second file beside them.
+type Store struct {
+	path        string
+	targetsPath string
+	limit       int
+
+	mu            sync.Mutex
+	loaded        bool
+	rounds        []Round
+	targetsLoaded bool
+	targets       []Target
 }
 
 func NewStore(dir string, limit int) *Store {
 	if limit <= 0 {
 		limit = 500
 	}
-	return &Store{path: filepath.Join(dir, fileName), limit: limit}
+	return &Store{
+		path:        filepath.Join(dir, fileName),
+		targetsPath: filepath.Join(dir, targetsFileName),
+		limit:       limit,
+	}
 }
 
 func (s *Store) ensureLoadedLocked() error {
@@ -201,6 +220,90 @@ func (s *Store) Rebind(dir string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.path = filepath.Join(dir, fileName)
+	s.targetsPath = filepath.Join(dir, targetsFileName)
 	s.rounds = nil
 	s.loaded = false
+	s.targets = nil
+	s.targetsLoaded = false
+}
+
+func (s *Store) ensureTargetsLoadedLocked() error {
+	if s.targetsLoaded {
+		return nil
+	}
+	data, err := os.ReadFile(s.targetsPath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		s.targetsLoaded = true
+		return nil
+	case err != nil:
+		return fmt.Errorf("read bmm targets: %w", err)
+	}
+	if err := json.Unmarshal(data, &s.targets); err != nil {
+		return fmt.Errorf("decode bmm targets: %w", err)
+	}
+	s.targetsLoaded = true
+	return nil
+}
+
+func (s *Store) flushTargetsLocked() error {
+	data, err := json.MarshalIndent(s.targets, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode bmm targets: %w", err)
+	}
+	tmp := s.targetsPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write bmm targets tmp: %w", err)
+	}
+	if err := os.Rename(tmp, s.targetsPath); err != nil {
+		return fmt.Errorf("rename bmm targets: %w", err)
+	}
+	return nil
+}
+
+// SaveTarget inserts or replaces the target for one sidechain.
+func (s *Store) SaveTarget(target Target) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureTargetsLoadedLocked(); err != nil {
+		return err
+	}
+	for i := range s.targets {
+		if s.targets[i].Sidechain == target.Sidechain {
+			s.targets[i] = target
+			return s.flushTargetsLocked()
+		}
+	}
+	s.targets = append(s.targets, target)
+	return s.flushTargetsLocked()
+}
+
+// DeleteTarget drops one sidechain's target, so a restart does not resume it.
+func (s *Store) DeleteTarget(sidechain int32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureTargetsLoadedLocked(); err != nil {
+		return err
+	}
+	kept := make([]Target, 0, len(s.targets))
+	for _, t := range s.targets {
+		if t.Sidechain != sidechain {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) == len(s.targets) {
+		return nil
+	}
+	s.targets = kept
+	return s.flushTargetsLocked()
+}
+
+// Targets lists every sidechain the engine bids for.
+func (s *Store) Targets() ([]Target, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureTargetsLoadedLocked(); err != nil {
+		return nil, err
+	}
+	return append([]Target(nil), s.targets...), nil
 }

--- a/sidechain-orchestrator/engines/bmmstate/store_test.go
+++ b/sidechain-orchestrator/engines/bmmstate/store_test.go
@@ -1,0 +1,86 @@
+package bmmstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetsSurviveANewStore(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, 0)
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 9, WalletID: "spender", MaxBidSats: 5000}))
+
+	reopened := NewStore(dir, 0)
+	targets, err := reopened.Targets()
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, int32(9), targets[0].Sidechain)
+	assert.Equal(t, "spender", targets[0].WalletID)
+	assert.Equal(t, int64(5000), targets[0].MaxBidSats)
+}
+
+func TestSaveTargetReplacesTheSameSidechain(t *testing.T) {
+	store := NewStore(t.TempDir(), 0)
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 9, MaxBidSats: 1000}))
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 9, MaxBidSats: 7000, CapToBlockWorth: true}))
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 4, MaxBidSats: 2000}))
+
+	targets, err := store.Targets()
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.Equal(t, int64(7000), targets[0].MaxBidSats)
+	assert.True(t, targets[0].CapToBlockWorth)
+}
+
+func TestDeleteTargetDropsOnlyThatSidechain(t *testing.T) {
+	store := NewStore(t.TempDir(), 0)
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 9, MaxBidSats: 1000}))
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 4, MaxBidSats: 2000}))
+	require.NoError(t, store.DeleteTarget(9))
+
+	targets, err := store.Targets()
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, int32(4), targets[0].Sidechain)
+
+	// Deleting what is not there is not an error, and it writes nothing.
+	require.NoError(t, store.DeleteTarget(9))
+}
+
+// A network swap points the store at another directory. The targets of the
+// old network must not follow it.
+func TestRebindDropsTheTargets(t *testing.T) {
+	first := t.TempDir()
+	store := NewStore(first, 0)
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 9, MaxBidSats: 1000}))
+
+	store.Rebind(t.TempDir())
+	targets, err := store.Targets()
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+
+	// The first network keeps its own file.
+	kept, err := NewStore(first, 0).Targets()
+	require.NoError(t, err)
+	require.Len(t, kept, 1)
+}
+
+func TestTargetsAndRoundsUseSeparateFiles(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, 0)
+	require.NoError(t, store.Save(Round{Sidechain: 9, PrevMainHash: "block-1"}))
+	require.NoError(t, store.SaveTarget(Target{Sidechain: 9, MaxBidSats: 1000}))
+
+	for _, name := range []string{fileName, targetsFileName} {
+		_, err := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, err, "%s exists", name)
+	}
+
+	rounds, err := store.List(9)
+	require.NoError(t, err)
+	require.Len(t, rounds, 1)
+}


### PR DESCRIPTION
The BMM engine kept its bidding targets in a plain map in RAM. Only the Start RPC wrote it, and nothing reloaded it at boot, so every restart silently stopped bidding. The engine still logged "bmm engine started", and `tick` then found no target and returned at once, so nothing said the chain had stopped.

That is what happened on alphanet. The last bid went out on Sep 04 at 19:25. Five restarts followed, each logging a clean start, and the node placed no bid for a day and a half while another node won every round.

A target is a decision the operator makes once, so it belongs on disk beside the rounds. `bmmstate.Store` gains a second file, `bmm_targets.json`: Start saves, Stop deletes, and the engine reloads them in `Run` next to the rounds it already resumes. Stop persists too, so a stopped sidechain stays stopped. A network swap drops the targets with the rest of that network's state.

Only the runtime part stays in memory. `lastTip` is which tip a round opened on, not a setting, so a resumed engine opens its round on the next tip it sees.

Nine tests cover it: the store round trip, replace, delete, rebind, the two files, and the two engine paths, resume and forget.