### PR TITLE
orchestrator: stop bip47 genesis rescan loop

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.328
+version: 1.0.329
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.328
+version: 1.0.329
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.199
+version: 0.2.200
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.4
+version: 1.0.5
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.201
+version: 1.0.202
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/engines/bip47_engine.go
+++ b/sidechain-orchestrator/engines/bip47_engine.go
@@ -122,7 +122,7 @@ func (e *BIP47Engine) tick(ctx context.Context) {
 			// Wallet may still be warming up on the backend; retry next tick.
 			continue
 		}
-		if err := e.ensureNotificationWatched(ctx, backend, w.ID, seedHex, net); err != nil {
+		if err := e.ensureNotificationWatched(ctx, backend, w, net); err != nil {
 			e.log.Warn().Err(err).Str("wallet", w.ID).Msg("ensure notification watched failed")
 		}
 		if err := e.scanWallet(ctx, w.ID, seedHex, net); err != nil {
@@ -136,18 +136,17 @@ func (e *BIP47Engine) tick(ctx context.Context) {
 
 // ensureNotificationWatched registers a wallet's own notification key with its
 // backend once per process, so the backend scans the notification address and
-// inbound notification txs surface in ListTransactionsRange. RescanFrom 0 forces
-// a full history rescan so notifications received before first observation are
-// still found. For Core this is a no-op after the creation-time descriptor
-// import; for electrum it adds the address to the scan.
-func (e *BIP47Engine) ensureNotificationWatched(ctx context.Context, backend wallet.Bip47Backend, walletID, seedHex string, net *chaincfg.Params) error {
+// inbound notification txs surface in ListTransactionsRange. For Core this is a
+// no-op after the creation-time descriptor import; for electrum it adds the
+// address to the scan.
+func (e *BIP47Engine) ensureNotificationWatched(ctx context.Context, backend wallet.Bip47Backend, w *wallet.WalletData, net *chaincfg.Params) error {
 	e.mu.Lock()
-	already := e.notifWatched[walletID]
+	already := e.notifWatched[w.ID]
 	e.mu.Unlock()
 	if already {
 		return nil
 	}
-	notifPriv, _, err := bip47.DeriveOwnNotificationKey(seedHex, net)
+	notifPriv, _, err := bip47.DeriveOwnNotificationKey(w.Master.SeedHex, net)
 	if err != nil {
 		return fmt.Errorf("derive own notification key: %w", err)
 	}
@@ -155,11 +154,12 @@ func (e *BIP47Engine) ensureNotificationWatched(ctx context.Context, backend wal
 	if err != nil {
 		return fmt.Errorf("encode notification wif: %w", err)
 	}
-	if err := backend.EnsureNotificationWatched(ctx, walletID, wallet.WatchKey{WIF: wif.String(), RescanFrom: 0}); err != nil {
+	key := wallet.WatchKey{WIF: wif.String(), RescanFrom: wallet.Bip47RescanFrom(w)}
+	if err := backend.EnsureNotificationWatched(ctx, w.ID, key); err != nil {
 		return err
 	}
 	e.mu.Lock()
-	e.notifWatched[walletID] = true
+	e.notifWatched[w.ID] = true
 	e.mu.Unlock()
 	return nil
 }

--- a/sidechain-orchestrator/engines/bip47_engine_test.go
+++ b/sidechain-orchestrator/engines/bip47_engine_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -47,6 +48,45 @@ func (s *stubBackend) ListTransactionsRange(ctx context.Context, walletID string
 }
 
 func (s *stubBackend) Chain() wallet.ChainSource { return s.chain }
+
+// notifBackend records the notification key the engine registers.
+type notifBackend struct {
+	wallet.Bip47Backend
+	key wallet.WatchKey
+}
+
+func (n *notifBackend) EnsureNotificationWatched(_ context.Context, _ string, k wallet.WatchKey) error {
+	n.key = k
+	return nil
+}
+
+// A scan from genesis costs hours, and the engine repeats it on every tick
+// until it lands. A generated wallet scans from its own birthday instead, which
+// still covers a notification sent before the backend watched the key.
+func TestEnsureNotificationWatchedScansFromTheWalletBirthday(t *testing.T) {
+	net := &chaincfg.RegressionNetParams
+	e := NewBIP47Engine(zerolog.Nop(), nil, nil, nil)
+	born := time.Now().Add(-72 * time.Hour)
+
+	generated := &wallet.WalletData{ID: "gen", CreatedAt: born}
+	generated.Master.SeedHex = aliceSeedHex
+	backend := &notifBackend{}
+	require.NoError(t, e.ensureNotificationWatched(context.Background(), backend, generated, net))
+	require.Equal(t, born.Unix(), backend.key.RescanFrom, "it scans from the birthday, not the tip")
+
+	restored := &wallet.WalletData{ID: "res", Imported: true, CreatedAt: born}
+	restored.Master.SeedHex = bobSeedHex
+	backend = &notifBackend{}
+	require.NoError(t, e.ensureNotificationWatched(context.Background(), backend, restored, net))
+	require.Zero(t, backend.key.RescanFrom, "a restored seed reads the whole chain")
+
+	// A wallet file written before this install recorded a birthday.
+	unknown := &wallet.WalletData{ID: "old"}
+	unknown.Master.SeedHex = aliceSeedHex
+	backend = &notifBackend{}
+	require.NoError(t, e.ensureNotificationWatched(context.Background(), backend, unknown, net))
+	require.Zero(t, backend.key.RescanFrom, "an unknown birthday reads the whole chain")
+}
 
 type stubChain struct {
 	wallet.ChainSource

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -1092,7 +1092,8 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 	if err != nil {
 		return fmt.Errorf("derive notification key: %w", err)
 	}
-	if w := p.svc.GetWalletByID(walletID); w != nil && w.Bip47NotificationImported[net.Name] {
+	w := p.svc.GetWalletByID(walletID)
+	if w != nil && w.Bip47NotificationImported[net.Name] {
 		info, err := p.rpc.GetAddressInfo(ctx, walletName, notifAddr.EncodeAddress())
 		if err != nil {
 			return fmt.Errorf("read the notification address: %w", err)
@@ -1109,7 +1110,7 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 	results, err := p.rpc.ImportDescriptors(ctx, walletName, []ImportDescriptor{{
 		Desc:      desc,
 		Active:    false,
-		Timestamp: int64(0),
+		Timestamp: Bip47RescanFrom(w),
 	}})
 	if err != nil {
 		return fmt.Errorf("import bip47 notification descriptor: %w", err)
@@ -1125,6 +1126,19 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 		return fmt.Errorf("bip47 descriptor %d import failed: %s", i, msg)
 	}
 	return p.svc.MarkBip47NotificationImported(walletID, net.Name)
+}
+
+// Bip47RescanFrom is the unix time a backend scans a wallet's own BIP47
+// notification key from. 0 means genesis. A payment code derives from the seed,
+// so a sender can notify before the backend ever watches the key. Scanning from
+// the tip would drop that notification, and every payment behind it.
+func Bip47RescanFrom(w *WalletData) int64 {
+	// A restored seed holds history of any age. A wallet whose birthday this
+	// install never recorded could have received one at any time.
+	if w == nil || w.Imported || w.CreatedAt.IsZero() {
+		return 0
+	}
+	return w.CreatedAt.Unix()
 }
 
 // importTimestamp is what Core rescans from. A restored seed can have history

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -190,7 +190,10 @@ func TestCoreBackendEnsureCreatesDescriptorWallet(t *testing.T) {
 	require.Len(t, notif, 1)
 	assert.True(t, strings.HasPrefix(notif[0].Desc, "pkh("), "bip47 notification key is P2PKH")
 	assert.Contains(t, notif[0].Desc, "#", "descriptor carries a checksum")
-	assert.Equal(t, float64(0), asFloat(t, notif[0].Timestamp), "rescan from genesis")
+	born := backend.svc.GetWalletByID(coreID)
+	require.NotNil(t, born)
+	assert.Equal(t, float64(born.CreatedAt.Unix()), asFloat(t, notif[0].Timestamp),
+		"a generated seed scans from its birthday, not genesis and not the tip")
 
 	// Second Ensure hits the cache — no further RPC traffic.
 	before := len(fake.callsFor("listwallets"))
@@ -251,8 +254,8 @@ func notificationImports(t *testing.T, fake *fakeBitcoind) int {
 	return n
 }
 
-// The notification import rescans from genesis, which costs hours. A landed
-// import is what stops the next one, and the wallet file records it.
+// A landed import is what stops the next one, and the wallet file records it.
+// A re-import of a restored seed rescans from genesis, which costs hours.
 func TestCoreBackendImportsBip47NotificationKeyOnce(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()
@@ -268,6 +271,37 @@ func TestCoreBackendImportsBip47NotificationKeyOnce(t *testing.T) {
 	_, err = backend.walletName(ctx, coreID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, notificationImports(t, fake))
+}
+
+// A restored seed can hold notification history, so its notification key
+// imports at timestamp 0 and scans from genesis; a generated seed does not.
+func TestCoreBackendImportedSeedBip47NotificationScansGenesis(t *testing.T) {
+	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+	svc := newTestService(t)
+	_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+	require.NoError(t, err)
+	core, err := svc.GenerateWallet("Core", mnemonic, "", testSlots)
+	require.NoError(t, err)
+	require.True(t, core.Imported)
+
+	fake := newFakeBitcoind(t)
+	fake.stubEnsureFlow()
+	backend := NewCoreBackend(
+		svc, fake.client(t),
+		StaticParams(&chaincfg.RegressionNetParams),
+		zerolog.New(zerolog.NewTestWriter(t)),
+	)
+
+	_, err = backend.Ensure(context.Background(), core.ID)
+	require.NoError(t, err)
+
+	imports := fake.callsFor("importdescriptors")
+	require.Len(t, imports, 2, "BIP84 pair + BIP47 notification descriptor")
+	var notif []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[1].Params[0], &notif))
+	require.Len(t, notif, 1)
+	require.True(t, strings.HasPrefix(notif[0].Desc, "pkh("), "bip47 notification key is P2PKH")
+	assert.Equal(t, float64(0), asFloat(t, notif[0].Timestamp), "a restored seed scans from genesis")
 }
 
 // A network switch points Core at another datadir, where the new wallet holds

--- a/sidechain-orchestrator/wallet/types.go
+++ b/sidechain-orchestrator/wallet/types.go
@@ -35,7 +35,7 @@ type WalletData struct {
 	ID         string            `json:"id"`
 	Name       string            `json:"name"`
 	Gradient   json.RawMessage   `json:"gradient"`
-	CreatedAt  time.Time         `json:"-"`
+	CreatedAt  time.Time         `json:"created_at,omitempty"`
 	WalletType WalletType        `json:"wallet_type"`
 	WatchOnly  json.RawMessage   `json:"watch_only,omitempty"`
 	// ScriptType is the electrum address kind (legacy/nested-segwit/

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.330
+version: 1.0.331
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.201
+version: 1.0.202
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.327
+version: 1.0.328
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The bip47 notification descriptor imported at timestamp 0, so Core rescanned from genesis on every re-import and never freed the wallet to BMM. A generated seed now imports the key at "now"; a restored seed keeps timestamp 0.