### PR TITLE
cli: stop only the chains one start booted

### DIFF
--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -182,6 +182,7 @@ var startCommand = &cli.Command{
 			Usage:   "start in background without streaming logs",
 		},
 	},
+	Before: rejectFlagAfterArgument,
 	Action: func(cctx *cli.Context) error {
 		return runStart(cctx, newClient(cctx))
 	},
@@ -445,6 +446,7 @@ var stopCommand = &cli.Command{
 			Usage: "force kill (SIGKILL) instead of graceful shutdown",
 		},
 	},
+	Before: rejectFlagAfterArgument,
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
 			return printUsageWithBinaries(cctx, "stop")

--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"os/signal"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -181,139 +183,256 @@ var startCommand = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.NArg() < 1 {
-			return printUsageWithBinaries(cctx, "start")
-		}
+		return runStart(cctx, newClient(cctx))
+	},
+}
 
-		name := cctx.Args().First()
-		client := newClient(cctx)
+func runStart(cctx *cli.Context, client rpc.OrchestratorServiceClient) error {
+	if cctx.NArg() < 1 {
+		return printUsageWithBinaries(cctx, "start")
+	}
 
-		withDeps := !cctx.Bool("without-deps")
+	name := cctx.Args().First()
+	withDeps := !cctx.Bool("without-deps")
+	daemon := cctx.Bool("daemon")
 
-		// Check which binaries need downloading.
-		var needed []string
-		if withDeps {
-			needed = []string{"bitcoind", "enforcer", name}
-		} else {
-			needed = []string{name}
-		}
+	// Check which binaries need downloading.
+	var needed []string
+	if withDeps {
+		needed = []string{"bitcoind", "enforcer", name}
+	} else {
+		needed = []string{name}
+	}
 
-		autoDownload := cctx.Bool("auto-download") || os.Getenv("ORCHESTRATOR_AUTO_DOWNLOAD") != ""
-		for _, bin := range needed {
-			resp, err := client.GetBinaryStatus(cctx.Context, connect.NewRequest(&pb.GetBinaryStatusRequest{
-				Name: bin,
-			}))
-			if err != nil {
-				return err
-			}
-			s := resp.Msg.Status
-			if s.Downloaded || !s.Downloadable {
-				continue
-			}
-
-			displayName := s.DisplayName
-			if displayName == "" {
-				displayName = s.Name
-			}
-
-			if autoDownload {
-				fmt.Printf("%s is not downloaded. Downloading now...\n", displayName)
-			} else {
-				fmt.Printf("%s is not downloaded. download now? [Y/n] ", displayName)
-				if !confirmYes() {
-					return fmt.Errorf("cannot start %s without %s", name, bin)
-				}
-			}
-
-			if err := runDownload(cctx.Context, client, bin, false, false, false); err != nil {
-				return err
-			}
-			fmt.Println()
-		}
-
-		if withDeps {
-			// Fire-and-forget on the server side — boot proceeds in a
-			// background goroutine. Poll GetSyncStatus / ListBinaries via
-			// `drivechain-cli status` for progress.
-			if _, err := client.StartWithL1(cctx.Context, connect.NewRequest(&pb.StartWithL1Request{
-				Target:     name,
-				TargetArgs: cctx.StringSlice("args"),
-			})); err != nil {
-				return err
-			}
-			fmt.Println("L1 boot kicked off; poll status for progress")
-		} else {
-			resp, err := client.StartBinary(cctx.Context, connect.NewRequest(&pb.StartBinaryRequest{
-				Name:      name,
-				ExtraArgs: cctx.StringSlice("args"),
-			}))
-			if err != nil {
-				return err
-			}
-			fmt.Printf("started %s (PID %d)\n", name, resp.Msg.Pid)
-		}
-
-		if cctx.Bool("daemon") {
-			return nil
-		}
-
-		// Stream logs until ctrl+c, then stop everything we started.
-		fmt.Printf("\nstreaming %s logs (ctrl+c to stop)...\n\n", name)
-
-		ctx, cancel := context.WithCancel(cctx.Context)
-		defer cancel()
-
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			<-sigCh
-			cancel()
-		}()
-
-		logStream, err := client.StreamLogs(ctx, connect.NewRequest(&pb.StreamLogsRequest{
-			Name: name,
-			Tail: 10,
+	autoDownload := cctx.Bool("auto-download") || os.Getenv("ORCHESTRATOR_AUTO_DOWNLOAD") != ""
+	for _, bin := range needed {
+		resp, err := client.GetBinaryStatus(cctx.Context, connect.NewRequest(&pb.GetBinaryStatusRequest{
+			Name: bin,
 		}))
 		if err != nil {
 			return err
 		}
-		for logStream.Receive() {
-			msg := logStream.Msg()
-			ts := time.Unix(msg.TimestampUnix, 0).Format("15:04:05")
-			fmt.Printf("[%s] %s\n", ts, msg.Line)
+		s := resp.Msg.Status
+		if s.Downloaded || !s.Downloadable {
+			continue
 		}
 
-		// Stop the binaries we started.
-		fmt.Println("\nstopping...")
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer stopCancel()
-
-		if withDeps {
-			shutdownStream, err := client.ShutdownAll(stopCtx, connect.NewRequest(&pb.ShutdownAllRequest{}))
-			if err != nil {
-				return fmt.Errorf("shutdown: %w", err)
-			}
-			for shutdownStream.Receive() {
-				msg := shutdownStream.Msg()
-				if msg.CurrentBinary != "" {
-					fmt.Printf("  stopping %s...\n", msg.CurrentBinary)
-				}
-				if msg.Done {
-					fmt.Println("stopped")
-				}
-			}
-			return shutdownStream.Err()
+		displayName := s.DisplayName
+		if displayName == "" {
+			displayName = s.Name
 		}
 
-		_, err = client.StopBinary(stopCtx, connect.NewRequest(&pb.StopBinaryRequest{
-			Name: name,
+		if autoDownload {
+			fmt.Printf("%s is not downloaded. Downloading now...\n", displayName)
+		} else {
+			fmt.Printf("%s is not downloaded. download now? [Y/n] ", displayName)
+			if !confirmYes() {
+				return fmt.Errorf("cannot start %s without %s", name, bin)
+			}
+		}
+
+		if err := runDownload(cctx.Context, client, bin, false, false, false); err != nil {
+			return err
+		}
+		fmt.Println()
+	}
+
+	// Every binary that is alive before the boot belongs to someone else. The
+	// cleanup below stops only the ones this command adds.
+	var before binarySnapshot
+	if !daemon {
+		var err error
+		before, err = takeBinarySnapshot(cctx.Context, client)
+		if err != nil {
+			return err
+		}
+	}
+
+	if withDeps {
+		// Fire-and-forget on the server side — boot proceeds in a
+		// background goroutine. Poll GetSyncStatus / ListBinaries via
+		// `drivechain-cli status` for progress.
+		if _, err := client.StartWithL1(cctx.Context, connect.NewRequest(&pb.StartWithL1Request{
+			Target:     name,
+			TargetArgs: cctx.StringSlice("args"),
+		})); err != nil {
+			return err
+		}
+		fmt.Println("L1 boot kicked off; poll status for progress")
+	} else {
+		resp, err := client.StartBinary(cctx.Context, connect.NewRequest(&pb.StartBinaryRequest{
+			Name:      name,
+			ExtraArgs: cctx.StringSlice("args"),
 		}))
 		if err != nil {
-			return fmt.Errorf("stop %s: %w", name, err)
+			return err
 		}
-		fmt.Printf("stopped %s\n", name)
+		fmt.Printf("started %s (PID %d)\n", name, resp.Msg.Pid)
+	}
+
+	if daemon {
 		return nil
-	},
+	}
+
+	// Stream logs until ctrl+c, then stop what this command started.
+	fmt.Printf("\nstreaming %s logs (ctrl+c to stop)...\n\n", name)
+
+	ctx, cancel := context.WithCancel(cctx.Context)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	logStream, err := client.StreamLogs(ctx, connect.NewRequest(&pb.StreamLogsRequest{
+		Name: name,
+		Tail: 10,
+	}))
+	if err != nil {
+		return err
+	}
+	for logStream.Receive() {
+		msg := logStream.Msg()
+		ts := time.Unix(msg.TimestampUnix, 0).Format("15:04:05")
+		fmt.Printf("[%s] %s\n", ts, msg.Line)
+	}
+
+	listCtx, listCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer listCancel()
+
+	now, err := takeBinarySnapshot(listCtx, client)
+	if err != nil {
+		return err
+	}
+
+	toStop := binariesToStop(name, withDeps, before, now)
+	if len(toStop) == 0 {
+		return nil
+	}
+
+	fmt.Println("\nstopping...")
+	var stopErrs []error
+	for _, bin := range toStop {
+		fmt.Printf("  stopping %s...\n", bin)
+		if err := stopOneBinary(client, bin); err != nil {
+			// A slow stop must not hold back the rest of the stack.
+			fmt.Printf("  stop %s: %v\n", bin, err)
+			stopErrs = append(stopErrs, fmt.Errorf("stop %s: %w", bin, err))
+		}
+	}
+	if len(stopErrs) > 0 {
+		return errors.Join(stopErrs...)
+	}
+	fmt.Println("stopped")
+	return nil
+}
+
+// stopBinaryTimeout covers one graceful stop. Bitcoin Core can take 90 seconds
+// to flush, so a shared budget would cut the stops that come after it.
+const stopBinaryTimeout = 2 * time.Minute
+
+func stopOneBinary(client rpc.OrchestratorServiceClient, name string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), stopBinaryTimeout)
+	defer cancel()
+
+	_, err := client.StopBinary(ctx, connect.NewRequest(&pb.StopBinaryRequest{Name: name}))
+	return err
+}
+
+// binarySnapshot records which binaries are alive at one moment.
+type binarySnapshot struct {
+	// daemons holds the binaries the process manager runs itself.
+	daemons map[string]bool
+	// busy holds those, plus the chains that hold an app window open, plus the
+	// ones whose port answers under another owner. A boot adopts such a
+	// process, so a daemon slot never proves ownership.
+	busy map[string]bool
+	// sidechains holds the busy layer 2 chains. Each one needs the L1 pair.
+	sidechains map[string]bool
+}
+
+func takeBinarySnapshot(ctx context.Context, client rpc.OrchestratorServiceClient) (binarySnapshot, error) {
+	resp, err := client.ListBinaries(ctx, connect.NewRequest(&pb.ListBinariesRequest{}))
+	if err != nil {
+		return binarySnapshot{}, fmt.Errorf("list binaries: %w", err)
+	}
+
+	snapshot := binarySnapshot{
+		daemons:    make(map[string]bool, len(resp.Msg.Binaries)),
+		busy:       make(map[string]bool, len(resp.Msg.Binaries)),
+		sidechains: make(map[string]bool, len(resp.Msg.Binaries)),
+	}
+	for _, s := range resp.Msg.Binaries {
+		if s.Running {
+			snapshot.daemons[s.Name] = true
+		}
+		if !s.Running && !s.WindowOpen && !s.PortInUse {
+			continue
+		}
+		snapshot.busy[s.Name] = true
+		if s.ChainLayer == 2 {
+			snapshot.sidechains[s.Name] = true
+		}
+	}
+	return snapshot, nil
+}
+
+// binariesToStop returns the binaries one start brought up, in shutdown order.
+// It holds the L1 pair up while a chain that this start did not add still
+// needs it.
+func binariesToStop(target string, withDeps bool, before, now binarySnapshot) []string {
+	candidates := []string{target}
+	if withDeps {
+		candidates = append(candidates, "enforcer", "bitcoind")
+	}
+
+	ours := make(map[string]bool, len(candidates))
+	for _, name := range candidates {
+		if before.busy[name] {
+			continue
+		}
+		// The command named the target, so a stop is right even after a crash:
+		// it also clears the restart timer that would boot the chain again.
+		if name == target || now.daemons[name] {
+			ours[name] = true
+		}
+	}
+
+	for name := range now.sidechains {
+		if !ours[name] {
+			delete(ours, "enforcer")
+			delete(ours, "bitcoind")
+			break
+		}
+	}
+
+	ordered := make([]string, 0, len(ours))
+	for name := range ours {
+		ordered = append(ordered, name)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ri, rj := shutdownRank(ordered[i]), shutdownRank(ordered[j]); ri != rj {
+			return ri < rj
+		}
+		return ordered[i] < ordered[j]
+	})
+	return ordered
+}
+
+// shutdownRank ranks a binary for shutdown: layer 2 first, then the enforcer,
+// then bitcoind.
+func shutdownRank(name string) int {
+	switch name {
+	case "enforcer":
+		return 1
+	case "bitcoind":
+		return 2
+	default:
+		return 0
+	}
 }
 
 var stopCommand = &cli.Command{

--- a/sidechain-orchestrator/commands/flagorder.go
+++ b/sidechain-orchestrator/commands/flagorder.go
@@ -1,0 +1,19 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// rejectFlagAfterArgument fails a command that got a flag after its argument.
+// The parser stops at the first argument, so that flag does nothing.
+func rejectFlagAfterArgument(cctx *cli.Context) error {
+	for _, arg := range cctx.Args().Slice() {
+		if len(arg) > 1 && strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("unknown argument %q: write a flag before the binary name", arg)
+		}
+	}
+	return nil
+}

--- a/sidechain-orchestrator/commands/flagorder_test.go
+++ b/sidechain-orchestrator/commands/flagorder_test.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestRejectFlagAfterArgument(t *testing.T) {
+	err := rejectFlagAfterArgument(startContext(t, "bitassets", "--daemon"))
+	require.ErrorContains(t, err, `unknown argument "--daemon"`)
+
+	require.NoError(t, rejectFlagAfterArgument(startContext(t, "--daemon", "bitassets")))
+}
+
+func TestStartCommandRejectsAFlagAfterTheArgument(t *testing.T) {
+	app := &cli.App{
+		Name:                   "drivechain-cli",
+		Flags:                  GlobalFlags,
+		Commands:               []*cli.Command{startCommand, stopCommand},
+		UseShortOptionHandling: true,
+	}
+
+	require.ErrorContains(t, app.Run([]string{"drivechain-cli", "start", "bitassets", "--daemon"}),
+		`unknown argument "--daemon"`)
+	require.ErrorContains(t, app.Run([]string{"drivechain-cli", "stop", "bitassets", "--force"}),
+		`unknown argument "--force"`)
+}

--- a/sidechain-orchestrator/commands/start_scope_test.go
+++ b/sidechain-orchestrator/commands/start_scope_test.go
@@ -1,0 +1,383 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// binaryLayers holds the chain layer of every binary the fake reports.
+var binaryLayers = map[string]int32{
+	"bitcoind":    1,
+	"enforcer":    1,
+	"drivechaind": 1,
+	"bitassets":   2,
+	"bitnames":    2,
+	"coinshift":   2,
+	"photon":      2,
+	"thunder":     2,
+}
+
+// fakeOrchestrator answers the RPCs that `start` calls. It keeps a set of
+// running binaries, and it records every stop.
+type fakeOrchestrator struct {
+	rpc.UnimplementedOrchestratorServiceHandler
+
+	mu sync.Mutex
+	// running holds the binaries that run right now.
+	running map[string]bool
+	// portInUse holds binaries that answer on their port under another owner.
+	portInUse map[string]bool
+	// windowOpen holds the chains that run as an app window, with no daemon.
+	windowOpen map[string]bool
+	// opensWindow names the chain that a boot opens as a window, with no
+	// daemon slot behind it.
+	opensWindow string
+	// stopFailures name the binaries whose stop returns an error.
+	stopFailures map[string]bool
+	// crashesDuringStream stop while the log stream is open, as a crash does.
+	crashesDuringStream []string
+	// startsDuringStream run while the log stream is open. A second client
+	// starts them, so `start` must not stop them.
+	startsDuringStream []string
+
+	stopped      []string
+	shutdownAlls int
+}
+
+func (f *fakeOrchestrator) isRunning(name string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.running[name]
+}
+
+func (f *fakeOrchestrator) runningNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	names := make([]string, 0, len(f.running))
+	for name := range f.running {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (f *fakeOrchestrator) ListBinaries(_ context.Context, _ *connect.Request[pb.ListBinariesRequest]) (*connect.Response[pb.ListBinariesResponse], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	resp := &pb.ListBinariesResponse{}
+	for name, layer := range binaryLayers {
+		resp.Binaries = append(resp.Binaries, &pb.BinaryStatusMsg{
+			Name:       name,
+			ChainLayer: layer,
+			Running:    f.running[name],
+			WindowOpen: f.windowOpen[name],
+			PortInUse:  !f.running[name] && f.portInUse[name],
+		})
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (f *fakeOrchestrator) GetBinaryStatus(_ context.Context, req *connect.Request[pb.GetBinaryStatusRequest]) (*connect.Response[pb.GetBinaryStatusResponse], error) {
+	return connect.NewResponse(&pb.GetBinaryStatusResponse{
+		Status: &pb.BinaryStatusMsg{Name: req.Msg.Name, Downloaded: true, Downloadable: true},
+	}), nil
+}
+
+func (f *fakeOrchestrator) StartWithL1(_ context.Context, req *connect.Request[pb.StartWithL1Request]) (*connect.Response[pb.StartWithL1Response], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.running["bitcoind"] = true
+	f.running["enforcer"] = true
+	if f.opensWindow == req.Msg.Target {
+		f.windowOpen[req.Msg.Target] = true
+	} else {
+		f.running[req.Msg.Target] = true
+	}
+	return connect.NewResponse(&pb.StartWithL1Response{}), nil
+}
+
+func (f *fakeOrchestrator) StartBinary(_ context.Context, req *connect.Request[pb.StartBinaryRequest]) (*connect.Response[pb.StartBinaryResponse], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.running[req.Msg.Name] = true
+	return connect.NewResponse(&pb.StartBinaryResponse{Pid: 1234}), nil
+}
+
+// StreamLogs ends at once, which is the ctrl+c path the user hits.
+func (f *fakeOrchestrator) StreamLogs(_ context.Context, _ *connect.Request[pb.StreamLogsRequest], _ *connect.ServerStream[pb.StreamLogsResponse]) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, name := range f.startsDuringStream {
+		f.running[name] = true
+	}
+	for _, name := range f.crashesDuringStream {
+		delete(f.running, name)
+	}
+	return nil
+}
+
+func (f *fakeOrchestrator) StopBinary(_ context.Context, req *connect.Request[pb.StopBinaryRequest]) (*connect.Response[pb.StopBinaryResponse], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopped = append(f.stopped, req.Msg.Name)
+	if f.stopFailures[req.Msg.Name] {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("stop timed out"))
+	}
+	delete(f.running, req.Msg.Name)
+	delete(f.windowOpen, req.Msg.Name)
+	return connect.NewResponse(&pb.StopBinaryResponse{}), nil
+}
+
+func (f *fakeOrchestrator) ShutdownAll(_ context.Context, _ *connect.Request[pb.ShutdownAllRequest], stream *connect.ServerStream[pb.ShutdownAllResponse]) error {
+	f.mu.Lock()
+	f.shutdownAlls++
+	f.mu.Unlock()
+	return stream.Send(&pb.ShutdownAllResponse{Done: true})
+}
+
+func newFakeOrchestrator(t *testing.T, alreadyRunning ...string) (*fakeOrchestrator, rpc.OrchestratorServiceClient) {
+	t.Helper()
+
+	fake := &fakeOrchestrator{
+		running:      map[string]bool{},
+		portInUse:    map[string]bool{},
+		windowOpen:   map[string]bool{},
+		stopFailures: map[string]bool{},
+	}
+	for _, name := range alreadyRunning {
+		fake.running[name] = true
+	}
+
+	_, handler := rpc.NewOrchestratorServiceHandler(fake)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return fake, rpc.NewOrchestratorServiceClient(server.Client(), server.URL)
+}
+
+func startContext(t *testing.T, argv ...string) *cli.Context {
+	t.Helper()
+
+	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	for _, f := range startCommand.Flags {
+		require.NoError(t, f.Apply(fs))
+	}
+	require.NoError(t, fs.Parse(argv))
+
+	cctx := cli.NewContext(cli.NewApp(), fs, nil)
+	cctx.Context = context.Background()
+	return cctx
+}
+
+func TestStartKeepsAChainItDidNotStart(t *testing.T) {
+	fake, client := newFakeOrchestrator(t, "bitcoind", "enforcer", "thunder")
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon"}, fake.stopped)
+	require.Zero(t, fake.shutdownAlls)
+	require.Equal(t, []string{"bitcoind", "enforcer", "thunder"}, fake.runningNames())
+}
+
+func TestStartStopsTheDependenciesItStarted(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon", "enforcer", "bitcoind"}, fake.stopped)
+	require.Zero(t, fake.shutdownAlls)
+	require.Empty(t, fake.runningNames())
+}
+
+func TestStartKeepsL1ForAChainThatArrivedLater(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.startsDuringStream = []string{"thunder"}
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon"}, fake.stopped)
+	require.Equal(t, []string{"bitcoind", "enforcer", "thunder"}, fake.runningNames())
+}
+
+func TestStartKeepsAnAdoptedDependency(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.portInUse["bitcoind"] = true
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon", "enforcer"}, fake.stopped)
+	require.True(t, fake.isRunning("bitcoind"))
+}
+
+func TestStartStopsL1WhileTheDaemonPortAnswers(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.portInUse["drivechaind"] = true
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon", "enforcer", "bitcoind"}, fake.stopped)
+}
+
+func TestStartStopsAChainItOpenedAsAWindow(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.opensWindow = "photon"
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon", "enforcer", "bitcoind"}, fake.stopped)
+}
+
+func TestStartKeepsL1ForAWindowItDidNotOpen(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.windowOpen["thunder"] = true
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon"}, fake.stopped)
+	require.True(t, fake.isRunning("bitcoind"))
+	require.True(t, fake.isRunning("enforcer"))
+}
+
+func TestStartLeavesAnOutsideBackendAlone(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.portInUse["photon"] = true
+	fake.opensWindow = "photon"
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Empty(t, fake.stopped)
+}
+
+func TestStartStopsATargetThatCrashed(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.crashesDuringStream = []string{"photon"}
+
+	require.NoError(t, runStart(startContext(t, "photon"), client))
+
+	require.Equal(t, []string{"photon", "enforcer", "bitcoind"}, fake.stopped)
+}
+
+func TestStartStopsTheRestAfterAFailedStop(t *testing.T) {
+	fake, client := newFakeOrchestrator(t)
+	fake.stopFailures["enforcer"] = true
+
+	err := runStart(startContext(t, "photon"), client)
+
+	require.ErrorContains(t, err, "stop enforcer")
+	require.Equal(t, []string{"photon", "enforcer", "bitcoind"}, fake.stopped)
+	require.False(t, fake.isRunning("bitcoind"))
+}
+
+func TestStartDaemonStopsNothing(t *testing.T) {
+	fake, client := newFakeOrchestrator(t, "thunder")
+
+	require.NoError(t, runStart(startContext(t, "--daemon", "photon"), client))
+
+	require.Empty(t, fake.stopped)
+	require.Zero(t, fake.shutdownAlls)
+	require.Equal(t, []string{"bitcoind", "enforcer", "photon", "thunder"}, fake.runningNames())
+}
+
+func TestStartWithoutDepsStopsOnlyTheTarget(t *testing.T) {
+	fake, client := newFakeOrchestrator(t, "bitcoind", "enforcer")
+
+	require.NoError(t, runStart(startContext(t, "--without-deps", "photon"), client))
+
+	require.Equal(t, []string{"photon"}, fake.stopped)
+	require.True(t, fake.isRunning("bitcoind"))
+	require.True(t, fake.isRunning("enforcer"))
+}
+
+func snapshotOf(daemons ...string) binarySnapshot {
+	snapshot := binarySnapshot{
+		daemons:    map[string]bool{},
+		busy:       map[string]bool{},
+		sidechains: map[string]bool{},
+	}
+	for _, name := range daemons {
+		snapshot.daemons[name] = true
+		snapshot.busy[name] = true
+		if binaryLayers[name] == 2 {
+			snapshot.sidechains[name] = true
+		}
+	}
+	return snapshot
+}
+
+func TestBinariesToStopOrdersL1Last(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		withDeps bool
+		before   binarySnapshot
+		now      binarySnapshot
+		want     []string
+	}{
+		{
+			name:     "target and both dependencies",
+			target:   "photon",
+			withDeps: true,
+			before:   snapshotOf(),
+			now:      snapshotOf("bitcoind", "enforcer", "photon"),
+			want:     []string{"photon", "enforcer", "bitcoind"},
+		},
+		{
+			name:     "enforcer as target keeps the shutdown order",
+			target:   "enforcer",
+			withDeps: true,
+			before:   snapshotOf(),
+			now:      snapshotOf("bitcoind", "enforcer"),
+			want:     []string{"enforcer", "bitcoind"},
+		},
+		{
+			name:     "bitcoind as target appears one time",
+			target:   "bitcoind",
+			withDeps: true,
+			before:   snapshotOf(),
+			now:      snapshotOf("bitcoind"),
+			want:     []string{"bitcoind"},
+		},
+		{
+			name:     "a target that exited still gets a stop",
+			target:   "photon",
+			withDeps: false,
+			before:   snapshotOf(),
+			now:      snapshotOf(),
+			want:     []string{"photon"},
+		},
+		{
+			name:     "a target that ran before this start stops nothing",
+			target:   "photon",
+			withDeps: false,
+			before:   snapshotOf("photon"),
+			now:      snapshotOf("photon"),
+			want:     []string{},
+		},
+		{
+			name:     "a dependency that ran before this start stays up",
+			target:   "photon",
+			withDeps: true,
+			before:   snapshotOf("bitcoind"),
+			now:      snapshotOf("bitcoind", "enforcer", "photon"),
+			want:     []string{"photon", "enforcer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, binariesToStop(tt.target, tt.withDeps, tt.before, tt.now))
+		})
+	}
+}


### PR DESCRIPTION
`start <chain>` called ShutdownAll on cleanup, which stopped every chain the daemon ran.
It now diffs the running set before and after the boot, and stops only what it added. It keeps bitcoind and the enforcer up while another chain still needs them.
It also rejects a flag written after the binary name, which the parser dropped in silence (`start bitassets --daemon`).