### PR TITLE
orchestrator: temp: download four sidechains from octobocto fork

### DIFF
--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -428,11 +428,11 @@
         "binary": "bitnames",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S2-BitNames-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S2-BitNames-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S2-BitNames-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S2-BitNames-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitnames/releases/latest",
+            "linux-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitnames-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -490,11 +490,11 @@
         "binary": "bitassets",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S4-BitAssets-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S4-BitAssets-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S4-BitAssets-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S4-BitAssets-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitassets/releases/latest",
+            "linux-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitassets-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -614,11 +614,11 @@
         "binary": "photon",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S99-Photon-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S99-Photon-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S99-Photon-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S99-Photon-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/photon/releases/latest",
+            "linux-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "photon-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -676,11 +676,11 @@
         "binary": "coinshift",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S255-Coinshift-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S255-Coinshift-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S255-Coinshift-latest-x86_64-apple-darwin.zip",
-            "windows-x86_64": "L2-S255-Coinshift-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/coinshift-rs/releases/latest",
+            "linux-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "coinshift-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -428,11 +428,11 @@
         "binary": "bitnames",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S2-BitNames-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S2-BitNames-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S2-BitNames-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S2-BitNames-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitnames/releases/latest",
+            "linux-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitnames-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -490,11 +490,11 @@
         "binary": "bitassets",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S4-BitAssets-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S4-BitAssets-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S4-BitAssets-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S4-BitAssets-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitassets/releases/latest",
+            "linux-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitassets-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -614,11 +614,11 @@
         "binary": "photon",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S99-Photon-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S99-Photon-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S99-Photon-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S99-Photon-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/photon/releases/latest",
+            "linux-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "photon-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -676,11 +676,11 @@
         "binary": "coinshift",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S255-Coinshift-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S255-Coinshift-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S255-Coinshift-latest-x86_64-apple-darwin.zip",
-            "windows-x86_64": "L2-S255-Coinshift-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/coinshift-rs/releases/latest",
+            "linux-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "coinshift-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -77,6 +78,25 @@ type DownloadManager struct {
 	// suffix is also used to namespace the in-flight key and the on-disk
 	// extract dir so prod and test builds can coexist without clobbering.
 	SidechainVariant func(BinaryConfig) (sidechainVariantSpec, bool)
+
+	// releases caches the asset list of one GitHub release, keyed by API URL.
+	// ReleaseChecker probes every binary every 10 minutes; seven of them read
+	// api.github.com, and an unauthenticated caller gets 60 requests an hour
+	// per IP. Without this cache BitWindow answers HTTP 403 instead.
+	releases sync.Map
+}
+
+// githubReleaseTTL is how long a resolved GitHub release stays usable.
+const githubReleaseTTL = time.Hour
+
+type githubRelease struct {
+	assets  []githubAsset
+	fetched time.Time
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
 // sidechainVariantSpec is the minimal projection of BinaryConfig fields the
@@ -335,6 +355,10 @@ func (d *DownloadManager) ClearState(name string) {
 // resolveGitHubURL queries the GitHub releases API and finds the asset
 // matching the regex pattern.
 func (d *DownloadManager) resolveGitHubURL(ctx context.Context, apiURL, pattern string) (string, error) {
+	if assets, ok := d.cachedGitHubAssets(apiURL); ok {
+		return matchAsset(assets, pattern)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
@@ -356,26 +380,40 @@ func (d *DownloadManager) resolveGitHubURL(ctx context.Context, apiURL, pattern 
 	}
 
 	var release struct {
-		Assets []struct {
-			Name               string `json:"name"`
-			BrowserDownloadURL string `json:"browser_download_url"`
-		} `json:"assets"`
+		Assets []githubAsset `json:"assets"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
 		return "", fmt.Errorf("decode response: %w", err)
 	}
+	d.releases.Store(apiURL, githubRelease{assets: release.Assets, fetched: time.Now()})
 
+	return matchAsset(release.Assets, pattern)
+}
+
+// cachedGitHubAssets returns the asset list of a release fetched inside the
+// last githubReleaseTTL.
+func (d *DownloadManager) cachedGitHubAssets(apiURL string) ([]githubAsset, bool) {
+	value, ok := d.releases.Load(apiURL)
+	if !ok {
+		return nil, false
+	}
+	cached, ok := value.(githubRelease)
+	if !ok || time.Since(cached.fetched) > githubReleaseTTL {
+		return nil, false
+	}
+	return cached.assets, true
+}
+
+func matchAsset(assets []githubAsset, pattern string) (string, error) {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return "", fmt.Errorf("compile pattern %q: %w", pattern, err)
 	}
-
-	for _, asset := range release.Assets {
+	for _, asset := range assets {
 		if re.MatchString(asset.Name) {
 			return asset.BrowserDownloadURL, nil
 		}
 	}
-
 	return "", fmt.Errorf("no asset matching %q in release", pattern)
 }
 

--- a/sidechain-orchestrator/download_test.go
+++ b/sidechain-orchestrator/download_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -235,4 +236,74 @@ func TestStripPlatformSuffix(t *testing.T) {
 			assert.Equal(t, tt.want, StripPlatformSuffix(tt.input))
 		})
 	}
+}
+
+// ReleaseChecker probes every binary every 10 minutes, and seven of them read
+// api.github.com. An unauthenticated caller gets 60 requests an hour per IP,
+// so one release must answer many patterns from one fetch.
+func TestResolveGitHubURLCachesOneRelease(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assets":[
+			{"name":"photon-0.17.2-x86_64-unknown-linux-gnu.zip","browser_download_url":"https://example.invalid/linux.zip"},
+			{"name":"photon-0.17.2-aarch64-apple-darwin.zip","browser_download_url":"https://example.invalid/arm.zip"}
+		]}`))
+	}))
+	defer srv.Close()
+
+	dm, _ := newTestDownloadManager(t)
+	ctx := context.Background()
+
+	linux, err := dm.resolveGitHubURL(ctx, srv.URL, `photon-\d+\.\d+\.\d+-x86_64-unknown-linux-gnu\.zip`)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.invalid/linux.zip", linux)
+
+	arm, err := dm.resolveGitHubURL(ctx, srv.URL, `photon-\d+\.\d+\.\d+-aarch64-apple-darwin\.zip`)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.invalid/arm.zip", arm)
+
+	assert.Equal(t, 1, calls, "the second pattern must read the cached release")
+}
+
+// A stale entry must not answer, or a new release never reaches the user.
+func TestResolveGitHubURLRefetchesAStaleRelease(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assets":[
+			{"name":"photon-0.17.2-x86_64-unknown-linux-gnu.zip","browser_download_url":"https://example.invalid/linux.zip"}
+		]}`))
+	}))
+	defer srv.Close()
+
+	dm, _ := newTestDownloadManager(t)
+	pattern := `photon-\d+\.\d+\.\d+-x86_64-unknown-linux-gnu\.zip`
+
+	_, err := dm.resolveGitHubURL(context.Background(), srv.URL, pattern)
+	require.NoError(t, err)
+
+	dm.releases.Store(srv.URL, githubRelease{
+		assets:  []githubAsset{{Name: "stale.zip"}},
+		fetched: time.Now().Add(-githubReleaseTTL - time.Minute),
+	})
+
+	_, err = dm.resolveGitHubURL(context.Background(), srv.URL, pattern)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "a stale release must be read again")
+}
+
+// A miss must not poison the cache into answering for a pattern no asset has.
+func TestResolveGitHubURLReportsAPatternNoAssetMatches(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assets":[{"name":"photon-0.17.2-x86_64-unknown-linux-gnu.zip"}]}`))
+	}))
+	defer srv.Close()
+
+	dm, _ := newTestDownloadManager(t)
+	_, err := dm.resolveGitHubURL(context.Background(), srv.URL, `nothing-matches\.zip`)
+	require.Error(t, err)
 }

