### PR TITLE
orchestrator: show a pending deposit as unconfirmed balance

### DIFF
--- a/sail_ui/test/balance_display_test.dart
+++ b/sail_ui/test/balance_display_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+Future<void> pumpBalance(
+  WidgetTester tester, {
+  required double balance,
+  required double pendingBalance,
+  required bool showUnconfirmed,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: SailTheme(
+        data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+        child: Scaffold(
+          body: BalanceDisplay(
+            balance: balance,
+            pendingBalance: pendingBalance,
+            balanceSyncing: false,
+            showUnconfirmed: showUnconfirmed,
+            onToggleUnconfirmed: () {},
+            usdBalance: null,
+          ),
+        ),
+      ),
+    ),
+  );
+  expect(tester.takeException(), isNull);
+}
+
+Finder get unconfirmed => find.byWidgetPredicate(
+  (widget) => widget is Tooltip && widget.message == 'Unconfirmed balance',
+);
+
+void main() {
+  // A sidechain deposit waits hours for the mainchain block that carries it.
+  // The bottom nav must report that money without a toggle, or the user reads
+  // the wallet as empty and thinks the deposit is lost.
+  testWidgets('the bottom nav shows a pending balance with the toggle off', (tester) async {
+    await pumpBalance(tester, balance: 0, pendingBalance: 0.01, showUnconfirmed: false);
+
+    expect(unconfirmed, findsOneWidget);
+    expect(find.text(formatBitcoin(0.01)), findsOneWidget);
+  });
+
+  testWidgets('nothing pending and the toggle off shows only the confirmed balance', (tester) async {
+    await pumpBalance(tester, balance: 1.5, pendingBalance: 0, showUnconfirmed: false);
+
+    expect(unconfirmed, findsNothing);
+  });
+
+  testWidgets('the toggle shows the unconfirmed balance while it reads zero', (tester) async {
+    await pumpBalance(tester, balance: 1.5, pendingBalance: 0, showUnconfirmed: true);
+
+    expect(unconfirmed, findsOneWidget);
+  });
+}

--- a/sidechain-orchestrator/api/deposit_balance.go
+++ b/sidechain-orchestrator/api/deposit_balance.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// depositPendingSats is what this wallet paid into a sidechain treasury that
+// the sidechain has not credited yet.
+//
+// A deposit is a mainchain transaction. The sidechain learns nothing of it
+// until it connects the mainchain block that carries it, and that wait runs to
+// hours. Without this the money reads as gone the whole time.
+func (h *Handler) depositPendingSats(ctx context.Context, cfg orchestrator.BinaryConfig) (int64, error) {
+	svc := h.orch.WalletSvc
+	// A Core derived sidechain speaks Core's own wallet RPCs, so neither
+	// address listing answers here.
+	if svc == nil || cfg.IsBitcoinCore || cfg.ChainLayer != 2 || cfg.Slot <= 0 {
+		return 0, nil
+	}
+
+	// One starter seeds the sidechain wallet for the whole install, so every
+	// deposit to an address it owns lands in this balance, whichever mainchain
+	// wallet paid for it.
+	deposits, err := svc.SidechainDeposits(ctx, uint32(cfg.Slot), "")
+	if err != nil {
+		return 0, fmt.Errorf("read the deposits of %s: %w", cfg.DisplayName, err)
+	}
+	open := make([]wallet.SidechainDeposit, 0, len(deposits))
+	for _, d := range deposits {
+		if d.CreditedAt.IsZero() {
+			open = append(open, d)
+		}
+	}
+	if len(open) == 0 {
+		return 0, nil
+	}
+
+	node, err := sidechainNode(cfg, config.NetworkFromString(h.orch.CurrentNetwork()))
+	if err != nil {
+		return 0, err
+	}
+	owned, err := sidechain.WalletAddresses(ctx, node)
+	if err != nil {
+		return 0, fmt.Errorf("read the %s wallet addresses: %w", cfg.DisplayName, err)
+	}
+	ourCoins, err := sidechain.OurCoins(ctx, node)
+	if err != nil {
+		return 0, fmt.Errorf("read the %s wallet coins: %w", cfg.DisplayName, err)
+	}
+
+	pendingSats, credited := splitCreditedDeposits(open, owned, ourCoins)
+	for _, txid := range credited {
+		if err := svc.MarkSidechainDepositCredited(ctx, txid); err != nil {
+			return 0, err
+		}
+	}
+	return pendingSats, nil
+}
+
+// splitCreditedDeposits sums what the sidechain still owes this wallet, and
+// names the deposits it now holds a coin for.
+//
+// A sidechain names the coin a deposit made after the mainchain outpoint that
+// paid it, so one deposit answers for one coin. That coin is the deposit
+// already inside the confirmed balance, and a deposit with no coin is in no
+// balance at all. So one listing puts a deposit in exactly one of the two.
+func splitCreditedDeposits(
+	deposits []wallet.SidechainDeposit, owned map[string]bool, ourCoins map[string]int64,
+) (pendingSats int64, credited []string) {
+	for _, d := range deposits {
+		// A deposit to somebody else's address never becomes our money.
+		if !owned[d.Destination] {
+			continue
+		}
+		if holdsDepositCoin(ourCoins, d.Txid) {
+			credited = append(credited, d.Txid)
+			continue
+		}
+		pendingSats += d.AmountSats
+	}
+	return pendingSats, credited
+}
+
+// holdsDepositCoin is true when the wallet lists the coin this deposit made.
+// A deposit outpoint is the mainchain txid and the vout it paid.
+func holdsDepositCoin(ourCoins map[string]int64, txid string) bool {
+	for key := range ourCoins {
+		if strings.HasPrefix(key, txid+":") {
+			return true
+		}
+	}
+	return false
+}

