### PR TITLE
thunder: read mempool input pairs

### DIFF
--- a/sidechain-orchestrator/api/thunder_mempool_balance_test.go
+++ b/sidechain-orchestrator/api/thunder_mempool_balance_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+func TestThunderBalanceTracksMempoolSpendAndReceipt(t *testing.T) {
+	const payment = `[{"txid":"payment","size":240,"tx":{
+		"inputs":[[{"Regular":{"txid":"old","vout":0}},"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]],
+		"outputs":[
+			{"address":"receiver","content":{"Value":3000}},
+			{"address":"sender","content":{"Value":6000}}
+		]}}]`
+	const senderCoins = `[{"outpoint":{"Regular":{"txid":"old","vout":0}},"output":{"address":"sender","content":{"Value":10000}}}]`
+	const receiverCoins = `[{"outpoint":{"Regular":{"txid":"saved","vout":0}},"output":{"address":"receiver","content":{"Value":2000}}}]`
+
+	for _, wallet := range []struct {
+		address       string
+		balance       int64
+		coins         string
+		minedBalance  int64
+		minedCoins    string
+		wantConfirmed uint64
+		wantPending   uint64
+	}{
+		{
+			address: "sender", balance: 10000, coins: senderCoins,
+			minedBalance: 6000,
+			minedCoins:   `[{"outpoint":{"Regular":{"txid":"payment","vout":1}},"output":{"address":"sender","content":{"Value":6000}}}]`,
+			wantPending:  6000,
+		},
+		{
+			address: "receiver", balance: 2000, coins: receiverCoins,
+			minedBalance: 5000,
+			minedCoins: `[
+				{"outpoint":{"Regular":{"txid":"saved","vout":0}},"output":{"address":"receiver","content":{"Value":2000}}},
+				{"outpoint":{"Regular":{"txid":"payment","vout":0}},"output":{"address":"receiver","content":{"Value":3000}}}
+			]`,
+			wantConfirmed: 2000, wantPending: 3000,
+		},
+	} {
+		t.Run(wallet.address, func(t *testing.T) {
+			for _, state := range []struct {
+				name          string
+				balance       int64
+				coins         string
+				mempool       string
+				wantConfirmed uint64
+				wantPending   uint64
+			}{
+				{name: "before", balance: wallet.balance, coins: wallet.coins, mempool: "[]", wantConfirmed: uint64(wallet.balance)},
+				{name: "pending", balance: wallet.balance, coins: wallet.coins, mempool: payment, wantConfirmed: wallet.wantConfirmed, wantPending: wallet.wantPending},
+				{name: "mined", balance: wallet.minedBalance, coins: wallet.minedCoins, mempool: "[]", wantConfirmed: uint64(wallet.minedBalance)},
+			} {
+				t.Run(state.name, func(t *testing.T) {
+					node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						var request struct {
+							ID     json.RawMessage `json:"id"`
+							Method string          `json:"method"`
+						}
+						if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+							t.Error(err)
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						response := map[string]any{"jsonrpc": "2.0", "id": request.ID}
+						switch request.Method {
+						case "balance":
+							response["result"] = map[string]int64{"total_sats": state.balance, "available_sats": state.balance}
+						case "get_wallet_addresses":
+							response["result"] = []string{wallet.address}
+						case "get_wallet_utxos":
+							response["result"] = json.RawMessage(state.coins)
+						case "list_mempool":
+							response["result"] = json.RawMessage(state.mempool)
+						default:
+							response["error"] = map[string]any{"code": -32601, "message": "method not found"}
+						}
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(response); err != nil {
+							t.Error(err)
+							return
+						}
+					}))
+					defer node.Close()
+					host, port := hostPort(t, node)
+					cfg := orchestrator.BinaryConfig{Name: "thunder", DisplayName: "Thunder", Host: host, Port: port}
+					orch := orchestrator.New(t.TempDir(), "regtest", t.TempDir(), []orchestrator.BinaryConfig{cfg}, zerolog.New(io.Discard))
+					handler := NewHandler(orch)
+					handler.SetThunderBalance(sidechain.NewJSONRPCProxy(host, port).GetBalance)
+
+					response, err := handler.GetSidechainBalance(context.Background(), connect.NewRequest(&pb.GetSidechainBalanceRequest{
+						Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER,
+					}))
+					require.NoError(t, err)
+					assert.Equal(t, state.wantConfirmed, response.Msg.ConfirmedSats)
+					assert.Equal(t, state.wantPending, response.Msg.PendingSats)
+				})
+			}
+		})
+	}
+}

