### PR TITLE
thunder: send to many recipients in one transaction

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.329
+version: 1.0.330
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.329
+version: 1.0.330
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.200
+version: 0.2.201
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.5
+version: 1.0.6
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.202
+version: 1.0.203
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/gen/thunder/v1/thunder.pb.go
+++ b/sidechain-orchestrator/gen/thunder/v1/thunder.pb.go
@@ -557,6 +557,103 @@ func (x *TransferResponse) GetTxid() string {
 	return ""
 }
 
+type TransferManyRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Amount in sats for each destination address.
+	Destinations  map[string]int64 `protobuf:"bytes,1,rep,name=destinations,proto3" json:"destinations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	FeeSats       int64            `protobuf:"varint,2,opt,name=fee_sats,json=feeSats,proto3" json:"fee_sats,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransferManyRequest) Reset() {
+	*x = TransferManyRequest{}
+	mi := &file_thunder_v1_thunder_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferManyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferManyRequest) ProtoMessage() {}
+
+func (x *TransferManyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_thunder_v1_thunder_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferManyRequest.ProtoReflect.Descriptor instead.
+func (*TransferManyRequest) Descriptor() ([]byte, []int) {
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *TransferManyRequest) GetDestinations() map[string]int64 {
+	if x != nil {
+		return x.Destinations
+	}
+	return nil
+}
+
+func (x *TransferManyRequest) GetFeeSats() int64 {
+	if x != nil {
+		return x.FeeSats
+	}
+	return 0
+}
+
+type TransferManyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransferManyResponse) Reset() {
+	*x = TransferManyResponse{}
+	mi := &file_thunder_v1_thunder_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferManyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferManyResponse) ProtoMessage() {}
+
+func (x *TransferManyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_thunder_v1_thunder_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferManyResponse.ProtoReflect.Descriptor instead.
+func (*TransferManyResponse) Descriptor() ([]byte, []int) {
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *TransferManyResponse) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
 type GetSidechainWealthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -565,7 +662,7 @@ type GetSidechainWealthRequest struct {
 
 func (x *GetSidechainWealthRequest) Reset() {
 	*x = GetSidechainWealthRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[12]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -577,7 +674,7 @@ func (x *GetSidechainWealthRequest) String() string {
 func (*GetSidechainWealthRequest) ProtoMessage() {}
 
 func (x *GetSidechainWealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[12]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +687,7 @@ func (x *GetSidechainWealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSidechainWealthRequest.ProtoReflect.Descriptor instead.
 func (*GetSidechainWealthRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{12}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{14}
 }
 
 type GetSidechainWealthResponse struct {
@@ -602,7 +699,7 @@ type GetSidechainWealthResponse struct {
 
 func (x *GetSidechainWealthResponse) Reset() {
 	*x = GetSidechainWealthResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[13]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -614,7 +711,7 @@ func (x *GetSidechainWealthResponse) String() string {
 func (*GetSidechainWealthResponse) ProtoMessage() {}
 
 func (x *GetSidechainWealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[13]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -627,7 +724,7 @@ func (x *GetSidechainWealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSidechainWealthResponse.ProtoReflect.Descriptor instead.
 func (*GetSidechainWealthResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{13}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetSidechainWealthResponse) GetSats() int64 {
@@ -648,7 +745,7 @@ type CreateDepositRequest struct {
 
 func (x *CreateDepositRequest) Reset() {
 	*x = CreateDepositRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[14]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -660,7 +757,7 @@ func (x *CreateDepositRequest) String() string {
 func (*CreateDepositRequest) ProtoMessage() {}
 
 func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[14]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -673,7 +770,7 @@ func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositRequest.ProtoReflect.Descriptor instead.
 func (*CreateDepositRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{14}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateDepositRequest) GetAddress() string {
@@ -706,7 +803,7 @@ type CreateDepositResponse struct {
 
 func (x *CreateDepositResponse) Reset() {
 	*x = CreateDepositResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[15]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -718,7 +815,7 @@ func (x *CreateDepositResponse) String() string {
 func (*CreateDepositResponse) ProtoMessage() {}
 
 func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[15]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -731,7 +828,7 @@ func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositResponse.ProtoReflect.Descriptor instead.
 func (*CreateDepositResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{15}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateDepositResponse) GetTxid() string {
@@ -749,7 +846,7 @@ type GetPendingWithdrawalBundleRequest struct {
 
 func (x *GetPendingWithdrawalBundleRequest) Reset() {
 	*x = GetPendingWithdrawalBundleRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[16]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -761,7 +858,7 @@ func (x *GetPendingWithdrawalBundleRequest) String() string {
 func (*GetPendingWithdrawalBundleRequest) ProtoMessage() {}
 
 func (x *GetPendingWithdrawalBundleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[16]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -774,7 +871,7 @@ func (x *GetPendingWithdrawalBundleRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetPendingWithdrawalBundleRequest.ProtoReflect.Descriptor instead.
 func (*GetPendingWithdrawalBundleRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{16}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{18}
 }
 
 type GetPendingWithdrawalBundleResponse struct {
@@ -787,7 +884,7 @@ type GetPendingWithdrawalBundleResponse struct {
 
 func (x *GetPendingWithdrawalBundleResponse) Reset() {
 	*x = GetPendingWithdrawalBundleResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[17]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -799,7 +896,7 @@ func (x *GetPendingWithdrawalBundleResponse) String() string {
 func (*GetPendingWithdrawalBundleResponse) ProtoMessage() {}
 
 func (x *GetPendingWithdrawalBundleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[17]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -812,7 +909,7 @@ func (x *GetPendingWithdrawalBundleResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetPendingWithdrawalBundleResponse.ProtoReflect.Descriptor instead.
 func (*GetPendingWithdrawalBundleResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{17}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetPendingWithdrawalBundleResponse) GetBundleJson() string {
@@ -831,7 +928,7 @@ type ConnectPeerRequest struct {
 
 func (x *ConnectPeerRequest) Reset() {
 	*x = ConnectPeerRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[18]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -843,7 +940,7 @@ func (x *ConnectPeerRequest) String() string {
 func (*ConnectPeerRequest) ProtoMessage() {}
 
 func (x *ConnectPeerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[18]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -856,7 +953,7 @@ func (x *ConnectPeerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectPeerRequest.ProtoReflect.Descriptor instead.
 func (*ConnectPeerRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{18}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ConnectPeerRequest) GetAddress() string {
@@ -874,7 +971,7 @@ type ConnectPeerResponse struct {
 
 func (x *ConnectPeerResponse) Reset() {
 	*x = ConnectPeerResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[19]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -886,7 +983,7 @@ func (x *ConnectPeerResponse) String() string {
 func (*ConnectPeerResponse) ProtoMessage() {}
 
 func (x *ConnectPeerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[19]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -899,7 +996,7 @@ func (x *ConnectPeerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectPeerResponse.ProtoReflect.Descriptor instead.
 func (*ConnectPeerResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{19}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{21}
 }
 
 type ListPeersRequest struct {
@@ -910,7 +1007,7 @@ type ListPeersRequest struct {
 
 func (x *ListPeersRequest) Reset() {
 	*x = ListPeersRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[20]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -922,7 +1019,7 @@ func (x *ListPeersRequest) String() string {
 func (*ListPeersRequest) ProtoMessage() {}
 
 func (x *ListPeersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[20]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -935,7 +1032,7 @@ func (x *ListPeersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPeersRequest.ProtoReflect.Descriptor instead.
 func (*ListPeersRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{20}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{22}
 }
 
 type ListPeersResponse struct {
@@ -947,7 +1044,7 @@ type ListPeersResponse struct {
 
 func (x *ListPeersResponse) Reset() {
 	*x = ListPeersResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[21]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -959,7 +1056,7 @@ func (x *ListPeersResponse) String() string {
 func (*ListPeersResponse) ProtoMessage() {}
 
 func (x *ListPeersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[21]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -972,7 +1069,7 @@ func (x *ListPeersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPeersResponse.ProtoReflect.Descriptor instead.
 func (*ListPeersResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{21}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListPeersResponse) GetPeersJson() string {
@@ -991,7 +1088,7 @@ type MineRequest struct {
 
 func (x *MineRequest) Reset() {
 	*x = MineRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[22]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1003,7 +1100,7 @@ func (x *MineRequest) String() string {
 func (*MineRequest) ProtoMessage() {}
 
 func (x *MineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[22]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1016,7 +1113,7 @@ func (x *MineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MineRequest.ProtoReflect.Descriptor instead.
 func (*MineRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{22}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *MineRequest) GetFeeSats() int64 {
@@ -1035,7 +1132,7 @@ type MineResponse struct {
 
 func (x *MineResponse) Reset() {
 	*x = MineResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[23]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1047,7 +1144,7 @@ func (x *MineResponse) String() string {
 func (*MineResponse) ProtoMessage() {}
 
 func (x *MineResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[23]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1060,7 +1157,7 @@ func (x *MineResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MineResponse.ProtoReflect.Descriptor instead.
 func (*MineResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{23}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *MineResponse) GetBmmResultJson() string {
@@ -1079,7 +1176,7 @@ type GetBlockRequest struct {
 
 func (x *GetBlockRequest) Reset() {
 	*x = GetBlockRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[24]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1091,7 +1188,7 @@ func (x *GetBlockRequest) String() string {
 func (*GetBlockRequest) ProtoMessage() {}
 
 func (x *GetBlockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[24]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1104,7 +1201,7 @@ func (x *GetBlockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlockRequest.ProtoReflect.Descriptor instead.
 func (*GetBlockRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{24}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetBlockRequest) GetHash() string {
@@ -1123,7 +1220,7 @@ type GetBlockResponse struct {
 
 func (x *GetBlockResponse) Reset() {
 	*x = GetBlockResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[25]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1135,7 +1232,7 @@ func (x *GetBlockResponse) String() string {
 func (*GetBlockResponse) ProtoMessage() {}
 
 func (x *GetBlockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[25]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1148,7 +1245,7 @@ func (x *GetBlockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlockResponse.ProtoReflect.Descriptor instead.
 func (*GetBlockResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{25}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetBlockResponse) GetBlockJson() string {
@@ -1166,7 +1263,7 @@ type GetBestMainchainBlockHashRequest struct {
 
 func (x *GetBestMainchainBlockHashRequest) Reset() {
 	*x = GetBestMainchainBlockHashRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[26]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1178,7 +1275,7 @@ func (x *GetBestMainchainBlockHashRequest) String() string {
 func (*GetBestMainchainBlockHashRequest) ProtoMessage() {}
 
 func (x *GetBestMainchainBlockHashRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[26]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1191,7 +1288,7 @@ func (x *GetBestMainchainBlockHashRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBestMainchainBlockHashRequest.ProtoReflect.Descriptor instead.
 func (*GetBestMainchainBlockHashRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{26}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{28}
 }
 
 type GetBestMainchainBlockHashResponse struct {
@@ -1203,7 +1300,7 @@ type GetBestMainchainBlockHashResponse struct {
 
 func (x *GetBestMainchainBlockHashResponse) Reset() {
 	*x = GetBestMainchainBlockHashResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[27]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1215,7 +1312,7 @@ func (x *GetBestMainchainBlockHashResponse) String() string {
 func (*GetBestMainchainBlockHashResponse) ProtoMessage() {}
 
 func (x *GetBestMainchainBlockHashResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[27]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1228,7 +1325,7 @@ func (x *GetBestMainchainBlockHashResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetBestMainchainBlockHashResponse.ProtoReflect.Descriptor instead.
 func (*GetBestMainchainBlockHashResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{27}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetBestMainchainBlockHashResponse) GetHash() string {
@@ -1246,7 +1343,7 @@ type GetBestSidechainBlockHashRequest struct {
 
 func (x *GetBestSidechainBlockHashRequest) Reset() {
 	*x = GetBestSidechainBlockHashRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[28]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1258,7 +1355,7 @@ func (x *GetBestSidechainBlockHashRequest) String() string {
 func (*GetBestSidechainBlockHashRequest) ProtoMessage() {}
 
 func (x *GetBestSidechainBlockHashRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[28]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1271,7 +1368,7 @@ func (x *GetBestSidechainBlockHashRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBestSidechainBlockHashRequest.ProtoReflect.Descriptor instead.
 func (*GetBestSidechainBlockHashRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{28}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{30}
 }
 
 type GetBestSidechainBlockHashResponse struct {
@@ -1283,7 +1380,7 @@ type GetBestSidechainBlockHashResponse struct {
 
 func (x *GetBestSidechainBlockHashResponse) Reset() {
 	*x = GetBestSidechainBlockHashResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[29]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1295,7 +1392,7 @@ func (x *GetBestSidechainBlockHashResponse) String() string {
 func (*GetBestSidechainBlockHashResponse) ProtoMessage() {}
 
 func (x *GetBestSidechainBlockHashResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[29]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1308,7 +1405,7 @@ func (x *GetBestSidechainBlockHashResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetBestSidechainBlockHashResponse.ProtoReflect.Descriptor instead.
 func (*GetBestSidechainBlockHashResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{29}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetBestSidechainBlockHashResponse) GetHash() string {
@@ -1327,7 +1424,7 @@ type GetBmmInclusionsRequest struct {
 
 func (x *GetBmmInclusionsRequest) Reset() {
 	*x = GetBmmInclusionsRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[30]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1339,7 +1436,7 @@ func (x *GetBmmInclusionsRequest) String() string {
 func (*GetBmmInclusionsRequest) ProtoMessage() {}
 
 func (x *GetBmmInclusionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[30]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1352,7 +1449,7 @@ func (x *GetBmmInclusionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBmmInclusionsRequest.ProtoReflect.Descriptor instead.
 func (*GetBmmInclusionsRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{30}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetBmmInclusionsRequest) GetBlockHash() string {
@@ -1371,7 +1468,7 @@ type GetBmmInclusionsResponse struct {
 
 func (x *GetBmmInclusionsResponse) Reset() {
 	*x = GetBmmInclusionsResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[31]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1383,7 +1480,7 @@ func (x *GetBmmInclusionsResponse) String() string {
 func (*GetBmmInclusionsResponse) ProtoMessage() {}
 
 func (x *GetBmmInclusionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[31]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1396,7 +1493,7 @@ func (x *GetBmmInclusionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBmmInclusionsResponse.ProtoReflect.Descriptor instead.
 func (*GetBmmInclusionsResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{31}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetBmmInclusionsResponse) GetInclusions() string {
@@ -1414,7 +1511,7 @@ type GetWalletUtxosRequest struct {
 
 func (x *GetWalletUtxosRequest) Reset() {
 	*x = GetWalletUtxosRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[32]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1426,7 +1523,7 @@ func (x *GetWalletUtxosRequest) String() string {
 func (*GetWalletUtxosRequest) ProtoMessage() {}
 
 func (x *GetWalletUtxosRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[32]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1439,7 +1536,7 @@ func (x *GetWalletUtxosRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletUtxosRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletUtxosRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{32}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{34}
 }
 
 type GetWalletUtxosResponse struct {
@@ -1451,7 +1548,7 @@ type GetWalletUtxosResponse struct {
 
 func (x *GetWalletUtxosResponse) Reset() {
 	*x = GetWalletUtxosResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[33]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1463,7 +1560,7 @@ func (x *GetWalletUtxosResponse) String() string {
 func (*GetWalletUtxosResponse) ProtoMessage() {}
 
 func (x *GetWalletUtxosResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[33]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1476,7 +1573,7 @@ func (x *GetWalletUtxosResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletUtxosResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletUtxosResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{33}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetWalletUtxosResponse) GetUtxosJson() string {
@@ -1494,7 +1591,7 @@ type ListUtxosRequest struct {
 
 func (x *ListUtxosRequest) Reset() {
 	*x = ListUtxosRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[34]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1506,7 +1603,7 @@ func (x *ListUtxosRequest) String() string {
 func (*ListUtxosRequest) ProtoMessage() {}
 
 func (x *ListUtxosRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[34]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1519,7 +1616,7 @@ func (x *ListUtxosRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUtxosRequest.ProtoReflect.Descriptor instead.
 func (*ListUtxosRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{34}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{36}
 }
 
 type ListUtxosResponse struct {
@@ -1531,7 +1628,7 @@ type ListUtxosResponse struct {
 
 func (x *ListUtxosResponse) Reset() {
 	*x = ListUtxosResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[35]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1543,7 +1640,7 @@ func (x *ListUtxosResponse) String() string {
 func (*ListUtxosResponse) ProtoMessage() {}
 
 func (x *ListUtxosResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[35]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1556,7 +1653,7 @@ func (x *ListUtxosResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUtxosResponse.ProtoReflect.Descriptor instead.
 func (*ListUtxosResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{35}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ListUtxosResponse) GetUtxosJson() string {
@@ -1575,7 +1672,7 @@ type RemoveFromMempoolRequest struct {
 
 func (x *RemoveFromMempoolRequest) Reset() {
 	*x = RemoveFromMempoolRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[36]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1587,7 +1684,7 @@ func (x *RemoveFromMempoolRequest) String() string {
 func (*RemoveFromMempoolRequest) ProtoMessage() {}
 
 func (x *RemoveFromMempoolRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[36]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1600,7 +1697,7 @@ func (x *RemoveFromMempoolRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveFromMempoolRequest.ProtoReflect.Descriptor instead.
 func (*RemoveFromMempoolRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{36}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *RemoveFromMempoolRequest) GetTxid() string {
@@ -1618,7 +1715,7 @@ type RemoveFromMempoolResponse struct {
 
 func (x *RemoveFromMempoolResponse) Reset() {
 	*x = RemoveFromMempoolResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[37]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1630,7 +1727,7 @@ func (x *RemoveFromMempoolResponse) String() string {
 func (*RemoveFromMempoolResponse) ProtoMessage() {}
 
 func (x *RemoveFromMempoolResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[37]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1643,7 +1740,7 @@ func (x *RemoveFromMempoolResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveFromMempoolResponse.ProtoReflect.Descriptor instead.
 func (*RemoveFromMempoolResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{37}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{39}
 }
 
 type GetLatestFailedWithdrawalBundleHeightRequest struct {
@@ -1654,7 +1751,7 @@ type GetLatestFailedWithdrawalBundleHeightRequest struct {
 
 func (x *GetLatestFailedWithdrawalBundleHeightRequest) Reset() {
 	*x = GetLatestFailedWithdrawalBundleHeightRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[38]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1666,7 +1763,7 @@ func (x *GetLatestFailedWithdrawalBundleHeightRequest) String() string {
 func (*GetLatestFailedWithdrawalBundleHeightRequest) ProtoMessage() {}
 
 func (x *GetLatestFailedWithdrawalBundleHeightRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[38]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1679,7 +1776,7 @@ func (x *GetLatestFailedWithdrawalBundleHeightRequest) ProtoReflect() protorefle
 
 // Deprecated: Use GetLatestFailedWithdrawalBundleHeightRequest.ProtoReflect.Descriptor instead.
 func (*GetLatestFailedWithdrawalBundleHeightRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{38}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{40}
 }
 
 type GetLatestFailedWithdrawalBundleHeightResponse struct {
@@ -1692,7 +1789,7 @@ type GetLatestFailedWithdrawalBundleHeightResponse struct {
 
 func (x *GetLatestFailedWithdrawalBundleHeightResponse) Reset() {
 	*x = GetLatestFailedWithdrawalBundleHeightResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[39]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1704,7 +1801,7 @@ func (x *GetLatestFailedWithdrawalBundleHeightResponse) String() string {
 func (*GetLatestFailedWithdrawalBundleHeightResponse) ProtoMessage() {}
 
 func (x *GetLatestFailedWithdrawalBundleHeightResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[39]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1717,7 +1814,7 @@ func (x *GetLatestFailedWithdrawalBundleHeightResponse) ProtoReflect() protorefl
 
 // Deprecated: Use GetLatestFailedWithdrawalBundleHeightResponse.ProtoReflect.Descriptor instead.
 func (*GetLatestFailedWithdrawalBundleHeightResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{39}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetLatestFailedWithdrawalBundleHeightResponse) GetHeight() int64 {
@@ -1735,7 +1832,7 @@ type GenerateMnemonicRequest struct {
 
 func (x *GenerateMnemonicRequest) Reset() {
 	*x = GenerateMnemonicRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[40]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1747,7 +1844,7 @@ func (x *GenerateMnemonicRequest) String() string {
 func (*GenerateMnemonicRequest) ProtoMessage() {}
 
 func (x *GenerateMnemonicRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[40]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1760,7 +1857,7 @@ func (x *GenerateMnemonicRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateMnemonicRequest.ProtoReflect.Descriptor instead.
 func (*GenerateMnemonicRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{40}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{42}
 }
 
 type GenerateMnemonicResponse struct {
@@ -1772,7 +1869,7 @@ type GenerateMnemonicResponse struct {
 
 func (x *GenerateMnemonicResponse) Reset() {
 	*x = GenerateMnemonicResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[41]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1784,7 +1881,7 @@ func (x *GenerateMnemonicResponse) String() string {
 func (*GenerateMnemonicResponse) ProtoMessage() {}
 
 func (x *GenerateMnemonicResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[41]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1797,7 +1894,7 @@ func (x *GenerateMnemonicResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateMnemonicResponse.ProtoReflect.Descriptor instead.
 func (*GenerateMnemonicResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{41}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *GenerateMnemonicResponse) GetMnemonic() string {
@@ -1816,7 +1913,7 @@ type SetSeedFromMnemonicRequest struct {
 
 func (x *SetSeedFromMnemonicRequest) Reset() {
 	*x = SetSeedFromMnemonicRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[42]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1828,7 +1925,7 @@ func (x *SetSeedFromMnemonicRequest) String() string {
 func (*SetSeedFromMnemonicRequest) ProtoMessage() {}
 
 func (x *SetSeedFromMnemonicRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[42]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1841,7 +1938,7 @@ func (x *SetSeedFromMnemonicRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSeedFromMnemonicRequest.ProtoReflect.Descriptor instead.
 func (*SetSeedFromMnemonicRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{42}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SetSeedFromMnemonicRequest) GetMnemonic() string {
@@ -1859,7 +1956,7 @@ type SetSeedFromMnemonicResponse struct {
 
 func (x *SetSeedFromMnemonicResponse) Reset() {
 	*x = SetSeedFromMnemonicResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[43]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1871,7 +1968,7 @@ func (x *SetSeedFromMnemonicResponse) String() string {
 func (*SetSeedFromMnemonicResponse) ProtoMessage() {}
 
 func (x *SetSeedFromMnemonicResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[43]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1884,7 +1981,7 @@ func (x *SetSeedFromMnemonicResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSeedFromMnemonicResponse.ProtoReflect.Descriptor instead.
 func (*SetSeedFromMnemonicResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{43}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{45}
 }
 
 type CallRawRequest struct {
@@ -1897,7 +1994,7 @@ type CallRawRequest struct {
 
 func (x *CallRawRequest) Reset() {
 	*x = CallRawRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[44]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1909,7 +2006,7 @@ func (x *CallRawRequest) String() string {
 func (*CallRawRequest) ProtoMessage() {}
 
 func (x *CallRawRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[44]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1922,7 +2019,7 @@ func (x *CallRawRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallRawRequest.ProtoReflect.Descriptor instead.
 func (*CallRawRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{44}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *CallRawRequest) GetMethod() string {
@@ -1948,7 +2045,7 @@ type CallRawResponse struct {
 
 func (x *CallRawResponse) Reset() {
 	*x = CallRawResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[45]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1960,7 +2057,7 @@ func (x *CallRawResponse) String() string {
 func (*CallRawResponse) ProtoMessage() {}
 
 func (x *CallRawResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[45]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1973,7 +2070,7 @@ func (x *CallRawResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallRawResponse.ProtoReflect.Descriptor instead.
 func (*CallRawResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{45}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CallRawResponse) GetResultJson() string {
@@ -1991,7 +2088,7 @@ type ListWalletTransactionsRequest struct {
 
 func (x *ListWalletTransactionsRequest) Reset() {
 	*x = ListWalletTransactionsRequest{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[46]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2003,7 +2100,7 @@ func (x *ListWalletTransactionsRequest) String() string {
 func (*ListWalletTransactionsRequest) ProtoMessage() {}
 
 func (x *ListWalletTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[46]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2016,7 +2113,7 @@ func (x *ListWalletTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListWalletTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{46}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{48}
 }
 
 type ListWalletTransactionsResponse struct {
@@ -2031,7 +2128,7 @@ type ListWalletTransactionsResponse struct {
 
 func (x *ListWalletTransactionsResponse) Reset() {
 	*x = ListWalletTransactionsResponse{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[47]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2043,7 +2140,7 @@ func (x *ListWalletTransactionsResponse) String() string {
 func (*ListWalletTransactionsResponse) ProtoMessage() {}
 
 func (x *ListWalletTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[47]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2056,7 +2153,7 @@ func (x *ListWalletTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListWalletTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{47}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ListWalletTransactionsResponse) GetTransactions() []*SidechainWalletTransaction {
@@ -2091,7 +2188,7 @@ type SidechainWalletTransaction struct {
 
 func (x *SidechainWalletTransaction) Reset() {
 	*x = SidechainWalletTransaction{}
-	mi := &file_thunder_v1_thunder_proto_msgTypes[48]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2103,7 +2200,7 @@ func (x *SidechainWalletTransaction) String() string {
 func (*SidechainWalletTransaction) ProtoMessage() {}
 
 func (x *SidechainWalletTransaction) ProtoReflect() protoreflect.Message {
-	mi := &file_thunder_v1_thunder_proto_msgTypes[48]
+	mi := &file_thunder_v1_thunder_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2116,7 +2213,7 @@ func (x *SidechainWalletTransaction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidechainWalletTransaction.ProtoReflect.Descriptor instead.
 func (*SidechainWalletTransaction) Descriptor() ([]byte, []int) {
-	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{48}
+	return file_thunder_v1_thunder_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SidechainWalletTransaction) GetTxid() string {
@@ -2201,6 +2298,14 @@ const file_thunder_v1_thunder_proto_rawDesc = "" +
 	"amountSats\x12\x19\n" +
 	"\bfee_sats\x18\x03 \x01(\x03R\afeeSats\"&\n" +
 	"\x10TransferResponse\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\"\xc8\x01\n" +
+	"\x13TransferManyRequest\x12U\n" +
+	"\fdestinations\x18\x01 \x03(\v21.thunder.v1.TransferManyRequest.DestinationsEntryR\fdestinations\x12\x19\n" +
+	"\bfee_sats\x18\x02 \x01(\x03R\afeeSats\x1a?\n" +
+	"\x11DestinationsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"*\n" +
+	"\x14TransferManyResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\"\x1b\n" +
 	"\x19GetSidechainWealthRequest\"0\n" +
 	"\x1aGetSidechainWealthResponse\x12\x12\n" +
@@ -2286,7 +2391,7 @@ const file_thunder_v1_thunder_proto_rawDesc = "" +
 	"\n" +
 	"block_time\x18\x05 \x01(\x03R\tblockTime\x12\x1c\n" +
 	"\tconfirmed\x18\x06 \x01(\bR\tconfirmed\x12\x12\n" +
-	"\x04vout\x18\a \x01(\rR\x04vout2\x99\x11\n" +
+	"\x04vout\x18\a \x01(\rR\x04vout2\xec\x11\n" +
 	"\x0eThunderService\x12K\n" +
 	"\n" +
 	"GetBalance\x12\x1d.thunder.v1.GetBalanceRequest\x1a\x1e.thunder.v1.GetBalanceResponse\x12T\n" +
@@ -2294,7 +2399,8 @@ const file_thunder_v1_thunder_proto_rawDesc = "" +
 	"\x04Stop\x12\x17.thunder.v1.StopRequest\x1a\x18.thunder.v1.StopResponse\x12T\n" +
 	"\rGetNewAddress\x12 .thunder.v1.GetNewAddressRequest\x1a!.thunder.v1.GetNewAddressResponse\x12E\n" +
 	"\bWithdraw\x12\x1b.thunder.v1.WithdrawRequest\x1a\x1c.thunder.v1.WithdrawResponse\x12E\n" +
-	"\bTransfer\x12\x1b.thunder.v1.TransferRequest\x1a\x1c.thunder.v1.TransferResponse\x12c\n" +
+	"\bTransfer\x12\x1b.thunder.v1.TransferRequest\x1a\x1c.thunder.v1.TransferResponse\x12Q\n" +
+	"\fTransferMany\x12\x1f.thunder.v1.TransferManyRequest\x1a .thunder.v1.TransferManyResponse\x12c\n" +
 	"\x12GetSidechainWealth\x12%.thunder.v1.GetSidechainWealthRequest\x1a&.thunder.v1.GetSidechainWealthResponse\x12T\n" +
 	"\rCreateDeposit\x12 .thunder.v1.CreateDepositRequest\x1a!.thunder.v1.CreateDepositResponse\x12{\n" +
 	"\x1aGetPendingWithdrawalBundle\x12-.thunder.v1.GetPendingWithdrawalBundleRequest\x1a..thunder.v1.GetPendingWithdrawalBundleResponse\x12N\n" +
@@ -2329,7 +2435,7 @@ func file_thunder_v1_thunder_proto_rawDescGZIP() []byte {
 	return file_thunder_v1_thunder_proto_rawDescData
 }
 
-var file_thunder_v1_thunder_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_thunder_v1_thunder_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_thunder_v1_thunder_proto_goTypes = []any{
 	(*GetBalanceRequest)(nil),                             // 0: thunder.v1.GetBalanceRequest
 	(*GetBalanceResponse)(nil),                            // 1: thunder.v1.GetBalanceResponse
@@ -2343,99 +2449,105 @@ var file_thunder_v1_thunder_proto_goTypes = []any{
 	(*WithdrawResponse)(nil),                              // 9: thunder.v1.WithdrawResponse
 	(*TransferRequest)(nil),                               // 10: thunder.v1.TransferRequest
 	(*TransferResponse)(nil),                              // 11: thunder.v1.TransferResponse
-	(*GetSidechainWealthRequest)(nil),                     // 12: thunder.v1.GetSidechainWealthRequest
-	(*GetSidechainWealthResponse)(nil),                    // 13: thunder.v1.GetSidechainWealthResponse
-	(*CreateDepositRequest)(nil),                          // 14: thunder.v1.CreateDepositRequest
-	(*CreateDepositResponse)(nil),                         // 15: thunder.v1.CreateDepositResponse
-	(*GetPendingWithdrawalBundleRequest)(nil),             // 16: thunder.v1.GetPendingWithdrawalBundleRequest
-	(*GetPendingWithdrawalBundleResponse)(nil),            // 17: thunder.v1.GetPendingWithdrawalBundleResponse
-	(*ConnectPeerRequest)(nil),                            // 18: thunder.v1.ConnectPeerRequest
-	(*ConnectPeerResponse)(nil),                           // 19: thunder.v1.ConnectPeerResponse
-	(*ListPeersRequest)(nil),                              // 20: thunder.v1.ListPeersRequest
-	(*ListPeersResponse)(nil),                             // 21: thunder.v1.ListPeersResponse
-	(*MineRequest)(nil),                                   // 22: thunder.v1.MineRequest
-	(*MineResponse)(nil),                                  // 23: thunder.v1.MineResponse
-	(*GetBlockRequest)(nil),                               // 24: thunder.v1.GetBlockRequest
-	(*GetBlockResponse)(nil),                              // 25: thunder.v1.GetBlockResponse
-	(*GetBestMainchainBlockHashRequest)(nil),              // 26: thunder.v1.GetBestMainchainBlockHashRequest
-	(*GetBestMainchainBlockHashResponse)(nil),             // 27: thunder.v1.GetBestMainchainBlockHashResponse
-	(*GetBestSidechainBlockHashRequest)(nil),              // 28: thunder.v1.GetBestSidechainBlockHashRequest
-	(*GetBestSidechainBlockHashResponse)(nil),             // 29: thunder.v1.GetBestSidechainBlockHashResponse
-	(*GetBmmInclusionsRequest)(nil),                       // 30: thunder.v1.GetBmmInclusionsRequest
-	(*GetBmmInclusionsResponse)(nil),                      // 31: thunder.v1.GetBmmInclusionsResponse
-	(*GetWalletUtxosRequest)(nil),                         // 32: thunder.v1.GetWalletUtxosRequest
-	(*GetWalletUtxosResponse)(nil),                        // 33: thunder.v1.GetWalletUtxosResponse
-	(*ListUtxosRequest)(nil),                              // 34: thunder.v1.ListUtxosRequest
-	(*ListUtxosResponse)(nil),                             // 35: thunder.v1.ListUtxosResponse
-	(*RemoveFromMempoolRequest)(nil),                      // 36: thunder.v1.RemoveFromMempoolRequest
-	(*RemoveFromMempoolResponse)(nil),                     // 37: thunder.v1.RemoveFromMempoolResponse
-	(*GetLatestFailedWithdrawalBundleHeightRequest)(nil),  // 38: thunder.v1.GetLatestFailedWithdrawalBundleHeightRequest
-	(*GetLatestFailedWithdrawalBundleHeightResponse)(nil), // 39: thunder.v1.GetLatestFailedWithdrawalBundleHeightResponse
-	(*GenerateMnemonicRequest)(nil),                       // 40: thunder.v1.GenerateMnemonicRequest
-	(*GenerateMnemonicResponse)(nil),                      // 41: thunder.v1.GenerateMnemonicResponse
-	(*SetSeedFromMnemonicRequest)(nil),                    // 42: thunder.v1.SetSeedFromMnemonicRequest
-	(*SetSeedFromMnemonicResponse)(nil),                   // 43: thunder.v1.SetSeedFromMnemonicResponse
-	(*CallRawRequest)(nil),                                // 44: thunder.v1.CallRawRequest
-	(*CallRawResponse)(nil),                               // 45: thunder.v1.CallRawResponse
-	(*ListWalletTransactionsRequest)(nil),                 // 46: thunder.v1.ListWalletTransactionsRequest
-	(*ListWalletTransactionsResponse)(nil),                // 47: thunder.v1.ListWalletTransactionsResponse
-	(*SidechainWalletTransaction)(nil),                    // 48: thunder.v1.SidechainWalletTransaction
+	(*TransferManyRequest)(nil),                           // 12: thunder.v1.TransferManyRequest
+	(*TransferManyResponse)(nil),                          // 13: thunder.v1.TransferManyResponse
+	(*GetSidechainWealthRequest)(nil),                     // 14: thunder.v1.GetSidechainWealthRequest
+	(*GetSidechainWealthResponse)(nil),                    // 15: thunder.v1.GetSidechainWealthResponse
+	(*CreateDepositRequest)(nil),                          // 16: thunder.v1.CreateDepositRequest
+	(*CreateDepositResponse)(nil),                         // 17: thunder.v1.CreateDepositResponse
+	(*GetPendingWithdrawalBundleRequest)(nil),             // 18: thunder.v1.GetPendingWithdrawalBundleRequest
+	(*GetPendingWithdrawalBundleResponse)(nil),            // 19: thunder.v1.GetPendingWithdrawalBundleResponse
+	(*ConnectPeerRequest)(nil),                            // 20: thunder.v1.ConnectPeerRequest
+	(*ConnectPeerResponse)(nil),                           // 21: thunder.v1.ConnectPeerResponse
+	(*ListPeersRequest)(nil),                              // 22: thunder.v1.ListPeersRequest
+	(*ListPeersResponse)(nil),                             // 23: thunder.v1.ListPeersResponse
+	(*MineRequest)(nil),                                   // 24: thunder.v1.MineRequest
+	(*MineResponse)(nil),                                  // 25: thunder.v1.MineResponse
+	(*GetBlockRequest)(nil),                               // 26: thunder.v1.GetBlockRequest
+	(*GetBlockResponse)(nil),                              // 27: thunder.v1.GetBlockResponse
+	(*GetBestMainchainBlockHashRequest)(nil),              // 28: thunder.v1.GetBestMainchainBlockHashRequest
+	(*GetBestMainchainBlockHashResponse)(nil),             // 29: thunder.v1.GetBestMainchainBlockHashResponse
+	(*GetBestSidechainBlockHashRequest)(nil),              // 30: thunder.v1.GetBestSidechainBlockHashRequest
+	(*GetBestSidechainBlockHashResponse)(nil),             // 31: thunder.v1.GetBestSidechainBlockHashResponse
+	(*GetBmmInclusionsRequest)(nil),                       // 32: thunder.v1.GetBmmInclusionsRequest
+	(*GetBmmInclusionsResponse)(nil),                      // 33: thunder.v1.GetBmmInclusionsResponse
+	(*GetWalletUtxosRequest)(nil),                         // 34: thunder.v1.GetWalletUtxosRequest
+	(*GetWalletUtxosResponse)(nil),                        // 35: thunder.v1.GetWalletUtxosResponse
+	(*ListUtxosRequest)(nil),                              // 36: thunder.v1.ListUtxosRequest
+	(*ListUtxosResponse)(nil),                             // 37: thunder.v1.ListUtxosResponse
+	(*RemoveFromMempoolRequest)(nil),                      // 38: thunder.v1.RemoveFromMempoolRequest
+	(*RemoveFromMempoolResponse)(nil),                     // 39: thunder.v1.RemoveFromMempoolResponse
+	(*GetLatestFailedWithdrawalBundleHeightRequest)(nil),  // 40: thunder.v1.GetLatestFailedWithdrawalBundleHeightRequest
+	(*GetLatestFailedWithdrawalBundleHeightResponse)(nil), // 41: thunder.v1.GetLatestFailedWithdrawalBundleHeightResponse
+	(*GenerateMnemonicRequest)(nil),                       // 42: thunder.v1.GenerateMnemonicRequest
+	(*GenerateMnemonicResponse)(nil),                      // 43: thunder.v1.GenerateMnemonicResponse
+	(*SetSeedFromMnemonicRequest)(nil),                    // 44: thunder.v1.SetSeedFromMnemonicRequest
+	(*SetSeedFromMnemonicResponse)(nil),                   // 45: thunder.v1.SetSeedFromMnemonicResponse
+	(*CallRawRequest)(nil),                                // 46: thunder.v1.CallRawRequest
+	(*CallRawResponse)(nil),                               // 47: thunder.v1.CallRawResponse
+	(*ListWalletTransactionsRequest)(nil),                 // 48: thunder.v1.ListWalletTransactionsRequest
+	(*ListWalletTransactionsResponse)(nil),                // 49: thunder.v1.ListWalletTransactionsResponse
+	(*SidechainWalletTransaction)(nil),                    // 50: thunder.v1.SidechainWalletTransaction
+	nil,                                                   // 51: thunder.v1.TransferManyRequest.DestinationsEntry
 }
 var file_thunder_v1_thunder_proto_depIdxs = []int32{
-	48, // 0: thunder.v1.ListWalletTransactionsResponse.transactions:type_name -> thunder.v1.SidechainWalletTransaction
-	0,  // 1: thunder.v1.ThunderService.GetBalance:input_type -> thunder.v1.GetBalanceRequest
-	2,  // 2: thunder.v1.ThunderService.GetBlockCount:input_type -> thunder.v1.GetBlockCountRequest
-	4,  // 3: thunder.v1.ThunderService.Stop:input_type -> thunder.v1.StopRequest
-	6,  // 4: thunder.v1.ThunderService.GetNewAddress:input_type -> thunder.v1.GetNewAddressRequest
-	8,  // 5: thunder.v1.ThunderService.Withdraw:input_type -> thunder.v1.WithdrawRequest
-	10, // 6: thunder.v1.ThunderService.Transfer:input_type -> thunder.v1.TransferRequest
-	12, // 7: thunder.v1.ThunderService.GetSidechainWealth:input_type -> thunder.v1.GetSidechainWealthRequest
-	14, // 8: thunder.v1.ThunderService.CreateDeposit:input_type -> thunder.v1.CreateDepositRequest
-	16, // 9: thunder.v1.ThunderService.GetPendingWithdrawalBundle:input_type -> thunder.v1.GetPendingWithdrawalBundleRequest
-	18, // 10: thunder.v1.ThunderService.ConnectPeer:input_type -> thunder.v1.ConnectPeerRequest
-	20, // 11: thunder.v1.ThunderService.ListPeers:input_type -> thunder.v1.ListPeersRequest
-	22, // 12: thunder.v1.ThunderService.Mine:input_type -> thunder.v1.MineRequest
-	24, // 13: thunder.v1.ThunderService.GetBlock:input_type -> thunder.v1.GetBlockRequest
-	26, // 14: thunder.v1.ThunderService.GetBestMainchainBlockHash:input_type -> thunder.v1.GetBestMainchainBlockHashRequest
-	28, // 15: thunder.v1.ThunderService.GetBestSidechainBlockHash:input_type -> thunder.v1.GetBestSidechainBlockHashRequest
-	30, // 16: thunder.v1.ThunderService.GetBmmInclusions:input_type -> thunder.v1.GetBmmInclusionsRequest
-	32, // 17: thunder.v1.ThunderService.GetWalletUtxos:input_type -> thunder.v1.GetWalletUtxosRequest
-	34, // 18: thunder.v1.ThunderService.ListUtxos:input_type -> thunder.v1.ListUtxosRequest
-	36, // 19: thunder.v1.ThunderService.RemoveFromMempool:input_type -> thunder.v1.RemoveFromMempoolRequest
-	38, // 20: thunder.v1.ThunderService.GetLatestFailedWithdrawalBundleHeight:input_type -> thunder.v1.GetLatestFailedWithdrawalBundleHeightRequest
-	40, // 21: thunder.v1.ThunderService.GenerateMnemonic:input_type -> thunder.v1.GenerateMnemonicRequest
-	42, // 22: thunder.v1.ThunderService.SetSeedFromMnemonic:input_type -> thunder.v1.SetSeedFromMnemonicRequest
-	44, // 23: thunder.v1.ThunderService.CallRaw:input_type -> thunder.v1.CallRawRequest
-	46, // 24: thunder.v1.ThunderService.ListWalletTransactions:input_type -> thunder.v1.ListWalletTransactionsRequest
-	1,  // 25: thunder.v1.ThunderService.GetBalance:output_type -> thunder.v1.GetBalanceResponse
-	3,  // 26: thunder.v1.ThunderService.GetBlockCount:output_type -> thunder.v1.GetBlockCountResponse
-	5,  // 27: thunder.v1.ThunderService.Stop:output_type -> thunder.v1.StopResponse
-	7,  // 28: thunder.v1.ThunderService.GetNewAddress:output_type -> thunder.v1.GetNewAddressResponse
-	9,  // 29: thunder.v1.ThunderService.Withdraw:output_type -> thunder.v1.WithdrawResponse
-	11, // 30: thunder.v1.ThunderService.Transfer:output_type -> thunder.v1.TransferResponse
-	13, // 31: thunder.v1.ThunderService.GetSidechainWealth:output_type -> thunder.v1.GetSidechainWealthResponse
-	15, // 32: thunder.v1.ThunderService.CreateDeposit:output_type -> thunder.v1.CreateDepositResponse
-	17, // 33: thunder.v1.ThunderService.GetPendingWithdrawalBundle:output_type -> thunder.v1.GetPendingWithdrawalBundleResponse
-	19, // 34: thunder.v1.ThunderService.ConnectPeer:output_type -> thunder.v1.ConnectPeerResponse
-	21, // 35: thunder.v1.ThunderService.ListPeers:output_type -> thunder.v1.ListPeersResponse
-	23, // 36: thunder.v1.ThunderService.Mine:output_type -> thunder.v1.MineResponse
-	25, // 37: thunder.v1.ThunderService.GetBlock:output_type -> thunder.v1.GetBlockResponse
-	27, // 38: thunder.v1.ThunderService.GetBestMainchainBlockHash:output_type -> thunder.v1.GetBestMainchainBlockHashResponse
-	29, // 39: thunder.v1.ThunderService.GetBestSidechainBlockHash:output_type -> thunder.v1.GetBestSidechainBlockHashResponse
-	31, // 40: thunder.v1.ThunderService.GetBmmInclusions:output_type -> thunder.v1.GetBmmInclusionsResponse
-	33, // 41: thunder.v1.ThunderService.GetWalletUtxos:output_type -> thunder.v1.GetWalletUtxosResponse
-	35, // 42: thunder.v1.ThunderService.ListUtxos:output_type -> thunder.v1.ListUtxosResponse
-	37, // 43: thunder.v1.ThunderService.RemoveFromMempool:output_type -> thunder.v1.RemoveFromMempoolResponse
-	39, // 44: thunder.v1.ThunderService.GetLatestFailedWithdrawalBundleHeight:output_type -> thunder.v1.GetLatestFailedWithdrawalBundleHeightResponse
-	41, // 45: thunder.v1.ThunderService.GenerateMnemonic:output_type -> thunder.v1.GenerateMnemonicResponse
-	43, // 46: thunder.v1.ThunderService.SetSeedFromMnemonic:output_type -> thunder.v1.SetSeedFromMnemonicResponse
-	45, // 47: thunder.v1.ThunderService.CallRaw:output_type -> thunder.v1.CallRawResponse
-	47, // 48: thunder.v1.ThunderService.ListWalletTransactions:output_type -> thunder.v1.ListWalletTransactionsResponse
-	25, // [25:49] is the sub-list for method output_type
-	1,  // [1:25] is the sub-list for method input_type
-	1,  // [1:1] is the sub-list for extension type_name
-	1,  // [1:1] is the sub-list for extension extendee
-	0,  // [0:1] is the sub-list for field type_name
+	51, // 0: thunder.v1.TransferManyRequest.destinations:type_name -> thunder.v1.TransferManyRequest.DestinationsEntry
+	50, // 1: thunder.v1.ListWalletTransactionsResponse.transactions:type_name -> thunder.v1.SidechainWalletTransaction
+	0,  // 2: thunder.v1.ThunderService.GetBalance:input_type -> thunder.v1.GetBalanceRequest
+	2,  // 3: thunder.v1.ThunderService.GetBlockCount:input_type -> thunder.v1.GetBlockCountRequest
+	4,  // 4: thunder.v1.ThunderService.Stop:input_type -> thunder.v1.StopRequest
+	6,  // 5: thunder.v1.ThunderService.GetNewAddress:input_type -> thunder.v1.GetNewAddressRequest
+	8,  // 6: thunder.v1.ThunderService.Withdraw:input_type -> thunder.v1.WithdrawRequest
+	10, // 7: thunder.v1.ThunderService.Transfer:input_type -> thunder.v1.TransferRequest
+	12, // 8: thunder.v1.ThunderService.TransferMany:input_type -> thunder.v1.TransferManyRequest
+	14, // 9: thunder.v1.ThunderService.GetSidechainWealth:input_type -> thunder.v1.GetSidechainWealthRequest
+	16, // 10: thunder.v1.ThunderService.CreateDeposit:input_type -> thunder.v1.CreateDepositRequest
+	18, // 11: thunder.v1.ThunderService.GetPendingWithdrawalBundle:input_type -> thunder.v1.GetPendingWithdrawalBundleRequest
+	20, // 12: thunder.v1.ThunderService.ConnectPeer:input_type -> thunder.v1.ConnectPeerRequest
+	22, // 13: thunder.v1.ThunderService.ListPeers:input_type -> thunder.v1.ListPeersRequest
+	24, // 14: thunder.v1.ThunderService.Mine:input_type -> thunder.v1.MineRequest
+	26, // 15: thunder.v1.ThunderService.GetBlock:input_type -> thunder.v1.GetBlockRequest
+	28, // 16: thunder.v1.ThunderService.GetBestMainchainBlockHash:input_type -> thunder.v1.GetBestMainchainBlockHashRequest
+	30, // 17: thunder.v1.ThunderService.GetBestSidechainBlockHash:input_type -> thunder.v1.GetBestSidechainBlockHashRequest
+	32, // 18: thunder.v1.ThunderService.GetBmmInclusions:input_type -> thunder.v1.GetBmmInclusionsRequest
+	34, // 19: thunder.v1.ThunderService.GetWalletUtxos:input_type -> thunder.v1.GetWalletUtxosRequest
+	36, // 20: thunder.v1.ThunderService.ListUtxos:input_type -> thunder.v1.ListUtxosRequest
+	38, // 21: thunder.v1.ThunderService.RemoveFromMempool:input_type -> thunder.v1.RemoveFromMempoolRequest
+	40, // 22: thunder.v1.ThunderService.GetLatestFailedWithdrawalBundleHeight:input_type -> thunder.v1.GetLatestFailedWithdrawalBundleHeightRequest
+	42, // 23: thunder.v1.ThunderService.GenerateMnemonic:input_type -> thunder.v1.GenerateMnemonicRequest
+	44, // 24: thunder.v1.ThunderService.SetSeedFromMnemonic:input_type -> thunder.v1.SetSeedFromMnemonicRequest
+	46, // 25: thunder.v1.ThunderService.CallRaw:input_type -> thunder.v1.CallRawRequest
+	48, // 26: thunder.v1.ThunderService.ListWalletTransactions:input_type -> thunder.v1.ListWalletTransactionsRequest
+	1,  // 27: thunder.v1.ThunderService.GetBalance:output_type -> thunder.v1.GetBalanceResponse
+	3,  // 28: thunder.v1.ThunderService.GetBlockCount:output_type -> thunder.v1.GetBlockCountResponse
+	5,  // 29: thunder.v1.ThunderService.Stop:output_type -> thunder.v1.StopResponse
+	7,  // 30: thunder.v1.ThunderService.GetNewAddress:output_type -> thunder.v1.GetNewAddressResponse
+	9,  // 31: thunder.v1.ThunderService.Withdraw:output_type -> thunder.v1.WithdrawResponse
+	11, // 32: thunder.v1.ThunderService.Transfer:output_type -> thunder.v1.TransferResponse
+	13, // 33: thunder.v1.ThunderService.TransferMany:output_type -> thunder.v1.TransferManyResponse
+	15, // 34: thunder.v1.ThunderService.GetSidechainWealth:output_type -> thunder.v1.GetSidechainWealthResponse
+	17, // 35: thunder.v1.ThunderService.CreateDeposit:output_type -> thunder.v1.CreateDepositResponse
+	19, // 36: thunder.v1.ThunderService.GetPendingWithdrawalBundle:output_type -> thunder.v1.GetPendingWithdrawalBundleResponse
+	21, // 37: thunder.v1.ThunderService.ConnectPeer:output_type -> thunder.v1.ConnectPeerResponse
+	23, // 38: thunder.v1.ThunderService.ListPeers:output_type -> thunder.v1.ListPeersResponse
+	25, // 39: thunder.v1.ThunderService.Mine:output_type -> thunder.v1.MineResponse
+	27, // 40: thunder.v1.ThunderService.GetBlock:output_type -> thunder.v1.GetBlockResponse
+	29, // 41: thunder.v1.ThunderService.GetBestMainchainBlockHash:output_type -> thunder.v1.GetBestMainchainBlockHashResponse
+	31, // 42: thunder.v1.ThunderService.GetBestSidechainBlockHash:output_type -> thunder.v1.GetBestSidechainBlockHashResponse
+	33, // 43: thunder.v1.ThunderService.GetBmmInclusions:output_type -> thunder.v1.GetBmmInclusionsResponse
+	35, // 44: thunder.v1.ThunderService.GetWalletUtxos:output_type -> thunder.v1.GetWalletUtxosResponse
+	37, // 45: thunder.v1.ThunderService.ListUtxos:output_type -> thunder.v1.ListUtxosResponse
+	39, // 46: thunder.v1.ThunderService.RemoveFromMempool:output_type -> thunder.v1.RemoveFromMempoolResponse
+	41, // 47: thunder.v1.ThunderService.GetLatestFailedWithdrawalBundleHeight:output_type -> thunder.v1.GetLatestFailedWithdrawalBundleHeightResponse
+	43, // 48: thunder.v1.ThunderService.GenerateMnemonic:output_type -> thunder.v1.GenerateMnemonicResponse
+	45, // 49: thunder.v1.ThunderService.SetSeedFromMnemonic:output_type -> thunder.v1.SetSeedFromMnemonicResponse
+	47, // 50: thunder.v1.ThunderService.CallRaw:output_type -> thunder.v1.CallRawResponse
+	49, // 51: thunder.v1.ThunderService.ListWalletTransactions:output_type -> thunder.v1.ListWalletTransactionsResponse
+	27, // [27:52] is the sub-list for method output_type
+	2,  // [2:27] is the sub-list for method input_type
+	2,  // [2:2] is the sub-list for extension type_name
+	2,  // [2:2] is the sub-list for extension extendee
+	0,  // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_thunder_v1_thunder_proto_init() }
@@ -2449,7 +2561,7 @@ func file_thunder_v1_thunder_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_thunder_v1_thunder_proto_rawDesc), len(file_thunder_v1_thunder_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   49,
+			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/thunder/v1/thunderv1connect/thunder.connect.go
+++ b/sidechain-orchestrator/gen/thunder/v1/thunderv1connect/thunder.connect.go
@@ -48,6 +48,9 @@ const (
 	ThunderServiceWithdrawProcedure = "/thunder.v1.ThunderService/Withdraw"
 	// ThunderServiceTransferProcedure is the fully-qualified name of the ThunderService's Transfer RPC.
 	ThunderServiceTransferProcedure = "/thunder.v1.ThunderService/Transfer"
+	// ThunderServiceTransferManyProcedure is the fully-qualified name of the ThunderService's
+	// TransferMany RPC.
+	ThunderServiceTransferManyProcedure = "/thunder.v1.ThunderService/TransferMany"
 	// ThunderServiceGetSidechainWealthProcedure is the fully-qualified name of the ThunderService's
 	// GetSidechainWealth RPC.
 	ThunderServiceGetSidechainWealthProcedure = "/thunder.v1.ThunderService/GetSidechainWealth"
@@ -115,6 +118,8 @@ type ThunderServiceClient interface {
 	Withdraw(context.Context, *connect.Request[v1.WithdrawRequest]) (*connect.Response[v1.WithdrawResponse], error)
 	// Transfer within sidechain.
 	Transfer(context.Context, *connect.Request[v1.TransferRequest]) (*connect.Response[v1.TransferResponse], error)
+	// Transfer to many addresses in one transaction.
+	TransferMany(context.Context, *connect.Request[v1.TransferManyRequest]) (*connect.Response[v1.TransferManyResponse], error)
 	// Get total sidechain wealth in sats.
 	GetSidechainWealth(context.Context, *connect.Request[v1.GetSidechainWealthRequest]) (*connect.Response[v1.GetSidechainWealthResponse], error)
 	// Create a deposit transaction.
@@ -199,6 +204,12 @@ func NewThunderServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			httpClient,
 			baseURL+ThunderServiceTransferProcedure,
 			connect.WithSchema(thunderServiceMethods.ByName("Transfer")),
+			connect.WithClientOptions(opts...),
+		),
+		transferMany: connect.NewClient[v1.TransferManyRequest, v1.TransferManyResponse](
+			httpClient,
+			baseURL+ThunderServiceTransferManyProcedure,
+			connect.WithSchema(thunderServiceMethods.ByName("TransferMany")),
 			connect.WithClientOptions(opts...),
 		),
 		getSidechainWealth: connect.NewClient[v1.GetSidechainWealthRequest, v1.GetSidechainWealthResponse](
@@ -320,6 +331,7 @@ type thunderServiceClient struct {
 	getNewAddress                         *connect.Client[v1.GetNewAddressRequest, v1.GetNewAddressResponse]
 	withdraw                              *connect.Client[v1.WithdrawRequest, v1.WithdrawResponse]
 	transfer                              *connect.Client[v1.TransferRequest, v1.TransferResponse]
+	transferMany                          *connect.Client[v1.TransferManyRequest, v1.TransferManyResponse]
 	getSidechainWealth                    *connect.Client[v1.GetSidechainWealthRequest, v1.GetSidechainWealthResponse]
 	createDeposit                         *connect.Client[v1.CreateDepositRequest, v1.CreateDepositResponse]
 	getPendingWithdrawalBundle            *connect.Client[v1.GetPendingWithdrawalBundleRequest, v1.GetPendingWithdrawalBundleResponse]
@@ -368,6 +380,11 @@ func (c *thunderServiceClient) Withdraw(ctx context.Context, req *connect.Reques
 // Transfer calls thunder.v1.ThunderService.Transfer.
 func (c *thunderServiceClient) Transfer(ctx context.Context, req *connect.Request[v1.TransferRequest]) (*connect.Response[v1.TransferResponse], error) {
 	return c.transfer.CallUnary(ctx, req)
+}
+
+// TransferMany calls thunder.v1.ThunderService.TransferMany.
+func (c *thunderServiceClient) TransferMany(ctx context.Context, req *connect.Request[v1.TransferManyRequest]) (*connect.Response[v1.TransferManyResponse], error) {
+	return c.transferMany.CallUnary(ctx, req)
 }
 
 // GetSidechainWealth calls thunder.v1.ThunderService.GetSidechainWealth.
@@ -475,6 +492,8 @@ type ThunderServiceHandler interface {
 	Withdraw(context.Context, *connect.Request[v1.WithdrawRequest]) (*connect.Response[v1.WithdrawResponse], error)
 	// Transfer within sidechain.
 	Transfer(context.Context, *connect.Request[v1.TransferRequest]) (*connect.Response[v1.TransferResponse], error)
+	// Transfer to many addresses in one transaction.
+	TransferMany(context.Context, *connect.Request[v1.TransferManyRequest]) (*connect.Response[v1.TransferManyResponse], error)
 	// Get total sidechain wealth in sats.
 	GetSidechainWealth(context.Context, *connect.Request[v1.GetSidechainWealthRequest]) (*connect.Response[v1.GetSidechainWealthResponse], error)
 	// Create a deposit transaction.
@@ -555,6 +574,12 @@ func NewThunderServiceHandler(svc ThunderServiceHandler, opts ...connect.Handler
 		ThunderServiceTransferProcedure,
 		svc.Transfer,
 		connect.WithSchema(thunderServiceMethods.ByName("Transfer")),
+		connect.WithHandlerOptions(opts...),
+	)
+	thunderServiceTransferManyHandler := connect.NewUnaryHandler(
+		ThunderServiceTransferManyProcedure,
+		svc.TransferMany,
+		connect.WithSchema(thunderServiceMethods.ByName("TransferMany")),
 		connect.WithHandlerOptions(opts...),
 	)
 	thunderServiceGetSidechainWealthHandler := connect.NewUnaryHandler(
@@ -679,6 +704,8 @@ func NewThunderServiceHandler(svc ThunderServiceHandler, opts ...connect.Handler
 			thunderServiceWithdrawHandler.ServeHTTP(w, r)
 		case ThunderServiceTransferProcedure:
 			thunderServiceTransferHandler.ServeHTTP(w, r)
+		case ThunderServiceTransferManyProcedure:
+			thunderServiceTransferManyHandler.ServeHTTP(w, r)
 		case ThunderServiceGetSidechainWealthProcedure:
 			thunderServiceGetSidechainWealthHandler.ServeHTTP(w, r)
 		case ThunderServiceCreateDepositProcedure:
@@ -746,6 +773,10 @@ func (UnimplementedThunderServiceHandler) Withdraw(context.Context, *connect.Req
 
 func (UnimplementedThunderServiceHandler) Transfer(context.Context, *connect.Request[v1.TransferRequest]) (*connect.Response[v1.TransferResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("thunder.v1.ThunderService.Transfer is not implemented"))
+}
+
+func (UnimplementedThunderServiceHandler) TransferMany(context.Context, *connect.Request[v1.TransferManyRequest]) (*connect.Response[v1.TransferManyResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("thunder.v1.ThunderService.TransferMany is not implemented"))
 }
 
 func (UnimplementedThunderServiceHandler) GetSidechainWealth(context.Context, *connect.Request[v1.GetSidechainWealthRequest]) (*connect.Response[v1.GetSidechainWealthResponse], error) {

--- a/sidechain-orchestrator/proto/thunder/v1/thunder.proto
+++ b/sidechain-orchestrator/proto/thunder/v1/thunder.proto
@@ -21,6 +21,9 @@ service ThunderService {
   // Transfer within sidechain.
   rpc Transfer(TransferRequest) returns (TransferResponse);
 
+  // Transfer to many addresses in one transaction.
+  rpc TransferMany(TransferManyRequest) returns (TransferManyResponse);
+
   // Get total sidechain wealth in sats.
   rpc GetSidechainWealth(GetSidechainWealthRequest) returns (GetSidechainWealthResponse);
 
@@ -130,6 +133,18 @@ message TransferRequest {
 }
 
 message TransferResponse {
+  string txid = 1;
+}
+
+// TransferMany
+
+message TransferManyRequest {
+  // Amount in sats for each destination address.
+  map<string, int64> destinations = 1;
+  int64 fee_sats = 2;
+}
+
+message TransferManyResponse {
   string txid = 1;
 }
 

--- a/sidechain-orchestrator/sidechain/thunder/backend.go
+++ b/sidechain-orchestrator/sidechain/thunder/backend.go
@@ -20,6 +20,8 @@ type WalletBackend interface {
 	UTXOs(ctx context.Context) (json.RawMessage, error)
 	// Transfer pays one address and returns the txid.
 	Transfer(ctx context.Context, address string, amountSats, feeSats int64) (string, error)
+	// TransferMany pays every address in destinations and returns the txid.
+	TransferMany(ctx context.Context, destinations map[string]int64, feeSats int64) (string, error)
 	// Withdraw asks for coins to leave the sidechain and returns the txid.
 	Withdraw(
 		ctx context.Context, address string, amountSats, sideFeeSats, mainFeeSats int64,
@@ -53,6 +55,17 @@ func (b *nodeBackend) Transfer(
 	var txid string
 	params := []any{address, amountSats, feeSats}
 	if err := b.proxy.Client.Call(ctx, "create_transfer", params, &txid); err != nil {
+		return "", err
+	}
+	return txid, nil
+}
+
+func (b *nodeBackend) TransferMany(
+	ctx context.Context, destinations map[string]int64, feeSats int64,
+) (string, error) {
+	var txid string
+	params := []any{destinations, feeSats}
+	if err := b.proxy.Client.Call(ctx, "create_transfer_many", params, &txid); err != nil {
 		return "", err
 	}
 	return txid, nil

--- a/sidechain-orchestrator/sidechain/thunder/handler.go
+++ b/sidechain-orchestrator/sidechain/thunder/handler.go
@@ -152,6 +152,18 @@ func (h *Handler) Transfer(ctx context.Context, req *connect.Request[pb.Transfer
 	return connect.NewResponse(&pb.TransferResponse{Txid: txid}), nil
 }
 
+func (h *Handler) TransferMany(ctx context.Context, req *connect.Request[pb.TransferManyRequest]) (*connect.Response[pb.TransferManyResponse], error) {
+	backend, err := h.backend(ctx)
+	if err != nil {
+		return nil, err
+	}
+	txid, err := backend.TransferMany(ctx, req.Msg.Destinations, req.Msg.FeeSats)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&pb.TransferManyResponse{Txid: txid}), nil
+}
+
 func (h *Handler) Mine(ctx context.Context, req *connect.Request[pb.MineRequest]) (*connect.Response[pb.MineResponse], error) {
 	raw, err := h.proxy.Mine(ctx, req.Msg.FeeSats)
 	if err != nil {

--- a/sidechain-orchestrator/sidechain/thunder/lightbackend.go
+++ b/sidechain-orchestrator/sidechain/thunder/lightbackend.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/btcsuite/btcd/chaincfg"
 
@@ -147,6 +149,43 @@ func (b *lightBackend) Transfer(
 
 	txid, err := b.wallet.Send(ctx, from,
 		[]tw.Recipient{{Address: to, ValueSats: amount}}, fee, change)
+	if err != nil {
+		return "", err
+	}
+	return txid.String(), nil
+}
+
+func (b *lightBackend) TransferMany(
+	ctx context.Context, destinations map[string]int64, feeSats int64,
+) (string, error) {
+	if len(destinations) == 0 {
+		return "", fmt.Errorf("the transfer has no destination")
+	}
+	if feeSats < 0 {
+		return "", fmt.Errorf("the fee is negative")
+	}
+	recipients := make([]tw.Recipient, 0, len(destinations))
+	for _, address := range slices.Sorted(maps.Keys(destinations)) {
+		to, err := tw.ParseAddress(address)
+		if err != nil {
+			return "", fmt.Errorf("read the address %q: %w", address, err)
+		}
+		amountSats := destinations[address]
+		if amountSats <= 0 {
+			return "", fmt.Errorf("the amount for %s must be above zero", address)
+		}
+		recipients = append(recipients, tw.Recipient{Address: to, ValueSats: uint64(amountSats)})
+	}
+	from, err := b.addresses(ctx)
+	if err != nil {
+		return "", err
+	}
+	change, err := b.changeAddress(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	txid, err := b.wallet.Send(ctx, from, recipients, uint64(feeSats), change)
 	if err != nil {
 		return "", err
 	}

--- a/sidechain-orchestrator/sidechain/thunder/send_method_test.go
+++ b/sidechain-orchestrator/sidechain/thunder/send_method_test.go
@@ -56,6 +56,24 @@ func TestTransferCallsCreateTransfer(t *testing.T) {
 	assert.Equal(t, []string{`create_transfer ["ocPdhEToXd9myNCN8si5mGxdaRQ",50000000,1000]`}, *seen)
 }
 
+func TestTransferManyCallsCreateTransferMany(t *testing.T) {
+	proxy, seen := sendMethodNode(t, map[string]string{"create_transfer_many": `"txid3"`})
+
+	resp, err := NewHandler(proxy).TransferMany(context.Background(),
+		connect.NewRequest(&pb.TransferManyRequest{
+			Destinations: map[string]int64{
+				"ocPdhEToXd9myNCN8si5mGxdaRQ":  50_000_000,
+				"ocDzT2wRnkYcvzy2pRYPZgeBRhwp": 25_000_000,
+			},
+			FeeSats: 1000,
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, "txid3", resp.Msg.Txid)
+	assert.Equal(t, []string{
+		`create_transfer_many [{"ocDzT2wRnkYcvzy2pRYPZgeBRhwp":25000000,"ocPdhEToXd9myNCN8si5mGxdaRQ":50000000},1000]`,
+	}, *seen)
+}
+
 func TestWithdrawCallsCreateWithdrawal(t *testing.T) {
 	proxy, seen := sendMethodNode(t, map[string]string{"create_withdrawal": `"txid2"`})
 

--- a/sidechain_core/lib/gen/thunder/v1/thunder.connect.client.dart
+++ b/sidechain_core/lib/gen/thunder/v1/thunder.connect.client.dart
@@ -116,6 +116,24 @@ extension type ThunderServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// Transfer to many addresses in one transaction.
+  Future<thunderv1thunder.TransferManyResponse> transferMany(
+    thunderv1thunder.TransferManyRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.ThunderService.transferMany,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// Get total sidechain wealth in sats.
   Future<thunderv1thunder.GetSidechainWealthResponse> getSidechainWealth(
     thunderv1thunder.GetSidechainWealthRequest input, {

--- a/sidechain_core/lib/gen/thunder/v1/thunder.connect.spec.dart
+++ b/sidechain_core/lib/gen/thunder/v1/thunder.connect.spec.dart
@@ -58,6 +58,14 @@ abstract final class ThunderService {
     thunderv1thunder.TransferResponse.new,
   );
 
+  /// Transfer to many addresses in one transaction.
+  static const transferMany = connect.Spec(
+    '/$name/TransferMany',
+    connect.StreamType.unary,
+    thunderv1thunder.TransferManyRequest.new,
+    thunderv1thunder.TransferManyResponse.new,
+  );
+
   /// Get total sidechain wealth in sats.
   static const getSidechainWealth = connect.Spec(
     '/$name/GetSidechainWealth',

--- a/sidechain_core/lib/gen/thunder/v1/thunder.pb.dart
+++ b/sidechain_core/lib/gen/thunder/v1/thunder.pb.dart
@@ -609,6 +609,115 @@ class TransferResponse extends $pb.GeneratedMessage {
   void clearTxid() => clearField(1);
 }
 
+class TransferManyRequest extends $pb.GeneratedMessage {
+  factory TransferManyRequest({
+    $core.Map<$core.String, $fixnum.Int64>? destinations,
+    $fixnum.Int64? feeSats,
+  }) {
+    final $result = create();
+    if (destinations != null) {
+      $result.destinations.addAll(destinations);
+    }
+    if (feeSats != null) {
+      $result.feeSats = feeSats;
+    }
+    return $result;
+  }
+  TransferManyRequest._() : super();
+  factory TransferManyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferManyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferManyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..m<$core.String, $fixnum.Int64>(1, _omitFieldNames ? '' : 'destinations', entryClassName: 'TransferManyRequest.DestinationsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.O6, packageName: const $pb.PackageName('thunder.v1'))
+    ..aInt64(2, _omitFieldNames ? '' : 'feeSats')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TransferManyRequest clone() => TransferManyRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferManyRequest copyWith(void Function(TransferManyRequest) updates) => super.copyWith((message) => updates(message as TransferManyRequest)) as TransferManyRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TransferManyRequest create() => TransferManyRequest._();
+  TransferManyRequest createEmptyInstance() => create();
+  static $pb.PbList<TransferManyRequest> createRepeated() => $pb.PbList<TransferManyRequest>();
+  @$core.pragma('dart2js:noInline')
+  static TransferManyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferManyRequest>(create);
+  static TransferManyRequest? _defaultInstance;
+
+  /// Amount in sats for each destination address.
+  @$pb.TagNumber(1)
+  $core.Map<$core.String, $fixnum.Int64> get destinations => $_getMap(0);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get feeSats => $_getI64(1);
+  @$pb.TagNumber(2)
+  set feeSats($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFeeSats() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFeeSats() => clearField(2);
+}
+
+class TransferManyResponse extends $pb.GeneratedMessage {
+  factory TransferManyResponse({
+    $core.String? txid,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    return $result;
+  }
+  TransferManyResponse._() : super();
+  factory TransferManyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferManyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferManyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TransferManyResponse clone() => TransferManyResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferManyResponse copyWith(void Function(TransferManyResponse) updates) => super.copyWith((message) => updates(message as TransferManyResponse)) as TransferManyResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TransferManyResponse create() => TransferManyResponse._();
+  TransferManyResponse createEmptyInstance() => create();
+  static $pb.PbList<TransferManyResponse> createRepeated() => $pb.PbList<TransferManyResponse>();
+  @$core.pragma('dart2js:noInline')
+  static TransferManyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferManyResponse>(create);
+  static TransferManyResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+}
+
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
@@ -2387,6 +2496,9 @@ class ThunderServiceApi {
   ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
     _client.invoke<TransferResponse>(ctx, 'ThunderService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<TransferManyResponse> transferMany($pb.ClientContext? ctx, TransferManyRequest request) =>
+    _client.invoke<TransferManyResponse>(ctx, 'ThunderService', 'TransferMany', request, TransferManyResponse())
   ;
   $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
     _client.invoke<GetSidechainWealthResponse>(ctx, 'ThunderService', 'GetSidechainWealth', request, GetSidechainWealthResponse())

--- a/sidechain_core/lib/gen/thunder/v1/thunder.pbjson.dart
+++ b/sidechain_core/lib/gen/thunder/v1/thunder.pbjson.dart
@@ -152,6 +152,45 @@ const TransferResponse$json = {
 final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
     'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
+@$core.Deprecated('Use transferManyRequestDescriptor instead')
+const TransferManyRequest$json = {
+  '1': 'TransferManyRequest',
+  '2': [
+    {'1': 'destinations', '3': 1, '4': 3, '5': 11, '6': '.thunder.v1.TransferManyRequest.DestinationsEntry', '10': 'destinations'},
+    {'1': 'fee_sats', '3': 2, '4': 1, '5': 3, '10': 'feeSats'},
+  ],
+  '3': [TransferManyRequest_DestinationsEntry$json],
+};
+
+@$core.Deprecated('Use transferManyRequestDescriptor instead')
+const TransferManyRequest_DestinationsEntry$json = {
+  '1': 'DestinationsEntry',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 3, '10': 'value'},
+  ],
+  '7': {'7': true},
+};
+
+/// Descriptor for `TransferManyRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List transferManyRequestDescriptor = $convert.base64Decode(
+    'ChNUcmFuc2Zlck1hbnlSZXF1ZXN0ElUKDGRlc3RpbmF0aW9ucxgBIAMoCzIxLnRodW5kZXIudj'
+    'EuVHJhbnNmZXJNYW55UmVxdWVzdC5EZXN0aW5hdGlvbnNFbnRyeVIMZGVzdGluYXRpb25zEhkK'
+    'CGZlZV9zYXRzGAIgASgDUgdmZWVTYXRzGj8KEURlc3RpbmF0aW9uc0VudHJ5EhAKA2tleRgBIA'
+    'EoCVIDa2V5EhQKBXZhbHVlGAIgASgDUgV2YWx1ZToCOAE=');
+
+@$core.Deprecated('Use transferManyResponseDescriptor instead')
+const TransferManyResponse$json = {
+  '1': 'TransferManyResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+  ],
+};
+
+/// Descriptor for `TransferManyResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List transferManyResponseDescriptor = $convert.base64Decode(
+    'ChRUcmFuc2Zlck1hbnlSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
   '1': 'GetSidechainWealthRequest',
@@ -591,6 +630,7 @@ const $core.Map<$core.String, $core.dynamic> ThunderServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.thunder.v1.GetNewAddressRequest', '3': '.thunder.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.thunder.v1.WithdrawRequest', '3': '.thunder.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.thunder.v1.TransferRequest', '3': '.thunder.v1.TransferResponse'},
+    {'1': 'TransferMany', '2': '.thunder.v1.TransferManyRequest', '3': '.thunder.v1.TransferManyResponse'},
     {'1': 'GetSidechainWealth', '2': '.thunder.v1.GetSidechainWealthRequest', '3': '.thunder.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.thunder.v1.CreateDepositRequest', '3': '.thunder.v1.CreateDepositResponse'},
     {'1': 'GetPendingWithdrawalBundle', '2': '.thunder.v1.GetPendingWithdrawalBundleRequest', '3': '.thunder.v1.GetPendingWithdrawalBundleResponse'},
@@ -626,6 +666,9 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> ThunderSer
   '.thunder.v1.WithdrawResponse': WithdrawResponse$json,
   '.thunder.v1.TransferRequest': TransferRequest$json,
   '.thunder.v1.TransferResponse': TransferResponse$json,
+  '.thunder.v1.TransferManyRequest': TransferManyRequest$json,
+  '.thunder.v1.TransferManyRequest.DestinationsEntry': TransferManyRequest_DestinationsEntry$json,
+  '.thunder.v1.TransferManyResponse': TransferManyResponse$json,
   '.thunder.v1.GetSidechainWealthRequest': GetSidechainWealthRequest$json,
   '.thunder.v1.GetSidechainWealthResponse': GetSidechainWealthResponse$json,
   '.thunder.v1.CreateDepositRequest': CreateDepositRequest$json,
@@ -675,36 +718,38 @@ final $typed_data.Uint8List thunderServiceDescriptor = $convert.base64Decode(
     'RyZXNzUmVxdWVzdBohLnRodW5kZXIudjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNlEkUKCFdpdGhk'
     'cmF3EhsudGh1bmRlci52MS5XaXRoZHJhd1JlcXVlc3QaHC50aHVuZGVyLnYxLldpdGhkcmF3Um'
     'VzcG9uc2USRQoIVHJhbnNmZXISGy50aHVuZGVyLnYxLlRyYW5zZmVyUmVxdWVzdBocLnRodW5k'
-    'ZXIudjEuVHJhbnNmZXJSZXNwb25zZRJjChJHZXRTaWRlY2hhaW5XZWFsdGgSJS50aHVuZGVyLn'
-    'YxLkdldFNpZGVjaGFpbldlYWx0aFJlcXVlc3QaJi50aHVuZGVyLnYxLkdldFNpZGVjaGFpbldl'
-    'YWx0aFJlc3BvbnNlElQKDUNyZWF0ZURlcG9zaXQSIC50aHVuZGVyLnYxLkNyZWF0ZURlcG9zaX'
-    'RSZXF1ZXN0GiEudGh1bmRlci52MS5DcmVhdGVEZXBvc2l0UmVzcG9uc2USewoaR2V0UGVuZGlu'
-    'Z1dpdGhkcmF3YWxCdW5kbGUSLS50aHVuZGVyLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZG'
-    'xlUmVxdWVzdBouLnRodW5kZXIudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXNwb25z'
-    'ZRJOCgtDb25uZWN0UGVlchIeLnRodW5kZXIudjEuQ29ubmVjdFBlZXJSZXF1ZXN0Gh8udGh1bm'
-    'Rlci52MS5Db25uZWN0UGVlclJlc3BvbnNlEkgKCUxpc3RQZWVycxIcLnRodW5kZXIudjEuTGlz'
-    'dFBlZXJzUmVxdWVzdBodLnRodW5kZXIudjEuTGlzdFBlZXJzUmVzcG9uc2USOQoETWluZRIXLn'
-    'RodW5kZXIudjEuTWluZVJlcXVlc3QaGC50aHVuZGVyLnYxLk1pbmVSZXNwb25zZRJFCghHZXRC'
-    'bG9jaxIbLnRodW5kZXIudjEuR2V0QmxvY2tSZXF1ZXN0GhwudGh1bmRlci52MS5HZXRCbG9ja1'
-    'Jlc3BvbnNlEngKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSLC50aHVuZGVyLnYxLkdldEJl'
-    'c3RNYWluY2hhaW5CbG9ja0hhc2hSZXF1ZXN0Gi0udGh1bmRlci52MS5HZXRCZXN0TWFpbmNoYW'
-    'luQmxvY2tIYXNoUmVzcG9uc2USeAoZR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaBIsLnRodW5k'
-    'ZXIudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLS50aHVuZGVyLnYxLkdldE'
-    'Jlc3RTaWRlY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJdChBHZXRCbW1JbmNsdXNpb25zEiMudGh1'
-    'bmRlci52MS5HZXRCbW1JbmNsdXNpb25zUmVxdWVzdBokLnRodW5kZXIudjEuR2V0Qm1tSW5jbH'
-    'VzaW9uc1Jlc3BvbnNlElcKDkdldFdhbGxldFV0eG9zEiEudGh1bmRlci52MS5HZXRXYWxsZXRV'
-    'dHhvc1JlcXVlc3QaIi50aHVuZGVyLnYxLkdldFdhbGxldFV0eG9zUmVzcG9uc2USSAoJTGlzdF'
-    'V0eG9zEhwudGh1bmRlci52MS5MaXN0VXR4b3NSZXF1ZXN0Gh0udGh1bmRlci52MS5MaXN0VXR4'
-    'b3NSZXNwb25zZRJgChFSZW1vdmVGcm9tTWVtcG9vbBIkLnRodW5kZXIudjEuUmVtb3ZlRnJvbU'
-    '1lbXBvb2xSZXF1ZXN0GiUudGh1bmRlci52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEpwB'
-    'CiVHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjgudGh1bmRlci52MS5HZX'
-    'RMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo5LnRodW5kZXIudjEu'
-    'R2V0TGF0ZXN0RmFpbGVkV2l0aGRyYXdhbEJ1bmRsZUhlaWdodFJlc3BvbnNlEl0KEEdlbmVyYX'
-    'RlTW5lbW9uaWMSIy50aHVuZGVyLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiQudGh1bmRl'
-    'ci52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USZgoTU2V0U2VlZEZyb21NbmVtb25pYxImLn'
-    'RodW5kZXIudjEuU2V0U2VlZEZyb21NbmVtb25pY1JlcXVlc3QaJy50aHVuZGVyLnYxLlNldFNl'
-    'ZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJCCgdDYWxsUmF3EhoudGh1bmRlci52MS5DYWxsUmF3Um'
-    'VxdWVzdBobLnRodW5kZXIudjEuQ2FsbFJhd1Jlc3BvbnNlEm8KFkxpc3RXYWxsZXRUcmFuc2Fj'
-    'dGlvbnMSKS50aHVuZGVyLnYxLkxpc3RXYWxsZXRUcmFuc2FjdGlvbnNSZXF1ZXN0GioudGh1bm'
-    'Rlci52MS5MaXN0V2FsbGV0VHJhbnNhY3Rpb25zUmVzcG9uc2U=');
+    'ZXIudjEuVHJhbnNmZXJSZXNwb25zZRJRCgxUcmFuc2Zlck1hbnkSHy50aHVuZGVyLnYxLlRyYW'
+    '5zZmVyTWFueVJlcXVlc3QaIC50aHVuZGVyLnYxLlRyYW5zZmVyTWFueVJlc3BvbnNlEmMKEkdl'
+    'dFNpZGVjaGFpbldlYWx0aBIlLnRodW5kZXIudjEuR2V0U2lkZWNoYWluV2VhbHRoUmVxdWVzdB'
+    'omLnRodW5kZXIudjEuR2V0U2lkZWNoYWluV2VhbHRoUmVzcG9uc2USVAoNQ3JlYXRlRGVwb3Np'
+    'dBIgLnRodW5kZXIudjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIS50aHVuZGVyLnYxLkNyZWF0ZU'
+    'RlcG9zaXRSZXNwb25zZRJ7ChpHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZRItLnRodW5kZXIu'
+    'djEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXF1ZXN0Gi4udGh1bmRlci52MS5HZXRQZW'
+    '5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEk4KC0Nvbm5lY3RQZWVyEh4udGh1bmRlci52'
+    'MS5Db25uZWN0UGVlclJlcXVlc3QaHy50aHVuZGVyLnYxLkNvbm5lY3RQZWVyUmVzcG9uc2USSA'
+    'oJTGlzdFBlZXJzEhwudGh1bmRlci52MS5MaXN0UGVlcnNSZXF1ZXN0Gh0udGh1bmRlci52MS5M'
+    'aXN0UGVlcnNSZXNwb25zZRI5CgRNaW5lEhcudGh1bmRlci52MS5NaW5lUmVxdWVzdBoYLnRodW'
+    '5kZXIudjEuTWluZVJlc3BvbnNlEkUKCEdldEJsb2NrEhsudGh1bmRlci52MS5HZXRCbG9ja1Jl'
+    'cXVlc3QaHC50aHVuZGVyLnYxLkdldEJsb2NrUmVzcG9uc2USeAoZR2V0QmVzdE1haW5jaGFpbk'
+    'Jsb2NrSGFzaBIsLnRodW5kZXIudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3Qa'
+    'LS50aHVuZGVyLnYxLkdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJ4ChlHZXRCZX'
+    'N0U2lkZWNoYWluQmxvY2tIYXNoEiwudGh1bmRlci52MS5HZXRCZXN0U2lkZWNoYWluQmxvY2tI'
+    'YXNoUmVxdWVzdBotLnRodW5kZXIudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlc3Bvbn'
+    'NlEl0KEEdldEJtbUluY2x1c2lvbnMSIy50aHVuZGVyLnYxLkdldEJtbUluY2x1c2lvbnNSZXF1'
+    'ZXN0GiQudGh1bmRlci52MS5HZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USVwoOR2V0V2FsbGV0VX'
+    'R4b3MSIS50aHVuZGVyLnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBoiLnRodW5kZXIudjEuR2V0'
+    'V2FsbGV0VXR4b3NSZXNwb25zZRJICglMaXN0VXR4b3MSHC50aHVuZGVyLnYxLkxpc3RVdHhvc1'
+    'JlcXVlc3QaHS50aHVuZGVyLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEmAKEVJlbW92ZUZyb21NZW1w'
+    'b29sEiQudGh1bmRlci52MS5SZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QaJS50aHVuZGVyLnYxLl'
+    'JlbW92ZUZyb21NZW1wb29sUmVzcG9uc2USnAEKJUdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxC'
+    'dW5kbGVIZWlnaHQSOC50aHVuZGVyLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbG'
+    'VIZWlnaHRSZXF1ZXN0GjkudGh1bmRlci52MS5HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVu'
+    'ZGxlSGVpZ2h0UmVzcG9uc2USXQoQR2VuZXJhdGVNbmVtb25pYxIjLnRodW5kZXIudjEuR2VuZX'
+    'JhdGVNbmVtb25pY1JlcXVlc3QaJC50aHVuZGVyLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNwb25z'
+    'ZRJmChNTZXRTZWVkRnJvbU1uZW1vbmljEiYudGh1bmRlci52MS5TZXRTZWVkRnJvbU1uZW1vbm'
+    'ljUmVxdWVzdBonLnRodW5kZXIudjEuU2V0U2VlZEZyb21NbmVtb25pY1Jlc3BvbnNlEkIKB0Nh'
+    'bGxSYXcSGi50aHVuZGVyLnYxLkNhbGxSYXdSZXF1ZXN0GhsudGh1bmRlci52MS5DYWxsUmF3Um'
+    'VzcG9uc2USbwoWTGlzdFdhbGxldFRyYW5zYWN0aW9ucxIpLnRodW5kZXIudjEuTGlzdFdhbGxl'
+    'dFRyYW5zYWN0aW9uc1JlcXVlc3QaKi50aHVuZGVyLnYxLkxpc3RXYWxsZXRUcmFuc2FjdGlvbn'
+    'NSZXNwb25zZQ==');
 

--- a/sidechain_core/lib/gen/thunder/v1/thunder.pbserver.dart
+++ b/sidechain_core/lib/gen/thunder/v1/thunder.pbserver.dart
@@ -27,6 +27,7 @@ abstract class ThunderServiceBase extends $pb.GeneratedService {
   $async.Future<$14.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $14.GetNewAddressRequest request);
   $async.Future<$14.WithdrawResponse> withdraw($pb.ServerContext ctx, $14.WithdrawRequest request);
   $async.Future<$14.TransferResponse> transfer($pb.ServerContext ctx, $14.TransferRequest request);
+  $async.Future<$14.TransferManyResponse> transferMany($pb.ServerContext ctx, $14.TransferManyRequest request);
   $async.Future<$14.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $14.GetSidechainWealthRequest request);
   $async.Future<$14.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $14.CreateDepositRequest request);
   $async.Future<$14.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $14.GetPendingWithdrawalBundleRequest request);
@@ -54,6 +55,7 @@ abstract class ThunderServiceBase extends $pb.GeneratedService {
       case 'GetNewAddress': return $14.GetNewAddressRequest();
       case 'Withdraw': return $14.WithdrawRequest();
       case 'Transfer': return $14.TransferRequest();
+      case 'TransferMany': return $14.TransferManyRequest();
       case 'GetSidechainWealth': return $14.GetSidechainWealthRequest();
       case 'CreateDeposit': return $14.CreateDepositRequest();
       case 'GetPendingWithdrawalBundle': return $14.GetPendingWithdrawalBundleRequest();
@@ -84,6 +86,7 @@ abstract class ThunderServiceBase extends $pb.GeneratedService {
       case 'GetNewAddress': return this.getNewAddress(ctx, request as $14.GetNewAddressRequest);
       case 'Withdraw': return this.withdraw(ctx, request as $14.WithdrawRequest);
       case 'Transfer': return this.transfer(ctx, request as $14.TransferRequest);
+      case 'TransferMany': return this.transferMany(ctx, request as $14.TransferManyRequest);
       case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $14.GetSidechainWealthRequest);
       case 'CreateDeposit': return this.createDeposit(ctx, request as $14.CreateDepositRequest);
       case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $14.GetPendingWithdrawalBundleRequest);

--- a/sidechain_core/lib/mocks/mocks.dart
+++ b/sidechain_core/lib/mocks/mocks.dart
@@ -320,6 +320,11 @@ class MockBbcRPC extends BbcRPC {
 class MockThunderRPC extends ThunderRPC {
   MockThunderRPC() : super(binaryType: BinaryType.BINARY_TYPE_THUNDER);
 
+  @override
+  Future<String> sideSendMany(Map<String, int> destinationSats) {
+    return Future.value('txid_sidechain_send_5678');
+  }
+
   bool _connected = false;
   bool _initializing = false;
   bool _stopping = false;

--- a/sidechain_core/lib/rpcs/thunder_rpc.dart
+++ b/sidechain_core/lib/rpcs/thunder_rpc.dart
@@ -21,6 +21,9 @@ import 'package:sidechain_core/models/core_transaction.dart';
 abstract class ThunderRPC extends SidechainRPC {
   ThunderRPC({required super.binaryType});
 
+  /// Pay many addresses in one transaction. Amounts are in sats.
+  Future<String> sideSendMany(Map<String, int> destinationSats);
+
   /// Get total sidechain wealth in BTC
   Future<double> getSidechainWealth();
 
@@ -223,6 +226,19 @@ class ThunderLive extends ThunderRPC {
   }
 
   @override
+  Future<String> sideSendMany(Map<String, int> destinationSats) async {
+    final resp = await _client.transferMany(
+      pb.TransferManyRequest(
+        destinations: destinationSats.map(
+          (address, sats) => MapEntry(address, Int64(sats)),
+        ),
+        feeSats: Int64(btcToSatoshi(0.00001).toInt()),
+      ),
+    );
+    return resp.txid;
+  }
+
+  @override
   Future<double> getSidechainWealth() async {
     final resp = await _client.getSidechainWealth(pb.GetSidechainWealthRequest());
     return satoshiToBTC(resp.sats.toInt());
@@ -342,6 +358,7 @@ final thunderRPCMethods = [
   'connect_peer',
   'create_deposit',
   'create_transfer',
+  'create_transfer_many',
   'create_withdrawal',
   'format_deposit_address',
   'generate_mnemonic',

--- a/thunder/lib/widgets/homepage_widget_catalog.dart
+++ b/thunder/lib/widgets/homepage_widget_catalog.dart
@@ -3,6 +3,7 @@ import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:sail_ui/pages/sidechains/sidechain_overview_page.dart';
 import 'package:stacked/stacked.dart';
+import 'package:thunder/widgets/send_card.dart';
 
 class ThunderWidgetCatalog {
   static final Map<String, HomepageWidgetInfo> _widgets = {
@@ -110,38 +111,9 @@ class ThunderWidgetCatalog {
       description: 'Send Thunder',
       size: WidgetSize.half,
       icon: SailSVGAsset.iconSend,
-      builder: (_) => ViewModelBuilder<OverviewTabViewModel>.reactive(
-        viewModelBuilder: () => OverviewTabViewModel(),
-        builder: (context, model, child) {
-          return SizedBox(
-            height: 300, // Fixed height for send form
-            child: SailCard(
-              title: 'Send on Sidechain',
-              error: model.sendError,
-              child: SailColumn(
-                spacing: SailStyleValues.padding16,
-                children: [
-                  SailText.secondary15('Pay to'),
-                  SailTextField(
-                    controller: model.bitcoinAddressController,
-                    hintText: 'Enter a bitcoin address',
-                  ),
-                  NumericField(
-                    label: 'Amount',
-                    controller: model.bitcoinAmountController,
-                    hintText: '0.00',
-                  ),
-                  SailButton(
-                    label: 'Send',
-                    disabled: !model.canSend,
-                    onPressed: () async => await model.executeSendOnSidechain(context),
-                    loading: model.isSending,
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
+      builder: (_) => const SizedBox(
+        height: 340, // Fixed height for send form
+        child: ThunderSendCard(),
       ),
     ),
 

--- a/thunder/lib/widgets/send_card.dart
+++ b/thunder/lib/widgets/send_card.dart
@@ -1,0 +1,279 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:stacked/stacked.dart';
+
+class ThunderSendCard extends StatelessWidget {
+  const ThunderSendCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<ThunderSendViewModel>.reactive(
+      viewModelBuilder: () => ThunderSendViewModel(),
+      builder: (context, model, child) {
+        final tabs = <TabItem>[
+          for (int i = 0; i < model.recipients.length; i++)
+            SingleTabItem(
+              label: model.tabLabel(i),
+              child: _RecipientFields(
+                key: ValueKey('recipient_fields_${model.recipients[i].id}'),
+                recipient: model.recipients[i],
+                onMax: () async => model.useAvailableBalance(i),
+              ),
+              icon: SailSVGAsset.iconClose,
+              onIconTap: () => model.removeRecipient(i),
+              onTap: () => model.selectRecipient(i),
+            ),
+          TabItem(
+            label: '',
+            child: const SizedBox.shrink(),
+            onTap: model.addRecipient,
+            icon: SailSVGAsset.plus,
+          ),
+        ];
+
+        return SailCard(
+          title: 'Send on Sidechain',
+          error: model.sendError,
+          child: SailColumn(
+            spacing: SailStyleValues.padding08,
+            children: [
+              Expanded(
+                child: InlineTabBar(
+                  tabs: tabs,
+                  selectedIndex: model.selectedRecipientIndex,
+                  onTabChanged: (index) {
+                    if (index < model.recipients.length) {
+                      model.selectRecipient(index);
+                    }
+                  },
+                ),
+              ),
+              SailButton(
+                label: 'Send',
+                disabled: !model.canSend,
+                onPressed: () async => model.executeSend(context),
+                loading: model.isSending,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RecipientFields extends StatelessWidget {
+  final SendRecipient recipient;
+  final Future<void> Function() onMax;
+
+  const _RecipientFields({super.key, required this.recipient, required this.onMax});
+
+  @override
+  Widget build(BuildContext context) {
+    return SailColumn(
+      spacing: SailStyleValues.padding08,
+      children: [
+        SailTextField(
+          label: 'Address',
+          controller: recipient.addressController,
+          hintText: 'Enter a bitcoin address',
+          size: TextFieldSize.small,
+          suffixWidget: PasteButton(
+            onPaste: (text) => recipient.addressController.text = text,
+          ),
+        ),
+        NumericField(
+          label: 'Amount',
+          controller: recipient.amountController,
+          hintText: '0.00',
+          suffixWidget: SailButton(
+            label: 'MAX',
+            variant: ButtonVariant.link,
+            onPressed: onMax,
+            padding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class SendRecipient {
+  final String id = UniqueKey().toString();
+  final addressController = TextEditingController();
+  final amountController = TextEditingController();
+
+  void dispose() {
+    addressController.dispose();
+    amountController.dispose();
+  }
+}
+
+class ThunderSendViewModel extends BaseViewModel {
+  ThunderRPC get _rpc => GetIt.I.get<ThunderRPC>();
+  BalanceProvider get _balanceProvider => GetIt.I.get<BalanceProvider>();
+  SidechainTransactionsProvider get _transactionsProvider => GetIt.I.get<SidechainTransactionsProvider>();
+
+  final recipients = <SendRecipient>[];
+  int selectedRecipientIndex = 0;
+  double? sidechainFee;
+  String? sendError;
+  bool isSending = false;
+
+  ThunderSendViewModel() {
+    addRecipient();
+    _balanceProvider.addListener(notifyListeners);
+    unawaited(_initFee());
+  }
+
+  Future<void> _initFee() async {
+    sidechainFee = await _rpc.sideEstimateFee();
+    notifyListeners();
+  }
+
+  double get balance => _balanceProvider.balance;
+  bool get balanceInitialized => _balanceProvider.initialized;
+  String get ticker => _rpc.chain.ticker;
+
+  double _amountOf(SendRecipient recipient) => double.tryParse(recipient.amountController.text) ?? 0;
+  double get totalAmount => recipients.fold(0.0, (sum, recipient) => sum + _amountOf(recipient));
+
+  bool get canSend {
+    if (!balanceInitialized || sidechainFee == null || isSending) {
+      return false;
+    }
+    for (final recipient in recipients) {
+      if (recipient.addressController.text.trim().isEmpty) {
+        return false;
+      }
+      final amount = double.tryParse(recipient.amountController.text);
+      if (amount == null || amount <= 0) {
+        return false;
+      }
+    }
+    return totalAmount + sidechainFee! <= balance;
+  }
+
+  String tabLabel(int index) {
+    final recipient = recipients[index];
+    final address = recipient.addressController.text;
+    final amountText = recipient.amountController.text;
+    if (address.isEmpty && amountText.isEmpty) {
+      return 'Recipient ${index + 1}';
+    }
+    final name = address.isEmpty ? 'Recipient ${index + 1}' : address.substring(0, min(address.length, 10));
+    final amount = double.tryParse(amountText);
+    if (amount == null || amount <= 0) {
+      return name;
+    }
+    return '$name (${amount.toStringAsFixed(8)})';
+  }
+
+  void addRecipient() {
+    final recipient = SendRecipient();
+    recipient.addressController.addListener(notifyListeners);
+    recipient.amountController.addListener(notifyListeners);
+    recipients.add(recipient);
+    selectedRecipientIndex = recipients.length - 1;
+    notifyListeners();
+  }
+
+  void removeRecipient(int index) {
+    if (recipients.length == 1) {
+      recipients[index].addressController.clear();
+      recipients[index].amountController.clear();
+      return;
+    }
+    recipients.removeAt(index).dispose();
+    selectedRecipientIndex = min(selectedRecipientIndex, recipients.length - 1);
+    notifyListeners();
+  }
+
+  void selectRecipient(int index) {
+    selectedRecipientIndex = index;
+    notifyListeners();
+  }
+
+  Future<void> useAvailableBalance(int index) async {
+    final others = totalAmount - _amountOf(recipients[index]);
+    final available = max(balance - (sidechainFee ?? 0) - others, 0.0);
+    recipients[index].amountController.text = available.toStringAsFixed(8);
+    notifyListeners();
+  }
+
+  Future<void> executeSend(BuildContext context) async {
+    sendError = null;
+
+    // The map sums in sats, so two rows with one address make one output.
+    final destinationSats = <String, int>{};
+    for (final recipient in recipients) {
+      final address = recipient.addressController.text.trim();
+      if (address.isEmpty) {
+        sendError = 'Please enter a destination address';
+        notifyListeners();
+        return;
+      }
+      final amount = double.tryParse(recipient.amountController.text);
+      if (amount == null || amount <= 0) {
+        sendError = 'Please enter a valid amount';
+        notifyListeners();
+        return;
+      }
+      // Round, because a double like 0.00000059 * 1e8 lands just under 59.
+      destinationSats[address] = (destinationSats[address] ?? 0) + (amount * 100000000).round();
+    }
+
+    if (!context.mounted) {
+      return;
+    }
+
+    isSending = true;
+    notifyListeners();
+
+    try {
+      final txid = await _rpc.sideSendMany(destinationSats);
+
+      unawaited(_balanceProvider.fetch());
+      unawaited(_transactionsProvider.fetch());
+
+      if (!context.mounted) {
+        return;
+      }
+
+      final totalSats = destinationSats.values.fold(0, (sum, sats) => sum + sats);
+      final total = formatBitcoin(satoshiToBTC(totalSats), symbol: ticker);
+      final target = destinationSats.length == 1 ? destinationSats.keys.first : '${destinationSats.length} recipients';
+      await successDialog(
+        context: context,
+        action: 'Send on sidechain',
+        title: 'You sent $total to $target',
+        subtitle: 'TXID: $txid',
+      );
+
+      while (recipients.length > 1) {
+        recipients.removeLast().dispose();
+      }
+      recipients.first.addressController.clear();
+      recipients.first.amountController.clear();
+      selectedRecipientIndex = 0;
+    } catch (error) {
+      sendError = error.toString();
+    } finally {
+      isSending = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _balanceProvider.removeListener(notifyListeners);
+    for (final recipient in recipients) {
+      recipient.dispose();
+    }
+    super.dispose();
+  }
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.331
+version: 1.0.332
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.202
+version: 1.0.203
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.328
+version: 1.0.329
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The latest thunder release adds create_transfer_many. The send card copies the BitWindow Pay To recipient tabs and pays every recipient in one transaction.

Design: https://www.figma.com/design/Uvj2xZiMJsOt3nDaSxDGLQ/drivechain-frontends?node-id=856-1003