--- a/sidechain_core/assets/chains_config.json
+++ b/sidechain_core/assets/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -428,11 +428,11 @@
         "binary": "bitnames",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S2-BitNames-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S2-BitNames-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S2-BitNames-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S2-BitNames-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitnames/releases/latest",
+            "linux-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitnames-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -490,11 +490,11 @@
         "binary": "bitassets",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S4-BitAssets-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S4-BitAssets-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S4-BitAssets-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S4-BitAssets-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitassets/releases/latest",
+            "linux-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitassets-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -614,11 +614,11 @@
         "binary": "photon",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S99-Photon-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S99-Photon-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S99-Photon-latest-aarch64-apple-darwin.zip",
-            "windows-x86_64": "L2-S99-Photon-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/photon/releases/latest",
+            "linux-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "photon-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -676,11 +676,11 @@
         "binary": "coinshift",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S255-Coinshift-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S255-Coinshift-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S255-Coinshift-latest-x86_64-apple-darwin.zip",
-            "windows-x86_64": "L2-S255-Coinshift-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/coinshift-rs/releases/latest",
+            "linux-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "coinshift-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },

--- a/sidechain_core/assets/migrations/016_chains_config.json
+++ b/sidechain_core/assets/migrations/016_chains_config.json
@@ -1,0 +1,62 @@
+{
+  "version": 16,
+  "migration": "patch",
+  "binaries": {
+    "bitnames": {
+      "download": {
+        "binary": "bitnames",
+        "files": {
+          "default": {
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitnames/releases/latest",
+            "linux-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitnames-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitnames-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
+          }
+        }
+      }
+    },
+    "bitassets": {
+      "download": {
+        "binary": "bitassets",
+        "files": {
+          "default": {
+            "base_url": "https://api.github.com/repos/octobocto/plain-bitassets/releases/latest",
+            "linux-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "bitassets-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "bitassets-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
+          }
+        }
+      }
+    },
+    "photon": {
+      "download": {
+        "binary": "photon",
+        "files": {
+          "default": {
+            "base_url": "https://api.github.com/repos/octobocto/photon/releases/latest",
+            "linux-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "photon-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "photon-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
+          }
+        }
+      }
+    },
+    "coinshift": {
+      "download": {
+        "binary": "coinshift",
+        "files": {
+          "default": {
+            "base_url": "https://api.github.com/repos/octobocto/coinshift-rs/releases/latest",
+            "linux-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "coinshift-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "coinshift-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
BitNames, BitAssets, Photon and Coinshift now come from the octobocto forks, which carry the block index and Esplora RPCs. Migration 016 moves an installed config over.

Seven binaries then read api.github.com every 10 minutes, against a 60 per hour unauthenticated limit, so a resolved release stays cached for an hour.