### PR TITLE
orchestrator: stop retrying a refused block

### DIFF
--- a/sidechain-orchestrator/api/bmm_connect_target_test.go
+++ b/sidechain-orchestrator/api/bmm_connect_target_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       string
+		inclusions []string
+		target     string
+	}{
+		{
+			name:       "the caller names the block the sidechain holds",
+			want:       "main-2",
+			inclusions: []string{"main-2"},
+			target:     "main-2",
+		},
+		{
+			name:       "the sidechain has not seen the named block yet",
+			want:       "main-2",
+			inclusions: nil,
+			target:     "",
+		},
+		{
+			name:       "the sidechain holds another block for the bid",
+			want:       "main-2",
+			inclusions: []string{"main-9"},
+			target:     "",
+		},
+		{
+			name:       "the caller names no block",
+			inclusions: []string{"main-2", "main-3"},
+			target:     "main-2",
+		},
+		{
+			name:       "the caller names no block and the sidechain lists none",
+			inclusions: nil,
+			target:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.target, connectTarget(tt.want, tt.inclusions))
+		})
+	}
+}

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -403,20 +404,15 @@ func (h *BMMHandler) ConnectBid(
 		return nil, err
 	}
 
-	// A sidechain reports an inclusion only for a block it already holds, and it
-	// gets ours from this very call.
-	mainBlockHash := req.Msg.MainBlockHash
+	inclusions, err := proxy.GetBmmInclusions(ctx, req.Msg.CriticalHash)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get bmm inclusions: %w", err))
+	}
+	mainBlockHash := connectTarget(req.Msg.MainBlockHash, inclusions)
 	if mainBlockHash == "" {
-		inclusions, err := proxy.GetBmmInclusions(ctx, req.Msg.CriticalHash)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get bmm inclusions: %w", err))
-		}
-		if len(inclusions) == 0 {
-			// The empty answer names no block, which is how the caller tells a
-			// bid the sidechain has not seen from a block it refused.
-			return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
-		}
-		mainBlockHash = inclusions[0]
+		// The empty answer names no block, which is how the caller tells a bid
+		// the sidechain has not seen from a block it refused.
+		return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
 	}
 
 	connected, err := proxy.ConnectBlock(ctx, json.RawMessage(req.Msg.BlockJson), mainBlockHash)
@@ -427,6 +423,22 @@ func (h *BMMHandler) ConnectBid(
 		Connected:     connected,
 		MainBlockHash: mainBlockHash,
 	}), nil
+}
+
+// connectTarget picks the mainchain block to connect the won block on, empty
+// while the sidechain lists no inclusion for it. A sidechain learns of an
+// inclusion by polling, so it holds the block the caller names only later.
+func connectTarget(want string, inclusions []string) string {
+	if want == "" {
+		if len(inclusions) == 0 {
+			return ""
+		}
+		return inclusions[0]
+	}
+	if !slices.Contains(inclusions, want) {
+		return ""
+	}
+	return want
 }
 
 // ListBids reads the slot's bids out of the mainchain mempool. An M8 is a

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -404,20 +404,35 @@ func (h *BMMHandler) ConnectBid(
 		return nil, err
 	}
 
-	inclusions, err := proxy.GetBmmInclusions(ctx, req.Msg.CriticalHash)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get bmm inclusions: %w", err))
-	}
-	mainBlockHash := connectTarget(req.Msg.MainBlockHash, inclusions)
+	// A sidechain reports an inclusion only for a block it already holds, and it
+	// gets ours from this very call.
+	mainBlockHash := req.Msg.MainBlockHash
 	if mainBlockHash == "" {
-		// The empty answer names no block, which is how the caller tells a bid
-		// the sidechain has not seen from a block it refused.
-		return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
+		inclusions, err := bmmInclusions(ctx, proxy, req.Msg.CriticalHash)
+		if err != nil {
+			return nil, err
+		}
+		mainBlockHash = connectTarget("", inclusions)
+		if mainBlockHash == "" {
+			return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
+		}
 	}
 
 	connected, err := proxy.ConnectBlock(ctx, json.RawMessage(req.Msg.BlockJson), mainBlockHash)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("connect block: %w", err))
