### PR TITLE
sail_ui: slightly increase padding to avoid overflow

### DIFF
--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -232,7 +232,7 @@ double progressBlockWidth(int rows) =>
 
 /// Height the progress block holds for [rows] stacked bars.
 double progressBlockHeight(BuildContext context, int rows) =>
-    progressRowHeight(context) * rows + SailStyleValues.padding08 * (rows - 1);
+    progressRowHeight(context) * rows + SailStyleValues.padding12 * (rows - 1);
 
 /// Daemon status in a block that always holds the same height, so a card never
 /// resizes as errors come and go. A message taller than the block hides behind


### PR DESCRIPTION
I was getting:
<img width="876" height="446" alt="image" src="https://github.com/user-attachments/assets/8293ab6d-5779-4b6d-aed3-3841384576ef" />

so I increased padding to the next standard value, result:

<img width="728" height="270" alt="image" src="https://github.com/user-attachments/assets/5345104e-de21-420e-a998-8ba0f65f8574" />
