### PR TITLE
clients: cut +build from windows exe version

### DIFF
--- a/bbc/windows/runner/CMakeLists.txt
+++ b/bbc/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/bitassets/windows/runner/CMakeLists.txt
+++ b/bitassets/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/bitnames/windows/runner/CMakeLists.txt
+++ b/bitnames/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/bitwindow/windows/runner/CMakeLists.txt
+++ b/bitwindow/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/coinshift/windows/runner/CMakeLists.txt
+++ b/coinshift/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/photon/windows/runner/CMakeLists.txt
+++ b/photon/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/thunder/windows/runner/CMakeLists.txt
+++ b/thunder/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/truthcoin/windows/runner/CMakeLists.txt
+++ b/truthcoin/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")

--- a/zside/windows/runner/CMakeLists.txt
+++ b/zside/windows/runner/CMakeLists.txt
@@ -21,7 +21,10 @@ add_executable(${BINARY_NAME} WIN32
 apply_standard_settings(${BINARY_NAME})
 
 # Add preprocessor definitions for the build version.
-target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+# WinSparkle compares this string to the appcast version. Cut the "+build"
+# part, or the prompt shows on every start.
+string(REGEX REPLACE "\\+.*$" "" APP_VERSION "${FLUTTER_VERSION}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${APP_VERSION}\"")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
 target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")


### PR DESCRIPTION
Fastforge passes the full pubspec version as the build number, so the windows exe reports 0.2.201+0.2.201. WinSparkle compares that string to the appcast value and shows the update prompt on every start.