### PR TITLE
explorer: read both deposit shapes a node sends

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.327
+version: 1.0.328
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.327
+version: 1.0.328
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.198
+version: 0.2.199
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.200
+version: 1.0.201
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/api/explorer_deposit_test.go
+++ b/sidechain-orchestrator/api/explorer_deposit_test.go
@@ -9,29 +9,35 @@ import (
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/explorer/v1"
 )
 
-// A node names a deposit's two halves: the mainchain outpoint that paid, and
-// the sidechain output it created. These bytes are one get_block_index reply,
-// copied from a thunder node on alphanet.
-func TestBlockIndexReadsADeposit(t *testing.T) {
-	raw := json.RawMessage(`{"txs":[],"deposits":[{"outpoint":{"Deposit":"cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc:0"},"output":{"address":"rQyAxKGtdbyiEM852yMtoRWfgVD","content":{"Value":54300}}}],"bundle_spends":[]}`)
-
-	var index nodeBlockIndex
-	if err := json.Unmarshal(raw, &index); err != nil {
-		t.Fatalf("read the block index: %v", err)
-	}
-	if got := len(index.Deposits); got != 1 {
-		t.Fatalf("the block holds %d deposits, want 1", got)
-	}
-	only := index.Deposits[0]
-	if only.Address != "rQyAxKGtdbyiEM852yMtoRWfgVD" {
-		t.Errorf("the deposit paid %s", only.Address)
-	}
-	if only.ValueSats != 54300 {
-		t.Errorf("the deposit is worth %d sats, want 54300", only.ValueSats)
-	}
-	want := "cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc"
-	if got := depositTxid(only.Outpoint); got != want {
-		t.Errorf("the outpoint names %s, want %s", got, want)
+// Two thunder builds both report 0.17.6 and write a deposit differently. These
+// are the two get_block_index replies, one from a node on a laptop and one from
+// the alphanet server, for the same block.
+func TestBlockIndexReadsBothDepositShapes(t *testing.T) {
+	const (
+		named  = `{"txs":[],"deposits":[{"outpoint":{"Deposit":"cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc:0"},"output":{"address":"rQyAxKGtdbyiEM852yMtoRWfgVD","content":{"Value":54300}}}],"bundle_spends":[]}`
+		paired = `{"txs":[],"deposits":[[{"Deposit":"cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc:0"},{"address":"rQyAxKGtdbyiEM852yMtoRWfgVD","content":{"Value":54300}}]],"bundle_spends":[]}`
+	)
+	for name, raw := range map[string]string{"named fields": named, "a pair": paired} {
+		t.Run(name, func(t *testing.T) {
+			var index nodeBlockIndex
+			if err := json.Unmarshal(json.RawMessage(raw), &index); err != nil {
+				t.Fatalf("read the block index: %v", err)
+			}
+			if got := len(index.Deposits); got != 1 {
+				t.Fatalf("the block holds %d deposits, want 1", got)
+			}
+			only := index.Deposits[0]
+			if only.Address != "rQyAxKGtdbyiEM852yMtoRWfgVD" {
+				t.Errorf("the deposit paid %s", only.Address)
+			}
+			if only.ValueSats != 54300 {
+				t.Errorf("the deposit is worth %d sats, want 54300", only.ValueSats)
+			}
+			want := "cef2cf2f248f78ae41109532e9a85d775fd724506834b076e745e941e31888bc"
+			if got := depositTxid(only.Outpoint); got != want {
+				t.Errorf("the outpoint names %s, want %s", got, want)
+			}
+		})
 	}
 }
 

--- a/sidechain-orchestrator/api/explorer_handler.go
+++ b/sidechain-orchestrator/api/explorer_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -788,30 +789,63 @@ type nodeDeposit struct {
 	ValueSats int64
 }
 
-// UnmarshalJSON reads what a node writes: the mainchain outpoint that paid,
+// UnmarshalJSON reads a deposit's two halves: the mainchain outpoint that paid,
 // and the sidechain output it created.
 func (d *nodeDeposit) UnmarshalJSON(raw []byte) error {
-	var deposit struct {
-		Outpoint struct {
-			Deposit string `json:"Deposit"`
-		} `json:"outpoint"`
-		Output struct {
-			Address string          `json:"address"`
-			Content json.RawMessage `json:"content"`
-		} `json:"output"`
+	halves, err := depositHalves(raw)
+	if err != nil {
+		return err
 	}
-	if err := json.Unmarshal(raw, &deposit); err != nil {
-		return fmt.Errorf("read the deposit: %w", err)
+	var outpoint struct {
+		Deposit string `json:"Deposit"`
+	}
+	if err := json.Unmarshal(halves[0], &outpoint); err != nil {
+		return fmt.Errorf("read the deposit outpoint: %w", err)
+	}
+	var output struct {
+		Address string          `json:"address"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(halves[1], &output); err != nil {
+		return fmt.Errorf("read the deposit output: %w", err)
 	}
 	// A payload that decodes but names no outpoint is a shape this reader does
 	// not know. Reading it as an empty deposit hides every deposit in the block.
-	if deposit.Outpoint.Deposit == "" {
+	if outpoint.Deposit == "" {
 		return fmt.Errorf("a deposit names no mainchain outpoint")
 	}
-	d.Outpoint = deposit.Outpoint.Deposit
-	d.Address = deposit.Output.Address
-	d.ValueSats = contentValue(deposit.Output.Content)
+	d.Outpoint = outpoint.Deposit
+	d.Address = output.Address
+	d.ValueSats = contentValue(output.Content)
 	return nil
+}
+
+// depositHalves splits one deposit into its outpoint and its output. Two
+// thunder builds both report 0.17.6 and write this differently: one names the
+// halves, the other writes them as a two-element array. Both are live.
+func depositHalves(raw []byte) ([2]json.RawMessage, error) {
+	var none [2]json.RawMessage
+	if bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+		var pair []json.RawMessage
+		if err := json.Unmarshal(raw, &pair); err != nil {
+			return none, fmt.Errorf("read the deposit pair: %w", err)
+		}
+		if len(pair) != 2 {
+			return none, fmt.Errorf("a deposit holds an outpoint and an output, got %d parts", len(pair))
+		}
+		return [2]json.RawMessage{pair[0], pair[1]}, nil
+	}
+	var named struct {
+		Outpoint json.RawMessage `json:"outpoint"`
+		Output   json.RawMessage `json:"output"`
+	}
+	if err := json.Unmarshal(raw, &named); err != nil {
+		return none, fmt.Errorf("read the deposit: %w", err)
+	}
+	if len(named.Outpoint) == 0 || len(named.Output) == 0 {
+		return none, fmt.Errorf("a deposit names neither an outpoint nor an output")
+	}
+	return [2]json.RawMessage{named.Outpoint, named.Output}, nil
 }
 
 // nodeHeader reads one block header from the node.

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.329
+version: 1.0.330
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.200
+version: 1.0.201
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.326
+version: 1.0.327
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Two thunder builds both report version 0.17.6 and write a deposit differently. One names the halves as outpoint and output; the other writes them as a two-element array. A node on a laptop sends the first, the alphanet server sends the second, for the same block.

My previous fix read only the named form, so it moved the crash rather than removing it: the explorer on the alphanet server started failing with "cannot unmarshal array". The reader sits at a network boundary, so it takes what the network sends.

The test carries both real get_block_index replies, captured from the two nodes.