### PR TITLE
orchestrator: remove noisy log

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.330
+version: 1.0.331
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.330
+version: 1.0.331
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.201
+version: 0.2.202
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.6
+version: 1.0.7
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.203
+version: 1.0.204
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/api/thunder_mempool_balance_test.go
+++ b/sidechain-orchestrator/api/thunder_mempool_balance_test.go
@@ -101,7 +101,7 @@ func TestThunderBalanceTracksMempoolSpendAndReceipt(t *testing.T) {
 					cfg := orchestrator.BinaryConfig{Name: "thunder", DisplayName: "Thunder", Host: host, Port: port}
 					orch := orchestrator.New(t.TempDir(), "regtest", t.TempDir(), []orchestrator.BinaryConfig{cfg}, zerolog.New(io.Discard))
 					handler := NewHandler(orch)
-					handler.SetThunderBalance(sidechain.NewJSONRPCProxy(host, port).GetBalance)
+					handler.SetSidechainBalance("thunder", sidechain.NewJSONRPCProxy(host, port).GetBalance)
 
 					response, err := handler.GetSidechainBalance(context.Background(), connect.NewRequest(&pb.GetSidechainBalanceRequest{
 						Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER,

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1971,13 +1971,6 @@ func (p *ElectrumBackend) multisigSigningDescriptorFor(w *WalletData, onlyXpub s
 		signWithXprv[c.Xpub] = xprv
 	}
 
-	p.log.Info().
-		Str("wallet", w.ID).
-		Int("m", ms.M).
-		Int("n", ms.N).
-		Int("with_origin", len(ms.Cosigners)-len(noOrigin)).
-		Strs("without_origin", noOrigin).
-		Msg("multisig signing descriptor")
 	if len(noOrigin) > 0 {
 		p.log.Warn().
 			Str("wallet", w.ID).

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.332
+version: 1.0.333
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.203
+version: 1.0.204
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.329
+version: 1.0.330
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Remove the repeated multisig descriptor log. Update the Thunder test to use the current balance setter. Wallet and API tests, lint, and the build pass.