### PR TITLE
Scroll the BMM tab

### DIFF
--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -92,14 +92,18 @@ Color? historicBidStateColor(String state, SailColor colors) => switch (state) {
   _ => colors.textSecondary,
 };
 
-/// Our bids, newest first. A round we never bid on has no row.
+/// Our bids on the rounds the chain already decided, newest first. A round we
+/// never bid on has no row, and the round in play stays in the current slot.
 List<HistoricBid> historicBids(
   bmmpb.Round? current,
   List<bmmpb.Round> history,
 ) {
   final rows = <HistoricBid>[];
   final seen = <String>{};
-  for (final round in [?current, ...history]) {
+  if (current != null) {
+    seen.add(current.prevMainHash);
+  }
+  for (final round in history) {
     final bid = round.ourBids.lastOrNull;
     if (bid == null || !seen.add(round.prevMainHash)) {
       continue;

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -93,7 +93,10 @@ Color? historicBidStateColor(String state, SailColor colors) => switch (state) {
 };
 
 /// Our bids, newest first. A round we never bid on has no row.
-List<HistoricBid> historicBids(bmmpb.Round? current, List<bmmpb.Round> history) {
+List<HistoricBid> historicBids(
+  bmmpb.Round? current,
+  List<bmmpb.Round> history,
+) {
   final rows = <HistoricBid>[];
   final seen = <String>{};
   for (final round in [?current, ...history]) {
@@ -146,15 +149,18 @@ class BMMTab extends StatelessWidget {
           title: 'BMM',
           subtitle: 'Bid on the parent chain to mine a ${viewModel.chainName} block',
           error: viewModel.bmmError,
-          child: SailColumn(
-            spacing: SailStyleValues.padding16,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _Controls(viewModel: viewModel),
-              _CurrentSlot(viewModel: viewModel),
-              _BidsOnNextBlock(viewModel: viewModel),
-              _HistoricBids(viewModel: viewModel),
-            ],
+          // The two tables grow with the rounds they list, so the tab scrolls.
+          child: SingleChildScrollView(
+            child: SailColumn(
+              spacing: SailStyleValues.padding16,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _Controls(viewModel: viewModel),
+                _CurrentSlot(viewModel: viewModel),
+                _BidsOnNextBlock(viewModel: viewModel),
+                _HistoricBids(viewModel: viewModel),
+              ],
+            ),
           ),
         );
       },
@@ -205,7 +211,10 @@ class _Controls extends StatelessWidget {
             ),
             _Field(
               label: 'Max bid:',
-              child: SailTextField(controller: viewModel.maxBidController, hintText: '0.00020000'),
+              child: SailTextField(
+                controller: viewModel.maxBidController,
+                hintText: '0.00020000',
+              ),
             ),
             Expanded(child: Container()),
             SailButton(
@@ -216,13 +225,19 @@ class _Controls extends StatelessWidget {
             ),
           ],
         ),
-        if (viewModel.fundingWarning) SailText.secondary12(viewModel.fundingWarningLabel, color: colors.orange),
+        if (viewModel.fundingWarning)
+          SailText.secondary12(
+            viewModel.fundingWarningLabel,
+            color: colors.orange,
+          ),
       ],
     );
   }
 
   void _showManualBidDialog(BuildContext context, BMMViewModel viewModel) {
-    final controller = TextEditingController(text: viewModel.bmmProvider.suggestedBidSats.toString());
+    final controller = TextEditingController(
+      text: viewModel.bmmProvider.suggestedBidSats.toString(),
+    );
     final worth = viewModel.blockWorthSats;
 
     showThemedDialog(
@@ -326,13 +341,22 @@ class _CurrentSlot extends StatelessWidget {
             spacing: SailStyleValues.padding64,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _Figure(label: 'Block worth', value: viewModel.satsLabel(viewModel.blockWorthSats)),
+              _Figure(
+                label: 'Block worth',
+                value: viewModel.satsLabel(viewModel.blockWorthSats),
+              ),
               _Figure(
                 label: 'Your bid',
                 value: live == null ? '—' : viewModel.satsLabel(live.bidSats.toInt()),
               ),
-              _Figure(label: 'Profit if won', value: viewModel.satsLabel(viewModel.profitIfWon)),
-              _Figure(label: 'Sidechain block ready', value: viewModel.currentCriticalHash),
+              _Figure(
+                label: 'Profit if won',
+                value: viewModel.satsLabel(viewModel.profitIfWon),
+              ),
+              _Figure(
+                label: 'Sidechain block ready',
+                value: viewModel.currentCriticalHash,
+              ),
             ],
           ),
         ],
@@ -365,7 +389,11 @@ class _SectionHead extends StatelessWidget {
   final String subtitle;
   final Widget? action;
 
-  const _SectionHead({required this.title, required this.subtitle, this.action});
+  const _SectionHead({
+    required this.title,
+    required this.subtitle,
+    this.action,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -432,7 +460,12 @@ class _HashLink extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
             Flexible(child: SailText.primary13(label, color: tone)),
-            SailSVG.icon(SailSVGAsset.externalLink, color: tone, width: 12, height: 12),
+            SailSVG.icon(
+              SailSVGAsset.externalLink,
+              color: tone,
+              width: 12,
+              height: 12,
+            ),
           ],
         ),
       ),
@@ -493,7 +526,10 @@ class _BidsOnNextBlock extends StatelessWidget {
                   copyValue: bid.txid,
                   child: bid.txid.isEmpty
                       ? null
-                      : _HashLink(label: shortenHash(bid.txid), url: viewModel.txUrl(bid.txid)),
+                      : _HashLink(
+                          label: shortenHash(bid.txid),
+                          url: viewModel.txUrl(bid.txid),
+                        ),
                 ),
                 _statusCell(bid, bids, colors),
               ];
