### PR TITLE
thunder/coinshift: release new version

### DIFF
--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.4
+version: 1.0.5
 
 environment:
   sdk: 3.12.2

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.330
+version: 1.0.331
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The last release run failed the thunder and coinshift windows builds. The upload step skips an equal version, so the windows files stayed old. This bump publishes them again.