--- a/sidechain-orchestrator/api/deposit_balance_test.go
+++ b/sidechain-orchestrator/api/deposit_balance_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// The sidechain names a deposit coin after the mainchain outpoint that paid
+// it. Anything else in the listing belongs to another payment.
+func TestHoldsDepositCoin(t *testing.T) {
+	const txid = "280a3c6e7e5c6f272e43df3aaece690c94d50b321d24f55f1e46abe8124e7cc3"
+	coins := map[string]int64{
+		txid + ":0":       1_000_000,
+		"sidechaintx:1":   4000,
+		"anothermain:0":   7000,
+		"280a3c6e7e5c6f2": 1,
+	}
+	assert.True(t, holdsDepositCoin(coins, txid))
+	assert.False(t, holdsDepositCoin(coins, "notadeposit"))
+	assert.False(t, holdsDepositCoin(map[string]int64{}, txid))
+}
+
+// A deposit lands in exactly one count: the pending sum while the sidechain
+// holds no coin for it, and the confirmed balance once it does.
+func TestSplitCreditedDeposits(t *testing.T) {
+	owned := map[string]bool{"mine": true, "mine-two": true}
+
+	for _, tc := range []struct {
+		name         string
+		deposits     []wallet.SidechainDeposit
+		coins        map[string]int64
+		wantPending  int64
+		wantCredited []string
+	}{
+		{
+			name:        "a deposit the sidechain has not seen is pending",
+			deposits:    []wallet.SidechainDeposit{{Txid: "m1", Destination: "mine", AmountSats: 1_000_000}},
+			coins:       map[string]int64{},
+			wantPending: 1_000_000,
+		},
+		{
+			name:         "the same deposit stops counting once the coin lands",
+			deposits:     []wallet.SidechainDeposit{{Txid: "m1", Destination: "mine", AmountSats: 1_000_000}},
+			coins:        map[string]int64{"m1:0": 1_000_000},
+			wantPending:  0,
+			wantCredited: []string{"m1"},
+		},
+		{
+			name: "one deposit of two lands, and only the other stays pending",
+			deposits: []wallet.SidechainDeposit{
+				{Txid: "m1", Destination: "mine", AmountSats: 1_000_000},
+				{Txid: "m2", Destination: "mine-two", AmountSats: 250_000},
+			},
+			coins:        map[string]int64{"m1:0": 1_000_000},
+			wantPending:  250_000,
+			wantCredited: []string{"m1"},
+		},
+		{
+			// The deposit page hands out one address, so a second deposit
+			// pays the address a credited one already holds a coin at.
+			name: "a second deposit to the same address stays pending",
+			deposits: []wallet.SidechainDeposit{
+				{Txid: "m1", Destination: "mine", AmountSats: 1_000_000},
+				{Txid: "m2", Destination: "mine", AmountSats: 250_000},
+			},
+			coins:        map[string]int64{"m1:0": 1_000_000},
+			wantPending:  250_000,
+			wantCredited: []string{"m1"},
+		},
+		{
+			name:        "a deposit to somebody else's address is nobody's pending balance",
+			deposits:    []wallet.SidechainDeposit{{Txid: "m1", Destination: "theirs", AmountSats: 1_000_000}},
+			coins:       map[string]int64{},
+			wantPending: 0,
+		},
+		{
+			name:        "a sidechain coin of our own leaves the deposit pending",
+			deposits:    []wallet.SidechainDeposit{{Txid: "m1", Destination: "mine", AmountSats: 1_000_000}},
+			coins:       map[string]int64{"sidechaintx:0": 5000},
+			wantPending: 1_000_000,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pending, credited := splitCreditedDeposits(tc.deposits, owned, tc.coins)
+			assert.Equal(t, tc.wantPending, pending)
+			assert.Equal(t, tc.wantCredited, credited)
+		})
+	}
+}

