### PR TITLE
sidechains: split the node interface in three

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.326
+version: 1.0.327
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.326
+version: 1.0.327
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.197
+version: 0.2.198
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.2
+version: 1.0.3
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.199
+version: 1.0.200
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -5,11 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog"
 	"math"
-	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"connectrpc.com/connect"
 	"github.com/samber/lo"
@@ -25,7 +25,6 @@ import (
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
 	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bbc"
 )
 
 // bmmAncestorWalk bounds the walk back from the tip when looking for the block
@@ -560,31 +559,16 @@ func (h *BMMHandler) BlockAfter(ctx context.Context, prevMainHash, tipHash strin
 
 func (h *BMMHandler) sidechainTarget(
 	binary pb.BinaryType,
-) (orchestrator.BinaryConfig, sidechain.SidechainRPCProxy, error) {
+) (orchestrator.BinaryConfig, sidechain.BMMNode, error) {
 	cfg, err := h.sidechainConfig(binary)
 	if err != nil {
 		return orchestrator.BinaryConfig{}, nil, err
 	}
-	proxy, err := sidechainProxy(cfg, config.NetworkFromString(h.orch.CurrentNetwork()))
+	node, err := bmmNode(cfg, config.NetworkFromString(h.orch.CurrentNetwork()))
 	if err != nil {
 		return orchestrator.BinaryConfig{}, nil, connect.NewError(connect.CodeUnavailable, err)
 	}
-	return cfg, proxy, nil
-}
-
-// sidechainProxy returns the RPC client for a sidechain. A Core derived chain
-// speaks Core's JSON-RPC authenticated by the cookie its node writes on start;
-// the CUSF chains speak a bare JSON-RPC with no credentials.
-func sidechainProxy(cfg orchestrator.BinaryConfig, network config.Network) (sidechain.SidechainRPCProxy, error) {
-	if !cfg.IsBitcoinCore {
-		return sidechain.NewJSONRPCProxy(cfg.RPCHost(), cfg.Port), nil
-	}
-	dirs, ok := config.DirConfigByName(cfg.Name)
-	if !ok {
-		return nil, fmt.Errorf("no directory config for %s", cfg.Name)
-	}
-	cookie := filepath.Join(dirs.DatadirNetwork(network, ""), ".cookie")
-	return bbc.NewClient(cfg.RPCHost(), cfg.Port, cookie), nil
+	return cfg, node, nil
 }
 
 // sidechainConfig resolves a sidechain binary to its config, with the slot it

--- a/sidechain-orchestrator/api/explorer_handler.go
+++ b/sidechain-orchestrator/api/explorer_handler.go
@@ -75,7 +75,7 @@ type source struct {
 	name  string
 	slot  uint32
 	index *sidechainesplora.Client
-	node  sidechain.SidechainRPCProxy
+	node  sidechain.Node
 	// core is true for a chain built on Bitcoin Core. Such a node speaks
 	// Core's own method names, not the CUSF ones this file reads.
 	core bool
@@ -129,7 +129,7 @@ func (h *ExplorerHandler) sourceFor(chain string) (source, error) {
 			return out, nil
 		}
 	}
-	node, err := sidechainProxy(cfg, network)
+	node, err := sidechainNode(cfg, network)
 	if err != nil {
 		return source{}, connect.NewError(connect.CodeUnavailable, err)
 	}
@@ -308,8 +308,10 @@ func nodeOverview(ctx context.Context, src source) (*pb.GetOverviewResponse, err
 		}
 	}
 