+	}
+	if !connected {
+		// A sidechain learns of an inclusion by polling, and refuses every block
+		// until it does. The empty answer names no block, which is how the caller
+		// tells that wait from a refusal it must not repeat.
+		inclusions, err := bmmInclusions(ctx, proxy, req.Msg.CriticalHash)
+		if err != nil {
+			return nil, err
+		}
+		if connectTarget(mainBlockHash, inclusions) == "" {
+			return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
+		}
 	}
 	return connect.NewResponse(&bmmpb.ConnectBidResponse{
 		Connected:     connected,
@@ -425,9 +440,16 @@ func (h *BMMHandler) ConnectBid(
 	}), nil
 }
 
+func bmmInclusions(ctx context.Context, proxy sidechain.BMMNode, criticalHash string) ([]string, error) {
+	inclusions, err := proxy.GetBmmInclusions(ctx, criticalHash)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get bmm inclusions: %w", err))
+	}
+	return inclusions, nil
+}
+
 // connectTarget picks the mainchain block to connect the won block on, empty
-// while the sidechain lists no inclusion for it. A sidechain learns of an
-// inclusion by polling, so it holds the block the caller names only later.
+// while the sidechain lists no inclusion for it.
 func connectTarget(want string, inclusions []string) string {
 	if want == "" {
 		if len(inclusions) == 0 {

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -412,6 +412,8 @@ func (h *BMMHandler) ConnectBid(
 			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get bmm inclusions: %w", err))
 		}
 		if len(inclusions) == 0 {
+			// The empty answer names no block, which is how the caller tells a
+			// bid the sidechain has not seen from a block it refused.
 			return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
 		}
 		mainBlockHash = inclusions[0]

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -1047,6 +1047,9 @@ func (e *BmmEngine) retryConnects(ctx context.Context, sidechain pb.BinaryType, 
 		}
 		round.BlocksWaited++
 		if round.BlocksWaited < bmmConnectAttempts {
+			// The count goes to disk, or a restart hands the round the whole
+			// budget again and the bound never binds.
+			e.save(round)
 			stillPending = append(stillPending, round)
 			continue
 		}

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -1007,6 +1007,8 @@ func (e *BmmEngine) settleOutrunRound(
 	round.Result = ResultWon
 	round.WinnerTxid = live.Txid
 	round.WinnerBidSats = live.BidSats
+	// Deciding the round spent its own attempts. The connect gets the full bound.
+	round.BlocksWaited = 0
 	step := e.connectWon(ctx, sidechain, round)
 	e.save(round)
 	return step

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -39,6 +39,25 @@ const (
 	ResultSkipped = "skipped"
 )
 
+// roundStep is what to do with a round after one attempt on it.
+type roundStep int
+
+const (
+	// stepRetry: the sidechain has not judged the block yet, so it goes back on
+	// the retry list.
+	stepRetry roundStep = iota
+	// stepDone: the round is settled and needs no more attempts.
+	stepDone
+	// stepRetire: the sidechain judged the block and refused it. The next
+	// attempt sends the same bytes, so there must be no next attempt.
+	stepRetire
+)
+
+const (
+	reasonRefused  = "the sidechain refused the block"
+	reasonNoAnswer = "the sidechain never accepted the block"
+)
+
 // Bid state values, for our own bids.
 const (
 	BidLive      = "live"
@@ -908,10 +927,13 @@ func (e *BmmEngine) settleRound(ctx context.Context, sidechain pb.BinaryType, ne
 		round.Result = ResultWon
 		round.WinnerTxid = live.Txid
 		round.WinnerBidSats = live.BidSats
-		// The fee is already paid, so a sidechain that rejects the block now is
+		// The fee is already paid, so a block the sidechain has not judged yet is
 		// worth retrying rather than forfeiting.
-		if !e.connectWon(ctx, sidechain, round) {
+		switch e.connectWon(ctx, sidechain, round) {
+		case stepRetry:
 			e.park(sidechain, round)
+		case stepRetire:
+			e.retire(sidechain, round, reasonRefused)
 		}
 		e.save(round)
 		return
@@ -920,8 +942,11 @@ func (e *BmmEngine) settleRound(ctx context.Context, sidechain pb.BinaryType, ne
 	// The tip ran past the block that decided this round, so its commitment says
 	// nothing about our bid: settle on the deciding block instead.
 	if live != nil && newHeight > round.PrevMainHeight+1 {
-		if !e.settleOutrunRound(ctx, sidechain, round, live, newTip, newHeight) {
+		switch e.settleOutrunRound(ctx, sidechain, round, live, newTip, newHeight) {
+		case stepRetry:
 			e.park(sidechain, round)
+		case stepRetire:
+			e.retire(sidechain, round, reasonRefused)
 		}
 		return
 	}
@@ -951,14 +976,14 @@ func (e *BmmEngine) markLost(round *bmmstate.Round, live *bmmstate.Bid, commitme
 func (e *BmmEngine) settleOutrunRound(
 	ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round, live *bmmstate.Bid,
 	tip string, tipHeight int32,
-) bool {
+) roundStep {
 	decider := tip
 	if tipHeight != round.PrevMainHeight+1 {
 		found, err := e.backend.BlockAfter(ctx, round.PrevMainHash, tip)
 		if err != nil || found == "" {
 			e.log.Warn().Err(err).Stringer("sidechain", sidechain).Str("round", round.PrevMainHash).
 				Msg("cannot name the block that decided this round")
-			return false
+			return stepRetry
 		}
 		decider = found
 	}
@@ -967,7 +992,7 @@ func (e *BmmEngine) settleOutrunRound(
 	if err != nil {
 		e.log.Warn().Err(err).Stringer("sidechain", sidechain).Str("main_block", decider).
 			Msg("read bmm commitment of the deciding block")
-		return false
+		return stepRetry
 	}
 
 	round.IncludedInBlock = decider
@@ -976,15 +1001,15 @@ func (e *BmmEngine) settleOutrunRound(
 
 	if commitment != live.CriticalHash {
 		e.markLost(round, live, commitment)
-		return true
+		return stepDone
 	}
 
 	round.Result = ResultWon
 	round.WinnerTxid = live.Txid
 	round.WinnerBidSats = live.BidSats
-	connected := e.connectWon(ctx, sidechain, round)
+	step := e.connectWon(ctx, sidechain, round)
 	e.save(round)
-	return connected
+	return step
 }
 
 // park queues a round for the retry pass and records it, so a restart mid-wait
@@ -1013,7 +1038,11 @@ func (e *BmmEngine) retryConnects(ctx context.Context, sidechain pb.BinaryType, 
 		if e.abandonBehindTip(sidechain, round, tipHeight) {
 			continue
 		}
-		if e.retryRound(ctx, sidechain, round, tip, tipHeight) {
+		switch e.retryRound(ctx, sidechain, round, tip, tipHeight) {
+		case stepDone:
+			continue
+		case stepRetire:
+			e.retire(sidechain, round, reasonRefused)
 			continue
 		}
 		round.BlocksWaited++
@@ -1026,7 +1055,11 @@ func (e *BmmEngine) retryConnects(ctx context.Context, sidechain pb.BinaryType, 
 		if round.Result == ResultOpen {
 			e.log.Warn().Stringer("sidechain", sidechain).Str("round", round.PrevMainHash).
 				Msg("giving up on deciding this round for now")
+			continue
 		}
+		// The attempts are spent on a block the sidechain never took. A refusal
+		// shape this engine cannot name still ends here.
+		e.retire(sidechain, round, reasonNoAnswer)
 	}
 
 	e.mu.Lock()
@@ -1065,27 +1098,46 @@ func (e *BmmEngine) abandonBehindTip(
 // named has to be decided first, the rest only have to connect.
 func (e *BmmEngine) retryRound(
 	ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round, tip string, tipHeight int32,
-) bool {
+) roundStep {
 	if round.Result == ResultOpen {
 		live := liveBid(round)
 		if live == nil {
-			return true
+			return stepDone
 		}
 		return e.settleOutrunRound(ctx, sidechain, round, live, tip, tipHeight)
 	}
-	if !e.connectWon(ctx, sidechain, round) {
-		return false
+	step := e.connectWon(ctx, sidechain, round)
+	if step == stepDone {
+		e.save(round)
 	}
+	return step
+}
+
+// retire ends a round the engine must not offer to the sidechain again. It
+// clears the live bid, so a restart cannot resume the round and hand it a fresh
+// attempt budget.
+func (e *BmmEngine) retire(sidechain pb.BinaryType, round *bmmstate.Round, reason string) {
+	if live := liveBid(round); live != nil {
+		live.State = BidFailed
+		live.Error = reason
+	}
+	e.log.Warn().Stringer("sidechain", sidechain).Str("round", round.PrevMainHash).
+		Str("main_block", round.IncludedInBlock).Str("reason", reason).
+		Msg("retiring a won block the sidechain will not take")
 	e.save(round)
-	return true
 }
 
 // connectWon hands the won block to the sidechain, naming the mainchain block
 // that carries the commitment — the sidechain cannot name a block it never saw.
-func (e *BmmEngine) connectWon(ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round) bool {
+//
+// An empty answer means the sidechain has not seen the inclusion yet; an answer
+// that names the block means the sidechain judged it and said no.
+func (e *BmmEngine) connectWon(
+	ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round,
+) roundStep {
 	live := liveBid(round)
 	if live == nil {
-		return false
+		return stepRetry
 	}
 	resp, err := e.backend.ConnectBid(ctx, connect.NewRequest(&bmmpb.ConnectBidRequest{
 		Sidechain:     sidechain,
@@ -1096,12 +1148,17 @@ func (e *BmmEngine) connectWon(ctx context.Context, sidechain pb.BinaryType, rou
 	if err != nil {
 		e.log.Warn().Err(err).Stringer("sidechain", sidechain).
 			Str("critical_hash", live.CriticalHash).Msg("connect won block")
-		return false
+		return stepRetry
 	}
 	if !resp.Msg.Connected {
+		if resp.Msg.MainBlockHash == "" {
+			e.log.Debug().Stringer("sidechain", sidechain).Str("critical_hash", live.CriticalHash).
+				Msg("the sidechain has not seen the bid included yet")
+			return stepRetry
+		}
 		e.log.Warn().Stringer("sidechain", sidechain).Str("critical_hash", live.CriticalHash).
-			Str("main_block", round.IncludedInBlock).Msg("sidechain refused the won block")
-		return false
+			Str("main_block", resp.Msg.MainBlockHash).Msg("sidechain refused the won block")
+		return stepRetire
 	}
 	live.State = BidConnected
 	round.Result = ResultWon
@@ -1111,7 +1168,7 @@ func (e *BmmEngine) connectWon(ctx context.Context, sidechain pb.BinaryType, rou
 	if resp.Msg.MainBlockHash != "" {
 		round.IncludedInBlock = resp.Msg.MainBlockHash
 	}
-	return true
+	return stepDone
 }
 
 func (e *BmmEngine) save(round *bmmstate.Round) {

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -1191,6 +1191,36 @@ func TestBmmEngineBoundsARepeatedRefusal(t *testing.T) {
 	assert.Zero(t, pendingCount(restarted), "a restart hands it no fresh budget")
 }
 
+// A round that spends its attempts before anything can decide it must still
+// get the whole bound for the connect, or one wait forfeits a paid block.
+func TestBmmEngineGivesAWonRoundAFreshBudget(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+
+	backend.blockAfterErr = errors.New("enforcer down")
+	tip.jump("block-5", 4)
+	engine.tick(ctx)
+
+	for range bmmConnectAttempts - 1 {
+		engine.retryConnects(ctx, testSidechain, tip.hash, tip.height)
+	}
+
+	backend.blockAfterErr = nil
+	backend.blockAfter = "block-2"
+	backend.commitmentByBlock = map[string]string{"block-2": "critical"}
+	backend.noInclusion = true
+	engine.retryConnects(ctx, testSidechain, tip.hash, tip.height)
+
+	won := roundOn(t, engine, "block-1")
+	require.Equal(t, ResultWon, won.Result)
+	assert.Equal(t, 1, won.BlocksWaited, "the connect counts from one")
+	assert.Equal(t, BidLive, won.OurBids[0].State, "the paid bid is not forfeited")
+	assert.Equal(t, 1, pendingCount(engine), "the won round waits for the sidechain")
+}
+
 // The bound only binds if it survives a restart, so a reloaded round carries
 // the attempts it already spent.
 func TestBmmEngineKeepsTheAttemptCountAcrossARestart(t *testing.T) {

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -27,6 +27,7 @@ type fakeBackend struct {
 	bids              int
 	connects          int
 	connected         bool
+	noInclusion       bool
 	lastMainBlockHash string
 	bidErr            error
 	feesSats          int64
@@ -84,6 +85,11 @@ func (f *fakeBackend) ConnectBid(
 	defer f.mu.Unlock()
 	f.connects++
 	f.lastMainBlockHash = req.Msg.MainBlockHash
+	// The handler names no block while the sidechain reports no inclusion for
+	// the critical hash.
+	if f.noInclusion {
+		return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
+	}
 	// The handler echoes the block it connected on, resolving it itself only
 	// when the caller named none.
 	main := req.Msg.MainBlockHash
@@ -668,9 +674,10 @@ func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 	ctx := context.Background()
 	engine.tick(ctx)
 
-	// The miner committed to our block, but the sidechain has not accepted it.
+	// The miner committed to our block, but the sidechain has not seen the
+	// inclusion yet.
 	backend.commitment = "critical"
-	backend.connected = false
+	backend.noInclusion = true
 	tip.set("block-2")
 	engine.tick(ctx)
 
@@ -681,6 +688,7 @@ func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
 	restarted.resumeUnconnected()
 
+	backend.noInclusion = false
 	backend.connected = true
 	before := backend.connects
 	restarted.retryConnects(ctx, testSidechain, tip.hash, tip.height)
@@ -1085,17 +1093,9 @@ func TestBmmEngineAbandonsAWonBlockBehindTheTip(t *testing.T) {
 // A won block within the horizon is still worth retrying: the fee is paid.
 func TestBmmEngineKeepsRetryingARecentWonBlock(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
+	backend.noInclusion = true
 
-	round := &bmmstate.Round{
-		Sidechain:        int32(testSidechain),
-		PrevMainHash:     "recent-round",
-		PrevMainHeight:   996770,
-		IncludedInHeight: 996771,
-		Result:           ResultWon,
-		OurBids: []bmmstate.Bid{{
-			Txid: "won-txid", CriticalHash: "critical", IsOurs: true, State: BidLive,
-		}},
-	}
+	round := unconnectedRound("recent-round", 996770)
 	engine.mu.Lock()
 	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
 	engine.mu.Unlock()
@@ -1103,6 +1103,113 @@ func TestBmmEngineKeepsRetryingARecentWonBlock(t *testing.T) {
 	engine.retryConnects(context.Background(), testSidechain, "tip", 996773)
 
 	assert.Positive(t, backend.connects, "a recent won block is still submitted")
+	assert.Equal(t, 1, pendingCount(engine), "the round waits for the next pass")
+}
+
+// The sidechain judged the block and said no. The next attempt sends the same
+// bytes, so the round is over.
+func TestBmmEngineRetiresARefusedBlock(t *testing.T) {
+	engine, backend, _, store := newEngine(t)
+	backend.connected = false
+
+	round := unconnectedRound("refused-round", 996770)
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+	engine.retryConnects(ctx, testSidechain, "tip", 996773)
+
+	assert.Equal(t, 1, backend.connects, "the refused block is offered once")
+	assert.Zero(t, pendingCount(engine), "the round leaves the retry list")
+	require.Len(t, round.OurBids, 1)
+	assert.Equal(t, BidFailed, round.OurBids[0].State)
+	assert.Equal(t, reasonRefused, round.OurBids[0].Error)
+
+	engine.retryConnects(ctx, testSidechain, "tip", 996774)
+	assert.Equal(t, 1, backend.connects, "a retired round is never offered again")
+
+	// A restart must not resume it, or the refusal starts over.
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, &fakeTip{}, newFakeFee(), store)
+	restarted.resumeUnconnected()
+	assert.Zero(t, pendingCount(restarted), "a restart leaves the retired round alone")
+}
+
+// A sidechain that has not seen the bid included names no block. The mainchain
+// block that carries it may still reach the sidechain, so the round waits.
+func TestBmmEngineRetriesABlockTheSidechainHasNotSeen(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.noInclusion = true
+
+	round := unconnectedRound("unseen-round", 996770)
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+	engine.retryConnects(ctx, testSidechain, "tip", 996773)
+	engine.retryConnects(ctx, testSidechain, "tip", 996773)
+
+	assert.Equal(t, 2, backend.connects, "the block goes back to the sidechain")
+	assert.Equal(t, 1, pendingCount(engine), "the round stays on the retry list")
+	assert.Equal(t, BidLive, round.OurBids[0].State)
+
+	backend.noInclusion = false
+	backend.connected = true
+	engine.retryConnects(ctx, testSidechain, "tip", 996773)
+
+	assert.Zero(t, pendingCount(engine), "the connected round leaves the list")
+	assert.Equal(t, BidConnected, round.OurBids[0].State)
+}
+
+// A refusal shape the engine cannot name must still end. The attempt bound
+// retires the round, so it never loops without end.
+func TestBmmEngineBoundsARepeatedRefusal(t *testing.T) {
+	engine, backend, _, store := newEngine(t)
+	backend.noInclusion = true
+
+	round := unconnectedRound("bounded-round", 996770)
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+	for range bmmConnectAttempts {
+		engine.retryConnects(ctx, testSidechain, "tip", 996773)
+	}
+
+	assert.Equal(t, bmmConnectAttempts, backend.connects)
+	assert.Zero(t, pendingCount(engine), "the bound takes the round off the list")
+	assert.Equal(t, BidFailed, round.OurBids[0].State)
+	assert.Equal(t, reasonNoAnswer, round.OurBids[0].Error)
+
+	engine.retryConnects(ctx, testSidechain, "tip", 996773)
+	assert.Equal(t, bmmConnectAttempts, backend.connects, "the bound holds")
+
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, &fakeTip{}, newFakeFee(), store)
+	restarted.resumeUnconnected()
+	assert.Zero(t, pendingCount(restarted), "a restart hands it no fresh budget")
+}
+
+// unconnectedRound is a round a miner took, waiting on the sidechain.
+func unconnectedRound(prevMainHash string, prevMainHeight int32) *bmmstate.Round {
+	return &bmmstate.Round{
+		Sidechain:        int32(testSidechain),
+		PrevMainHash:     prevMainHash,
+		PrevMainHeight:   prevMainHeight,
+		IncludedInBlock:  "main-block",
+		IncludedInHeight: prevMainHeight + 1,
+		Result:           ResultWon,
+		OurBids: []bmmstate.Bid{{
+			Txid: "won-txid", CriticalHash: "critical", IsOurs: true, State: BidLive,
+		}},
+	}
+}
+
+func pendingCount(engine *BmmEngine) int {
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	return len(engine.unconnected[testSidechain])
 }
 
 // A restart before the tip moves finds the round still in play. Bidding again

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -1191,6 +1191,37 @@ func TestBmmEngineBoundsARepeatedRefusal(t *testing.T) {
 	assert.Zero(t, pendingCount(restarted), "a restart hands it no fresh budget")
 }
 
+// The bound only binds if it survives a restart, so a reloaded round carries
+// the attempts it already spent.
+func TestBmmEngineKeepsTheAttemptCountAcrossARestart(t *testing.T) {
+	engine, backend, _, store := newEngine(t)
+	backend.noInclusion = true
+
+	round := unconnectedRound("counted-round", 996770)
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+	for range 3 {
+		engine.retryConnects(ctx, testSidechain, "tip", 996773)
+	}
+
+	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, &fakeTip{}, newFakeFee(), store)
+	restarted.resumeUnconnected()
+	restarted.mu.Lock()
+	resumed := restarted.unconnected[testSidechain]
+	restarted.mu.Unlock()
+	require.Len(t, resumed, 1)
+	assert.Equal(t, 3, resumed[0].BlocksWaited, "the restart carries the spent attempts")
+
+	for range bmmConnectAttempts - 3 {
+		restarted.retryConnects(ctx, testSidechain, "tip", 996773)
+	}
+
+	assert.Zero(t, pendingCount(restarted), "the bound binds after a restart")
+}
+
 // unconnectedRound is a round a miner took, waiting on the sidechain.
 func unconnectedRound(prevMainHash string, prevMainHeight int32) *bmmstate.Round {
 	return &bmmstate.Round{


### PR DESCRIPTION
A ConnectBid answer that names a mainchain block means the sidechain judged the block and refused it, so the round retires instead of looping every tick.
An empty answer still means the sidechain has not seen the inclusion yet, so that case keeps retrying.
The attempt bound now retires the round too, so no refusal shape can loop without end.