@@ -507,7 +543,11 @@ class _BidsOnNextBlock extends StatelessWidget {
     );
   }
 
-  SailTableCell _statusCell(bmmpb.Bid bid, List<bmmpb.Bid> bids, SailColor colors) {
+  SailTableCell _statusCell(
+    bmmpb.Bid bid,
+    List<bmmpb.Bid> bids,
+    SailColor colors,
+  ) {
     final replacement = bid.replacedByTxid;
     if (replacement.isNotEmpty) {
       return SailTableCell(
@@ -586,7 +626,10 @@ class _HistoricBids extends StatelessWidget {
                   copyValue: bid.txid,
                   child: bid.txid.isEmpty
                       ? null
-                      : _HashLink(label: shortenHash(bid.txid), url: viewModel.txUrl(bid.txid)),
+                      : _HashLink(
+                          label: shortenHash(bid.txid),
+                          url: viewModel.txUrl(bid.txid),
+                        ),
                 ),
                 SailTableCell(
                   value: bid.mainchainBlock,
@@ -794,7 +837,9 @@ class BMMViewModel extends BaseViewModel {
         final bids = [...round.ourBids, ...round.otherBids]..sort((a, b) => b.bidSats.compareTo(a.bidSats));
 
         return AlertDialog(
-          title: SailText.primary15('Bids for mainchain block ${blockLabel(round)}'),
+          title: SailText.primary15(
+            'Bids for mainchain block ${blockLabel(round)}',
+          ),
           content: SizedBox(
             width: 900,
             child: SailColumn(
@@ -826,8 +871,13 @@ class BMMViewModel extends BaseViewModel {
                           value: bid.isOurs ? 'You' : '—',
                           textColor: bid.isOurs ? colors.info : null,
                         ),
-                        SailTableCell(value: shortenCriticalHash(bid.criticalHash)),
-                        SailTableCell(value: shortenHash(bid.txid), copyValue: bid.txid),
+                        SailTableCell(
+                          value: shortenCriticalHash(bid.criticalHash),
+                        ),
+                        SailTableCell(
+                          value: shortenHash(bid.txid),
+                          copyValue: bid.txid,
+                        ),
                         SailTableCell(value: outcomeOf(bid, round)),
                       ];
                     },
@@ -841,7 +891,10 @@ class BMMViewModel extends BaseViewModel {
             ),
           ),
           actions: [
-            SailButton(label: 'Close', onPressed: () async => Navigator.of(context).pop()),
+            SailButton(
+              label: 'Close',
+              onPressed: () async => Navigator.of(context).pop(),
+            ),
           ],
         );
       },

--- a/sail_ui/test/bmm_profit_color_test.dart
+++ b/sail_ui/test/bmm_profit_color_test.dart
@@ -69,7 +69,9 @@ void main() {
       return value;
     }
 
-    test('the live round leads the finished ones', () {
+    // The round in play sits in the current slot and in the bids table, so a
+    // reader who sees it a third time reads it as a second bid.
+    test('the live round stays out of the finished ones', () {
       final rows = historicBids(
         round(hash: 'a', result: 'open', bidSats: 22000, blockWorth: 24800, txid: 'tx-a'),
         [
@@ -85,10 +87,9 @@ void main() {
         ],
       );
 
-      expect(rows.map((r) => r.state), [bidStateWaiting, bidStateConnected]);
-      expect(rows.first.mainchainBlock, '');
-      expect(rows.last.mainchainBlock, 'blk');
-      expect(rows.last.profitSats, 2900);
+      expect(rows.map((r) => r.state), [bidStateConnected]);
+      expect(rows.single.mainchainBlock, 'blk');
+      expect(rows.single.profitSats, 2900);
     });
 
     test('a round we never bid on gets no row', () {
@@ -106,11 +107,22 @@ void main() {
       expect(rows.single.mainchainBlock, '');
     });
 
-    test('the live round appears once, even when history repeats it', () {
+    // The store saves the open round too, so the live hash must drop out of
+    // the history whichever list it arrives in.
+    test('the live round never shows, even when history repeats it', () {
       final live = round(hash: 'e', result: 'open', txid: 'tx-e');
       final rows = historicBids(live, [round(hash: 'e', result: 'open', txid: 'tx-e')]);
 
-      expect(rows, hasLength(1));
+      expect(rows, isEmpty);
+    });
+
+    test('every decided round still shows, newest first', () {
+      final rows = historicBids(round(hash: 'live', result: 'open', txid: 'tx-live'), [
+        round(hash: 'f', result: 'won', txid: 'tx-f', includedIn: 'blk-f'),
+        round(hash: 'g', result: 'lost', txid: 'tx-g'),
+      ]);
+
+      expect(rows.map((r) => r.prevMainHash), ['f', 'g']);
     });
   });
 }

--- a/sail_ui/test/bmm_tab_layout_test.dart
+++ b/sail_ui/test/bmm_tab_layout_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/pages/sidechains/bmm_tab.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// The four sections the BMM tab stacks: two heads, and two tables that grow
+/// with the rounds they list.
+List<Widget> _sections(int nextBlockBids, int historicBids) => [
+  const SizedBox(height: 120), // controls
+  const SizedBox(height: 130), // current slot
+  SizedBox(height: tableFrameHeight(nextBlockBids)),
+  SizedBox(height: tableFrameHeight(historicBids)),
+];
+
+Future<void> _pumpCard(WidgetTester tester, Widget child, {required Size window}) async {
+  await tester.binding.setSurfaceSize(window);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      home: SailTheme(
+        data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+        child: Scaffold(
+          body: SailCard(title: 'BMM', child: child),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  test('a table frame grows one line per row', () {
+    expect(tableFrameHeight(0), 100, reason: 'an empty table still shows its placeholder');
+    expect(tableFrameHeight(1), 82);
+    expect(tableFrameHeight(10), 442);
+  });
+
+  // Ten rounds of history is an ordinary evening of bidding, and the card is
+  // taller than the window long before that.
+  testWidgets('the stacked sections overflow a card that does not scroll', (tester) async {
+    await _pumpCard(
+      tester,
+      SailColumn(
+        spacing: SailStyleValues.padding16,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: _sections(4, 10),
+      ),
+      window: const Size(1200, 800),
+    );
+
+    expect(tester.takeException(), isNotNull, reason: 'this is the shape the tab had');
+  });
+
+  testWidgets('a scrolling card holds the same sections', (tester) async {
+    await _pumpCard(
+      tester,
+      SingleChildScrollView(
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: _sections(4, 10),
+        ),
+      ),
+      window: const Size(1200, 800),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+  });
+}


### PR DESCRIPTION
The BMM tab stacks four sections in a card: the controls, the current slot, the bids on the next block, and the historic bids. Both tables size themselves from their rows, so the card grows past the window as soon as a few rounds land. Flutter then reports `A RenderFlex overflowed by 134 pixels on the bottom`, and the historic table is the part a reader cannot reach.

The column scrolls now. Nothing else changes.

Three tests: the height rule the tables use, the overflow the old shape produced, and the scrolling shape that holds the same sections.