### PR TITLE
wallet: treat a wallet Core has not loaded as transient

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -46,6 +46,12 @@ type CoreBackend struct {
 	mu          sync.Mutex
 	coreWallets map[string]string // walletID -> Core wallet name
 
+	// staleMu guards staleWallets, and it is never held across an RPC. The
+	// error hook runs inside a call that may already hold mu, so the two locks
+	// stay apart.
+	staleMu      sync.Mutex
+	staleWallets map[string]bool // Core wallet name -> Core does not hold it
+
 	// walletID -> earliest retry of a BIP47 notification descriptor import
 	// that failed. A failure there doesn't block wallet loading, so the
 	// wallet stays cached and later Ensure calls retry the import, gated by
@@ -67,14 +73,40 @@ var (
 
 // NewCoreBackend creates the Bitcoin Core wallet backend.
 func NewCoreBackend(svc *Service, rpc *CoreRPCClient, params ParamsFunc, log zerolog.Logger) *CoreBackend {
-	return &CoreBackend{
+	backend := &CoreBackend{
 		svc:             svc,
 		rpc:             rpc,
 		log:             log.With().Str("component", "core-backend").Logger(),
 		params:          params,
 		coreWallets:     make(map[string]string),
 		bip47NotifRetry: make(map[string]time.Time),
+		staleWallets:    make(map[string]bool),
 	}
+	rpc.OnWalletError = backend.markWalletStale
+	return backend
+}
+
+// markWalletStale records that Core no longer holds a wallet. Any wallet call
+// reports here, so a wallet that goes away between two calls is caught wherever
+// it surfaces rather than only on the paths that check for it.
+func (p *CoreBackend) markWalletStale(walletName string, err error) {
+	if !isWalletNotLoadedErr(err) {
+		return
+	}
+	p.staleMu.Lock()
+	defer p.staleMu.Unlock()
+	p.staleWallets[walletName] = true
+}
+
+// takeStale reports whether Core stopped holding this wallet, and clears the mark.
+func (p *CoreBackend) takeStale(walletName string) bool {
+	p.staleMu.Lock()
+	defer p.staleMu.Unlock()
+	if !p.staleWallets[walletName] {
+		return false
+	}
+	delete(p.staleWallets, walletName)
+	return true
 }
 
 // ResetNetworkState drops the wallet-name cache: a different network means a
@@ -98,9 +130,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Check cache
-	if name, ok := p.coreWallets[walletID]; ok {
-		p.retryBip47NotificationDescriptor(ctx, walletID, name)
+	if name, ok := p.cachedWalletName(ctx, walletID); ok {
 		return name, nil
 	}
 
@@ -154,6 +184,15 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 	// next time Ensure runs.
 	if targetWallet.WalletType == WalletTypeBitcoinCore && !targetWallet.IsWatchOnly() {
 		if perr := p.ensureBip47NotificationDescriptor(ctx, walletID, walletName, targetWallet.Master.SeedHex); perr != nil {
+			// This call reaches the wallet itself, so a "not loaded" answer means
+			// the load did not take. Caching the name here would point every
+			// later call at a wallet Core does not hold. A wallet that is merely
+			// busy stays cached and takes the retry path below.
+			if isWalletNotLoadedErr(perr) {
+				p.loadingUntil = time.Now().Add(walletLoadingBackoff)
+				p.loadingErr = perr
+				return "", perr
+			}
 			p.log.Warn().Err(perr).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
 			p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
 		}
@@ -188,12 +227,11 @@ func (p *CoreBackend) EnsureAll(ctx context.Context) (int, error) {
 // walletName returns the Core wallet name for a wallet ID, ensuring it exists.
 func (p *CoreBackend) walletName(ctx context.Context, walletID string) (string, error) {
 	p.mu.Lock()
-	if name, ok := p.coreWallets[walletID]; ok {
-		p.retryBip47NotificationDescriptor(ctx, walletID, name)
-		p.mu.Unlock()
+	name, ok := p.cachedWalletName(ctx, walletID)
+	p.mu.Unlock()
+	if ok {
 		return name, nil
 	}
-	p.mu.Unlock()
 
 	return p.Ensure(ctx, walletID)
 }
@@ -1155,6 +1193,28 @@ func importTimestamp(w *WalletData) any {
 // earlier import failed, so a transient failure doesn't leave an already
 // cached wallet without it forever. No-op unless an import is outstanding and
 // its backoff has elapsed. Caller holds p.mu.
+// cachedWalletName returns the cached Core wallet name, after a due BIP47 retry
+// has had its chance to drop it. Not ok means Core no longer holds the wallet,
+// and the caller loads it again rather than acting on a name nothing answers.
+// The caller holds p.mu.
+func (p *CoreBackend) cachedWalletName(ctx context.Context, walletID string) (string, bool) {
+	name, ok := p.coreWallets[walletID]
+	if !ok {
+		return "", false
+	}
+	// A wallet call already met "not loaded", so the name is dead whatever the
+	// BIP47 retry says.
+	if p.takeStale(name) {
+		delete(p.coreWallets, walletID)
+		return "", false
+	}
+	p.retryBip47NotificationDescriptor(ctx, walletID, name)
+	if _, live := p.coreWallets[walletID]; !live {
+		return "", false
+	}
+	return name, true
+}
+
 func (p *CoreBackend) retryBip47NotificationDescriptor(ctx context.Context, walletID, walletName string) {
 	retryAt, pending := p.bip47NotifRetry[walletID]
 	if !pending || time.Now().Before(retryAt) {
@@ -1166,6 +1226,13 @@ func (p *CoreBackend) retryBip47NotificationDescriptor(ctx context.Context, wall
 		return
 	}
 	if err := p.ensureBip47NotificationDescriptor(ctx, walletID, walletName, w.Master.SeedHex); err != nil {
+		// Core no longer holds the wallet this name points at, so the cached
+		// name is stale. Drop it and let the next Ensure load the wallet again.
+		if isWalletNotLoadedErr(err) {
+			delete(p.coreWallets, walletID)
+			p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
+			return
+		}
 		p.log.Warn().Err(err).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
 		p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
 		return
@@ -1374,6 +1441,16 @@ func createAndImport(
 	// timestamp 0, and Core restarts a genesis rescan on every re-import of it.
 	if !created {
 		active, err := rpc.CountActiveDescriptors(ctx, walletName)
+		if isWalletNotLoadedErr(err) {
+			// listwallets named it, so this path skipped the load. Core does not
+			// hold it, and only a load fixes that — a retry asks the same
+			// question and gets the same -18.
+			log.Info().Str("wallet", walletName).Msg("core lists the wallet but does not hold it; loading it")
+			if loadErr := rpc.LoadWallet(ctx, walletName); loadErr != nil && !isWalletAlreadyLoadedErr(loadErr) {
+				return fmt.Errorf("load listed wallet: %w", loadErr)
+			}
+			active, err = rpc.CountActiveDescriptors(ctx, walletName)
+		}
 		if err != nil {
 			return fmt.Errorf("list descriptors: %w", err)
 		}

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -1780,21 +1780,259 @@ func TestMarkBip47NotificationImportedRollsBackOnSaveFailure(t *testing.T) {
 	assert.False(t, svc.GetWalletByID(w.ID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 }
 
-// Core drops a wallet on restart unless its settings name it, and then the next
-// call answers -18. The create asks Core to keep it.
-func TestCoreKeepsTheWalletAcrossItsOwnRestart(t *testing.T) {
-	const loadOnStartupArg = 6 // name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup
+// stubEnsureFlowBip47Unloaded serves the wallet creation, then answers every
+// call that reaches the wallet itself the way Core does while it still loads it.
+func (f *fakeBitcoind) stubEnsureFlowBip47Unloaded() {
+	f.stubEnsureFlow()
+	const notLoaded = "Requested wallet does not exist or is not loaded"
+	f.handle("getaddressinfo", func(bitcoindCall) (any, string) { return nil, notLoaded })
+	f.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		// The notification import carries one descriptor; the single-sig batch
+		// carries the BIP84 and BIP86 pairs.
+		if len(descs) == 1 {
+			return nil, notLoaded
+		}
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+}
 
+// Core lists a wallet before it finishes loading it, so the BIP47 import can
+// answer "not loaded" for a wallet that just reported created. Caching the name
+// then points every later balance and history call at a wallet Core does not
+// hold, which is how one slow start turns into a permanent -18 loop.
+func TestEnsureDoesNotCacheAWalletCoreDoesNotHold(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlowBip47Unloaded()
+
+	_, err := backend.Ensure(context.Background(), coreID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist or is not loaded")
+
+	_, cached := backend.coreWallets[coreID]
+	assert.False(t, cached, "a wallet Core does not hold must not be cached")
+}
+
+// A wallet that goes away after it was cached leaves a name no call can use.
+// The next Ensure loads it again rather than handing the stale name back.
+func TestEnsureReloadsAfterTheCachedWalletGoesAway(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	name, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+
+	// Core drops the wallet, and the pending BIP47 retry comes due.
+	fake.stubEnsureFlowBip47Unloaded()
+	backend.bip47NotifRetry[coreID] = time.Now().Add(-time.Second)
+
+	_, err = backend.Ensure(context.Background(), coreID)
+	require.Error(t, err, "the stale name must not come back as a success")
+
+	_, cached := backend.coreWallets[coreID]
+	assert.False(t, cached, "the stale entry must be dropped")
+	assert.Equal(t, "wallet_"+coreID[:8], name)
+}
+
+// Balance reads the wallet through the same cache, so a name Core stopped
+// holding must not reach getbalance. This is the path that produced the
+// repeating "balance failed: getbalance RPC error -18" on a slow Core start.
+func TestBalanceReloadsRatherThanReadAStaleWallet(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()
 
 	_, err := backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err)
 
-	creates := fake.callsFor("createwallet")
-	require.Len(t, creates, 1)
-	require.Len(t, creates[0].Params, loadOnStartupArg+1, "createwallet must reach load_on_startup")
-	assert.JSONEq(t, "true", string(creates[0].Params[loadOnStartupArg]),
-		"Core forgets the wallet on restart without this")
-	assert.JSONEq(t, "true", string(creates[0].Params[5]), "descriptor wallet, stated rather than defaulted")
+	// Core drops the wallet, and the pending BIP47 retry comes due.
+	fake.stubEnsureFlowBip47Unloaded()
+	backend.bip47NotifRetry[coreID] = time.Now().Add(-time.Second)
+
+	_, _, err = backend.Balance(context.Background(), coreID)
+	require.Error(t, err, "a stale name must not reach getbalance")
+
+	assert.Empty(t, fake.callsFor("getbalance"), "no balance call may go to a wallet Core does not hold")
+	_, cached := backend.coreWallets[coreID]
+	assert.False(t, cached, "the stale entry must be dropped")
+}
+
+// A rescanning wallet is loaded and it keeps serving. Core refuses a new import
+// while it rescans, and that can run for hours, so refusing the wallet over it
+// would take balances away for the whole rescan. The alphanet server answers
+// exactly this during a Core start.
+func TestARescanningWalletKeepsServing(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		if len(descs) == 1 {
+			return nil, "Wallet is currently rescanning. Abort existing rescan or wait."
+		}
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+
+	name, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err, "a rescan must not take the wallet away")
+	assert.Equal(t, "wallet_"+coreID[:8], name)
+
+	cached, ok := backend.coreWallets[coreID]
+	assert.True(t, ok, "a loaded wallet stays cached through a rescan")
+	assert.Equal(t, name, cached)
+	_, pending := backend.bip47NotifRetry[coreID]
+	assert.True(t, pending, "the notification import retries once the rescan ends")
+}
+
+// Core lists a wallet it no longer holds, so this path skips the load and every
+// wallet call answers -18. A retry asks the same question, so the backend loads
+// the wallet instead.
+func TestEnsureLoadsAWalletCoreListsButDoesNotHold(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	name := "wallet_" + coreID[:8]
+	fake.stubEnsureFlow()
+
+	// listwallets names it, so the create is skipped.
+	fake.handle("listwallets", func(bitcoindCall) (any, string) { return []string{name}, "" })
+	// Core holds it only after a load.
+	held := false
+	fake.handle("loadwallet", func(bitcoindCall) (any, string) {
+		held = true
+		return map[string]any{"name": name}, ""
+	})
+	fake.handle("listdescriptors", func(bitcoindCall) (any, string) {
+		if !held {
+			return nil, "Requested wallet does not exist or is not loaded"
+		}
+		descs := make([]map[string]any, 4)
+		for i := range descs {
+			descs[i] = map[string]any{"active": true}
+		}
+		return map[string]any{"descriptors": descs}, ""
+	})
+
+	got, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+	assert.Equal(t, name, got)
+
+	loads := fake.callsFor("loadwallet")
+	require.Len(t, loads, 1, "the backend loads the wallet Core listed but did not hold")
+	assert.Equal(t, name, mustString(t, loads[0].Params[0]))
+}
+
+// Core answers "already loaded" when it holds the wallet, which is the outcome
+// a load asks for. That is a success, not a boot failure.
+func TestAnAlreadyLoadedWalletIsNotAFailure(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	name := "wallet_" + coreID[:8]
+	fake.stubEnsureFlow()
+	fake.handle("listwallets", func(bitcoindCall) (any, string) { return []string{name}, "" })
+	fake.handle("loadwallet", func(bitcoindCall) (any, string) {
+		return nil, "Wallet \"" + name + "\" is already loaded."
+	})
+	first := true
+	fake.handle("listdescriptors", func(bitcoindCall) (any, string) {
+		if first {
+			first = false
+			return nil, "Requested wallet does not exist or is not loaded"
+		}
+		descs := make([]map[string]any, 4)
+		for i := range descs {
+			descs[i] = map[string]any{"active": true}
+		}
+		return map[string]any{"descriptors": descs}, ""
+	})
+
+	_, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err, "already loaded is the outcome the load asked for")
+}
+
+// Core drops a wallet on restart unless its settings name it, and then the next
+// call answers -18. Both the create and the load ask Core to keep it.
+func TestCoreKeepsTheWalletAcrossItsOwnRestart(t *testing.T) {
+	const loadOnStartupArg = 6 // createwallet: name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup
+
+	t.Run("createwallet", func(t *testing.T) {
+		backend, fake, coreID := newCoreBackendFixture(t)
+		fake.stubEnsureFlow()
+
+		_, err := backend.Ensure(context.Background(), coreID)
+		require.NoError(t, err)
+
+		creates := fake.callsFor("createwallet")
+		require.Len(t, creates, 1)
+		require.Len(t, creates[0].Params, loadOnStartupArg+1, "createwallet must reach load_on_startup")
+		assert.JSONEq(t, "true", string(creates[0].Params[loadOnStartupArg]),
+			"Core forgets the wallet on restart without this")
+		assert.JSONEq(t, "true", string(creates[0].Params[5]), "descriptor wallet, stated rather than defaulted")
+	})
+
+	t.Run("loadwallet", func(t *testing.T) {
+		backend, fake, coreID := newCoreBackendFixture(t)
+		name := "wallet_" + coreID[:8]
+		fake.stubEnsureFlow()
+		fake.handle("listwallets", func(bitcoindCall) (any, string) { return []string{name}, "" })
+		held := false
+		fake.handle("loadwallet", func(bitcoindCall) (any, string) {
+			held = true
+			return map[string]any{"name": name}, ""
+		})
+		fake.handle("listdescriptors", func(bitcoindCall) (any, string) {
+			if !held {
+				return nil, "Requested wallet does not exist or is not loaded"
+			}
+			descs := make([]map[string]any, 4)
+			for i := range descs {
+				descs[i] = map[string]any{"active": true}
+			}
+			return map[string]any{"descriptors": descs}, ""
+		})
+
+		_, err := backend.Ensure(context.Background(), coreID)
+		require.NoError(t, err)
+
+		loads := fake.callsFor("loadwallet")
+		require.Len(t, loads, 1)
+		require.Len(t, loads[0].Params, 2, "loadwallet must reach load_on_startup")
+		assert.JSONEq(t, "true", string(loads[0].Params[1]))
+	})
+}
+
+// Core can unload a wallet at any time, and then no BIP47 retry is pending to
+// notice. Any wallet call that meets "not loaded" drops the cached name, so the
+// next call loads the wallet rather than repeating -18 for good.
+func TestAnyWalletCallDropsAWalletCoreUnloaded(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	name := "wallet_" + coreID[:8]
+	fake.stubEnsureFlow()
+
+	_, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+	require.Empty(t, backend.bip47NotifRetry, "the happy path leaves no retry to hang the eviction on")
+
+	// Core unloads the wallet, so the next balance read meets -18.
+	fake.handle("getbalance", func(bitcoindCall) (any, string) {
+		return nil, "Requested wallet does not exist or is not loaded"
+	})
+	_, _, err = backend.Balance(context.Background(), coreID)
+	require.Error(t, err)
+
+	// Core holds it again. The next call must load it rather than read the
+	// cached name and meet -18 for good.
+	fake.stubEnsureFlow()
+	before := len(fake.callsFor("createwallet"))
+
+	got, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+	assert.Equal(t, name, got)
+	assert.Greater(t, len(fake.callsFor("createwallet")), before,
+		"the cached name was used, and Core no longer holds that wallet")
 }

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -1779,3 +1779,22 @@ func TestMarkBip47NotificationImportedRollsBackOnSaveFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, svc.GetWalletByID(w.ID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 }
+
+// Core drops a wallet on restart unless its settings name it, and then the next
+// call answers -18. The create asks Core to keep it.
+func TestCoreKeepsTheWalletAcrossItsOwnRestart(t *testing.T) {
+	const loadOnStartupArg = 6 // name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup
+
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	_, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+
+	creates := fake.callsFor("createwallet")
+	require.Len(t, creates, 1)
+	require.Len(t, creates[0].Params, loadOnStartupArg+1, "createwallet must reach load_on_startup")
+	assert.JSONEq(t, "true", string(creates[0].Params[loadOnStartupArg]),
+		"Core forgets the wallet on restart without this")
+	assert.JSONEq(t, "true", string(creates[0].Params[5]), "descriptor wallet, stated rather than defaulted")
+}

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -38,6 +38,11 @@ func StaticCoreEndpoint(host string, port int, user, password string) CoreEndpoi
 type CoreRPCClient struct {
 	resolve CoreEndpointFunc
 	client  *http.Client
+
+	// OnWalletError sees every failed call that names a wallet. The backend
+	// reads it to drop a wallet Core stopped holding, which reaches all of its
+	// wallet calls rather than the few a reader remembers to change.
+	OnWalletError func(walletName string, err error)
 }
 
 // NewCoreRPCClient creates a new Bitcoin Core RPC client.
@@ -74,6 +79,14 @@ type rpcError struct {
 // call makes a JSON-RPC call to Bitcoin Core.
 // If walletName is non-empty, routes to /wallet/<name>.
 func (c *CoreRPCClient) call(ctx context.Context, walletName, method string, params ...interface{}) (json.RawMessage, error) {
+	raw, err := c.callWallet(ctx, walletName, method, params...)
+	if err != nil && walletName != "" && c.OnWalletError != nil {
+		c.OnWalletError(walletName, err)
+	}
+	return raw, err
+}
+
+func (c *CoreRPCClient) callWallet(ctx context.Context, walletName, method string, params ...interface{}) (json.RawMessage, error) {
 	if params == nil {
 		params = []interface{}{}
 	}

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -132,13 +132,25 @@ func (c *CoreRPCClient) call(ctx context.Context, walletName, method string, par
 
 // CreateWallet creates a new Bitcoin Core wallet.
 func (c *CoreRPCClient) CreateWallet(ctx context.Context, name string, disablePrivateKeys, blank bool) error {
-	_, err := c.call(ctx, "", "createwallet", name, disablePrivateKeys, blank)
+	// load_on_startup writes the wallet into Core's settings, so Core loads it
+	// again by itself after a restart. Without it every restart drops the
+	// wallet, and the next call answers -18.
+	const (
+		passphrase    = ""
+		avoidReuse    = false
+		descriptors   = true
+		loadOnStartup = true
+	)
+	_, err := c.call(ctx, "", "createwallet",
+		name, disablePrivateKeys, blank, passphrase, avoidReuse, descriptors, loadOnStartup)
 	return err
 }
 
-// LoadWallet loads an existing Bitcoin Core wallet.
+// LoadWallet loads an existing Bitcoin Core wallet, and asks Core to load it on
+// every later start.
 func (c *CoreRPCClient) LoadWallet(ctx context.Context, name string) error {
-	_, err := c.call(ctx, "", "loadwallet", name)
+	const loadOnStartup = true
+	_, err := c.call(ctx, "", "loadwallet", name, loadOnStartup)
 	return err
 }
 

--- a/sidechain-orchestrator/wallet/startup_errors.go
+++ b/sidechain-orchestrator/wallet/startup_errors.go
@@ -13,11 +13,19 @@ var transientWalletErrPatterns = []string{
 	"-28 -",
 	"-4: Wallet already loading",
 	"Wallet already loading",
+	// Core lists a wallet before it finishes loading it, so a wallet RPC in
+	// that window answers -18 for a wallet that is on its way up.
+	"-18:",
+	"does not exist or is not loaded",
 	"Verifying blocks",
 	"Loading block index",
 	"Loading wallet",
 	"Rescanning",
 	"Still rescanning",
+	// Core writes this one in lower case: "Wallet is currently rescanning.
+	// Abort existing rescan or wait." The patterns match case, so it takes
+	// its own entry.
+	"currently rescanning",
 }
 
 // IsTransientWalletErr reports whether a wallet-related bitcoind error means
@@ -39,4 +47,34 @@ func isTransientWalletErr(err error) bool {
 		}
 	}
 	return false
+}
+
+// walletNotLoadedPatterns are the substrings Core answers when it does not hold
+// the wallet at all. A wallet that is loaded but busy — a rescan, for one — is a
+// different thing, and it stays usable.
+var walletNotLoadedPatterns = []string{
+	"-18:",
+	"does not exist or is not loaded",
+}
+
+// isWalletNotLoadedErr reports whether Core says it does not hold this wallet.
+// Narrower than isTransientWalletErr on purpose: a rescanning wallet is
+// transient and loaded, so it keeps serving.
+func isWalletNotLoadedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, p := range walletNotLoadedPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWalletAlreadyLoadedErr reports whether Core refused a load because it
+// already holds the wallet. That is the same outcome as a load that worked.
+func isWalletAlreadyLoadedErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already loaded")
 }

--- a/sidechain-orchestrator/wallet/startup_errors_test.go
+++ b/sidechain-orchestrator/wallet/startup_errors_test.go
@@ -26,3 +26,52 @@ func TestIsTransientWalletErr(t *testing.T) {
 		})
 	}
 }
+
+// Core lists a wallet before it finishes loading it, so a wallet RPC in that
+// window answers -18 for a wallet that is on its way up. Reading that as
+// permanent leaves the caller on a wallet it never retries.
+func TestWalletNotLoadedIsTransient(t *testing.T) {
+	for _, msg := range []string{
+		"importdescriptors RPC error -18: Requested wallet does not exist or is not loaded",
+		"getbalance RPC error -18: Requested wallet does not exist or is not loaded",
+		"listtransactions RPC error -1: Requested wallet does not exist or is not loaded",
+	} {
+		if !IsTransientWalletErr(errors.New(msg)) {
+			t.Errorf("this reads as permanent, and the wallet is still on its way up: %s", msg)
+		}
+	}
+}
+
+// A wallet error that names a real fault stays permanent, so a caller fails
+// rather than waits for a wallet that never arrives.
+func TestARealWalletFaultStaysPermanent(t *testing.T) {
+	for _, msg := range []string{
+		"createwallet RPC error -4: Wallet file verification failed",
+		"importdescriptors RPC error -5: Invalid descriptor",
+	} {
+		if IsTransientWalletErr(errors.New(msg)) {
+			t.Errorf("this reads as transient, and it never clears: %s", msg)
+		}
+	}
+}
+
+// "Not loaded" and "busy" are different. A rescan is transient, and the wallet
+// is still loaded, so the caller keeps using it.
+func TestOnlyAnAbsentWalletReadsAsNotLoaded(t *testing.T) {
+	notLoaded := "importdescriptors RPC error -18: Requested wallet does not exist or is not loaded"
+	if !isWalletNotLoadedErr(errors.New(notLoaded)) {
+		t.Error("Core says it does not hold the wallet, and this reads otherwise")
+	}
+	for _, msg := range []string{
+		"importdescriptors RPC error -4: Wallet is currently rescanning. Abort existing rescan or wait.",
+		"createwallet RPC error -4: Wallet already loading",
+		"getbalance RPC error -28: Loading block index",
+	} {
+		if isWalletNotLoadedErr(errors.New(msg)) {
+			t.Errorf("the wallet is loaded and busy, and this reads as absent: %s", msg)
+		}
+		if !isTransientWalletErr(errors.New(msg)) {
+			t.Errorf("this clears on its own, and it reads as permanent: %s", msg)
+		}
+	}
+}


### PR DESCRIPTION
Core lists a wallet before it finishes loading it, so a wallet RPC in that window answers -18 "Requested wallet does not exist or is not loaded". That string was missing from the transient list, so the backend read it as a permanent fault.

Two things followed. Ensure cached the wallet name and cleared the loading gate right after the BIP47 import reported the wallet unloaded, so every later getbalance and listtransactions went to a wallet Core does not hold. The cache hit then retried BIP47 on a five second timer, logged the same -18, and never reloaded, which is the repeating warning in a slow start.

The backend now backs off instead of caching, drops a cached name once Core stops holding it, and reloads on the next Ensure.