--- a/sidechain-orchestrator/api/deposit_pending_balance_test.go
+++ b/sidechain-orchestrator/api/deposit_pending_balance_test.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// depositNodeState is what the fake sidechain answers right now.
+type depositNodeState struct {
+	balanceSats int64
+	coins       string
+	addresses   []string
+}
+
+// newDepositTestHandler starts a fake sidechain node and wires a handler with
+// a real wallet service to it.
+func newDepositTestHandler(t *testing.T, state *depositNodeState) (*Handler, *wallet.Service) {
+	t.Helper()
+
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Error(err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		response := map[string]any{"jsonrpc": "2.0", "id": request.ID}
+		switch request.Method {
+		case "balance":
+			response["result"] = map[string]int64{
+				"total_sats": state.balanceSats, "available_sats": state.balanceSats,
+			}
+		case "get_wallet_addresses":
+			response["result"] = state.addresses
+		case "get_wallet_utxos":
+			response["result"] = json.RawMessage(state.coins)
+		case "list_mempool":
+			response["result"] = json.RawMessage("[]")
+		default:
+			response["error"] = map[string]any{"code": -32601, "message": "method not found"}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(node.Close)
+
+	host, port := hostPort(t, node)
+	cfg := orchestrator.BinaryConfig{
+		Name: "thunder", DisplayName: "Thunder", Host: host, Port: port,
+		ChainLayer: 2, Slot: 9,
+	}
+	orch := orchestrator.New(
+		t.TempDir(), string(config.NetworkECash), t.TempDir(),
+		[]orchestrator.BinaryConfig{cfg}, zerolog.New(io.Discard),
+	)
+
+	svc := wallet.NewService(t.TempDir(), zerolog.Nop())
+	svc.SetNetwork(string(config.NetworkECash))
+	require.NoError(t, svc.Init())
+	t.Cleanup(svc.Close)
+	_, err := svc.GenerateWallet("depositor", "", "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, svc.ActiveWalletID())
+	orch.WalletSvc = svc
+
+	handler := NewHandler(orch)
+	handler.SetSidechainBalance("thunder", sidechain.NewJSONRPCProxy(host, port).GetBalance)
+	return handler, svc
+}
+
+func thunderBalance(t *testing.T, handler *Handler) (confirmed, pending uint64) {
+	t.Helper()
+	response, err := handler.GetSidechainBalance(context.Background(), connect.NewRequest(
+		&pb.GetSidechainBalanceRequest{Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER},
+	))
+	require.NoError(t, err)
+	return response.Msg.ConfirmedSats, response.Msg.PendingSats
+}
+
+// depositCoins writes the coin listing a sidechain answers for these deposit
+// txids, each paying the same address.
+func depositCoins(destination string, txids ...string) string {
+	rows := make([]string, 0, len(txids))
+	for _, txid := range txids {
+		rows = append(rows, `{"outpoint":{"Deposit":"`+txid+`:0"},`+
+			`"output":{"address":"`+destination+`","content":{"Value":1000000}}}`)
+	}
+	return "[" + strings.Join(rows, ",") + "]"
+}
+
+// A deposit is a mainchain transaction, so the sidechain node reads zero for
+// hours after the broadcast. The money must read as unconfirmed the whole
+// time, then move to confirmed exactly once, and never count twice.
+func TestSidechainBalanceCountsAPendingDeposit(t *testing.T) {
+	const (
+		depositTxid = "280a3c6e7e5c6f272e43df3aaece690c94d50b321d24f55f1e46abe8124e7cc3"
+		destination = "2yxqLNxuYiLRMWATFQcqf3iV3nKh"
+		amountSats  = 1_000_000
+	)
+	ctx := context.Background()
+	state := &depositNodeState{coins: "[]", addresses: []string{destination}}
+	handler, svc := newDepositTestHandler(t, state)
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+		Txid: depositTxid, WalletID: svc.ActiveWalletID(), Slot: 9,
+		Destination: destination, AmountSats: amountSats, FeeSats: 10_000,
+	}))
+
+	confirmed, pending := thunderBalance(t, handler)
+	assert.Zero(t, confirmed, "the sidechain has not seen the deposit yet")
+	assert.Equal(t, uint64(amountSats), pending, "the deposit reads as unconfirmed while it waits")
+
+	// The sidechain connects the mainchain block and pays the coin.
+	state.balanceSats = amountSats
+	state.coins = depositCoins(destination, depositTxid)
+
+	confirmed, pending = thunderBalance(t, handler)
+	assert.Equal(t, uint64(amountSats), confirmed)
+	assert.Zero(t, pending, "a credited deposit leaves the unconfirmed count")
+	assert.Equal(t, uint64(amountSats), confirmed+pending, "the deposit counts once, not twice")
+
+	// The user spends the deposit coin, so it leaves the listing. The stamp is
+	// permanent, so the deposit never reads as pending again.
+	state.balanceSats = 0
+	state.coins = "[]"
+
+	confirmed, pending = thunderBalance(t, handler)
+	assert.Zero(t, confirmed)
+	assert.Zero(t, pending, "a spent deposit never returns to the unconfirmed count")
+}
+
+// The deposit page hands out one address, so two deposits pay the same one.
+// The coin the first deposit made must not credit the second.
+func TestSidechainBalanceCountsASecondDepositToOneAddress(t *testing.T) {
+	const (
+		firstTxid   = "280a3c6e7e5c6f272e43df3aaece690c94d50b321d24f55f1e46abe8124e7cc3"
+		secondTxid  = "d6584dc6145a7c7d219ba1cd2e333bfe8288055965636bbc5c405ed5394bdd8c"
+		destination = "2yxqLNxuYiLRMWATFQcqf3iV3nKh"
+		amountSats  = 1_000_000
+	)
+	ctx := context.Background()
+	state := &depositNodeState{
+		balanceSats: amountSats,
+		coins:       depositCoins(destination, firstTxid),
+		addresses:   []string{destination},
+	}
+	handler, svc := newDepositTestHandler(t, state)
+
+	for _, txid := range []string{firstTxid, secondTxid} {
+		require.NoError(t, svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+			Txid: txid, WalletID: svc.ActiveWalletID(), Slot: 9,
+			Destination: destination, AmountSats: amountSats, FeeSats: 10_000,
+		}))
+	}
+
+	confirmed, pending := thunderBalance(t, handler)
+	assert.Equal(t, uint64(amountSats), confirmed)
+	assert.Equal(t, uint64(amountSats), pending, "the second deposit is still on its way")
+
+	// The sidechain pays the second deposit too.
+	state.balanceSats = 2 * amountSats
+	state.coins = depositCoins(destination, firstTxid, secondTxid)
+
+	confirmed, pending = thunderBalance(t, handler)
+	assert.Equal(t, uint64(2*amountSats), confirmed)
+	assert.Zero(t, pending, "both deposits count once")
+}
+
+// The balance answers for one chain. A deposit to another slot pays another
+// treasury, so it would report money this view never holds.
+func TestSidechainBalanceIgnoresAnotherSlot(t *testing.T) {
+	const destination = "2yxqLNxuYiLRMWATFQcqf3iV3nKh"
+	ctx := context.Background()
+	state := &depositNodeState{coins: "[]", addresses: []string{destination}}
+	handler, svc := newDepositTestHandler(t, state)
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+		Txid: "other-slot", WalletID: svc.ActiveWalletID(), Slot: 2,
+		Destination: destination, AmountSats: 700_000,
+	}))
+
+	confirmed, pending := thunderBalance(t, handler)
+	assert.Zero(t, confirmed)
+	assert.Zero(t, pending, "another slot never reaches this balance")
+}
+
+// One starter seeds the sidechain wallet for the whole install. A switch of
+// the mainchain wallet leaves the sidechain balance alone, so a deposit
+// another mainchain wallet paid for still lands here.
+func TestSidechainBalanceKeepsADepositFromAnotherMainchainWallet(t *testing.T) {
+	const destination = "2yxqLNxuYiLRMWATFQcqf3iV3nKh"
+	ctx := context.Background()
+	state := &depositNodeState{coins: "[]", addresses: []string{destination}}
+	handler, svc := newDepositTestHandler(t, state)
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+		Txid: "other-wallet", WalletID: "SOMEOTHERWALLET", Slot: 9,
+		Destination: destination, AmountSats: 400_000,
+	}))
+
+	confirmed, pending := thunderBalance(t, handler)
+	assert.Zero(t, confirmed)
+	assert.Equal(t, uint64(400_000), pending, "the coins land in this sidechain wallet")
+}
+
+// A deposit paid to somebody else's address never becomes our money, so it
+// must not read as our unconfirmed balance.
+func TestSidechainBalanceIgnoresADepositToAForeignAddress(t *testing.T) {
+	ctx := context.Background()
+	state := &depositNodeState{coins: "[]", addresses: []string{"mine"}}
+	handler, svc := newDepositTestHandler(t, state)
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+		Txid: "gift", WalletID: svc.ActiveWalletID(), Slot: 9,
+		Destination: "a-friends-address", AmountSats: 900_000,
+	}))
+
+	confirmed, pending := thunderBalance(t, handler)
+	assert.Zero(t, confirmed)
+	assert.Zero(t, pending)
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -621,6 +621,14 @@ func (h *Handler) GetSidechainBalance(ctx context.Context, req *connect.Request[
 	confirmedSats, pendingSats = applyMempoolDelta(
 		confirmedSats, pendingSats, h.mempoolDelta(ctx, cfg),
 	)
+	// Read the deposits last. The sidechain credits a deposit into the balance
+	// above, so a deposit that lands between the two reads counts in neither
+	// for one poll, and never in both.
+	depositSats, err := h.depositPendingSats(ctx, cfg)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, err)
+	}
+	pendingSats += depositSats
 
 	if h.orch.WalletSvc != nil {
 		_ = h.orch.WalletSvc.SyncBalance(

--- a/sidechain-orchestrator/sidechain/mempool.go
+++ b/sidechain-orchestrator/sidechain/mempool.go
@@ -414,8 +414,29 @@ func mempoolUTXORows(txs []MempoolTx) []json.RawMessage {
 	return rows
 }
 
+// AddressLister names the addresses its own wallet holds. A chain that splits
+// its addresses by kind serves no single get_wallet_addresses.
+type AddressLister interface {
+	WalletAddressList(ctx context.Context) ([]string, error)
+}
+
 // WalletAddresses reads the addresses a node's own wallet holds.
 func WalletAddresses(ctx context.Context, node Node) (map[string]bool, error) {
+	list, err := walletAddressList(ctx, node)
+	if err != nil {
+		return nil, err
+	}
+	owned := make(map[string]bool, len(list))
+	for _, address := range list {
+		owned[address] = true
+	}
+	return owned, nil
+}
+
+func walletAddressList(ctx context.Context, node Node) ([]string, error) {
+	if lister, ok := node.(AddressLister); ok {
+		return lister.WalletAddressList(ctx)
+	}
 	raw, err := node.CallRaw(ctx, "get_wallet_addresses", nil)
 	if err != nil {
 		return nil, fmt.Errorf("read the wallet addresses: %w", err)
@@ -424,11 +445,7 @@ func WalletAddresses(ctx context.Context, node Node) (map[string]bool, error) {
 	if err := json.Unmarshal(raw, &list); err != nil {
 		return nil, fmt.Errorf("read the wallet addresses: %w", err)
 	}
-	owned := make(map[string]bool, len(list))
-	for _, address := range list {
-		owned[address] = true
-	}
-	return owned, nil
+	return list, nil
 }
 
 // OurCoins maps each coin a node's wallet holds to what it holds, keyed

--- a/sidechain-orchestrator/sidechain/nodes/nodes.go
+++ b/sidechain-orchestrator/sidechain/nodes/nodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bbc"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/freebank"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/zside"
 )
 
 // New returns the client for a sidechain. A Core derived chain speaks Core's
@@ -18,6 +19,9 @@ import (
 // chains speak a bare JSON-RPC with no credentials.
 func New(name, host string, port int, isBitcoinCore bool, network config.Network) (sidechain.Node, error) {
 	if !isBitcoinCore {
+		if name == "zside" {
+			return zside.NewNode(host, port), nil
+		}
 		return sidechain.NewJSONRPCProxy(host, port), nil
 	}
 	dirs, ok := config.DirConfigByName(name)

--- a/sidechain-orchestrator/sidechain/zside/node.go
+++ b/sidechain-orchestrator/sidechain/zside/node.go
@@ -1,0 +1,49 @@
+package zside
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+var _ sidechain.AddressLister = (*Node)(nil)
+
+// Node speaks the zSide JSON-RPC. It is the plain sidechain client plus the
+// address listing zSide serves under two names of its own.
+type Node struct {
+	*sidechain.JSONRPCProxy
+}
+
+// NewNode builds the zSide node client.
+func NewNode(host string, port int) *Node {
+	return &Node{JSONRPCProxy: sidechain.NewJSONRPCProxy(host, port)}
+}
+
+// WalletAddressList joins both kinds of address the wallet holds. zSide keeps
+// its transparent and its shielded addresses apart, and serves no combined
+// method.
+func (n *Node) WalletAddressList(ctx context.Context) ([]string, error) {
+	transparent, err := n.addresses(ctx, "get_transparent_wallet_addresses")
+	if err != nil {
+		return nil, err
+	}
+	shielded, err := n.addresses(ctx, "get_shielded_wallet_addresses")
+	if err != nil {
+		return nil, err
+	}
+	return append(transparent, shielded...), nil
+}
+
+func (n *Node) addresses(ctx context.Context, method string) ([]string, error) {
+	raw, err := n.CallRaw(ctx, method, nil)
+	if err != nil {
+		return nil, fmt.Errorf("read the zSide wallet addresses with %s: %w", method, err)
+	}
+	var list []string
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("read the zSide wallet addresses with %s: %w", method, err)
+	}
+	return list, nil
+}

--- a/sidechain-orchestrator/sidechain/zside/node_test.go
+++ b/sidechain-orchestrator/sidechain/zside/node_test.go
@@ -1,0 +1,65 @@
+package zside
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+func nodeServer(t *testing.T, results map[string]any) *Node {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		response := map[string]any{"jsonrpc": "2.0", "id": request.ID}
+		if result, ok := results[request.Method]; ok {
+			response["result"] = result
+		} else {
+			response["error"] = map[string]any{"code": -32601, "message": "Method not found"}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, portText, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	return NewNode(host, port)
+}
+
+// zSide serves no get_wallet_addresses. A caller that asks for it reads a
+// method-not-found error, and every balance the node answers then fails.
+func TestZSideListsBothAddressKinds(t *testing.T) {
+	node := nodeServer(t, map[string]any{
+		"get_transparent_wallet_addresses": []string{"t-one", "t-two"},
+		"get_shielded_wallet_addresses":    []string{"z-one"},
+	})
+
+	owned, err := sidechain.WalletAddresses(context.Background(), node)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"t-one": true, "t-two": true, "z-one": true}, owned)
+}
+
+// A node that answers neither method must report the fault rather than an
+// empty wallet, which would read as somebody else's money.
+func TestZSideAddressesReportTheFault(t *testing.T) {
+	node := nodeServer(t, map[string]any{})
+
+	_, err := sidechain.WalletAddresses(context.Background(), node)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get_transparent_wallet_addresses")
+}

--- a/sidechain-orchestrator/wallet/deposits.go
+++ b/sidechain-orchestrator/wallet/deposits.go
@@ -15,6 +15,9 @@ type SidechainDeposit struct {
 	AmountSats  int64
 	FeeSats     int64
 	CreatedAt   time.Time
+	// CreditedAt is when the sidechain first held the coin. It is the zero
+	// time while the sidechain still knows nothing of the deposit.
+	CreditedAt time.Time
 }
 
 // RecordSidechainDeposit remembers a deposit the wallet just broadcast. An M5
@@ -44,7 +47,7 @@ func (s *Service) SidechainDeposits(ctx context.Context, slot uint32, walletID s
 		return nil, fmt.Errorf("list sidechain deposits: database not open")
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT txid, wallet_id, slot, destination, amount_sats, fee_sats, created_at
+		SELECT txid, wallet_id, slot, destination, amount_sats, fee_sats, created_at, credited_at
 		FROM sidechain_deposits
 		WHERE network = ? AND slot = ? AND (? = '' OR wallet_id = ?)
 		ORDER BY created_at DESC`, s.Network(), slot, walletID, walletID)
@@ -56,17 +59,38 @@ func (s *Service) SidechainDeposits(ctx context.Context, slot uint32, walletID s
 	var out []SidechainDeposit
 	for rows.Next() {
 		var d SidechainDeposit
-		var createdAt int64
-		if err := rows.Scan(&d.Txid, &d.WalletID, &d.Slot, &d.Destination, &d.AmountSats, &d.FeeSats, &createdAt); err != nil {
+		var createdAt, creditedAt int64
+		if err := rows.Scan(&d.Txid, &d.WalletID, &d.Slot, &d.Destination, &d.AmountSats, &d.FeeSats, &createdAt, &creditedAt); err != nil {
 			return nil, fmt.Errorf("scan sidechain deposit: %w", err)
 		}
 		d.CreatedAt = time.Unix(createdAt, 0)
+		if creditedAt > 0 {
+			d.CreditedAt = time.Unix(creditedAt, 0)
+		}
 		out = append(out, d)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read sidechain deposits: %w", err)
 	}
 	return out, nil
+}
+
+// MarkSidechainDepositCredited stamps the deposit the sidechain now holds a
+// coin for. The stamp never clears, so a later spend of that coin cannot read
+// the deposit back as an unconfirmed balance.
+func (s *Service) MarkSidechainDepositCredited(ctx context.Context, txid string) error {
+	db := s.db()
+	if db == nil {
+		return fmt.Errorf("credit sidechain deposit: database not open")
+	}
+	_, err := db.ExecContext(ctx, `
+		UPDATE sidechain_deposits SET credited_at = ?
+		WHERE network = ? AND txid = ? AND credited_at = 0`,
+		time.Now().Unix(), s.Network(), txid)
+	if err != nil {
+		return fmt.Errorf("credit sidechain deposit: %w", err)
+	}
+	return nil
 }
 
 // SidechainDepositTotals sums what this install deposited: all time, and since

--- a/sidechain-orchestrator/wallet/deposits_credited_test.go
+++ b/sidechain-orchestrator/wallet/deposits_credited_test.go
@@ -1,0 +1,102 @@
+package wallet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A fresh deposit carries no credit stamp, and the stamp lands on the one
+// deposit named. The balance path counts every unstamped deposit, so a stamp
+// on the wrong row hides money the sidechain still owes.
+func TestMarkSidechainDepositCredited(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(t.TempDir(), zerolog.Nop())
+	svc.SetNetwork("signet")
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, SidechainDeposit{
+		Txid: "aaa", WalletID: "w1", Slot: 9, Destination: "addr-1", AmountSats: 50_000,
+	}))
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, SidechainDeposit{
+		Txid: "bbb", WalletID: "w1", Slot: 9, Destination: "addr-2", AmountSats: 10_000,
+	}))
+
+	fresh, err := svc.SidechainDeposits(ctx, 9, "w1")
+	require.NoError(t, err)
+	require.Len(t, fresh, 2)
+	for _, d := range fresh {
+		assert.True(t, d.CreditedAt.IsZero(), "a fresh deposit carries no credit stamp")
+	}
+
+	require.NoError(t, svc.MarkSidechainDepositCredited(ctx, "aaa"))
+
+	stamped, err := svc.SidechainDeposits(ctx, 9, "w1")
+	require.NoError(t, err)
+	byTxid := map[string]SidechainDeposit{}
+	for _, d := range stamped {
+		byTxid[d.Txid] = d
+	}
+	assert.False(t, byTxid["aaa"].CreditedAt.IsZero(), "the named deposit carries the stamp")
+	assert.True(t, byTxid["bbb"].CreditedAt.IsZero(), "the other deposit keeps none")
+}
+
+// The stamp says the sidechain credited the coins. A second call must not move
+// it, because the first moment is the one the balance path reads.
+func TestMarkSidechainDepositCreditedKeepsTheFirstStamp(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(t.TempDir(), zerolog.Nop())
+	svc.SetNetwork("signet")
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, SidechainDeposit{
+		Txid: "aaa", WalletID: "w1", Slot: 9, Destination: "addr-1", AmountSats: 50_000,
+	}))
+	require.NoError(t, svc.MarkSidechainDepositCredited(ctx, "aaa"))
+
+	first, err := svc.SidechainDeposits(ctx, 9, "w1")
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	require.NoError(t, svc.MarkSidechainDepositCredited(ctx, "aaa"))
+
+	second, err := svc.SidechainDeposits(ctx, 9, "w1")
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, first[0].CreditedAt, second[0].CreditedAt)
+}
+
+// Rows are keyed by network. A stamp written on one network must leave the
+// other network's deposit pending.
+func TestMarkSidechainDepositCreditedIsScopedToTheNetwork(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(t.TempDir(), zerolog.Nop())
+	svc.SetNetwork("signet")
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, SidechainDeposit{
+		Txid: "aaa", WalletID: "w1", Slot: 9, Destination: "addr-1", AmountSats: 50_000,
+	}))
+	require.NoError(t, svc.RebindNetwork("regtest"))
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, SidechainDeposit{
+		Txid: "aaa", WalletID: "w1", Slot: 9, Destination: "addr-1", AmountSats: 50_000,
+	}))
+	require.NoError(t, svc.MarkSidechainDepositCredited(ctx, "aaa"))
+
+	regtest, err := svc.SidechainDeposits(ctx, 9, "w1")
+	require.NoError(t, err)
+	require.Len(t, regtest, 1)
+	assert.False(t, regtest[0].CreditedAt.IsZero())
+
+	require.NoError(t, svc.RebindNetwork("signet"))
+	signet, err := svc.SidechainDeposits(ctx, 9, "w1")
+	require.NoError(t, err)
+	require.Len(t, signet, 1)
+	assert.True(t, signet[0].CreditedAt.IsZero(), "the other network keeps its deposit pending")
+}

--- a/sidechain-orchestrator/wallet/migrations/007_deposit_credited.sql
+++ b/sidechain-orchestrator/wallet/migrations/007_deposit_credited.sql
@@ -1,0 +1,4 @@
+-- The sidechain credits a deposit hours after the broadcast. This stamp is the
+-- only permanent record of that moment, so a spent deposit coin never reads
+-- back as an unconfirmed balance.
+ALTER TABLE sidechain_deposits ADD COLUMN credited_at INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
A deposit is a mainchain transaction, so the sidechain reads zero for hours and the money looks lost. GetSidechainBalance now adds the deposits this wallet made to that slot and the sidechain has not credited yet.

A deposit leaves the pending sum the moment the sidechain wallet lists a coin for it, and a permanent stamp keeps it out. The same listing decides both counts, so a deposit is never counted twice.