-	if template, err := src.node.GetBlockTemplate(ctx); err == nil && template != nil {
-		out.Mempool.FeesSats = template.FeesSats
+	if bmm, ok := src.node.(sidechain.BMMNode); ok {
+		if template, err := bmm.GetBlockTemplate(ctx); err == nil && template != nil {
+			out.Mempool.FeesSats = template.FeesSats
+		}
 	}
 	// The unconfirmed rows lead the mined ones, the way an explorer reads.
 	if pool, err := sidechain.Mempool(ctx, src.node); err == nil {
@@ -319,8 +321,10 @@ func nodeOverview(ctx context.Context, src source) (*pb.GetOverviewResponse, err
 			out.Recent = out.Recent[:activityListSize]
 		}
 	}
-	if raw, err := src.node.GetPendingWithdrawalBundle(ctx); err == nil {
-		out.PendingBundle = parseBundle(raw)
+	if bundles, ok := src.node.(sidechain.WithdrawalNode); ok {
+		if raw, err := bundles.GetPendingWithdrawalBundle(ctx); err == nil {
+			out.PendingBundle = parseBundle(raw)
+		}
 	}
 	return out, nil
 }
@@ -638,12 +642,16 @@ func (h *ExplorerHandler) GetWithdrawals(
 		return connect.NewResponse(out), nil
 	}
 
-	raw, err := src.node.GetPendingWithdrawalBundle(ctx)
+	bundles, err := withdrawalNode(src.node, src.name)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, err)
+	}
+	raw, err := bundles.GetPendingWithdrawalBundle(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
 	out.Bundle = parseBundle(raw)
-	height, err := src.node.GetLatestFailedWithdrawalBundleHeight(ctx)
+	height, err := bundles.GetLatestFailedWithdrawalBundleHeight(ctx)
 	if err == nil && height >= 0 {
 		out.LastFailedHeight = uint32(height)
 	}

--- a/sidechain-orchestrator/api/explorer_test.go
+++ b/sidechain-orchestrator/api/explorer_test.go
@@ -226,7 +226,7 @@ func TestNodeWalksBackByThePreviousHash(t *testing.T) {
 
 // recordingNode answers a fixed set of RPCs and records what it was asked.
 type recordingNode struct {
-	sidechain.SidechainRPCProxy
+	sidechain.BMMNode
 	count   int64
 	answers map[string]string
 	byHash  map[string]string
@@ -246,6 +246,10 @@ func (n *recordingNode) GetBlockTemplate(context.Context) (*sidechain.BlockTempl
 
 func (n *recordingNode) GetPendingWithdrawalBundle(context.Context) (json.RawMessage, error) {
 	return nil, fmt.Errorf("this node proposes no bundle")
+}
+
+func (n *recordingNode) GetLatestFailedWithdrawalBundleHeight(context.Context) (int64, error) {
+	return 0, fmt.Errorf("this node proposes no bundle")
 }
 
 func (n *recordingNode) CallRaw(_ context.Context, method string, params any) (json.RawMessage, error) {

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,14 +18,6 @@ import (
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bbc"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitassets"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitnames"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/coinshift"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/photon"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/thunder"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/truthcoin"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/zside"
 )
 
 var _ rpc.OrchestratorServiceHandler = new(Handler)
@@ -616,7 +607,7 @@ func (h *Handler) GetSidechainBalance(ctx context.Context, req *connect.Request[
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("sidechain %s is not configured", name))
 	}
 
-	confirmedSats, pendingSats, err := h.fetchSidechainBalance(ctx, req.Msg.Sidechain, cfg.Port)
+	confirmedSats, pendingSats, err := h.fetchSidechainBalance(ctx, req.Msg.Sidechain, cfg)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
@@ -667,81 +658,27 @@ func sidechainNames(binary pb.BinaryType) (name, displayName string, err error) 
 	}
 }
 
-func (h *Handler) fetchSidechainBalance(ctx context.Context, binary pb.BinaryType, port int) (confirmedSats, pendingSats int64, err error) {
-	switch binary {
-	case pb.BinaryType_BINARY_TYPE_THUNDER:
-		if h.thunderBalance != nil {
-			total, available, err := h.thunderBalance(ctx)
-			if err != nil {
-				return 0, 0, err
-			}
-			confirmed, pending := balanceFromTotalAvailable(total, available)
-			return confirmed, pending, nil
-		}
-		resp, err := thunder.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_ZSIDE:
-		resp, err := zside.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_BITNAMES:
-		resp, err := bitnames.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_BITASSETS:
-		resp, err := bitassets.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_TRUTHCOIN:
-		resp, err := truthcoin.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_PHOTON:
-		resp, err := photon.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_COINSHIFT:
-		resp, err := coinshift.NewClient("localhost", port).Balance(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		confirmed, pending := balanceFromTotalAvailable(resp.TotalSats, resp.AvailableSats)
-		return confirmed, pending, nil
-	case pb.BinaryType_BINARY_TYPE_BBC:
-		total, available, err := bbc.NewClient("localhost", port, h.bbcCookiePath()).GetBalance(ctx)
+func (h *Handler) fetchSidechainBalance(ctx context.Context, binary pb.BinaryType, cfg orchestrator.BinaryConfig) (confirmedSats, pendingSats int64, err error) {
+	// A thunder light wallet reads an index, not a local node.
+	if binary == pb.BinaryType_BINARY_TYPE_THUNDER && h.thunderBalance != nil {
+		total, available, err := h.thunderBalance(ctx)
 		if err != nil {
 			return 0, 0, err
 		}
 		confirmed, pending := balanceFromTotalAvailable(total, available)
 		return confirmed, pending, nil
-	default:
-		return 0, 0, fmt.Errorf("unsupported sidechain binary type: %s", binary)
 	}
-}
 
-// bbcCookiePath is the .cookie the node writes into its datadir.
-func (h *Handler) bbcCookiePath() string {
-	network := config.NetworkFromString(h.orch.CurrentNetwork())
-	return filepath.Join(config.BbcDirs.DatadirNetwork(network, ""), ".cookie")
+	node, err := sidechainNode(cfg, config.NetworkFromString(h.orch.CurrentNetwork()))
+	if err != nil {
+		return 0, 0, err
+	}
+	total, available, err := node.GetBalance(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	confirmed, pending := balanceFromTotalAvailable(total, available)
+	return confirmed, pending, nil
 }
 
 // mempoolDelta is what the sidechain mempool does to this wallet. A chain that
@@ -752,7 +689,7 @@ func (h *Handler) mempoolDelta(ctx context.Context, cfg orchestrator.BinaryConfi
 	if cfg.IsBitcoinCore || h.orch.NodeMode() == orchestrator.NodeModeLight {
 		return sidechain.MempoolDelta{}
 	}
-	node, err := sidechainProxy(cfg, config.NetworkFromString(h.orch.CurrentNetwork()))
+	node, err := sidechainNode(cfg, config.NetworkFromString(h.orch.CurrentNetwork()))
 	if err != nil {
 		return sidechain.MempoolDelta{}
 	}

--- a/sidechain-orchestrator/api/sidechain_node.go
+++ b/sidechain-orchestrator/api/sidechain_node.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bbc"
+)
+
+// sidechainNode builds the RPC client for a sidechain. A Core derived chain
+// speaks Core's JSON-RPC authenticated by the cookie its node writes on start;
+// the CUSF chains speak a bare JSON-RPC with no credentials.
+func sidechainNode(cfg orchestrator.BinaryConfig, network config.Network) (sidechain.Node, error) {
+	if !cfg.IsBitcoinCore {
+		return sidechain.NewJSONRPCProxy(cfg.RPCHost(), cfg.Port), nil
+	}
+	dirs, ok := config.DirConfigByName(cfg.Name)
+	if !ok {
+		return nil, fmt.Errorf("no directory config for %s", cfg.Name)
+	}
+	cookie := filepath.Join(dirs.DatadirNetwork(network, ""), ".cookie")
+	return bbc.NewClient(cfg.RPCHost(), cfg.Port, cookie), nil
+}
+
+// bmmNode is the same client, for a chain whose blocks the BMM engine produces.
+// A chain that mines its own blocks is refused here rather than deeper down,
+// where the node's own error text says nothing about why.
+func bmmNode(cfg orchestrator.BinaryConfig, network config.Network) (sidechain.BMMNode, error) {
+	node, err := sidechainNode(cfg, network)
+	if err != nil {
+		return nil, err
+	}
+	bmm, ok := node.(sidechain.BMMNode)
+	if !ok {
+		return nil, fmt.Errorf("%s produces its own blocks: the BMM engine does not drive it", cfg.DisplayName)
+	}
+	return bmm, nil
+}
+
+// withdrawalNode is the same client, for a chain that proposes withdrawal
+// bundles. A chain that settles withdrawals elsewhere is refused here.
+func withdrawalNode(node sidechain.Node, displayName string) (sidechain.WithdrawalNode, error) {
+	bundles, ok := node.(sidechain.WithdrawalNode)
+	if !ok {
+		return nil, fmt.Errorf("%s proposes no withdrawal bundle: it settles withdrawals elsewhere", displayName)
+	}
+	return bundles, nil
+}

--- a/sidechain-orchestrator/api/sidechain_node_test.go
+++ b/sidechain-orchestrator/api/sidechain_node_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+// hostPort splits a test server's URL into the two fields a BinaryConfig holds.
+func hostPort(t *testing.T, srv *httptest.Server) (string, int) {
+	t.Helper()
+	parsed, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	return host, port
+}
+
+// A CUSF chain answers every interface, so nothing about it is optional.
+func TestCusfChainSatisfiesEveryInterface(t *testing.T) {
+	node, err := sidechainNode(orchestrator.BinaryConfig{Name: "thunder", Port: 6009}, config.NetworkRegtest)
+	require.NoError(t, err)
+
+	_, drivesBMM := node.(sidechain.BMMNode)
+	assert.True(t, drivesBMM)
+	_, proposesBundles := node.(sidechain.WithdrawalNode)
+	assert.True(t, proposesBundles)
+}
+
+// A Core fork answers what it answers. Bbc drives BMM and settles withdrawals
+// elsewhere, so the caller reads that from the type.
+func TestCoreForkAnswersOnlyWhatItDrives(t *testing.T) {
+	cfg := orchestrator.BinaryConfig{Name: "bbc", DisplayName: "Big Block Covenant", Port: 18743, IsBitcoinCore: true}
+	node, err := sidechainNode(cfg, config.NetworkRegtest)
+	require.NoError(t, err)
+
+	bmm, err := bmmNode(cfg, config.NetworkRegtest)
+	require.NoError(t, err)
+	assert.NotNil(t, bmm)
+
+	_, err = withdrawalNode(node, cfg.DisplayName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Big Block Covenant")
+	assert.Contains(t, err.Error(), "proposes no withdrawal bundle")
+}
+
+// A chain with no directory config names itself in the failure, rather than
+// dialling a port that belongs to something else.
+func TestCoreForkWithoutDirsFails(t *testing.T) {
+	_, err := sidechainNode(orchestrator.BinaryConfig{Name: "nosuchchain", IsBitcoinCore: true}, config.NetworkRegtest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nosuchchain")
+}
+
+// One balance path serves every chain. It reads the node the config names, and
+// counts what is not spendable as pending.
+func TestBalanceReadsTheNodeTheConfigNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"total_sats":300,"available_sats":125}}`))
+	}))
+	defer srv.Close()
+	host, port := hostPort(t, srv)
+
+	h := &Handler{orch: &orchestrator.Orchestrator{Network: string(config.NetworkRegtest)}}
+	confirmed, pending, err := h.fetchSidechainBalance(
+		context.Background(),
+		pb.BinaryType_BINARY_TYPE_BITNAMES,
+		orchestrator.BinaryConfig{Name: "bitnames", Host: host, Port: port},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(125), confirmed)
+	assert.Equal(t, int64(175), pending)
+}
+
+// Thunder light mode starts no node, so the balance comes from the wallet the
+// thunder RPCs read and nothing dials a port.
+func TestThunderLightBalanceNeverDialsANode(t *testing.T) {
+	h := &Handler{
+		orch: &orchestrator.Orchestrator{Network: string(config.NetworkRegtest)},
+		thunderBalance: func(context.Context) (int64, int64, error) {
+			return 900, 400, nil
+		},
+	}
+	confirmed, pending, err := h.fetchSidechainBalance(
+		context.Background(),
+		pb.BinaryType_BINARY_TYPE_THUNDER,
+		// A port nothing listens on: a dial here fails the test.
+		orchestrator.BinaryConfig{Name: "thunder", Host: "127.0.0.1", Port: 1},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(400), confirmed)
+	assert.Equal(t, int64(500), pending)
+}

--- a/sidechain-orchestrator/rpc/client.go
+++ b/sidechain-orchestrator/rpc/client.go
@@ -7,18 +7,26 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 )
 
 // Client is a minimal JSON-RPC 2.0 HTTP client.
 type Client struct {
 	url    string
+	http   *http.Client
 	nextID atomic.Int64
 }
+
+// callTimeout bounds one RPC. A node that accepts the connection and then
+// answers nothing would otherwise hold the caller's goroutine for as long as
+// the node runs.
+const callTimeout = 30 * time.Second
 
 // New creates a JSON-RPC client targeting the given host and port.
 func New(host string, port int) *Client {
 	return &Client{
-		url: fmt.Sprintf("http://%s:%d", host, port),
+		url:  fmt.Sprintf("http://%s:%d", host, port),
+		http: &http.Client{Timeout: callTimeout},
 	}
 }
 
@@ -66,7 +74,7 @@ func (c *Client) Call(ctx context.Context, method string, params any, out any) e
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := c.http.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("http post: %w", err)
 	}
@@ -110,7 +118,7 @@ func (c *Client) CallRaw(ctx context.Context, method string, params any) (json.R
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := c.http.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("http post: %w", err)
 	}

--- a/sidechain-orchestrator/rpc/client_test.go
+++ b/sidechain-orchestrator/rpc/client_test.go
@@ -1,0 +1,61 @@
+package rpc
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func clientFor(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	parsed, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	return New(host, port)
+}
+
+// A node that accepts the connection and then answers nothing must not hold the
+// caller. The client carries its own deadline, so a caller with no context
+// deadline still returns.
+func TestCallStopsOnASilentNode(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+	}()
+
+	client := clientFor(t, srv)
+	client.http.Timeout = 100 * time.Millisecond
+
+	err := client.Call(context.Background(), "balance", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http post")
+}
+
+func TestCallReadsTheResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"total_sats":7}}`))
+	}))
+	defer srv.Close()
+
+	var out struct {
+		TotalSats int64 `json:"total_sats"`
+	}
+	require.NoError(t, clientFor(t, srv).Call(context.Background(), "balance", nil, &out))
+	assert.Equal(t, int64(7), out.TotalSats)
+}

--- a/sidechain-orchestrator/sidechain/bbc/client.go
+++ b/sidechain-orchestrator/sidechain/bbc/client.go
@@ -1,7 +1,8 @@
-// Package bbc is the RPC client for the Bbc sidechain, a
-// Bitcoin Core fork carrying the covenant opcodes. It speaks Core's JSON-RPC
-// with cookie auth, unlike the CUSF sidechains, and adds the blind-merge-mining
-// methods the BMM engine drives.
+// Package bbc is the RPC client for the Bbc sidechain, a Bitcoin Core fork
+// carrying the covenant opcodes. It speaks Core's JSON-RPC with cookie auth,
+// unlike the CUSF sidechains, and adds the blind-merge-mining methods the BMM
+// engine drives. Bbc settles withdrawals elsewhere, so it is no
+// sidechain.WithdrawalNode.
 package bbc
 
 import (
@@ -18,7 +19,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 )
 
-var _ sidechain.SidechainRPCProxy = (*Client)(nil)
+var _ sidechain.BMMNode = (*Client)(nil)
 
 // Client talks to an Bbc node.
 type Client struct {
@@ -161,14 +162,6 @@ func (c *Client) GetNewAddress(ctx context.Context) (string, error) {
 	return unmarshalWallet[string](c, ctx, "getnewaddress", nil)
 }
 
-func (c *Client) GetWalletUtxos(ctx context.Context) (json.RawMessage, error) {
-	return c.walletCall(ctx, "listunspent", nil)
-}
-
-func (c *Client) ListUtxos(ctx context.Context) (json.RawMessage, error) {
-	return c.walletCall(ctx, "listunspent", nil)
-}
-
 // ListUnspent returns the wallet's UTXOs.
 func (c *Client) ListUnspent(ctx context.Context) ([]Unspent, error) {
 	return unmarshalWallet[[]Unspent](c, ctx, "listunspent", nil)
@@ -184,12 +177,6 @@ func (c *Client) SendToAddress(ctx context.Context, address string, amountSats i
 	amountBTC := float64(amountSats) / 1e8
 	return unmarshalWallet[string](c, ctx, "sendtoaddress",
 		[]any{address, amountBTC, "", "", subtractFeeFromAmount})
-}
-
-// Transfer sends amountSats to address. Core sets the fee from its own
-// estimator, so feeSats is ignored rather than applied as something it is not.
-func (c *Client) Transfer(ctx context.Context, address string, amountSats, _ int64) (string, error) {
-	return c.SendToAddress(ctx, address, amountSats, false)
 }
 
 // FallbackFeeRate is what a chain with no fee history estimates at, in BTC/kvB.
@@ -280,31 +267,6 @@ func (c *Client) GetBmmCommitment(ctx context.Context, mainchainBlockHash string
 	}
 	return commitment, nil
 }
-
-// Mine is how the CUSF chains produce a block on demand. Bbc blocks are
-// blind merge mined, which needs a mainchain transaction this node cannot make.
-func (c *Client) Mine(context.Context, int64) (json.RawMessage, error) {
-	return nil, fmt.Errorf("bbc blocks are blind merge mined: use the BMM service")
-}
-
-// ---------------------------------------------------------------------------
-// Withdrawals — not yet wired into consensus. Reporting "none" would be
-// indistinguishable from a working chain with nothing pending.
-// ---------------------------------------------------------------------------
-
-func (c *Client) Withdraw(context.Context, string, int64, int64, int64) (string, error) {
-	return "", errWithdrawalsUnwired
-}
-
-func (c *Client) GetPendingWithdrawalBundle(context.Context) (json.RawMessage, error) {
-	return nil, errWithdrawalsUnwired
-}
-
-func (c *Client) GetLatestFailedWithdrawalBundleHeight(context.Context) (int64, error) {
-	return 0, errWithdrawalsUnwired
-}
-
-var errWithdrawalsUnwired = fmt.Errorf("bbc withdrawals are not wired into consensus yet")
 
 // ---------------------------------------------------------------------------
 // Lifecycle

--- a/sidechain-orchestrator/sidechain/bbc/client_test.go
+++ b/sidechain-orchestrator/sidechain/bbc/client_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 )
 
 type recordedRequest struct {
@@ -124,10 +126,16 @@ func TestUnauthenticatedResponseReportsHTTPStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "401")
 }
 
