### PR TITLE
explorer: read the deposit shape a node sends

### DIFF
--- a/sidechain-orchestrator/api/explorer_deposit_test.go
+++ b/sidechain-orchestrator/api/explorer_deposit_test.go
@@ -9,40 +9,40 @@ import (
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
 )
 
-// A node writes a deposit as a pair: the mainchain outpoint, then the
-// sidechain output it created. This is the shape a live thunder node sends.
-func TestBlockIndexReadsTheDepositPair(t *testing.T) {
-	raw := json.RawMessage(`{
-		"txs": [],
-		"deposits": [
-			[{"Deposit": "7215d16ed52a4f26b4ed5cbef066dd2aedc9336ad5c2069942f1e36c9973b0c4:0"},
-			 {"address": "hbpj5v1raA6qHnJKjab8Wh9NDW2", "content": {"Value": 12300}}],
-			[{"Deposit": "d9f0a85ccd0205a5fee36c6afad63a8704c5b0339f2e8b8cb8431d5d458e3e61:0"},
-			 {"address": "2fPNxpAMPdBL6KyzYt7ZuzvgPkUM", "content": {"Value": 200000000}}]
-		],
-		"bundle_spends": []
-	}`)
+// A node names a deposit's two halves: the mainchain outpoint that paid, and
+// the sidechain output it created. These bytes are one get_block_index reply,
+// copied from a thunder node on alphanet.
+func TestBlockIndexReadsADeposit(t *testing.T) {
+	raw := json.RawMessage(`{"txs":[],"deposits":[{"outpoint":{"Deposit":"cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc:0"},"output":{"address":"rQyAxKGtdbyiEM852yMtoRWfgVD","content":{"Value":54300}}}],"bundle_spends":[]}`)
 
 	var index nodeBlockIndex
 	if err := json.Unmarshal(raw, &index); err != nil {
 		t.Fatalf("read the block index: %v", err)
 	}
-	if got := len(index.Deposits); got != 2 {
-		t.Fatalf("the block holds %d deposits, want 2", got)
+	if got := len(index.Deposits); got != 1 {
+		t.Fatalf("the block holds %d deposits, want 1", got)
 	}
-	first := index.Deposits[0]
-	if first.Address != "hbpj5v1raA6qHnJKjab8Wh9NDW2" {
-		t.Errorf("the first deposit paid %s", first.Address)
+	only := index.Deposits[0]
+	if only.Address != "rQyAxKGtdbyiEM852yMtoRWfgVD" {
+		t.Errorf("the deposit paid %s", only.Address)
 	}
-	if first.ValueSats != 12300 {
-		t.Errorf("the first deposit is worth %d sats, want 12300", first.ValueSats)
+	if only.ValueSats != 54300 {
+		t.Errorf("the deposit is worth %d sats, want 54300", only.ValueSats)
 	}
-	want := "7215d16ed52a4f26b4ed5cbef066dd2aedc9336ad5c2069942f1e36c9973b0c4"
-	if got := depositTxid(first.Outpoint); got != want {
-		t.Errorf("the first outpoint names %s, want %s", got, want)
+	want := "cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc"
+	if got := depositTxid(only.Outpoint); got != want {
+		t.Errorf("the outpoint names %s, want %s", got, want)
 	}
-	if index.Deposits[1].ValueSats != 200000000 {
-		t.Errorf("the second deposit is worth %d sats", index.Deposits[1].ValueSats)
+}
+
+// The reader refuses a deposit it cannot name, rather than reading it as an
+// empty one. A block whose deposits all read empty looks like a block with no
+// deposits, which is how a shape change hides.
+func TestDepositWithNoOutpointIsRefused(t *testing.T) {
+	var d nodeDeposit
+	err := d.UnmarshalJSON([]byte(`{"output":{"address":"sc1","content":{"Value":1}}}`))
+	if err == nil {
+		t.Fatal("the read passed, and a deposit with no outpoint must fail")
 	}
 }
 
@@ -59,8 +59,8 @@ func TestNodeBlockReportsWhatWasDeposited(t *testing.T) {
 		},
 		index: map[string]string{
 			"aa": `{"txs":[],"deposits":[
-				[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}],
-				[{"Deposit":"d9f0a85c:0"},{"address":"sc2","content":{"Value":200000000}}]
+				{"outpoint":{"Deposit":"7215d16e:0"},"output":{"address":"sc1","content":{"Value":12300}}},
+				{"outpoint":{"Deposit":"d9f0a85c:0"},"output":{"address":"sc2","content":{"Value":200000000}}}
 			]}`,
 		},
 	}
@@ -133,7 +133,7 @@ func TestOverviewWalksPastTheBlockWindowForRows(t *testing.T) {
 		node.index[hash] = `{"txs":[],"deposits":[]}`
 	}
 	node.index["b0"] = `{"txs":[],"deposits":[
-		[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+		{"outpoint":{"Deposit":"7215d16e:0"},"output":{"address":"sc1","content":{"Value":12300}}}
 	]}`
 
 	src := source{name: "thunder", node: node, cache: newBlockCache()}
@@ -226,7 +226,7 @@ func TestNodeBlockCachesNoIncompleteRead(t *testing.T) {
 	}
 
 	node.index["aa"] = `{"txs":[],"deposits":[
-		[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+		{"outpoint":{"Deposit":"7215d16e:0"},"output":{"address":"sc1","content":{"Value":12300}}}
 	]}`
 	_, activity, err := nodeBlock(ctx, src, "aa", 0)
 	if err != nil {
@@ -289,7 +289,7 @@ func TestOverviewResolvesOnlyTheBlocksThePageUses(t *testing.T) {
 		node.index[hash] = `{"txs":[],"deposits":[]}`
 	}
 	node.index["b0"] = `{"txs":[],"deposits":[
-		[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+		{"outpoint":{"Deposit":"7215d16e:0"},"output":{"address":"sc1","content":{"Value":12300}}}
 	]}`
 
 	var asked []string
@@ -328,7 +328,7 @@ func TestNodeBlockRestampsAHeightTheNodeNeverNamed(t *testing.T) {
 			"aa": `{"header":{"merkle_root":"m1","prev_main_hash":"x1"},"body":{"transactions":[]}}`,
 		},
 		index: map[string]string{"aa": `{"txs":[],"deposits":[
-			[{"Deposit":"7215d16e:0"},{"address":"sc1","content":{"Value":12300}}]
+			{"outpoint":{"Deposit":"7215d16e:0"},"output":{"address":"sc1","content":{"Value":12300}}}
 		]}`},
 	}
 	src := source{name: "thunder", node: node, cache: newBlockCache()}

--- a/sidechain-orchestrator/api/explorer_handler.go
+++ b/sidechain-orchestrator/api/explorer_handler.go
@@ -788,32 +788,29 @@ type nodeDeposit struct {
 	ValueSats int64
 }
 
-// UnmarshalJSON reads the pair a node writes: the mainchain outpoint, then the
-// sidechain output it created.
+// UnmarshalJSON reads what a node writes: the mainchain outpoint that paid,
+// and the sidechain output it created.
 func (d *nodeDeposit) UnmarshalJSON(raw []byte) error {
-	var pair []json.RawMessage
-	if err := json.Unmarshal(raw, &pair); err != nil {
-		return fmt.Errorf("read the deposit pair: %w", err)
+	var deposit struct {
+		Outpoint struct {
+			Deposit string `json:"Deposit"`
+		} `json:"outpoint"`
+		Output struct {
+			Address string          `json:"address"`
+			Content json.RawMessage `json:"content"`
+		} `json:"output"`
 	}
-	if len(pair) != 2 {
-		return fmt.Errorf("a deposit holds an outpoint and an output, got %d parts", len(pair))
+	if err := json.Unmarshal(raw, &deposit); err != nil {
+		return fmt.Errorf("read the deposit: %w", err)
 	}
-	var outpoint struct {
-		Deposit string `json:"Deposit"`
+	// A payload that decodes but names no outpoint is a shape this reader does
+	// not know. Reading it as an empty deposit hides every deposit in the block.
+	if deposit.Outpoint.Deposit == "" {
+		return fmt.Errorf("a deposit names no mainchain outpoint")
 	}
-	if err := json.Unmarshal(pair[0], &outpoint); err != nil {
-		return fmt.Errorf("read the deposit outpoint: %w", err)
-	}
-	var output struct {
-		Address string          `json:"address"`
-		Content json.RawMessage `json:"content"`
-	}
-	if err := json.Unmarshal(pair[1], &output); err != nil {
-		return fmt.Errorf("read the deposit output: %w", err)
-	}
-	d.Outpoint = outpoint.Deposit
-	d.Address = output.Address
-	d.ValueSats = contentValue(output.Content)
+	d.Outpoint = deposit.Outpoint.Deposit
+	d.Address = deposit.Output.Address
+	d.ValueSats = contentValue(deposit.Output.Content)
 	return nil
 }
 


### PR DESCRIPTION
The block explorer failed on every block that carries a deposit, with "read the deposit pair: json: cannot unmarshal object into Go value of type []json.RawMessage". A node writes a deposit as an object with named outpoint and output fields; the reader expected a two-element array.

Tests covered this already, but the fixture carried the array shape and its comment claimed that was what a live node sends. So the tests passed while the app broke. The fixtures now carry one real get_block_index reply, copied from a thunder node on alphanet.

A deposit that decodes but names no outpoint is refused rather than read as an empty one, so the next shape change fails loudly instead of hiding every deposit in the block.