### PR TITLE
orchestrator: boot all Rust chains in light mode

### DIFF
--- a/.github/workflows/bitwindow-e2e.yml
+++ b/.github/workflows/bitwindow-e2e.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -name '*google-chrome*' -delete
           sudo apt-get update
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -88,9 +88,10 @@ jobs:
 
         # https://docs.flutter.dev/platform-integration/linux/building
       - name: Install Linux build dependencies
-        run:
-          sudo apt-get update -y && sudo apt-get install -y clang cmake
-          ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+        run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -name '*google-chrome*' -delete
+          sudo apt-get update -y
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
 
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Install SQLite
         if: matrix.install-sqlite
         run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -name '*google-chrome*' -delete
           sudo apt-get update
           sudo apt-get install -y sqlite3 libsqlite3-dev
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Install SQLite
         run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -name '*google-chrome*' -delete
           sudo apt-get update
           sudo apt-get install -y sqlite3 libsqlite3-dev
 
@@ -111,6 +112,7 @@ jobs:
       - name: Install SQLite (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -name '*google-chrome*' -delete
           sudo apt-get update
           sudo apt-get install -y sqlite3 libsqlite3-dev
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -name '*google-chrome*' -delete
           sudo apt-get update -y
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev \

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.332
+version: 1.0.333
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.332
+version: 1.0.333
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.203
+version: 0.2.204
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.205
+version: 1.0.206
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -552,11 +552,11 @@
         "binary": "truthcoin",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S13-Truthcoin-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S13-Truthcoin-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S13-Truthcoin-latest-x86_64-apple-darwin.zip",
-            "windows-x86_64": "L2-S13-Truthcoin-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/truthcoin-dc/releases/latest",
+            "linux-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "truthcoin-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -759,10 +759,10 @@
         "binary": "thunder-orchard",
         "files": {
           "default": {
-            "base_url": "https://api.github.com/repos/iwakura-rein/thunder-orchard/releases/latest",
-            "linux-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu",
-            "macos-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin",
-            "macos-arm64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin",
+            "base_url": "https://api.github.com/repos/octobocto/thunder-orchard/releases/latest",
+            "linux-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
             "windows-x86_64": ""
           }
         }

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -552,11 +552,11 @@
         "binary": "truthcoin",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S13-Truthcoin-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S13-Truthcoin-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S13-Truthcoin-latest-x86_64-apple-darwin.zip",
-            "windows-x86_64": "L2-S13-Truthcoin-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/truthcoin-dc/releases/latest",
+            "linux-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "truthcoin-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -759,10 +759,10 @@
         "binary": "thunder-orchard",
         "files": {
           "default": {
-            "base_url": "https://api.github.com/repos/iwakura-rein/thunder-orchard/releases/latest",
-            "linux-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu",
-            "macos-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin",
-            "macos-arm64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin",
+            "base_url": "https://api.github.com/repos/octobocto/thunder-orchard/releases/latest",
+            "linux-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
             "windows-x86_64": ""
           }
         }

--- a/sidechain-orchestrator/config/sidechain_conf.go
+++ b/sidechain-orchestrator/config/sidechain_conf.go
@@ -605,6 +605,7 @@ var KnownSidechainSpecs = map[string]SidechainConfSpec{
 		DirKey:         "bitnames",
 	},
 	"zside": {
+		EnforcerArg:    "mainchain-grpc-url",
 		Name:           "ZSide",
 		ConfigFilename: "zside.conf",
 		BasePort:       6098,

--- a/sidechain-orchestrator/config/sidechain_enforcer_args_test.go
+++ b/sidechain-orchestrator/config/sidechain_enforcer_args_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSidechainEnforcerArgsUseTheDaemonFlags(t *testing.T) {
-	for _, name := range []string{"thunder", "photon", "coinshift"} {
+	for _, name := range []string{"thunder", "photon", "coinshift", "zside"} {
 		args, err := KnownSidechainSpecs[name].EnforcerArgs("http://127.0.0.1:32123")
 		require.NoError(t, err)
 		require.Equal(t, []string{"--mainchain-grpc-url=http://127.0.0.1:32123"}, args)
@@ -30,6 +30,6 @@ func TestSidechainEnforcerHostRejectsURLsItCannotRepresent(t *testing.T) {
 		_, err := KnownSidechainSpecs["bitnames"].EnforcerArgs(endpoint)
 		require.Error(t, err)
 	}
-	_, err := KnownSidechainSpecs["zside"].EnforcerArgs("http://127.0.0.1:50051")
+	_, err := KnownSidechainSpecs["liquid-signet"].EnforcerArgs("http://127.0.0.1:50051")
 	require.ErrorContains(t, err, "does not support a remote enforcer")
 }

--- a/sidechain-orchestrator/remote_enforcer.go
+++ b/sidechain-orchestrator/remote_enforcer.go
@@ -167,7 +167,7 @@ func (o *Orchestrator) prepareRemoteSidechainArgs(cfg BinaryConfig, opts *StartO
 		return fmt.Errorf("%s does not support a remote enforcer; select full mode", cfg.Name)
 	}
 	network := config.CusfNetworkName(config.Network(o.CurrentNetwork()), config.ECashNetworkID())
-	if network == "" || (spec.DirKey == "truthcoin" && network == "alphanet") {
+	if network == "" {
 		return fmt.Errorf("%s on %s: %w", cfg.Name, o.CurrentNetwork(), errSidechainNetworkUnknown)
 	}
 	endpoint, err := o.EnforcerURL()

--- a/sidechain-orchestrator/remote_enforcer_test.go
+++ b/sidechain-orchestrator/remote_enforcer_test.go
@@ -200,7 +200,7 @@ func TestRemoteSidechainArgsMatchEachDaemon(t *testing.T) {
 	require.NoError(t, err)
 	u, err := url.Parse(endpoint)
 	require.NoError(t, err)
-	for _, name := range []string{"thunder", "bitnames", "bitassets", "photon", "coinshift", "truthcoin"} {
+	for _, name := range []string{"thunder", "bitnames", "bitassets", "photon", "coinshift", "truthcoin", "zside"} {
 		t.Run(name, func(t *testing.T) {
 			cfg, err := o.getConfig(name)
 			require.NoError(t, err)
@@ -256,6 +256,48 @@ func TestRemoteSidechainRejectsMissingEndpoint(t *testing.T) {
 	cfg, err := o.getConfig("thunder")
 	require.NoError(t, err)
 	require.ErrorContains(t, o.prepareSidechainArgs(cfg, &opts), "no remote enforcer endpoint")
+}
+
+func TestRemoteSidechainAlphanetArgs(t *testing.T) {
+	server := remoteValidatorServer(t, 42, nil)
+	o := remoteTestOrchestrator(t, server.URL)
+	previous := config.ECashEndpoints()
+	previousID := config.ECashNetworkID()
+	entry := netcatalog.EmbeddedECash()
+	entry.Services.Enforcer.URL = server.URL
+	config.SetECashEndpoints(entry)
+	config.SetECashNetworkID(entry.ID)
+	t.Cleanup(func() {
+		config.SetECashEndpoints(previous)
+		config.SetECashNetworkID(previousID)
+	})
+	o.setNetwork("ecash")
+	endpoint, err := o.EnforcerURL()
+	require.NoError(t, err)
+	u, err := url.Parse(endpoint)
+	require.NoError(t, err)
+	for _, name := range []string{"thunder", "bitnames", "bitassets", "photon", "coinshift", "truthcoin", "zside"} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := o.getConfig(name)
+			require.NoError(t, err)
+			opts := StartOpts{ForceBackend: true, TargetArgs: []string{
+				"--network=signet", "--mainchain-grpc-url=http://localhost:50051",
+				"--mainchain-grpc-host", "localhost", "--mainchain-grpc-port", "50051",
+			}}
+			require.NoError(t, o.prepareSidechainArgs(cfg, &opts))
+			require.Contains(t, opts.TargetArgs, "--network=alphanet")
+			require.NotContains(t, strings.Join(opts.TargetArgs, " "), "localhost")
+			switch name {
+			case "bitnames", "bitassets", "truthcoin":
+				require.Contains(t, opts.TargetArgs, "--mainchain-grpc-host="+u.Hostname())
+				require.Contains(t, opts.TargetArgs, "--mainchain-grpc-port="+u.Port())
+				require.False(t, hasCLIFlag(opts.TargetArgs, "--mainchain-grpc-url"))
+			default:
+				require.Contains(t, opts.TargetArgs, "--mainchain-grpc-url="+endpoint)
+				require.False(t, hasCLIFlag(opts.TargetArgs, "--mainchain-grpc-host"))
+			}
+		})
+	}
 }
 
 func TestRemoteSidechainRejectsUnknownNetwork(t *testing.T) {

--- a/sidechain-orchestrator/rust_download_test.go
+++ b/sidechain-orchestrator/rust_download_test.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRustDownloadsSelectForkArchives(t *testing.T) {
+	for _, cfg := range AllDefaults() {
+		if cfg.Name != "truthcoin" && cfg.Name != "zside" {
+			continue
+		}
+		t.Run(cfg.Name, func(t *testing.T) {
+			repo, version := "truthcoin-dc", "0.17.1"
+			if cfg.Name == "zside" {
+				repo, version = "thunder-orchard", "0.17.3"
+				require.Empty(t, cfg.Files["windows-x86_64"])
+			}
+			require.Equal(t, "https://api.github.com/repos/octobocto/"+repo+"/releases/latest", cfg.DownloadURLs["default"])
+			platforms := map[string]string{
+				"linux-x86_64":   "x86_64-unknown-linux-gnu",
+				"macos-x86_64":   "x86_64-apple-darwin",
+				"macos-arm64":    "aarch64-apple-darwin",
+				"windows-x86_64": "x86_64-pc-windows-gnu",
+			}
+			var assets []map[string]string
+			for platform, target := range platforms {
+				if cfg.Name == "zside" && platform == "windows-x86_64" {
+					continue
+				}
+				name := cfg.BinaryName + "-" + version + "-" + target
+				for _, suffix := range []string{"", ".zip"} {
+					assets = append(assets, map[string]string{
+						"name": name + suffix, "browser_download_url": "https://example.invalid/" + name + suffix,
+					})
+				}
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(map[string]any{"assets": assets}); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer server.Close()
+			dm, _ := newTestDownloadManager(t)
+			for platform, target := range platforms {
+				if cfg.Name == "zside" && platform == "windows-x86_64" {
+					continue
+				}
+				got, err := dm.resolveGitHubURL(context.Background(), server.URL, cfg.Files[platform])
+				require.NoError(t, err)
+				require.Equal(t, "https://example.invalid/"+cfg.BinaryName+"-"+version+"-"+target+".zip", got)
+			}
+		})
+	}
+}

--- a/sidechain_core/assets/chains_config.json
+++ b/sidechain_core/assets/chains_config.json
@@ -552,11 +552,11 @@
         "binary": "truthcoin",
         "files": {
           "default": {
-            "base_url": "https://releases.drivechain.info/",
-            "linux-x86_64": "L2-S13-Truthcoin-latest-x86_64-unknown-linux-gnu.zip",
-            "macos-x86_64": "L2-S13-Truthcoin-latest-x86_64-apple-darwin.zip",
-            "macos-arm64": "L2-S13-Truthcoin-latest-x86_64-apple-darwin.zip",
-            "windows-x86_64": "L2-S13-Truthcoin-latest-x86_64-pc-windows-gnu.zip"
+            "base_url": "https://api.github.com/repos/octobocto/truthcoin-dc/releases/latest",
+            "linux-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "truthcoin-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
+            "windows-x86_64": "truthcoin-\\d+\\.\\d+\\.\\d+-x86_64-pc-windows-gnu\\.zip"
           }
         }
       },
@@ -759,10 +759,10 @@
         "binary": "thunder-orchard",
         "files": {
           "default": {
-            "base_url": "https://api.github.com/repos/iwakura-rein/thunder-orchard/releases/latest",
-            "linux-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu",
-            "macos-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin",
-            "macos-arm64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin",
+            "base_url": "https://api.github.com/repos/octobocto/thunder-orchard/releases/latest",
+            "linux-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "thunder-orchard-\\d+\\.\\d+\\.\\d+-aarch64-apple-darwin\\.zip",
             "windows-x86_64": ""
           }
         }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.334
+version: 1.0.335
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.205
+version: 1.0.206
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.331
+version: 1.0.332
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
This starts Truthcoin and ZSide in light mode with remote validation and native wallets.
It selects fork ZIP releases and native macOS ARM64 builds. CI omits the unused Chrome package index.
The release updates depend on https://github.com/octobocto/truthcoin-dc/pull/1 and https://github.com/octobocto/thunder-orchard/pull/1.