-func TestWithdrawalsFailLoudly(t *testing.T) {
-	client := clientFor(t, httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})), "")
-	_, err := client.Withdraw(context.Background(), "bc1qexample", 1, 1, 1)
-	require.ErrorIs(t, err, errWithdrawalsUnwired)
+// The BMM engine drives Bbc blocks, but Bbc settles withdrawals elsewhere. The
+// explorer reads that from the type rather than from a stub error.
+func TestBbcDrivesBmmButProposesNoBundle(t *testing.T) {
+	var node sidechain.Node = NewClient("127.0.0.1", 1, "")
+
+	_, drivesBMM := node.(sidechain.BMMNode)
+	assert.True(t, drivesBMM)
+
+	_, proposesBundles := node.(sidechain.WithdrawalNode)
+	assert.False(t, proposesBundles, "bbc withdrawals are not wired into consensus")
 }
 
 // Regtest answers estimatesmartfee with errors and no rate; a zero rate builds

--- a/sidechain-orchestrator/sidechain/bitassets/handler.go
+++ b/sidechain-orchestrator/sidechain/bitassets/handler.go
@@ -25,7 +25,7 @@ func NewHandler(proxy *sidechain.JSONRPCProxy) *Handler {
 	return &Handler{proxy: proxy}
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	// BitAssets uses "bitcoin_balance" instead of "balance"

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -25,7 +25,7 @@ func NewHandler(proxy *sidechain.JSONRPCProxy) *Handler {
 	return &Handler{proxy: proxy}
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	total, available, err := h.proxy.GetBalance(ctx)

--- a/sidechain-orchestrator/sidechain/coinshift/handler.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler.go
@@ -25,7 +25,7 @@ func NewHandler(proxy *sidechain.JSONRPCProxy) *Handler {
 	return &Handler{proxy: proxy}
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	total, available, err := h.proxy.GetBalance(ctx)

--- a/sidechain-orchestrator/sidechain/jsonrpc_proxy.go
+++ b/sidechain-orchestrator/sidechain/jsonrpc_proxy.go
@@ -8,14 +8,18 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
 )
 
-// JSONRPCProxy implements SidechainRPCProxy by forwarding calls to a sidechain
-// binary's JSON-RPC endpoint. All sidechains share the same JSON-RPC protocol,
-// so this single implementation works for thunder, bitassets, bitnames, etc.
+// JSONRPCProxy forwards calls to a CUSF sidechain binary's JSON-RPC endpoint.
+// Those chains share one JSON-RPC protocol, so this single implementation works
+// for thunder, bitassets, bitnames and the rest.
 type JSONRPCProxy struct {
 	Client *rpc.Client
 }
 
-var _ SidechainRPCProxy = (*JSONRPCProxy)(nil)
+var (
+	_ Node           = (*JSONRPCProxy)(nil)
+	_ BMMNode        = (*JSONRPCProxy)(nil)
+	_ WithdrawalNode = (*JSONRPCProxy)(nil)
+)
 
 // NewJSONRPCProxy creates a proxy targeting the given host:port.
 func NewJSONRPCProxy(host string, port int) *JSONRPCProxy {

--- a/sidechain-orchestrator/sidechain/mempool.go
+++ b/sidechain-orchestrator/sidechain/mempool.go
@@ -38,7 +38,7 @@ type MempoolTx struct {
 // list_mempool answers it whole, with a txid per transaction. A node without
 // that method answers the block template instead, which holds the same
 // transactions and no txid.
-func Mempool(ctx context.Context, node SidechainRPCProxy) ([]MempoolTx, error) {
+func Mempool(ctx context.Context, node Node) ([]MempoolTx, error) {
 	if txs, ok := listMempool(ctx, node); ok {
 		return txs, nil
 	}
@@ -226,7 +226,7 @@ func (w withdrawalAmounts) total() int64 {
 
 // listMempool reads the node's own mempool listing. It answers false on a
 // node that serves no such method.
-func listMempool(ctx context.Context, node SidechainRPCProxy) ([]MempoolTx, bool) {
+func listMempool(ctx context.Context, node Node) ([]MempoolTx, bool) {
 	raw, err := node.CallRaw(ctx, "list_mempool", nil)
 	if err != nil || len(raw) == 0 || string(raw) == "null" {
 		return nil, false
@@ -252,9 +252,14 @@ func listMempool(ctx context.Context, node SidechainRPCProxy) ([]MempoolTx, bool
 }
 
 // templateMempool reads the block the node would mine next. Its body is the
-// set the node holds, and it names no txid.
-func templateMempool(ctx context.Context, node SidechainRPCProxy) ([]MempoolTx, error) {
-	template, err := node.GetBlockTemplate(ctx)
+// set the node holds, and it names no txid. A chain the BMM engine does not
+// drive builds no template, so it answers nothing here.
+func templateMempool(ctx context.Context, node Node) ([]MempoolTx, error) {
+	bmm, ok := node.(BMMNode)
+	if !ok {
+		return nil, nil
+	}
+	template, err := bmm.GetBlockTemplate(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("read the block template: %w", err)
 	}
@@ -286,7 +291,7 @@ func templateMempool(ctx context.Context, node SidechainRPCProxy) ([]MempoolTx, 
 //
 // Only a node that names its mempool txids contributes rows: a coin with no
 // outpoint is not a coin. The balance counts those payments regardless.
-func WithMempoolUTXOs(ctx context.Context, node SidechainRPCProxy, confirmed json.RawMessage) json.RawMessage {
+func WithMempoolUTXOs(ctx context.Context, node Node, confirmed json.RawMessage) json.RawMessage {
 	owned, err := WalletAddresses(ctx, node)
 	if err != nil || len(owned) == 0 {
 		return confirmed
@@ -392,7 +397,7 @@ func mempoolUTXORows(txs []MempoolTx) []json.RawMessage {
 }
 
 // WalletAddresses reads the addresses a node's own wallet holds.
-func WalletAddresses(ctx context.Context, node SidechainRPCProxy) (map[string]bool, error) {
+func WalletAddresses(ctx context.Context, node Node) (map[string]bool, error) {
 	raw, err := node.CallRaw(ctx, "get_wallet_addresses", nil)
 	if err != nil {
 		return nil, fmt.Errorf("read the wallet addresses: %w", err)
@@ -411,8 +416,8 @@ func WalletAddresses(ctx context.Context, node SidechainRPCProxy) (map[string]bo
 // OurCoins maps each coin a node's wallet holds to what it holds, keyed
 // "txid:vout". A caller reads it to know what an unconfirmed transaction
 // spends of ours.
-func OurCoins(ctx context.Context, node SidechainRPCProxy) (map[string]int64, error) {
-	raw, err := node.GetWalletUtxos(ctx)
+func OurCoins(ctx context.Context, node Node) (map[string]int64, error) {
+	raw, err := node.CallRaw(ctx, "get_wallet_utxos", nil)
 	if err != nil {
 		return nil, fmt.Errorf("read the wallet coins: %w", err)
 	}

--- a/sidechain-orchestrator/sidechain/mempool_test.go
+++ b/sidechain-orchestrator/sidechain/mempool_test.go
@@ -12,20 +12,12 @@ import (
 
 // fakeNode answers the two feeds a mempool read can use.
 type fakeNode struct {
-	SidechainRPCProxy
+	BMMNode
 	mempool   string
 	template  string
 	addresses string
 	utxos     string
 	called    []string
-}
-
-func (n *fakeNode) GetWalletUtxos(_ context.Context) (json.RawMessage, error) {
-	n.called = append(n.called, "get_wallet_utxos")
-	if n.utxos == "" {
-		return json.RawMessage("[]"), nil
-	}
-	return json.RawMessage(n.utxos), nil
 }
 
 func (n *fakeNode) CallRaw(_ context.Context, method string, _ any) (json.RawMessage, error) {
@@ -35,6 +27,12 @@ func (n *fakeNode) CallRaw(_ context.Context, method string, _ any) (json.RawMes
 	}
 	if method == "get_wallet_addresses" && n.addresses != "" {
 		return json.RawMessage(n.addresses), nil
+	}
+	if method == "get_wallet_utxos" {
+		if n.utxos == "" {
+			return json.RawMessage("[]"), nil
+		}
+		return json.RawMessage(n.utxos), nil
 	}
 	return nil, fmt.Errorf("this node serves no %s", method)
 }

--- a/sidechain-orchestrator/sidechain/photon/handler.go
+++ b/sidechain-orchestrator/sidechain/photon/handler.go
@@ -25,7 +25,7 @@ func NewHandler(proxy *sidechain.JSONRPCProxy) *Handler {
 	return &Handler{proxy: proxy}
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	total, available, err := h.proxy.GetBalance(ctx)

--- a/sidechain-orchestrator/sidechain/proxy.go
+++ b/sidechain-orchestrator/sidechain/proxy.go
@@ -14,37 +14,52 @@ type BlockTemplate struct {
 	FeesSats     int64           `json:"fees_sats"`
 }
 
-// SidechainRPCProxy defines the common operations shared by all sidechain binaries.
-// Each sidechain handler embeds a proxy implementation and adds sidechain-specific methods.
-type SidechainRPCProxy interface {
-	// Wallet
+// Node is every operation the orchestrator asks of a sidechain, whatever the
+// chain is built on. A new sidechain satisfies this and nothing more.
+type Node interface {
+	// GetBalance reports the wallet total and the part of it that is spendable.
 	GetBalance(ctx context.Context) (totalSats, availableSats int64, err error)
+
+	// GetNewAddress returns a fresh address on the sidechain.
 	GetNewAddress(ctx context.Context) (string, error)
-	GetWalletUtxos(ctx context.Context) (json.RawMessage, error)
 
-	// Chain
+	// GetBlockCount returns the height of the chain tip.
 	GetBlockCount(ctx context.Context) (int64, error)
-	ListUtxos(ctx context.Context) (json.RawMessage, error)
 
-	// Transfers
-	Transfer(ctx context.Context, address string, amountSats, feeSats int64) (txid string, err error)
-	Withdraw(ctx context.Context, address string, amountSats, sideFeeSats, mainFeeSats int64) (txid string, err error)
-
-	// Mining
-	Mine(ctx context.Context, feeSats int64) (json.RawMessage, error)
-	GetBlockTemplate(ctx context.Context) (*BlockTemplate, error)
-	ConnectBlock(ctx context.Context, block json.RawMessage, mainBlockHash string) (bool, error)
-	GetBmmInclusions(ctx context.Context, criticalHash string) ([]string, error)
-
-	// Withdrawal bundles
-	GetPendingWithdrawalBundle(ctx context.Context) (json.RawMessage, error)
-	GetLatestFailedWithdrawalBundleHeight(ctx context.Context) (int64, error)
-
-	// Lifecycle
+	// Stop asks the node to shut down.
 	Stop(ctx context.Context) error
 
-	// Raw passthrough for debug console
+	// CallRaw sends one JSON-RPC call and returns the undecoded result.
 	CallRaw(ctx context.Context, method string, params any) (json.RawMessage, error)
+}
+
+// BMMNode is a sidechain whose blocks the orchestrator's BMM engine produces.
+// A chain that mines its own blocks is a Node and not a BMMNode.
+type BMMNode interface {
+	Node
+
+	// GetBlockTemplate returns the block the node builds next.
+	GetBlockTemplate(ctx context.Context) (*BlockTemplate, error)
+
+	// ConnectBlock hands a won block back to the node, with the mainchain block
+	// that carried the bid.
+	ConnectBlock(ctx context.Context, block json.RawMessage, mainBlockHash string) (bool, error)
+
+	// GetBmmInclusions returns the mainchain blocks that carry a critical hash.
+	GetBmmInclusions(ctx context.Context, criticalHash string) ([]string, error)
+}
+
+// WithdrawalNode is a sidechain that proposes withdrawal bundles. A chain that
+// settles withdrawals elsewhere is a Node and not a WithdrawalNode.
+type WithdrawalNode interface {
+	Node
+
+	// GetPendingWithdrawalBundle returns the bundle the node proposes, if any.
+	GetPendingWithdrawalBundle(ctx context.Context) (json.RawMessage, error)
+
+	// GetLatestFailedWithdrawalBundleHeight returns the height of the last
+	// bundle the mainchain refused.
+	GetLatestFailedWithdrawalBundleHeight(ctx context.Context) (int64, error)
 }
 
 // CoreWalletName is the wallet a Bitcoin Core derived sidechain loads. Core

--- a/sidechain-orchestrator/sidechain/thunder/handler.go
+++ b/sidechain-orchestrator/sidechain/thunder/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) backend(ctx context.Context) (WalletBackend, error) {
 	return backend, nil
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	backend, err := h.backend(ctx)

--- a/sidechain-orchestrator/sidechain/truthcoin/handler.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler.go
@@ -25,7 +25,7 @@ func NewHandler(proxy *sidechain.JSONRPCProxy) *Handler {
 	return &Handler{proxy: proxy}
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	// Truthcoin uses "bitcoin_balance" instead of "balance"

--- a/sidechain-orchestrator/sidechain/zside/handler.go
+++ b/sidechain-orchestrator/sidechain/zside/handler.go
@@ -25,7 +25,7 @@ func NewHandler(proxy *sidechain.JSONRPCProxy) *Handler {
 	return &Handler{proxy: proxy}
 }
 
-// --- Common SidechainRPCProxy methods ---
+// --- Common Node methods ---
 
 func (h *Handler) GetBalance(ctx context.Context, req *connect.Request[pb.GetBalanceRequest]) (*connect.Response[pb.GetBalanceResponse], error) {
 	// ZSide has a custom balance response with shielded and transparent pools

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.328
+version: 1.0.329
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.199
+version: 1.0.200
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.325
+version: 1.0.326
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
One 15-method interface made every chain write stubs for what it does not do.

The interface splits in three. Node is what every chain answers. BMMNode is a chain the BMM engine drives. WithdrawalNode proposes withdrawal bundles. The explorer and the BMM engine read the type instead of a stub error.