### PR TITLE
orchestrator: read L1 balance via wallet engine

### DIFF
--- a/sidechain-orchestrator/mainchain_balance_test.go
+++ b/sidechain-orchestrator/mainchain_balance_test.go
@@ -1,39 +1,136 @@
 package orchestrator
 
 import (
-	"encoding/json"
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
-func TestParseMainchainBalance(t *testing.T) {
-	raw := json.RawMessage(`{"mine":{"trusted":1.25,"untrusted_pending":0.5,"immature":0}}`)
-
-	got, err := parseMainchainBalance(raw)
-	if err != nil {
-		t.Fatalf("parseMainchainBalance: %v", err)
-	}
-	if got.Confirmed != 1.25 {
-		t.Errorf("confirmed = %v, want 1.25", got.Confirmed)
-	}
-	if got.Unconfirmed != 0.5 {
-		t.Errorf("unconfirmed = %v, want 0.5", got.Unconfirmed)
-	}
+// balanceBackend answers Balance and records the wallet ID that reached it.
+// Every other Backend method panics through the nil embedded interface.
+type balanceBackend struct {
+	wallet.Backend
+	confirmed   float64
+	unconfirmed float64
+	err         error
+	gotWalletID string
 }
 
-func TestParseMainchainBalanceWatchOnlyWalletStaysZero(t *testing.T) {
-	raw := json.RawMessage(`{"mine":{"trusted":0,"untrusted_pending":0,"immature":0},"watchonly":{"trusted":9}}`)
-
-	got, err := parseMainchainBalance(raw)
-	if err != nil {
-		t.Fatalf("parseMainchainBalance: %v", err)
+func (b *balanceBackend) Balance(_ context.Context, walletID string) (float64, float64, error) {
+	b.gotWalletID = walletID
+	if b.err != nil {
+		return 0, 0, b.err
 	}
-	if got.Confirmed != 0 || got.Unconfirmed != 0 {
-		t.Errorf("got %+v, want zero balances", got)
-	}
+	return b.confirmed, b.unconfirmed, nil
 }
 
-func TestParseMainchainBalanceRejectsBadJSON(t *testing.T) {
-	if _, err := parseMainchainBalance(json.RawMessage(`not json`)); err == nil {
-		t.Fatal("want an error for bad JSON")
-	}
+func newBalanceWalletService(t *testing.T) *wallet.Service {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	svc := wallet.NewService(t.TempDir(), log)
+	require.NoError(t, svc.Init())
+	t.Cleanup(func() { svc.Close() })
+	return svc
+}
+
+// newBalanceOrchestrator wires an orchestrator to a router over the two fakes,
+// exactly as cmd/drivechaind wires the real backends.
+func newBalanceOrchestrator(t *testing.T, svc *wallet.Service, chain, electrum wallet.Backend) *Orchestrator {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	router := wallet.NewBackendRouter(svc, chain, electrum)
+	engine := wallet.NewWalletEngine(svc, router, wallet.StaticParams(&chaincfg.MainNetParams), log)
+	o := &Orchestrator{}
+	o.SetWalletEngine(engine)
+	return o
+}
+
+func TestGetMainchainBalanceReadsAnElectrumWallet(t *testing.T) {
+	svc := newBalanceWalletService(t)
+	w, err := svc.CreateElectrumWallet("Light", nil, nil, "", "", "", "", 0, "")
+	require.NoError(t, err)
+	require.Equal(t, wallet.WalletTypeElectrum, w.WalletType)
+	require.NoError(t, svc.SwitchWallet(w.ID))
+
+	chain := &balanceBackend{confirmed: 9, unconfirmed: 9}
+	electrum := &balanceBackend{confirmed: 4.9999, unconfirmed: 0.25}
+	o := newBalanceOrchestrator(t, svc, chain, electrum)
+
+	bal, err := o.GetMainchainBalance(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 4.9999, bal.Confirmed)
+	assert.Equal(t, 0.25, bal.Unconfirmed)
+	assert.Equal(t, w.ID, electrum.gotWalletID)
+	assert.Empty(t, chain.gotWalletID)
+}
+
+func TestGetMainchainBalanceReadsACoreWallet(t *testing.T) {
+	svc := newBalanceWalletService(t)
+	w, err := svc.GenerateWallet("Full", "", "", nil)
+	require.NoError(t, err)
+	require.Equal(t, wallet.WalletTypeBitcoinCore, w.WalletType)
+	require.NoError(t, svc.SwitchWallet(w.ID))
+
+	chain := &balanceBackend{confirmed: 1.25, unconfirmed: 0.5}
+	electrum := &balanceBackend{confirmed: 9, unconfirmed: 9}
+	o := newBalanceOrchestrator(t, svc, chain, electrum)
+
+	bal, err := o.GetMainchainBalance(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1.25, bal.Confirmed)
+	assert.Equal(t, 0.5, bal.Unconfirmed)
+	assert.Equal(t, w.ID, chain.gotWalletID)
+	assert.Empty(t, electrum.gotWalletID)
+}
+
+func TestGetMainchainBalanceRefusesWithoutAWalletEngine(t *testing.T) {
+	o := &Orchestrator{}
+
+	bal, err := o.GetMainchainBalance(context.Background())
+	require.ErrorContains(t, err, "no wallet engine is wired")
+	assert.Nil(t, bal)
+}
+
+func TestGetMainchainBalanceRefusesWithoutAnActiveWallet(t *testing.T) {
+	svc := newBalanceWalletService(t)
+	o := newBalanceOrchestrator(t, svc, &balanceBackend{}, &balanceBackend{})
+
+	bal, err := o.GetMainchainBalance(context.Background())
+	require.ErrorContains(t, err, "no active wallet")
+	assert.Nil(t, bal)
+}
+
+func TestGetMainchainBalanceRefusesWithoutABackend(t *testing.T) {
+	svc := newBalanceWalletService(t)
+	w, err := svc.CreateElectrumWallet("Light", nil, nil, "", "", "", "", 0, "")
+	require.NoError(t, err)
+	require.NoError(t, svc.SwitchWallet(w.ID))
+
+	o := newBalanceOrchestrator(t, svc, nil, nil)
+
+	bal, err := o.GetMainchainBalance(context.Background())
+	require.ErrorContains(t, err, "electrum wallet backend not configured")
+	assert.Nil(t, bal)
+}
+
+func TestGetMainchainBalanceReportsABackendFailure(t *testing.T) {
+	svc := newBalanceWalletService(t)
+	w, err := svc.GenerateWallet("Full", "", "", nil)
+	require.NoError(t, err)
+	require.NoError(t, svc.SwitchWallet(w.ID))
+
+	chain := &balanceBackend{err: errors.New("connection refused")}
+	o := newBalanceOrchestrator(t, svc, chain, nil)
+
+	bal, err := o.GetMainchainBalance(context.Background())
+	require.ErrorContains(t, err, "connection refused")
+	require.ErrorContains(t, err, w.ID)
+	assert.Nil(t, bal)
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -3154,7 +3154,7 @@ type MainchainBlockchainInfo struct {
 	Pruned               bool    `json:"pruned"`
 }
 
-// MainchainBalance holds confirmed + unconfirmed balances from bitcoind.
+// MainchainBalance holds confirmed and unconfirmed L1 balances, in BTC.
 type MainchainBalance struct {
 	Confirmed   float64
 	Unconfirmed float64
@@ -4005,36 +4005,25 @@ func connectJSONPost(ctx context.Context, client *http.Client, url string, out i
 	return nil
 }
 
-// GetMainchainBalance proxies getbalances from bitcoind.
+// GetMainchainBalance reads the active wallet's L1 balance through the wallet
+// engine, so an electrum wallet answers in light mode and a Core wallet answers
+// from bitcoind.
 func (o *Orchestrator) GetMainchainBalance(ctx context.Context) (*MainchainBalance, error) {
-	client, err := o.CoreStatusClient()
+	if o.walletEngine == nil {
+		return nil, errors.New("mainchain balance: no wallet engine is wired")
+	}
+
+	walletID, err := o.walletEngine.ResolveWalletID("")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("mainchain balance: %w", err)
 	}
 
-	result, err := client.call(ctx, "getbalances")
+	confirmed, unconfirmed, err := o.walletEngine.Backend().Balance(ctx, walletID)
 	if err != nil {
-		return nil, fmt.Errorf("getbalances: %w", err)
+		return nil, fmt.Errorf("mainchain balance for wallet %s: %w", walletID, err)
 	}
 
-	return parseMainchainBalance(result)
-}
-
-func parseMainchainBalance(raw json.RawMessage) (*MainchainBalance, error) {
-	var balances struct {
-		Mine struct {
-			Trusted          float64 `json:"trusted"`
-			UntrustedPending float64 `json:"untrusted_pending"`
-		} `json:"mine"`
-	}
-	if err := json.Unmarshal(raw, &balances); err != nil {
-		return nil, fmt.Errorf("decode getbalances: %w", err)
-	}
-
-	return &MainchainBalance{
-		Confirmed:   balances.Mine.Trusted,
-		Unconfirmed: balances.Mine.UntrustedPending,
-	}, nil
+	return &MainchainBalance{Confirmed: confirmed, Unconfirmed: unconfirmed}, nil
 }
 
 // CoreStatusClient builds a CoreStatusClient from the current config.


### PR DESCRIPTION
`drivechain-cli balance` failed in light mode because GetMainchainBalance always dialled Bitcoin Core.
It now reads the active wallet through the wallet engine, so electrum and Core wallets both answer.
With no engine or no backend it returns a named error, never a zero.