--- a/sidechain-orchestrator/sidechain/mempool.go
+++ b/sidechain-orchestrator/sidechain/mempool.go
@@ -1,6 +1,7 @@
 package sidechain
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -127,17 +128,34 @@ func OwnedOutputs(txs []MempoolTx, owned map[string]bool) []MempoolTx {
 
 // mempoolBody is the transaction shape both feeds share.
 type mempoolBody struct {
-	Inputs []struct {
-		Regular *struct {
-			Txid string `json:"txid"`
-			Vout uint32 `json:"vout"`
-		} `json:"Regular"`
-		Deposit *string `json:"Deposit"`
-	} `json:"inputs"`
+	Inputs  []mempoolOutpoint `json:"inputs"`
 	Outputs []struct {
 		Address string          `json:"address"`
 		Content json.RawMessage `json:"content"`
 	} `json:"outputs"`
+}
+
+type mempoolOutpoint struct {
+	Regular *struct {
+		Txid string `json:"txid"`
+		Vout uint32 `json:"vout"`
+	} `json:"Regular"`
+	Deposit *string `json:"Deposit"`
+}
+
+func (p *mempoolOutpoint) UnmarshalJSON(raw []byte) error {
+	if bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+		var pair []json.RawMessage
+		if err := json.Unmarshal(raw, &pair); err != nil {
+			return err
+		}
+		if len(pair) != 2 {
+			return fmt.Errorf("a transaction input holds an outpoint and a hash, got %d parts", len(pair))
+		}
+		raw = pair[0]
+	}
+	type outpoint mempoolOutpoint
+	return json.Unmarshal(raw, (*outpoint)(p))
 }
 
 // spends are the coins this transaction takes, each as the key its outpoint

--- a/sidechain-orchestrator/sidechain/mempool_test.go
+++ b/sidechain-orchestrator/sidechain/mempool_test.go
@@ -81,6 +81,40 @@ func TestMempoolFallsBackToTheTemplate(t *testing.T) {
 	assert.Equal(t, int64(7000), txs[0].Outputs[0].ValueSats)
 }
 
+func TestMempoolReadsThunderInputPairs(t *testing.T) {
+	const transaction = `{"inputs":[
+		[{"Regular":{"txid":"old","vout":2}},"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"],
+		[{"Deposit":"maintxid:0"},"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
+	],"outputs":[{"address":"mine","content":{"Value":9000}}]}`
+	for _, tc := range []struct {
+		name string
+		node *fakeNode
+		txid string
+	}{
+		{
+			name: "mempool",
+			node: &fakeNode{mempool: `[{"txid":"spend","size":240,"tx":` + transaction + `}]`},
+			txid: "spend",
+		},
+		{
+			name: "template",
+			node: &fakeNode{template: `{"body":{"transactions":[` + transaction + `]}}`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			txs, err := Mempool(context.Background(), tc.node)
+			require.NoError(t, err)
+			require.Len(t, txs, 1)
+			assert.Equal(t, tc.txid, txs[0].Txid)
+			assert.Equal(t, []MempoolInput{{Key: "old:2"}, {Key: "maintxid:0"}}, txs[0].Inputs)
+			assert.Equal(t, []MempoolOutput{{Address: "mine", Vout: 0, ValueSats: 9000}}, txs[0].Outputs)
+			if tc.txid != "" {
+				assert.NotContains(t, tc.node.called, "get_block_template")
+			}
+		})
+	}
+}
+
 func TestMempoolIsEmptyWhenNeitherFeedAnswers(t *testing.T) {
 	txs, err := Mempool(context.Background(), &fakeNode{})
 	require.Error(t, err)
@@ -271,7 +305,7 @@ func TestWithMempoolUTXOsDropsWhatTheMempoolSpends(t *testing.T) {
 	node := &fakeNode{
 		addresses: `["mine"]`,
 		mempool: `[{"txid":"spend","size":100,"tx":{
-		    "inputs":[{"Regular":{"txid":"old","vout":0}}],
+		    "inputs":[[{"Regular":{"txid":"old","vout":0}},"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]],
 		    "outputs":[{"address":"mine","content":{"Value":9000}}]}}]`,
 	}
 	confirmed := json.RawMessage(`[


### PR DESCRIPTION
Read Thunder's outpoint and hash pairs so pending sends update both wallet balances.
Tests cover both wallets before a send, in the mempool, and after a block.
