### PR TITLE
orchestrator: close the three light mode findings from PR 2211

### DIFF
--- a/bitassets/lib/providers/asset_analytics_provider.dart
+++ b/bitassets/lib/providers/asset_analytics_provider.dart
@@ -160,19 +160,11 @@ class AssetAnalyticsProvider extends ChangeNotifier {
       for (final utxo in utxos) {
         if (utxo is! BitAssetsUTXO) continue;
 
-        final content = utxo.output['content'] as Map<String, dynamic>?;
-        if (content == null) continue;
+        final holding = utxo.holding;
+        if (holding == null) continue;
 
-        if (content.containsKey('BitAsset')) {
-          final assetData = content['BitAsset'] as Map<String, dynamic>;
-          final assetId = assetData['asset_id'] as String?;
-          final amount = assetData['amount'] as int?;
-
-          if (assetId != null && amount != null) {
-            assetAmounts[assetId] = (assetAmounts[assetId] ?? 0) + amount;
-            totalValue += amount;
-          }
-        }
+        assetAmounts[holding.assetId] = (assetAmounts[holding.assetId] ?? 0) + holding.amount;
+        totalValue += holding.amount;
       }
 
       // Create holdings list with percentages

--- a/sail_ui/lib/pages/sidechains/parent_chain_page.dart
+++ b/sail_ui/lib/pages/sidechains/parent_chain_page.dart
@@ -107,6 +107,9 @@ class ParentChainTabViewModel extends BaseViewModel with ChangeTrackingMixin {
   String? get depositError => _addressProvider.depositError;
   String? withdrawError;
 
+  /// Names why this chain can sign no withdrawal, or null when it can.
+  String? get spendUnavailable => _rpc.spendUnavailable;
+
   double? get pegAmount => double.tryParse(bitcoinAmountController.text);
   double? get maxAmount => max(
     _balanceProvider.balance - (sidechainFee ?? 0) - (mainchainFee ?? 0),
@@ -127,6 +130,7 @@ class ParentChainTabViewModel extends BaseViewModel with ChangeTrackingMixin {
     _transactionsProvider.addListener(_onChange);
     _balanceProvider.addListener(_onChange);
     _addressProvider.addListener(_onChange);
+    _rpc.addListener(_onChange);
   }
 
   void _onChange() {
@@ -134,6 +138,7 @@ class ParentChainTabViewModel extends BaseViewModel with ChangeTrackingMixin {
     track('pendingBalance', _balanceProvider.pendingBalance);
     track('transactions', _transactionsProvider.sidechainTransactions);
     track('depositAddress', depositAddress);
+    track('spendUnavailable', spendUnavailable);
     notifyIfChanged();
   }
 
@@ -248,6 +253,7 @@ class ParentChainTabViewModel extends BaseViewModel with ChangeTrackingMixin {
     _transactionsProvider.removeListener(_onChange);
     _balanceProvider.removeListener(_onChange);
     _addressProvider.removeListener(_onChange);
+    _rpc.removeListener(_onChange);
     super.dispose();
   }
 }
@@ -314,7 +320,7 @@ class WithdrawTab extends ViewModelWidget<ParentChainTabViewModel> {
     return SailCard(
       title: 'Withdraw to Parent Chain',
       subtitle: 'Withdraw bitcoin from the sidechain to the parent chain',
-      error: viewModel.withdrawError,
+      error: viewModel.withdrawError ?? viewModel.spendUnavailable,
       child: Column(
         children: [
           SailTextField(
@@ -412,6 +418,7 @@ class WithdrawTab extends ViewModelWidget<ParentChainTabViewModel> {
                 children: [
                   SailButton(
                     label: 'Send',
+                    disabled: viewModel.spendUnavailable != null,
                     onPressed: () => viewModel.executePegOut(context),
                     loading: viewModel.isBusy,
                   ),

--- a/sail_ui/lib/pages/sidechains/sidechain_overview_page.dart
+++ b/sail_ui/lib/pages/sidechains/sidechain_overview_page.dart
@@ -103,7 +103,7 @@ class SidechainOverviewTabPage extends StatelessWidget {
                       ),
                       SailCard(
                         title: 'Send on Sidechain',
-                        error: model.sendError,
+                        error: model.sendError ?? model.spendUnavailable,
                         child: SailColumn(
                           spacing: SailStyleValues.padding16,
                           children: [
@@ -178,8 +178,14 @@ class OverviewTabViewModel extends BaseViewModel with ChangeTrackingMixin {
 
   bool get allConnected => _rpc.connected;
 
+  /// Names why this chain can sign no send, or null when it can.
+  String? get spendUnavailable => _rpc.spendUnavailable;
+
   /// Whether the send form is valid and ready to submit
   bool get canSend {
+    if (spendUnavailable != null) {
+      return false;
+    }
     if (!balanceInitialized) {
       return false;
     }
@@ -214,6 +220,7 @@ class OverviewTabViewModel extends BaseViewModel with ChangeTrackingMixin {
     track('transactions', transactions);
     track('receiveAddress', receiveAddress);
     track('allConnected', allConnected);
+    track('spendUnavailable', spendUnavailable);
     track('balanceInitialized', balanceInitialized);
     notifyIfChanged();
   }

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -1053,6 +1053,7 @@ func statusToProto(s orchestrator.BinaryStatus) *pb.BinaryStatusMsg {
 		Running:                 s.Running,
 		WindowOpen:              s.WindowOpen,
 		ServesLightWallet:       s.ServesLightWallet,
+		WalletCanSpend:          s.WalletCanSpend,
 		Healthy:                 s.Healthy,
 		Pid:                     int32(s.Pid),
 		UptimeSeconds:           int64(s.Uptime.Seconds()),

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -659,7 +659,11 @@ func run(cctx *cli.Context) error {
 			}
 			// The mode carries both halves: light mode, and an index to read.
 			// A network with no index for this chain reads its local node.
-			orch.RegisterLightWallet(name, func() bool { return !thunderMode().LocalNode })
+			orch.RegisterLightWallet(name, orchestrator.LightWallet{
+				ReadsIndex: func() bool { return !thunderMode().LocalNode },
+				// Thunder signs and broadcasts through the index.
+				CanSpend: func() bool { return true },
+			})
 			h := thundersvc.NewHandlerWithSeed(proxy, thunderMode, func() ([]byte, error) {
 				mnemonic, err := orch.WalletSvc.GetOrDeriveSidechainStarter(
 					thunderCfg.Slot, thunderCfg.DisplayName,
@@ -679,7 +683,9 @@ func run(cctx *cli.Context) error {
 			h := bitnamessvc.NewLightHandler(proxy, lightMode(name), walletSeed(cfg))
 			// The mode carries both halves: light mode, and an index to read.
 			// A network with no index for this chain reads its local node.
-			orch.RegisterLightWallet(name, h.ReadsIndex)
+			orch.RegisterLightWallet(name, orchestrator.LightWallet{
+				ReadsIndex: h.ReadsIndex, CanSpend: h.CanSpend,
+			})
 			// The sidechain balance the frontend reads must come from the same
 			// wallet, because light mode starts no daemon to dial.
 			handler.SetSidechainBalance(name, h.WalletBalance)
@@ -690,7 +696,9 @@ func run(cctx *cli.Context) error {
 			h := bitassetssvc.NewLightHandler(proxy, lightMode(name), walletSeed(cfg))
 			// The mode carries both halves: light mode, and an index to read.
 			// A network with no index for this chain reads its local node.
-			orch.RegisterLightWallet(name, h.ReadsIndex)
+			orch.RegisterLightWallet(name, orchestrator.LightWallet{
+				ReadsIndex: h.ReadsIndex, CanSpend: h.CanSpend,
+			})
 			// The sidechain balance the frontend reads must come from the same
 			// wallet, because light mode starts no daemon to dial.
 			handler.SetSidechainBalance(name, h.WalletBalance)
@@ -701,7 +709,9 @@ func run(cctx *cli.Context) error {
 			h := photonsvc.NewLightHandler(proxy, lightMode(name), walletSeed(cfg))
 			// The mode carries both halves: light mode, and an index to read.
 			// A network with no index for this chain reads its local node.
-			orch.RegisterLightWallet(name, h.ReadsIndex)
+			orch.RegisterLightWallet(name, orchestrator.LightWallet{
+				ReadsIndex: h.ReadsIndex, CanSpend: h.CanSpend,
+			})
 			// The sidechain balance the frontend reads must come from the same
 			// wallet, because light mode starts no daemon to dial.
 			handler.SetSidechainBalance(name, h.WalletBalance)
@@ -717,7 +727,9 @@ func run(cctx *cli.Context) error {
 			h := coinshiftsvc.NewLightHandler(proxy, lightMode(name), walletSeed(cfg))
 			// The mode carries both halves: light mode, and an index to read.
 			// A network with no index for this chain reads its local node.
-			orch.RegisterLightWallet(name, h.ReadsIndex)
+			orch.RegisterLightWallet(name, orchestrator.LightWallet{
+				ReadsIndex: h.ReadsIndex, CanSpend: h.CanSpend,
+			})
 			// The sidechain balance the frontend reads must come from the same
 			// wallet, because light mode starts no daemon to dial.
 			handler.SetSidechainBalance(name, h.WalletBalance)

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -406,8 +406,11 @@ type BinaryStatusMsg struct {
 	// The chain answers with no local daemon, through a remote index. Only a
 	// chain with a light backend can serve a wallet in light mode.
 	ServesLightWallet bool `protobuf:"varint,28,opt,name=serves_light_wallet,json=servesLightWallet,proto3" json:"serves_light_wallet,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// The wallet can sign a spend. False for a chain that reads a remote index
+	// and holds no spend path, so the frontend must offer no send there.
+	WalletCanSpend bool `protobuf:"varint,29,opt,name=wallet_can_spend,json=walletCanSpend,proto3" json:"wallet_can_spend,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *BinaryStatusMsg) Reset() {
@@ -632,6 +635,13 @@ func (x *BinaryStatusMsg) GetWindowOpen() bool {
 func (x *BinaryStatusMsg) GetServesLightWallet() bool {
 	if x != nil {
 		return x.ServesLightWallet
+	}
+	return false
+}
+
+func (x *BinaryStatusMsg) GetWalletCanSpend() bool {
+	if x != nil {
+		return x.WalletCanSpend
 	}
 	return false
 }
@@ -4915,7 +4925,7 @@ var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
 
 const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\n" +
-	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\xea\a\n" +
+	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\x94\b\n" +
 	"\x0fBinaryStatusMsg\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
@@ -4950,7 +4960,8 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x19downloaded_timestamp_unix\x18\x1a \x01(\x03R\x17downloadedTimestampUnix\x12\x1f\n" +
 	"\vwindow_open\x18\x1b \x01(\bR\n" +
 	"windowOpen\x12.\n" +
-	"\x13serves_light_wallet\x18\x1c \x01(\bR\x11servesLightWallet\"U\n" +
+	"\x13serves_light_wallet\x18\x1c \x01(\bR\x11servesLightWallet\x12(\n" +
+	"\x10wallet_can_spend\x18\x1d \x01(\bR\x0ewalletCanSpend\"U\n" +
 	"\x12StartupLogEntryMsg\x12%\n" +
 	"\x0etimestamp_unix\x18\x01 \x01(\x03R\rtimestampUnix\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\":\n" +

--- a/sidechain-orchestrator/light_mode_window_test.go
+++ b/sidechain-orchestrator/light_mode_window_test.go
@@ -101,7 +101,10 @@ func TestLightWalletRegistrationGatesTheWindow(t *testing.T) {
 	}
 
 	readsIndex := true
-	o.RegisterLightWallet("thunder", func() bool { return readsIndex })
+	o.RegisterLightWallet("thunder", LightWallet{
+		ReadsIndex: func() bool { return readsIndex },
+		CanSpend:   func() bool { return true },
+	})
 
 	if !o.servesLightWallet("thunder") {
 		t.Error("a registered chain must serve a light wallet")
@@ -115,6 +118,40 @@ func TestLightWalletRegistrationGatesTheWindow(t *testing.T) {
 	readsIndex = false
 	if o.servesLightWallet("thunder") {
 		t.Error("a network with no index must not serve a light wallet")
+	}
+}
+
+// A chain that reads an index and holds no spend path must report that it can
+// sign nothing, because the frontend hides its send and withdraw there.
+func TestWalletCanSpendFollowsTheLightBackend(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	if !o.walletCanSpend("truthcoin") {
+		t.Error("a chain with a local daemon must report that it can spend")
+	}
+
+	readsIndex := true
+	o.RegisterLightWallet("bitassets", LightWallet{
+		ReadsIndex: func() bool { return readsIndex },
+		CanSpend:   func() bool { return false },
+	})
+	if o.walletCanSpend("bitassets") {
+		t.Error("a light wallet with no spend path must report that it cannot spend")
+	}
+
+	// The same chain runs a daemon on a network with no index, and that daemon
+	// signs.
+	readsIndex = false
+	if !o.walletCanSpend("bitassets") {
+		t.Error("a chain that reads no index must report that it can spend")
+	}
+
+	o.RegisterLightWallet("thunder", LightWallet{
+		ReadsIndex: func() bool { return true },
+		CanSpend:   func() bool { return true },
+	})
+	if !o.walletCanSpend("thunder") {
+		t.Error("thunder holds a light spend path, so it must report that it can spend")
 	}
 }
 

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -71,6 +71,9 @@ type BinaryStatus struct {
 	UpdateAvailable   bool      // a newer build is published than the one on disk
 	RemoteTimestamp   time.Time // Last-Modified of the published download
 	LocalTimestamp    time.Time // mtime of the binary on disk
+	// WalletCanSpend says the wallet can sign a spend. False for a chain that
+	// reads a remote index and holds no spend path.
+	WalletCanSpend bool
 }
 
 // StartupProgress reports progress during StartWithL1. Download fields
@@ -165,10 +168,10 @@ type Orchestrator struct {
 
 	Settings *SettingsStore
 
-	// lightWallets answers, per chain, whether it reads a remote index right
-	// now. The service that wires a chain's light backend registers it.
+	// lightWallets answers, per chain, what it can do with no local daemon.
+	// The service that wires a chain's light backend registers it.
 	lightMu      sync.RWMutex
-	lightWallets map[string]func() bool
+	lightWallets map[string]LightWallet
 
 	// forkEngine is the single source of truth for eCash fork state; wired by
 	// InitForkEngine once Core RPC is up.
@@ -751,6 +754,7 @@ func (o *Orchestrator) StatusWithOptions(name string, opts DownloadOptions) Bina
 	if config.ChainLayer == 2 {
 		status.WindowOpen = o.process.IsRunning(sidechainGUIProcessName(config.Name))
 		status.ServesLightWallet = o.servesLightWallet(config.Name)
+		status.WalletCanSpend = o.walletCanSpend(config.Name)
 	}
 
 	// Quick port probe if not already known to be running.
@@ -1986,24 +1990,45 @@ func enforcerAtTip(r *ChainSyncResult) bool {
 	return r != nil && r.Error == "" && r.Headers > 0 && r.Blocks == r.Headers
 }
 
-// RegisterLightWallet records how to ask whether a chain reads a remote index.
-// The handler that wires the chain's light backend is the only thing that
-// knows, and the answer moves with the network, so it stays a question.
-func (o *Orchestrator) RegisterLightWallet(name string, readsIndex func() bool) {
+// LightWallet names what one chain can do with no local daemon. Both answers
+// move with the network, so each one stays a question.
+type LightWallet struct {
+	// ReadsIndex reports whether the chain reads a remote index right now.
+	ReadsIndex func() bool
+	// CanSpend reports whether the chain can sign a spend right now.
+	CanSpend func() bool
+}
+
+// RegisterLightWallet records what a chain can do with no local daemon. The
+// handler that wires the chain's light backend is the only thing that knows.
+func (o *Orchestrator) RegisterLightWallet(name string, wallet LightWallet) {
 	o.lightMu.Lock()
 	defer o.lightMu.Unlock()
 	if o.lightWallets == nil {
-		o.lightWallets = map[string]func() bool{}
+		o.lightWallets = map[string]LightWallet{}
 	}
-	o.lightWallets[name] = readsIndex
+	o.lightWallets[name] = wallet
 }
 
 // servesLightWallet reports whether a chain reads its chain with no daemon.
 func (o *Orchestrator) servesLightWallet(name string) bool {
 	o.lightMu.RLock()
-	readsIndex := o.lightWallets[name]
+	wallet := o.lightWallets[name]
 	o.lightMu.RUnlock()
-	return readsIndex != nil && readsIndex()
+	return wallet.ReadsIndex != nil && wallet.ReadsIndex()
+}
+
+// walletCanSpend reports whether a chain can sign a spend right now. A chain
+// that runs its own daemon signs there, so only an index-backed wallet can
+// answer no.
+func (o *Orchestrator) walletCanSpend(name string) bool {
+	o.lightMu.RLock()
+	wallet := o.lightWallets[name]
+	o.lightMu.RUnlock()
+	if wallet.ReadsIndex == nil || !wallet.ReadsIndex() {
+		return true
+	}
+	return wallet.CanSpend != nil && wallet.CanSpend()
 }
 
 func sidechainGUIProcessName(name string) string {

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -202,6 +202,9 @@ message BinaryStatusMsg {
   // The chain answers with no local daemon, through a remote index. Only a
   // chain with a light backend can serve a wallet in light mode.
   bool serves_light_wallet = 28;
+  // The wallet can sign a spend. False for a chain that reads a remote index
+  // and holds no spend path, so the frontend must offer no send there.
+  bool wallet_can_spend = 29;
 }
 
 message StartupLogEntryMsg {

--- a/sidechain-orchestrator/sidechain/bitassets/handler.go
+++ b/sidechain-orchestrator/sidechain/bitassets/handler.go
@@ -66,6 +66,9 @@ func (h *Handler) GetNewAddress(ctx context.Context, req *connect.Request[pb.Get
 }
 
 func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.WithdrawRequest]) (*connect.Response[pb.WithdrawResponse], error) {
+	if err := h.refuseSpend("withdraw"); err != nil {
+		return nil, err
+	}
 	txid, err := h.proxy.Withdraw(ctx, req.Msg.Address, req.Msg.AmountSats, req.Msg.SideFeeSats, req.Msg.MainFeeSats)
 	if err != nil {
 		return nil, err
@@ -74,6 +77,9 @@ func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.Withdraw
 }
 
 func (h *Handler) Transfer(ctx context.Context, req *connect.Request[pb.TransferRequest]) (*connect.Response[pb.TransferResponse], error) {
+	if err := h.refuseSpend("send"); err != nil {
+		return nil, err
+	}
 	// BitAssets transfer accepts [dest, value, fee, memo]
 	params := []any{req.Msg.Address, req.Msg.AmountSats, req.Msg.FeeSats}
 	if req.Msg.Memo != nil {

--- a/sidechain-orchestrator/sidechain/bitassets/light.go
+++ b/sidechain-orchestrator/sidechain/bitassets/light.go
@@ -20,6 +20,7 @@ func NewLightHandler(
 		Output: lightwallet.OutputShape{
 			ValueKey: lightwallet.ValueKeyBitcoinSats,
 			Memo:     true,
+			Holdings: []string{"bitasset"},
 		},
 	})}
 }

--- a/sidechain-orchestrator/sidechain/bitassets/light.go
+++ b/sidechain-orchestrator/sidechain/bitassets/light.go
@@ -27,6 +27,17 @@ func NewLightHandler(
 // ReadsIndex reports whether this chain reads a remote index right now.
 func (h *Handler) ReadsIndex() bool { return h.light.ReadsIndex() }
 
+// CanSpend reports whether this chain can sign a spend right now.
+func (h *Handler) CanSpend() bool { return h.light.CanSpend() }
+
+// refuseSpend answers the refusal a caller must get when no node signs here.
+func (h *Handler) refuseSpend(action string) error {
+	if h.light.CanSpend() {
+		return nil
+	}
+	return lightwallet.SpendUnsupported("bitassets", action)
+}
+
 // WalletBalance reads the balance whatever mode runs. Another service answers
 // the same number from here, so both modes agree.
 func (h *Handler) WalletBalance(ctx context.Context) (total, available int64, err error) {

--- a/sidechain-orchestrator/sidechain/bitassets/light_test.go
+++ b/sidechain-orchestrator/sidechain/bitassets/light_test.go
@@ -189,3 +189,72 @@ func TestFullHandlerSpendsThroughTheNode(t *testing.T) {
 		t.Error("a full install refuses a send the node would sign")
 	}
 }
+
+// A holder must read the assets the wallet owns. The index carries the node's
+// own payload, and the asset id and the amount live only there. Bitcoin and an
+// asset count in separate places, so the asset must leave the balance alone.
+func TestLightHandlerKeepsTheAssetPayload(t *testing.T) {
+	seed := bip39.NewSeed(testMnemonic, "")
+	first, err := deriveAddress(seed, 0)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+
+	// The node writes a BitAsset output content as the pair [asset id, amount].
+	const asset = `{"BitAsset":["c0ffee",500]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/address/")
+		switch {
+		case path == first.String()+"/utxo":
+			_, _ = io.WriteString(w, `[
+				{"txid":"`+testDepositTxid+`","vout":0,"value":21000,
+				 "outpoint_kind":"deposit","content_type":"value",
+				 "content":{"BitcoinSats":21000},
+				 "status":{"confirmed":true,"block_height":1,"block_time":1}},
+				{"txid":"`+testDepositTxid+`","vout":1,"value":0,
+				 "outpoint_kind":"regular","content_type":"bitasset",
+				 "content":`+asset+`,
+				 "status":{"confirmed":true,"block_height":1,"block_time":1}}]`)
+		case strings.HasSuffix(path, "/utxo"), strings.HasSuffix(path, "/deposits"):
+			_, _ = io.WriteString(w, "[]")
+		default:
+			count := "0"
+			if path == first.String() {
+				count = "1"
+			}
+			_, _ = io.WriteString(w, `{"address":"`+path+`",
+				"chain_stats":{"funded_txo_count":`+count+`,"funded_txo_sum":0,
+				"spent_txo_count":0,"spent_txo_sum":0,"tx_count":0},
+				"mempool_stats":{"funded_txo_count":0,"funded_txo_sum":0,
+				"spent_txo_count":0,"spent_txo_sum":0,"tx_count":0}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(true, server.URL) },
+		func() ([]byte, error) { return seed, nil },
+	)
+
+	ctx := context.Background()
+	utxos, err := h.GetWalletUtxos(ctx, connect.NewRequest(&pb.GetWalletUtxosRequest{}))
+	if err != nil {
+		t.Fatalf("utxos: %v", err)
+	}
+	if !strings.Contains(utxos.Msg.UtxosJson, asset) {
+		t.Errorf("utxos = %s, want the asset pair %s", utxos.Msg.UtxosJson, asset)
+	}
+	if !strings.Contains(utxos.Msg.UtxosJson, `"BitcoinSats":21000`) {
+		t.Errorf("utxos = %s, want the bitcoin coin too", utxos.Msg.UtxosJson)
+	}
+
+	balance, err := h.GetBalance(ctx, connect.NewRequest(&pb.GetBalanceRequest{}))
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if balance.Msg.TotalSats != 21000 || balance.Msg.AvailableSats != 21000 {
+		t.Errorf("balance = %d total and %d available, want 21000 of each",
+			balance.Msg.TotalSats, balance.Msg.AvailableSats)
+	}
+}

--- a/sidechain-orchestrator/sidechain/bitassets/light_test.go
+++ b/sidechain-orchestrator/sidechain/bitassets/light_test.go
@@ -133,3 +133,59 @@ func TestLightHandlerRefusesAnUnhostedNetwork(t *testing.T) {
 		t.Error("a network with no index reads one anyway")
 	}
 }
+
+// A light install can sign nothing on this chain, so a send and a withdrawal
+// must refuse with a missing capability. A dial error would tell the user the
+// node is down, and no node is meant to run here.
+func TestLightHandlerRefusesToSpend(t *testing.T) {
+	seed := bip39.NewSeed(testMnemonic, "")
+	first, err := deriveAddress(seed, 0)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	url := testIndex(t, first.String())
+
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(true, url) },
+		func() ([]byte, error) { return seed, nil },
+	)
+	if h.CanSpend() {
+		t.Fatal("a light wallet with no spend path reports that it can spend")
+	}
+
+	ctx := context.Background()
+	_, err = h.Transfer(ctx, connect.NewRequest(&pb.TransferRequest{
+		Address: first.String(), AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("transfer answered %v, want a missing capability", err)
+	}
+
+	_, err = h.Withdraw(ctx, connect.NewRequest(&pb.WithdrawRequest{
+		Address: "tb1qexample", AmountSats: 1000, SideFeeSats: 10, MainFeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("withdraw answered %v, want a missing capability", err)
+	}
+}
+
+// A full install runs a node that signs, so the guard must let the call
+// through to it.
+func TestFullHandlerSpendsThroughTheNode(t *testing.T) {
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(false, "https://index.example") },
+		func() ([]byte, error) { return bip39.NewSeed(testMnemonic, ""), nil },
+	)
+	if !h.CanSpend() {
+		t.Fatal("a full install reports that it cannot spend")
+	}
+
+	_, err := h.Transfer(context.Background(), connect.NewRequest(&pb.TransferRequest{
+		Address: "anything", AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) == connect.CodeUnimplemented {
+		t.Error("a full install refuses a send the node would sign")
+	}
+}

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -66,6 +66,9 @@ func (h *Handler) GetNewAddress(ctx context.Context, req *connect.Request[pb.Get
 }
 
 func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.WithdrawRequest]) (*connect.Response[pb.WithdrawResponse], error) {
+	if err := h.refuseSpend("withdraw"); err != nil {
+		return nil, err
+	}
 	params := []any{req.Msg.Address, req.Msg.AmountSats, req.Msg.SideFeeSats, req.Msg.MainFeeSats}
 	var txid string
 	if err := h.proxy.Client.Call(ctx, "create_withdrawal", params, &txid); err != nil {
@@ -75,6 +78,9 @@ func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.Withdraw
 }
 
 func (h *Handler) Transfer(ctx context.Context, req *connect.Request[pb.TransferRequest]) (*connect.Response[pb.TransferResponse], error) {
+	if err := h.refuseSpend("send"); err != nil {
+		return nil, err
+	}
 	// create_transfer takes a 4th memo parameter here.
 	params := []any{req.Msg.Address, req.Msg.AmountSats, req.Msg.FeeSats}
 	if req.Msg.Memo != nil {

--- a/sidechain-orchestrator/sidechain/bitnames/light.go
+++ b/sidechain-orchestrator/sidechain/bitnames/light.go
@@ -27,6 +27,17 @@ func NewLightHandler(
 // ReadsIndex reports whether this chain reads a remote index right now.
 func (h *Handler) ReadsIndex() bool { return h.light.ReadsIndex() }
 
+// CanSpend reports whether this chain can sign a spend right now.
+func (h *Handler) CanSpend() bool { return h.light.CanSpend() }
+
+// refuseSpend answers the refusal a caller must get when no node signs here.
+func (h *Handler) refuseSpend(action string) error {
+	if h.light.CanSpend() {
+		return nil
+	}
+	return lightwallet.SpendUnsupported("bitnames", action)
+}
+
 // WalletBalance reads the balance whatever mode runs. Another service answers
 // the same number from here, so both modes agree.
 func (h *Handler) WalletBalance(ctx context.Context) (total, available int64, err error) {

--- a/sidechain-orchestrator/sidechain/bitnames/light_test.go
+++ b/sidechain-orchestrator/sidechain/bitnames/light_test.go
@@ -133,3 +133,59 @@ func TestLightHandlerRefusesAnUnhostedNetwork(t *testing.T) {
 		t.Error("a network with no index reads one anyway")
 	}
 }
+
+// A light install can sign nothing on this chain, so a send and a withdrawal
+// must refuse with a missing capability. A dial error would tell the user the
+// node is down, and no node is meant to run here.
+func TestLightHandlerRefusesToSpend(t *testing.T) {
+	seed := bip39.NewSeed(testMnemonic, "")
+	first, err := deriveAddress(seed, 0)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	url := testIndex(t, first.String())
+
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(true, url) },
+		func() ([]byte, error) { return seed, nil },
+	)
+	if h.CanSpend() {
+		t.Fatal("a light wallet with no spend path reports that it can spend")
+	}
+
+	ctx := context.Background()
+	_, err = h.Transfer(ctx, connect.NewRequest(&pb.TransferRequest{
+		Address: first.String(), AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("transfer answered %v, want a missing capability", err)
+	}
+
+	_, err = h.Withdraw(ctx, connect.NewRequest(&pb.WithdrawRequest{
+		Address: "tb1qexample", AmountSats: 1000, SideFeeSats: 10, MainFeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("withdraw answered %v, want a missing capability", err)
+	}
+}
+
+// A full install runs a node that signs, so the guard must let the call
+// through to it.
+func TestFullHandlerSpendsThroughTheNode(t *testing.T) {
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(false, "https://index.example") },
+		func() ([]byte, error) { return bip39.NewSeed(testMnemonic, ""), nil },
+	)
+	if !h.CanSpend() {
+		t.Fatal("a full install reports that it cannot spend")
+	}
+
+	_, err := h.Transfer(context.Background(), connect.NewRequest(&pb.TransferRequest{
+		Address: "anything", AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) == connect.CodeUnimplemented {
+		t.Error("a full install refuses a send the node would sign")
+	}
+}

--- a/sidechain-orchestrator/sidechain/coinshift/handler.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler.go
@@ -66,6 +66,9 @@ func (h *Handler) GetNewAddress(ctx context.Context, req *connect.Request[pb.Get
 }
 
 func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.WithdrawRequest]) (*connect.Response[pb.WithdrawResponse], error) {
+	if err := h.refuseSpend("withdraw"); err != nil {
+		return nil, err
+	}
 	txid, err := h.proxy.Withdraw(ctx, req.Msg.Address, req.Msg.AmountSats, req.Msg.SideFeeSats, req.Msg.MainFeeSats)
 	if err != nil {
 		return nil, err
@@ -74,6 +77,9 @@ func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.Withdraw
 }
 
 func (h *Handler) Transfer(ctx context.Context, req *connect.Request[pb.TransferRequest]) (*connect.Response[pb.TransferResponse], error) {
+	if err := h.refuseSpend("send"); err != nil {
+		return nil, err
+	}
 	txid, err := h.proxy.Transfer(ctx, req.Msg.Address, req.Msg.AmountSats, req.Msg.FeeSats)
 	if err != nil {
 		return nil, err

--- a/sidechain-orchestrator/sidechain/coinshift/light.go
+++ b/sidechain-orchestrator/sidechain/coinshift/light.go
@@ -26,6 +26,17 @@ func NewLightHandler(
 // ReadsIndex reports whether this chain reads a remote index right now.
 func (h *Handler) ReadsIndex() bool { return h.light.ReadsIndex() }
 
+// CanSpend reports whether this chain can sign a spend right now.
+func (h *Handler) CanSpend() bool { return h.light.CanSpend() }
+
+// refuseSpend answers the refusal a caller must get when no node signs here.
+func (h *Handler) refuseSpend(action string) error {
+	if h.light.CanSpend() {
+		return nil
+	}
+	return lightwallet.SpendUnsupported("coinshift", action)
+}
+
 // WalletBalance reads the balance whatever mode runs. Another service answers
 // the same number from here, so both modes agree.
 func (h *Handler) WalletBalance(ctx context.Context) (total, available int64, err error) {

--- a/sidechain-orchestrator/sidechain/coinshift/light_test.go
+++ b/sidechain-orchestrator/sidechain/coinshift/light_test.go
@@ -133,3 +133,59 @@ func TestLightHandlerRefusesAnUnhostedNetwork(t *testing.T) {
 		t.Error("a network with no index reads one anyway")
 	}
 }
+
+// A light install can sign nothing on this chain, so a send and a withdrawal
+// must refuse with a missing capability. A dial error would tell the user the
+// node is down, and no node is meant to run here.
+func TestLightHandlerRefusesToSpend(t *testing.T) {
+	seed := bip39.NewSeed(testMnemonic, "")
+	first, err := deriveAddress(seed, 0)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	url := testIndex(t, first.String())
+
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(true, url) },
+		func() ([]byte, error) { return seed, nil },
+	)
+	if h.CanSpend() {
+		t.Fatal("a light wallet with no spend path reports that it can spend")
+	}
+
+	ctx := context.Background()
+	_, err = h.Transfer(ctx, connect.NewRequest(&pb.TransferRequest{
+		Address: first.String(), AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("transfer answered %v, want a missing capability", err)
+	}
+
+	_, err = h.Withdraw(ctx, connect.NewRequest(&pb.WithdrawRequest{
+		Address: "tb1qexample", AmountSats: 1000, SideFeeSats: 10, MainFeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("withdraw answered %v, want a missing capability", err)
+	}
+}
+
+// A full install runs a node that signs, so the guard must let the call
+// through to it.
+func TestFullHandlerSpendsThroughTheNode(t *testing.T) {
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(false, "https://index.example") },
+		func() ([]byte, error) { return bip39.NewSeed(testMnemonic, ""), nil },
+	)
+	if !h.CanSpend() {
+		t.Fatal("a full install reports that it cannot spend")
+	}
+
+	_, err := h.Transfer(context.Background(), connect.NewRequest(&pb.TransferRequest{
+		Address: "anything", AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) == connect.CodeUnimplemented {
+		t.Error("a full install refuses a send the node would sign")
+	}
+}

--- a/sidechain-orchestrator/sidechain/lightwallet/backend.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/backend.go
@@ -3,6 +3,7 @@ package lightwallet
 import (
 	"context"
 	"encoding/json"
+	"slices"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
 )
@@ -28,20 +29,25 @@ func NewBackend(client *sidechainesplora.Client, window *Window, shape OutputSha
 	}
 }
 
-// Balance sums the coins the index holds for this wallet. A coin no block
+// Balance sums the bitcoin the index holds for this wallet. A coin no block
 // carries yet counts in the total and not in what the wallet can spend, so a
-// deposit shows the moment the index sees it.
+// deposit shows the moment the index sees it. An asset output holds no
+// bitcoin, so it counts in neither.
 func (b *Backend) Balance(ctx context.Context) (total, available int64, err error) {
 	confirmed, pending, err := b.walletCoins(ctx)
 	if err != nil {
 		return 0, 0, err
 	}
 	for _, coin := range confirmed {
-		available += int64(coin.ValueSats)
+		if coin.Spendable {
+			available += int64(coin.ValueSats)
+		}
 	}
 	total = available
 	for _, coin := range pending {
-		total += int64(coin.ValueSats)
+		if coin.Spendable {
+			total += int64(coin.ValueSats)
+		}
 	}
 	return total, available, nil
 }
@@ -85,5 +91,21 @@ func (b *Backend) walletCoins(ctx context.Context) (confirmed, pending []Coin, e
 	if err != nil {
 		return nil, nil, err
 	}
-	return b.coins.Split(ctx, addresses)
+	confirmed, pending, err = b.coins.Split(ctx, addresses)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b.listed(confirmed), b.listed(pending), nil
+}
+
+// listed drops the outputs this chain's wallet does not show. A withdrawal is
+// leaving the chain, and the treasury already pays it out.
+func (b *Backend) listed(coins []Coin) []Coin {
+	out := make([]Coin, 0, len(coins))
+	for _, coin := range coins {
+		if coin.Spendable || slices.Contains(b.shape.Holdings, coin.ContentType) {
+			out = append(out, coin)
+		}
+	}
+	return out
 }

--- a/sidechain-orchestrator/sidechain/lightwallet/backend_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/backend_test.go
@@ -3,6 +3,7 @@ package lightwallet
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
@@ -159,9 +160,9 @@ func TestBackendReadsPastAUsedAddress(t *testing.T) {
 	}
 }
 
-// The walk stops one gap in, or a fresh wallet would cost one request for
-// every key it could ever hold.
-func TestBackendStopsAfterTheGap(t *testing.T) {
+// A wallet holds one gap of unused addresses after its last used one, so a
+// receive page always has one to hand out.
+func TestBackendHoldsOneGapAfterTheLastUsedAddress(t *testing.T) {
 	index := newFakeIndex(t)
 	index.deposit(testAddress(t, gapLimit+1).String(), depositTxid, 7000, true)
 
@@ -169,8 +170,49 @@ func TestBackendStopsAfterTheGap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("addresses: %v", err)
 	}
-	if len(addresses) != gapLimit {
-		t.Errorf("the walk read %d addresses, want %d", len(addresses), gapLimit)
+	if want := gapLimit + 2 + gapLimit; len(addresses) != want {
+		t.Errorf("the wallet holds %d addresses, want %d", len(addresses), want)
+	}
+}
+
+// A wallet that ran a node first holds addresses the node issued and nobody
+// paid. A walk that stops at a gap loses the coins of every key after them, so
+// the balance and the listing read as empty after a switch to light mode.
+func TestBackendReadsAFundedAddressPastALongRunOfEmptyOnes(t *testing.T) {
+	index := newFakeIndex(t)
+	// The node issued the first addresses over many sessions, and one payment
+	// landed well past the gap.
+	funded := uint32(2 * gapLimit)
+	index.deposit(testAddress(t, funded).String(), depositTxid, 7000, true)
+
+	backend := testBackend(t, index)
+	total, available, err := backend.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if total != 7000 || available != 7000 {
+		t.Errorf("balance = %d total and %d available, want 7000 of each", total, available)
+	}
+
+	raw, err := backend.UTXOs(context.Background())
+	if err != nil {
+		t.Fatalf("utxos: %v", err)
+	}
+	var rows []json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		t.Fatalf("read the listing %s: %v", raw, err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("the wallet lists %d coins, want 1", len(rows))
+	}
+
+	addresses, err := backend.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	if !slices.Contains(addresses, testAddress(t, funded).String()) {
+		t.Errorf("the wallet holds %d addresses, and the funded one is not among them",
+			len(addresses))
 	}
 }
 

--- a/sidechain-orchestrator/sidechain/lightwallet/backend_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/backend_test.go
@@ -173,3 +173,99 @@ func TestBackendStopsAfterTheGap(t *testing.T) {
 		t.Errorf("the walk read %d addresses, want %d", len(addresses), gapLimit)
 	}
 }
+
+// A withdrawal output is leaving the chain, and the treasury already pays it
+// out. Listing it inflates the wallet.
+func TestBackendDropsAWithdrawalOutput(t *testing.T) {
+	index := newFakeIndex(t)
+	index.rows(testAddress(t, 0).String(), `[
+		{"txid":"`+depositTxid+`","vout":0,"value":5000000,"outpoint_kind":"regular",
+		 "content_type":"withdrawal",
+		 "status":{"confirmed":true,"block_height":1,"block_time":1}},
+		{"txid":"`+depositTxid+`","vout":1,"value":4999000,"outpoint_kind":"regular",
+		 "content_type":"value",
+		 "status":{"confirmed":true,"block_height":1,"block_time":1}}]`)
+
+	backend := testBackend(t, index)
+	raw, err := backend.UTXOs(context.Background())
+	if err != nil {
+		t.Fatalf("utxos: %v", err)
+	}
+	var rows []json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		t.Fatalf("read the listing %s: %v", raw, err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("the wallet lists %d coins, want the plain one alone", len(rows))
+	}
+
+	total, available, err := backend.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if total != 4999000 || available != 4999000 {
+		t.Errorf("balance = %d total and %d available, want 4999000 of each", total, available)
+	}
+}
+
+// A chain that holds more than bitcoin lists the payloads it names, and the
+// index carries the asset id and the amount. A chain that names none lists a
+// plain coin alone, because its frontend can read no other payload.
+func TestBackendListsOnlyTheHoldingsTheChainNames(t *testing.T) {
+	const asset = `{"BitAsset":["c0ffee",500]}`
+	listing := `[
+		{"txid":"` + depositTxid + `","vout":0,"value":21000,"outpoint_kind":"regular",
+		 "content_type":"value","content":{"BitcoinSats":21000},
+		 "status":{"confirmed":true,"block_height":1,"block_time":1}},
+		{"txid":"` + depositTxid + `","vout":1,"value":0,"outpoint_kind":"regular",
+		 "content_type":"bitasset","content":` + asset + `,
+		 "status":{"confirmed":true,"block_height":1,"block_time":1}}]`
+
+	for name, tc := range map[string]struct {
+		shape OutputShape
+		rows  int
+	}{
+		"a chain that holds assets": {
+			OutputShape{ValueKey: ValueKeyBitcoinSats, Holdings: []string{"bitasset"}}, 2,
+		},
+		"a chain that holds bitcoin alone": {
+			OutputShape{ValueKey: ValueKeyBitcoinSats}, 1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			index := newFakeIndex(t)
+			index.rows(testAddress(t, 0).String(), listing)
+			backend := NewBackend(
+				sidechainesplora.New(index.server.URL), testWallet(testSeed), tc.shape)
+
+			raw, err := backend.UTXOs(context.Background())
+			if err != nil {
+				t.Fatalf("utxos: %v", err)
+			}
+			var rows []struct {
+				Output struct {
+					Content json.RawMessage `json:"content"`
+				} `json:"output"`
+			}
+			if err := json.Unmarshal(raw, &rows); err != nil {
+				t.Fatalf("read the listing %s: %v", raw, err)
+			}
+			if len(rows) != tc.rows {
+				t.Fatalf("the wallet lists %d coins, want %d", len(rows), tc.rows)
+			}
+			if tc.rows == 2 && string(rows[1].Output.Content) != asset {
+				t.Errorf("content = %s, want %s", rows[1].Output.Content, asset)
+			}
+
+			// An asset amount counts units of that asset, not satoshis.
+			total, available, err := backend.Balance(context.Background())
+			if err != nil {
+				t.Fatalf("balance: %v", err)
+			}
+			if total != 21000 || available != 21000 {
+				t.Errorf("balance = %d total and %d available, want 21000 of each",
+					total, available)
+			}
+		})
+	}
+}

--- a/sidechain-orchestrator/sidechain/lightwallet/coins.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/coins.go
@@ -3,6 +3,7 @@ package lightwallet
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -37,6 +38,14 @@ type Coin struct {
 	OutPoint  OutPoint
 	Address   Address
 	ValueSats uint64
+	// ContentType names what the output holds, such as "value" or "bitasset".
+	ContentType string
+	// Content is the chain-specific payload the node wrote for this output. It
+	// names the asset a bitassets output holds, so a holder reads it back.
+	Content json.RawMessage
+	// Spendable is true for a plain coin. Only a plain coin counts in the
+	// bitcoin balance.
+	Spendable bool
 }
 
 // IndexCoins reads the coins a set of addresses holds from an Esplora index.
@@ -49,9 +58,9 @@ func NewIndexCoins(client *sidechainesplora.Client) *IndexCoins {
 	return &IndexCoins{client: client}
 }
 
-// Split lists what a set of addresses holds, in two halves: the coins a block
-// carries, and the coins no block carries yet. A wallet spends the first half
-// and shows both.
+// Split lists every output a set of addresses holds, in two halves: the ones a
+// block carries, and the ones no block carries yet. The caller picks which
+// payloads its chain shows.
 func (i *IndexCoins) Split(
 	ctx context.Context, addresses []Address,
 ) (confirmed, pending []Coin, err error) {
@@ -90,11 +99,6 @@ func (i *IndexCoins) readAddress(
 		return nil, nil, fmt.Errorf("read utxos for %s: %w", address, err)
 	}
 	for _, utxo := range utxos {
-		// A withdrawal output is leaving the chain. Counting it inflates the
-		// balance, because the treasury already pays it out.
-		if !utxo.Spendable() {
-			continue
-		}
 		coin, err := newCoin(address, utxo)
 		if err != nil {
 			return nil, nil, err
@@ -117,9 +121,12 @@ func newCoin(address Address, utxo sidechainesplora.UTXO) (Coin, error) {
 		return Coin{}, fmt.Errorf("%s holds a coin worth %d sats", address, utxo.Value)
 	}
 	return Coin{
-		OutPoint:  outpoint,
-		Address:   address,
-		ValueSats: uint64(utxo.Value),
+		OutPoint:    outpoint,
+		Address:     address,
+		ValueSats:   uint64(utxo.Value),
+		ContentType: utxo.ContentType,
+		Content:     utxo.Content,
+		Spendable:   utxo.Spendable(),
 	}, nil
 }
 

--- a/sidechain-orchestrator/sidechain/lightwallet/coins_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/coins_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
 )
 
-// A withdrawal output is leaving the chain, and the treasury already pays it
-// out. Counting it inflates the balance.
-func TestIndexCoinsSkipsAWithdrawalOutput(t *testing.T) {
+// The index answers every output an address holds, and the wallet decides
+// which of them it shows.
+func TestIndexCoinsReadsEveryOutput(t *testing.T) {
 	index := newFakeIndex(t)
 	address := testAddress(t, 0)
 	index.rows(address.String(), `[
@@ -26,8 +26,11 @@ func TestIndexCoinsSkipsAWithdrawalOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split: %v", err)
 	}
-	if len(confirmed) != 1 || confirmed[0].ValueSats != 4999000 {
-		t.Errorf("coins = %+v, want the plain one alone", confirmed)
+	if len(confirmed) != 2 {
+		t.Fatalf("the index answered %d coins, want 2", len(confirmed))
+	}
+	if confirmed[0].Spendable || !confirmed[1].Spendable {
+		t.Errorf("coins = %+v, want the withdrawal marked unspendable", confirmed)
 	}
 }
 

--- a/sidechain-orchestrator/sidechain/lightwallet/discover.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/discover.go
@@ -10,20 +10,24 @@ import (
 )
 
 const (
-	// gapLimit is how many addresses in a row must be empty before a wallet
-	// decides it reached its own end. Twenty is the usual choice.
+	// gapLimit is how many unused addresses a wallet holds ready after the
+	// last one that took a coin. Twenty is the usual choice.
 	gapLimit = 20
 	// discoveryTTL is how long one walk holds. A refresh reads the addresses
 	// several times, and the set changes only when a new one takes a coin.
 	discoveryTTL = 30 * time.Second
+	// scanAhead is how many addresses one walk reads at the same time. The
+	// first walk of a seed reads the whole window, and a narrower walk would
+	// outlast the balance timeout the frontend holds.
+	scanAhead = 32
 )
 
 // Discovery names the addresses a wallet actually uses.
 //
-// It walks the derived keys in order and stops after gapLimit addresses in a
-// row that never received a coin. A wallet that used more than the first few
-// keys is found in full, and a fresh wallet costs gapLimit requests rather
-// than one for every key it could ever hold.
+// The first walk of a seed reads every key of the window, because a wallet that
+// ran a node first may hold a funded address after a long run of addresses the
+// node issued and nobody paid. It answers each key up to the last one that took
+// a coin, and gapLimit more after it for a receive page to hand out.
 type Discovery struct {
 	window *Window
 	client *sidechainesplora.Client
@@ -32,6 +36,8 @@ type Discovery struct {
 	cached     []Address
 	generation uint64
 	read       time.Time
+	// scanned names the seed whose whole window this discovery already walked.
+	scanned uint64
 }
 
 // NewDiscovery walks one window through one index.
@@ -47,39 +53,83 @@ func (d *Discovery) Addresses(ctx context.Context) ([]Address, error) {
 	}
 
 	d.mu.Lock()
-	if d.cached != nil && d.generation == generation && time.Since(d.read) < discoveryTTL {
-		out := d.cached
+	cached, held, scanned := d.cached, d.generation, d.scanned
+	if cached != nil && held == generation && time.Since(d.read) < discoveryTTL {
 		d.mu.Unlock()
-		return out, nil
+		return cached, nil
 	}
 	d.mu.Unlock()
 
+	// Only the first walk of a seed reads the whole window. After it the wallet
+	// hands out its own addresses, and Unused never reaches past the gap, so a
+	// refresh reads what the walk already reached.
+	count := d.window.Limit()
+	if cached != nil && held == generation && scanned == generation {
+		count = uint32(len(cached))
+	}
+
+	used, err := d.usedWindow(ctx, count)
+	if err != nil {
+		return nil, err
+	}
 	lastUsed := -1
-	var out []Address
-	for index := uint32(0); index < d.window.Limit(); index++ {
-		if int(index)-lastUsed > gapLimit {
-			break
+	for index, took := range used {
+		if took {
+			lastUsed = index
 		}
+	}
+	reach := min(uint32(lastUsed+1+gapLimit), d.window.Limit())
+
+	out := make([]Address, 0, reach)
+	for index := uint32(0); index < reach; index++ {
 		address, err := d.window.At(index)
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, address)
-		used, err := d.used(ctx, address)
-		if err != nil {
-			return nil, err
-		}
-		if used {
-			lastUsed = int(index)
-		}
 	}
 
 	d.mu.Lock()
 	d.cached = out
 	d.generation = generation
+	d.scanned = generation
 	d.read = time.Now()
 	d.mu.Unlock()
 	return out, nil
+}
+
+// usedWindow reads the first count keys and says which ones took a coin.
+func (d *Discovery) usedWindow(ctx context.Context, count uint32) ([]bool, error) {
+	addresses := make([]Address, count)
+	for index := range addresses {
+		address, err := d.window.At(uint32(index))
+		if err != nil {
+			return nil, err
+		}
+		addresses[index] = address
+	}
+
+	used := make([]bool, len(addresses))
+	errs := make([]error, len(addresses))
+	var wg sync.WaitGroup
+	limit := make(chan struct{}, scanAhead)
+	for at, address := range addresses {
+		wg.Add(1)
+		limit <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-limit }()
+			used[at], errs[at] = d.used(ctx, address)
+		}()
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+	return used, nil
 }
 
 // Unused returns an address that received nothing. skip says how many such

--- a/sidechain-orchestrator/sidechain/lightwallet/discover_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/discover_test.go
@@ -1,0 +1,102 @@
+package lightwallet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
+)
+
+// expire drops the cached walk without moving the seed, which is what the TTL
+// does between two balance polls.
+func expire(d *Discovery) {
+	d.mu.Lock()
+	d.read = time.Time{}
+	d.mu.Unlock()
+}
+
+// The first walk of a seed reads the whole window, so a wallet that ran a node
+// first finds its later coins. Every walk after it reads what the first one
+// reached, or a balance poll would spend the whole window on every refresh.
+func TestDiscoveryReadsTheWholeWindowOnlyOnce(t *testing.T) {
+	index := newFakeIndex(t)
+	index.deposit(testAddress(t, 2*gapLimit).String(), depositTxid, 7000, true)
+
+	window := testWallet(testSeed)
+	discovery := NewDiscovery(window, sidechainesplora.New(index.server.URL))
+
+	first, err := discovery.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	if got, want := index.reads(), int(window.Limit()); got != want {
+		t.Errorf("the first walk read %d addresses, want the whole window of %d", got, want)
+	}
+	if want := 2*gapLimit + 1 + gapLimit; len(first) != want {
+		t.Fatalf("the wallet holds %d addresses, want %d", len(first), want)
+	}
+
+	expire(discovery)
+	second, err := discovery.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	if got := index.reads(); got != len(first) {
+		t.Errorf("the second walk read %d addresses, want the %d it reached", got, len(first))
+	}
+	if len(second) != len(first) {
+		t.Errorf("the wallet holds %d addresses, want the %d it held", len(second), len(first))
+	}
+}
+
+// A coin on the last address the wallet reached moves its end, so the next
+// walk holds one whole gap after it again.
+func TestDiscoveryGrowsWhenTheLastAddressTakesACoin(t *testing.T) {
+	index := newFakeIndex(t)
+	window := testWallet(testSeed)
+	discovery := NewDiscovery(window, sidechainesplora.New(index.server.URL))
+
+	first, err := discovery.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	if len(first) != gapLimit {
+		t.Fatalf("a fresh wallet holds %d addresses, want %d", len(first), gapLimit)
+	}
+
+	last := uint32(len(first) - 1)
+	index.deposit(testAddress(t, last).String(), depositTxid, 7000, true)
+	expire(discovery)
+
+	second, err := discovery.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	if want := int(last) + 1 + gapLimit; len(second) != want {
+		t.Errorf("the wallet holds %d addresses, want %d", len(second), want)
+	}
+}
+
+// A restore names another wallet, so the walk must read the whole window again
+// rather than trust what the seed before it reached.
+func TestDiscoveryReadsTheWholeWindowAgainAfterARestore(t *testing.T) {
+	index := newFakeIndex(t)
+	seed := testSeed
+	window := NewWindow(func() ([]byte, error) { return seed, nil }, testDerive, AddressWindow)
+	discovery := NewDiscovery(window, sidechainesplora.New(index.server.URL))
+
+	if _, err := discovery.Addresses(context.Background()); err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	index.reads()
+
+	seed = []byte("another wallet seed, of a restore that named another wallet")
+	expire(discovery)
+	if _, err := discovery.Addresses(context.Background()); err != nil {
+		t.Fatalf("addresses: %v", err)
+	}
+	if got, want := index.reads(), int(window.Limit()); got != want {
+		t.Errorf("the walk read %d addresses, want the whole window of %d", got, want)
+	}
+}

--- a/sidechain-orchestrator/sidechain/lightwallet/index_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/index_test.go
@@ -1,6 +1,7 @@
 package lightwallet
 
 import (
+	"encoding/binary"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,9 @@ type fakeIndex struct {
 	utxos    map[string]string
 	deposits map[string]string
 	funded   map[string]bool
-	server   *httptest.Server
+	// stats counts the address reads one walk made.
+	stats  int
+	server *httptest.Server
 }
 
 func newFakeIndex(t *testing.T) *fakeIndex {
@@ -69,6 +72,7 @@ func (f *fakeIndex) serve(w http.ResponseWriter, r *http.Request) {
 	case strings.HasSuffix(path, "/deposits"):
 		f.write(w, f.deposits[strings.TrimSuffix(path, "/deposits")])
 	default:
+		f.stats++
 		count := 0
 		if f.funded[path] {
 			count = 1
@@ -79,6 +83,16 @@ func (f *fakeIndex) serve(w http.ResponseWriter, r *http.Request) {
 			"mempool_stats":{"funded_txo_count":0,"funded_txo_sum":0,
 			"spent_txo_count":0,"spent_txo_sum":0,"tx_count":0}}`)
 	}
+}
+
+// reads answers how many addresses the index saw a stats call for, and starts
+// the count again.
+func (f *fakeIndex) reads() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	count := f.stats
+	f.stats = 0
+	return count
 }
 
 func (f *fakeIndex) write(w http.ResponseWriter, body string) {
@@ -94,7 +108,8 @@ var testSeed = []byte("a light wallet seed of sixty-four bytes, which bip39 answ
 // testDerive stands in for a chain's key derivation. It answers a different
 // address per seed and per index, which is all the read path needs.
 func testDerive(seed []byte, index uint32) (Address, error) {
-	return AddressForKey(append(append([]byte{}, seed...), byte(index))), nil
+	key := binary.BigEndian.AppendUint32(append([]byte{}, seed...), index)
+	return AddressForKey(key), nil
 }
 
 func testAddress(t *testing.T, index uint32) Address {

--- a/sidechain-orchestrator/sidechain/lightwallet/mode.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/mode.go
@@ -89,6 +89,10 @@ func (w *Wallet) Backend() *Backend {
 	}
 	mode := w.mode()
 	if mode.LocalNode || mode.IndexURL == "" {
+		// A local node issues and funds addresses while it runs. The wallet
+		// that comes back to the index must walk its whole window again, or it
+		// reads none of what the node did.
+		w.drop()
 		return nil
 	}
 
@@ -103,4 +107,12 @@ func (w *Wallet) Backend() *Backend {
 		)
 	}
 	return w.backend
+}
+
+// drop forgets the backend, so the next light request builds a new one.
+func (w *Wallet) drop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.backend = nil
+	w.url = ""
 }

--- a/sidechain-orchestrator/sidechain/lightwallet/mode.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/mode.go
@@ -1,7 +1,10 @@
 package lightwallet
 
 import (
+	"fmt"
 	"sync"
+
+	"connectrpc.com/connect"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/sidechainesplora"
 )
@@ -63,6 +66,20 @@ func NewWallet(mode ModeFunc, chain Chain) *Wallet {
 // light install starts no daemon for a chain that answers false.
 func (w *Wallet) ReadsIndex() bool {
 	return w != nil && w.Backend() != nil
+}
+
+// CanSpend reports whether the wallet can sign a spend right now. A local node
+// signs, and this package reads an index and holds no spend path.
+func (w *Wallet) CanSpend() bool {
+	return w == nil || w.Backend() == nil
+}
+
+// SpendUnsupported is the refusal a chain gives for a spend it cannot sign.
+// The code names a capability the backend lacks, so a caller never reads it as
+// a dead node.
+func SpendUnsupported(chain, action string) error {
+	return connect.NewError(connect.CodeUnimplemented, fmt.Errorf(
+		"%s reads a remote index in light mode, so it cannot %s yet", chain, action))
 }
 
 // Backend answers the light wallet, or nil when a local node answers instead.

--- a/sidechain-orchestrator/sidechain/lightwallet/mode_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/mode_test.go
@@ -1,0 +1,77 @@
+package lightwallet
+
+import (
+	"context"
+	"testing"
+)
+
+func testChain() Chain {
+	return Chain{
+		Seed:   func() ([]byte, error) { return testSeed, nil },
+		Derive: testDerive,
+		Output: OutputShape{ValueKey: ValueKeyValue},
+	}
+}
+
+// A local node issues and funds addresses while it runs. A wallet that comes
+// back to the index must build a new backend, because the one before it walked
+// its window and would read none of what the node did.
+func TestWalletDropsTheBackendWhileANodeRuns(t *testing.T) {
+	index := newFakeIndex(t)
+	light := true
+	wallet := NewWallet(
+		func() Mode { return NewMode(light, index.server.URL) }, testChain())
+
+	first := wallet.Backend()
+	if first == nil {
+		t.Fatal("light mode reads no index")
+	}
+	if wallet.Backend() != first {
+		t.Error("one light session builds more than one backend")
+	}
+
+	light = false
+	if wallet.Backend() != nil {
+		t.Fatal("a chain with a local node still reads the index")
+	}
+
+	light = true
+	second := wallet.Backend()
+	if second == nil {
+		t.Fatal("light mode reads no index after the node stops")
+	}
+	if second == first {
+		t.Error("the wallet kept the backend the node ran behind")
+	}
+}
+
+// The whole point of the new backend: a coin the node took past the walk the
+// light wallet already made must still count.
+func TestWalletReadsACoinTheNodeTookPastTheOldWalk(t *testing.T) {
+	index := newFakeIndex(t)
+	light := true
+	wallet := NewWallet(
+		func() Mode { return NewMode(light, index.server.URL) }, testChain())
+
+	total, _, err := wallet.Backend().Balance(context.Background())
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("a fresh wallet holds %d sats, want 0", total)
+	}
+
+	// The node runs, and it funds an address far past what the walk reached.
+	light = false
+	wallet.Backend()
+	index.deposit(testAddress(t, 3*gapLimit).String(), depositTxid, 7000, true)
+
+	light = true
+	total, available, err := wallet.Backend().Balance(context.Background())
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if total != 7000 || available != 7000 {
+		t.Errorf("balance = %d total and %d available, want 7000 of each", total, available)
+	}
+}

--- a/sidechain-orchestrator/sidechain/lightwallet/utxos.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/utxos.go
@@ -18,6 +18,10 @@ type OutputShape struct {
 	ValueKey string
 	// Memo says whether every output of this chain carries a memo.
 	Memo bool
+	// Holdings names the content types this chain lists beside a plain coin,
+	// such as an asset a wallet owns. A type the frontend cannot read must
+	// stay out of the listing.
+	Holdings []string
 }
 
 // MarshalUTXOs writes coins in the shape get_wallet_utxos answers with, so a
@@ -36,7 +40,7 @@ func MarshalUTXOs(shape OutputShape, confirmed, pending []Coin) ([]byte, error) 
 			}
 			output := map[string]any{
 				"address": coin.Address.String(),
-				"content": map[string]any{shape.ValueKey: coin.ValueSats},
+				"content": outputContent(shape, coin),
 			}
 			// The node writes a memo as an array of numbers, and a coin the
 			// index reports carries none.
@@ -70,4 +74,13 @@ func encodeOutPoint(o OutPoint) (map[string]any, error) {
 	default:
 		return nil, fmt.Errorf("outpoint kind %q is not known", o.Kind)
 	}
+}
+
+// outputContent writes what the coin holds. The index carries the node's own
+// payload, and an asset id and its amount live only there.
+func outputContent(shape OutputShape, coin Coin) any {
+	if len(coin.Content) > 0 {
+		return coin.Content
+	}
+	return map[string]any{shape.ValueKey: coin.ValueSats}
 }

--- a/sidechain-orchestrator/sidechain/lightwallet/utxos_test.go
+++ b/sidechain-orchestrator/sidechain/lightwallet/utxos_test.go
@@ -106,3 +106,32 @@ func TestMarshalUTXOsWritesTheMemoTheChainNames(t *testing.T) {
 		}
 	}
 }
+
+// A bitassets wallet holds assets beside its bitcoin. The index carries the
+// node's own payload, and the asset id and the amount live only there.
+func TestMarshalUTXOsKeepsTheIndexPayload(t *testing.T) {
+	asset := `{"BitAsset":["c0ffee",500]}`
+	raw, err := MarshalUTXOs(
+		OutputShape{ValueKey: ValueKeyBitcoinSats, Memo: true},
+		[]Coin{{
+			OutPoint:  OutPoint{Kind: KindRegular, Txid: depositTxid, Vout: 1},
+			Address:   testAddress(t, 0),
+			Content:   json.RawMessage(asset),
+			Spendable: false,
+		}}, nil)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var rows []struct {
+		Output struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		t.Fatalf("read the listing: %v", err)
+	}
+	if got := string(rows[0].Output.Content); got != asset {
+		t.Errorf("content = %s, want %s", got, asset)
+	}
+}

--- a/sidechain-orchestrator/sidechain/photon/handler.go
+++ b/sidechain-orchestrator/sidechain/photon/handler.go
@@ -66,6 +66,9 @@ func (h *Handler) GetNewAddress(ctx context.Context, req *connect.Request[pb.Get
 }
 
 func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.WithdrawRequest]) (*connect.Response[pb.WithdrawResponse], error) {
+	if err := h.refuseSpend("withdraw"); err != nil {
+		return nil, err
+	}
 	params := []any{req.Msg.Address, req.Msg.AmountSats, req.Msg.SideFeeSats, req.Msg.MainFeeSats}
 	var txid string
 	if err := h.proxy.Client.Call(ctx, "create_withdrawal", params, &txid); err != nil {
@@ -75,6 +78,9 @@ func (h *Handler) Withdraw(ctx context.Context, req *connect.Request[pb.Withdraw
 }
 
 func (h *Handler) Transfer(ctx context.Context, req *connect.Request[pb.TransferRequest]) (*connect.Response[pb.TransferResponse], error) {
+	if err := h.refuseSpend("send"); err != nil {
+		return nil, err
+	}
 	params := []any{req.Msg.Address, req.Msg.AmountSats, req.Msg.FeeSats}
 	var txid string
 	if err := h.proxy.Client.Call(ctx, "create_transfer", params, &txid); err != nil {

--- a/sidechain-orchestrator/sidechain/photon/light.go
+++ b/sidechain-orchestrator/sidechain/photon/light.go
@@ -26,6 +26,17 @@ func NewLightHandler(
 // ReadsIndex reports whether this chain reads a remote index right now.
 func (h *Handler) ReadsIndex() bool { return h.light.ReadsIndex() }
 
+// CanSpend reports whether this chain can sign a spend right now.
+func (h *Handler) CanSpend() bool { return h.light.CanSpend() }
+
+// refuseSpend answers the refusal a caller must get when no node signs here.
+func (h *Handler) refuseSpend(action string) error {
+	if h.light.CanSpend() {
+		return nil
+	}
+	return lightwallet.SpendUnsupported("photon", action)
+}
+
 // WalletBalance reads the balance whatever mode runs. Another service answers
 // the same number from here, so both modes agree.
 func (h *Handler) WalletBalance(ctx context.Context) (total, available int64, err error) {

--- a/sidechain-orchestrator/sidechain/photon/light_test.go
+++ b/sidechain-orchestrator/sidechain/photon/light_test.go
@@ -133,3 +133,59 @@ func TestLightHandlerRefusesAnUnhostedNetwork(t *testing.T) {
 		t.Error("a network with no index reads one anyway")
 	}
 }
+
+// A light install can sign nothing on this chain, so a send and a withdrawal
+// must refuse with a missing capability. A dial error would tell the user the
+// node is down, and no node is meant to run here.
+func TestLightHandlerRefusesToSpend(t *testing.T) {
+	seed := bip39.NewSeed(testMnemonic, "")
+	first, err := deriveAddress(seed, 0)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	url := testIndex(t, first.String())
+
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(true, url) },
+		func() ([]byte, error) { return seed, nil },
+	)
+	if h.CanSpend() {
+		t.Fatal("a light wallet with no spend path reports that it can spend")
+	}
+
+	ctx := context.Background()
+	_, err = h.Transfer(ctx, connect.NewRequest(&pb.TransferRequest{
+		Address: first.String(), AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("transfer answered %v, want a missing capability", err)
+	}
+
+	_, err = h.Withdraw(ctx, connect.NewRequest(&pb.WithdrawRequest{
+		Address: "tb1qexample", AmountSats: 1000, SideFeeSats: 10, MainFeeSats: 10,
+	}))
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("withdraw answered %v, want a missing capability", err)
+	}
+}
+
+// A full install runs a node that signs, so the guard must let the call
+// through to it.
+func TestFullHandlerSpendsThroughTheNode(t *testing.T) {
+	h := NewLightHandler(
+		sidechain.NewJSONRPCProxy("127.0.0.1", 1),
+		func() lightwallet.Mode { return lightwallet.NewMode(false, "https://index.example") },
+		func() ([]byte, error) { return bip39.NewSeed(testMnemonic, ""), nil },
+	)
+	if !h.CanSpend() {
+		t.Fatal("a full install reports that it cannot spend")
+	}
+
+	_, err := h.Transfer(context.Background(), connect.NewRequest(&pb.TransferRequest{
+		Address: "anything", AmountSats: 1000, FeeSats: 10,
+	}))
+	if connect.CodeOf(err) == connect.CodeUnimplemented {
+		t.Error("a full install refuses a send the node would sign")
+	}
+}

--- a/sidechain-orchestrator/sidechain/sidechainesplora/client.go
+++ b/sidechain-orchestrator/sidechain/sidechainesplora/client.go
@@ -75,10 +75,17 @@ type UTXO struct {
 	// ContentType reads "value" for a plain coin, and "withdrawal" for one
 	// that is leaving the chain. Only a plain coin is spendable.
 	ContentType string `json:"content_type"`
+	// Content is the chain-specific payload the node wrote. It names the asset
+	// a bitassets output holds, and the name a bitnames output holds.
+	Content json.RawMessage `json:"content,omitempty"`
 }
 
-// ContentValue names a plain spendable coin.
-const ContentValue = "value"
+// ContentValue names a plain spendable coin, and ContentWithdrawal one that is
+// leaving the chain.
+const (
+	ContentValue      = "value"
+	ContentWithdrawal = "withdrawal"
+)
 
 // Spendable is true for a plain coin. A withdrawal output belongs to the
 // chain's payout, and a wallet that spends it builds a transaction no node

--- a/sidechain-orchestrator/start_with_l1_electrum_test.go
+++ b/sidechain-orchestrator/start_with_l1_electrum_test.go
@@ -49,7 +49,10 @@ func TestStartWithL1NeedsBackendsInFullMode(t *testing.T) {
 func TestStartWithL1StartsNoSidechainDaemonInLightMode(t *testing.T) {
 	o := newTestOrchestrator(t)
 	require.NoError(t, WriteNodeMode(o.BitwindowDir, NodeModeLight))
-	o.RegisterLightWallet("thunder", func() bool { return true })
+	o.RegisterLightWallet("thunder", LightWallet{
+		ReadsIndex: func() bool { return true },
+		CanSpend:   func() bool { return true },
+	})
 	o.SidechainConfs = map[string]*config.SidechainConfManager{
 		"thunder": {Spec: config.SidechainConfSpec{PortStyle: "grpc"}},
 	}

--- a/sidechain_core/lib/classes/rpc_connection.dart
+++ b/sidechain_core/lib/classes/rpc_connection.dart
@@ -54,6 +54,10 @@ abstract class RPCConnection extends ChangeNotifier implements DaemonState {
   /// The chain answers through a remote index, so it works with no local
   /// daemon. False for a chain that only proxies to its own daemon.
   bool servesLightWallet = false;
+
+  /// The wallet can sign a spend. False for a chain that reads a remote index
+  /// and holds no spend path, so the UI must offer no send there.
+  bool walletCanSpend = true;
   @override
   bool initializingBinary = false;
   @override

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -49,6 +49,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     $fixnum.Int64? downloadedTimestampUnix,
     $core.bool? windowOpen,
     $core.bool? servesLightWallet,
+    $core.bool? walletCanSpend,
   }) {
     final $result = create();
     if (name != null) {
@@ -135,6 +136,9 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     if (servesLightWallet != null) {
       $result.servesLightWallet = servesLightWallet;
     }
+    if (walletCanSpend != null) {
+      $result.walletCanSpend = walletCanSpend;
+    }
     return $result;
   }
   BinaryStatusMsg._() : super();
@@ -170,6 +174,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     ..aInt64(26, _omitFieldNames ? '' : 'downloadedTimestampUnix')
     ..aOB(27, _omitFieldNames ? '' : 'windowOpen')
     ..aOB(28, _omitFieldNames ? '' : 'servesLightWallet')
+    ..aOB(29, _omitFieldNames ? '' : 'walletCanSpend')
     ..hasRequiredFields = false
   ;
 
@@ -451,6 +456,17 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   $core.bool hasServesLightWallet() => $_has(27);
   @$pb.TagNumber(28)
   void clearServesLightWallet() => clearField(28);
+
+  /// The wallet can sign a spend. False for a chain that reads a remote index
+  /// and holds no spend path, so the frontend must offer no send there.
+  @$pb.TagNumber(29)
+  $core.bool get walletCanSpend => $_getBF(28);
+  @$pb.TagNumber(29)
+  set walletCanSpend($core.bool v) { $_setBool(28, v); }
+  @$pb.TagNumber(29)
+  $core.bool hasWalletCanSpend() => $_has(28);
+  @$pb.TagNumber(29)
+  void clearWalletCanSpend() => clearField(29);
 }
 
 class StartupLogEntryMsg extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -161,6 +161,7 @@ const BinaryStatusMsg$json = {
     {'1': 'downloaded_timestamp_unix', '3': 26, '4': 1, '5': 3, '10': 'downloadedTimestampUnix'},
     {'1': 'window_open', '3': 27, '4': 1, '5': 8, '10': 'windowOpen'},
     {'1': 'serves_light_wallet', '3': 28, '4': 1, '5': 8, '10': 'servesLightWallet'},
+    {'1': 'wallet_can_spend', '3': 29, '4': 1, '5': 8, '10': 'walletCanSpend'},
   ],
 };
 
@@ -184,7 +185,7 @@ final $typed_data.Uint8List binaryStatusMsgDescriptor = $convert.base64Decode(
     'l4GBkgASgDUhNyZW1vdGVUaW1lc3RhbXBVbml4EjoKGWRvd25sb2FkZWRfdGltZXN0YW1wX3Vu'
     'aXgYGiABKANSF2Rvd25sb2FkZWRUaW1lc3RhbXBVbml4Eh8KC3dpbmRvd19vcGVuGBsgASgIUg'
     'p3aW5kb3dPcGVuEi4KE3NlcnZlc19saWdodF93YWxsZXQYHCABKAhSEXNlcnZlc0xpZ2h0V2Fs'
-    'bGV0');
+    'bGV0EigKEHdhbGxldF9jYW5fc3BlbmQYHSABKAhSDndhbGxldENhblNwZW5k');
 
 @$core.Deprecated('Use startupLogEntryMsgDescriptor instead')
 const StartupLogEntryMsg$json = {

--- a/sidechain_core/lib/providers/backend_state_provider.dart
+++ b/sidechain_core/lib/providers/backend_state_provider.dart
@@ -151,6 +151,7 @@ class BackendStateProvider extends ChangeNotifier {
     if (rpc.connected == status.connected &&
         rpc.windowOpen == status.windowOpen &&
         rpc.servesLightWallet == status.servesLightWallet &&
+        rpc.walletCanSpend == status.walletCanSpend &&
         rpc.stoppingBinary == status.stopping &&
         rpc.initializingBinary == status.initializing &&
         rpc.connectModeOnly == status.connectModeOnly &&
@@ -162,6 +163,7 @@ class BackendStateProvider extends ChangeNotifier {
     rpc.connected = status.connected;
     rpc.windowOpen = status.windowOpen;
     rpc.servesLightWallet = status.servesLightWallet;
+    rpc.walletCanSpend = status.walletCanSpend;
     rpc.stoppingBinary = status.stopping;
     rpc.initializingBinary = status.initializing;
     rpc.connectModeOnly = status.connectModeOnly;

--- a/sidechain_core/lib/rpcs/bitassets_rpc.dart
+++ b/sidechain_core/lib/rpcs/bitassets_rpc.dart
@@ -1133,14 +1133,14 @@ class BitAssetsUTXO extends SidechainUTXO {
          valueSats: _extractValueSats(output['content']),
        );
 
+  /// The asset this output holds, or null when it holds no asset.
+  BitAssetHolding? get holding => BitAssetHolding.fromContent(output['content'] as Map<String, dynamic>?);
+
   static int _extractValueSats(Map<String, dynamic> content) {
-    // Extract value based on content type
     if (content.containsKey('BitcoinSats')) {
       return content['BitcoinSats'] as int;
-    } else if (content.containsKey('BitAsset')) {
-      return content['BitAsset']['amount'] as int;
     }
-    return 0;
+    return BitAssetHolding.fromContent(content)?.amount ?? 0;
   }
 
   factory BitAssetsUTXO.fromJson(Map<String, dynamic> json) {
@@ -1151,5 +1151,28 @@ class BitAssetsUTXO extends SidechainUTXO {
       confirmed: json['confirmed'] as bool? ?? true,
       output: json['output'] as Map<String, dynamic>,
     );
+  }
+}
+
+/// One asset an output holds. The node writes a BitAsset output content as the
+/// pair [asset id, amount].
+class BitAssetHolding {
+  final String assetId;
+  final int amount;
+
+  const BitAssetHolding({required this.assetId, required this.amount});
+
+  /// Reads the pair, or answers null when the content holds no asset.
+  static BitAssetHolding? fromContent(Map<String, dynamic>? content) {
+    final pair = content?['BitAsset'];
+    if (pair is! List || pair.length != 2) {
+      return null;
+    }
+    final assetId = pair[0];
+    final amount = pair[1];
+    if (assetId is! String || amount is! int) {
+      return null;
+    }
+    return BitAssetHolding(assetId: assetId, amount: amount);
   }
 }

--- a/sidechain_core/lib/rpcs/rpc_sidechain.dart
+++ b/sidechain_core/lib/rpcs/rpc_sidechain.dart
@@ -15,6 +15,10 @@ abstract class SidechainRPC extends RPCConnection {
 
   Sidechain get chain => Sidechain.fromBinary(binary);
 
+  /// Names why this chain can sign no spend, or null when it can.
+  String? get spendUnavailable =>
+      walletCanSpend ? null : '${chain.name} reads a remote index in light mode. It cannot sign a transaction yet.';
+
   Future<dynamic> callRAW(String method, [List<dynamic>? params]);
 
   Future<List<CoreTransaction>> listTransactions();

--- a/sidechain_core/test/sidechain_spend_gate_test.dart
+++ b/sidechain_core/test/sidechain_spend_gate_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sidechain_core/mocks/mocks.dart';
+import 'package:sidechain_core/providers/binaries/binary_provider.dart';
+
+void main() {
+  setUpAll(() {
+    GetIt.I.registerLazySingleton<BinaryProvider>(() => MockBinaryProvider());
+  });
+
+  test('a chain that signs names no refusal', () {
+    final rpc = MockBitnamesRPC();
+    rpc.walletCanSpend = true;
+
+    expect(rpc.spendUnavailable, isNull);
+  });
+
+  test('a light chain with no spend path names its refusal', () {
+    final rpc = MockBitnamesRPC();
+    rpc.walletCanSpend = false;
+
+    expect(rpc.spendUnavailable, contains('cannot sign a transaction'));
+  });
+
+  test('a chain reads as able to spend before a status arrives', () {
+    expect(MockBitnamesRPC().walletCanSpend, isTrue);
+  });
+}

--- a/sidechain_core/test/sidechain_utxo_test.dart
+++ b/sidechain_core/test/sidechain_utxo_test.dart
@@ -98,4 +98,40 @@ void main() {
     expect(utxo.valueSats, 900);
     expect(utxo.confirmed, isFalse);
   });
+
+  // The node writes a BitAsset output content as the pair [asset id, amount].
+  test('a bitassets coin keeps the asset it holds', () {
+    final utxo = BitAssetsUTXO.fromJson({
+      'outpoint': {
+        'Regular': {'txid': 'dd', 'vout': 1},
+      },
+      'output': {
+        'address': 'mine',
+        'content': {
+          'BitAsset': ['c0ffee', 500],
+        },
+        'memo': <int>[],
+      },
+    });
+
+    expect(utxo.holding?.assetId, 'c0ffee');
+    expect(utxo.holding?.amount, 500);
+    expect(utxo.valueSats, 500);
+  });
+
+  test('a bitassets coin that holds bitcoin names no asset', () {
+    final utxo = BitAssetsUTXO.fromJson({
+      'outpoint': {
+        'Regular': {'txid': 'ee', 'vout': 0},
+      },
+      'output': {
+        'address': 'mine',
+        'content': {'BitcoinSats': 900},
+        'memo': <int>[],
+      },
+    });
+
+    expect(utxo.holding, isNull);
+    expect(utxo.valueSats, 900);
+  });
 }


### PR DESCRIPTION
A light wallet on bitnames, bitassets, photon and coinshift now refuses a send and a withdrawal with a missing capability, and the shared pages hide both buttons. Thunder keeps them.

The wallet listing keeps the index output payload, so a bitassets holder reads the assets it owns.

Address discovery reads the whole window, so a funded address after a long run of empty issued ones still counts.