### PR TITLE
orchestrator: adopt only the Core the datadir names

### DIFF
--- a/sidechain-orchestrator/bitcoind_boot_adopt_test.go
+++ b/sidechain-orchestrator/bitcoind_boot_adopt_test.go
@@ -161,6 +161,18 @@ func TestAdoptIfCoreOwnsDatadir_LockConflictAdopts(t *testing.T) {
 	}
 }
 
+// TestAdoptIfCoreOwnsDatadir_NamelessOwnerAdoptsNothing covers the lock
+// conflict whose owner the datadir does not name. The boot still reports
+// success, because the lock proves a live node, but it adopts no stranger:
+// a process this install cannot identify is a process it must not stop.
+func TestAdoptIfCoreOwnsDatadir_NamelessOwnerAdoptsNothing(t *testing.T) {
+	o := fakeCoreFixture(t, "#!/bin/sh\nsleep 30\n")
+	coreLookalike(t, o)
+
+	require.NoError(t, o.adoptIfCoreOwnsDatadir(o.configs["bitcoind"], errors.New(lockConflictError)))
+	require.False(t, o.process.IsRunning("bitcoind"))
+}
+
 // TestAdoptIfCoreOwnsDatadir_OtherErrorStillFails keeps the adopt narrow.
 func TestAdoptIfCoreOwnsDatadir_OtherErrorStillFails(t *testing.T) {
 	o := fakeCoreFixture(t, "#!/bin/sh\nsleep 30\n")

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1468,8 +1468,9 @@ func (o *Orchestrator) adoptIfCoreOwnsDatadir(cfg BinaryConfig, startErr error) 
 	if startErr == nil || !ownsDatadirAlready(startErr) {
 		return startErr
 	}
-	// The lock is the proof of ownership here, so the wider lookup is safe.
-	o.adoptCore(cfg, o.discoverPid(cfg), startErr)
+	// The lock proves an owner, but not which process it is. Adopt only the
+	// one the datadir names: a stranger adopted here is a stranger stopped.
+	o.adoptCore(cfg, o.datadirOwnerPid(cfg), startErr)
 	return nil
 }
 


### PR DESCRIPTION
Follow-up to #2212, which merged before this last review point landed.

A datadir lock conflict proves an owner, but not which process it is, so the post-conflict adopt now reads the same native bitcoind.pid the pre-start check reads. An owner the datadir does not name is still a success, and this install adopts nothing rather than stop a stranger's node.