### PR TITLE
orchestrator: give connect_block its own deadline

### DIFF
--- a/sidechain-orchestrator/rpc/client.go
+++ b/sidechain-orchestrator/rpc/client.go
@@ -12,21 +12,20 @@ import (
 
 // Client is a minimal JSON-RPC 2.0 HTTP client.
 type Client struct {
-	url    string
-	http   *http.Client
-	nextID atomic.Int64
+	url  string
+	http *http.Client
+	// timeout is the deadline one method gets. http.Client.Timeout would cap
+	// every method at the shortest of them.
+	timeout func(method string) time.Duration
+	nextID  atomic.Int64
 }
-
-// callTimeout bounds one RPC. A node that accepts the connection and then
-// answers nothing would otherwise hold the caller's goroutine for as long as
-// the node runs.
-const callTimeout = 30 * time.Second
 
 // New creates a JSON-RPC client targeting the given host and port.
 func New(host string, port int) *Client {
 	return &Client{
-		url:  fmt.Sprintf("http://%s:%d", host, port),
-		http: &http.Client{Timeout: callTimeout},
+		url:     fmt.Sprintf("http://%s:%d", host, port),
+		http:    &http.Client{},
+		timeout: MethodTimeout,
 	}
 }
 
@@ -67,6 +66,9 @@ func (c *Client) Call(ctx context.Context, method string, params any, out any) e
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout(method))
+	defer cancel()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
 	if err != nil {
@@ -111,6 +113,9 @@ func (c *Client) CallRaw(ctx context.Context, method string, params any) (json.R
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout(method))
+	defer cancel()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
 	if err != nil {

--- a/sidechain-orchestrator/rpc/client_test.go
+++ b/sidechain-orchestrator/rpc/client_test.go
@@ -39,7 +39,7 @@ func TestCallStopsOnASilentNode(t *testing.T) {
 	}()
 
 	client := clientFor(t, srv)
-	client.http.Timeout = 100 * time.Millisecond
+	client.timeout = func(string) time.Duration { return 100 * time.Millisecond }
 
 	err := client.Call(context.Background(), "balance", nil, nil)
 	require.Error(t, err)
@@ -58,4 +58,86 @@ func TestCallReadsTheResult(t *testing.T) {
 	}
 	require.NoError(t, clientFor(t, srv).Call(context.Background(), "balance", nil, &out))
 	assert.Equal(t, int64(7), out.TotalSats)
+}
+
+// slowServer answers after delay. release stops a handler still waiting, so a
+// test that never gets an answer still returns.
+func slowServer(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-time.After(delay):
+		case <-release:
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+	return srv
+}
+
+// connect_block stores the mainchain ancestors of the block before it answers,
+// so it takes a deadline the ordinary calls never get.
+func TestConnectBlockOutlastsAnOrdinaryCall(t *testing.T) {
+	client := clientFor(t, slowServer(t, 200*time.Millisecond))
+	client.timeout = func(method string) time.Duration {
+		if method == "connect_block" {
+			return 5 * time.Second
+		}
+		return 50 * time.Millisecond
+	}
+
+	var connected bool
+	require.NoError(t, client.Call(context.Background(), "connect_block", []any{"{}", "hash"}, &connected))
+	assert.True(t, connected)
+
+	err := client.Call(context.Background(), "getblockcount", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http post")
+}
+
+// The longer deadline still ends the call. A node that hangs must not hold the
+// BMM engine for as long as it runs.
+func TestConnectBlockStopsAtItsOwnDeadline(t *testing.T) {
+	client := clientFor(t, slowServer(t, time.Hour))
+	client.timeout = func(string) time.Duration { return 100 * time.Millisecond }
+
+	err := client.Call(context.Background(), "connect_block", []any{"{}", "hash"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http post")
+}
+
+func TestCallRawStopsAtTheMethodDeadline(t *testing.T) {
+	client := clientFor(t, slowServer(t, time.Hour))
+	client.timeout = func(string) time.Duration { return 100 * time.Millisecond }
+
+	_, err := client.CallRaw(context.Background(), "mine", []any{1000})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http post")
+}
+
+// A caller that asks for less than the method allows gets what it asked for.
+func TestACallerDeadlineShorterThanTheMethodWins(t *testing.T) {
+	client := clientFor(t, slowServer(t, time.Hour))
+	client.timeout = func(string) time.Duration { return time.Hour }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := client.Call(ctx, "connect_block", []any{"{}", "hash"}, nil)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 30*time.Second)
+}
+
+func TestMethodTimeoutGivesConnectBlockTheLongOne(t *testing.T) {
+	assert.Equal(t, ConnectBlockTimeout, MethodTimeout("connect_block"))
+	assert.Equal(t, CallTimeout, MethodTimeout("get_block_template"))
+	assert.Equal(t, CallTimeout, MethodTimeout("balance"))
+	assert.Greater(t, ConnectBlockTimeout, CallTimeout)
 }

--- a/sidechain-orchestrator/rpc/timeout.go
+++ b/sidechain-orchestrator/rpc/timeout.go
@@ -1,0 +1,22 @@
+package rpc
+
+import "time"
+
+// CallTimeout bounds one ordinary RPC. A node that accepts the connection and
+// then answers nothing would otherwise hold the caller's goroutine for as long
+// as the node runs.
+const CallTimeout = 30 * time.Second
+
+// ConnectBlockTimeout bounds connect_block, which stores the mainchain
+// ancestors of the block inside the call and takes minutes on a node that was
+// offline. It stays under one mainchain block: one goroutine drives every chain.
+const ConnectBlockTimeout = 3 * time.Minute
+
+// MethodTimeout returns the deadline one JSON-RPC method gets. Every sidechain
+// transport reads this, so no chain gets a deadline of its own.
+func MethodTimeout(method string) time.Duration {
+	if method == "connect_block" {
+		return ConnectBlockTimeout
+	}
+	return CallTimeout
+}

--- a/sidechain-orchestrator/sidechain/corenode/client.go
+++ b/sidechain-orchestrator/sidechain/corenode/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 )
 
@@ -44,6 +45,9 @@ type Client struct {
 	opts       Options
 	cookiePath string
 	http       *http.Client
+	// timeout is the deadline one method gets. http.Client.Timeout would cap
+	// every method at the shortest of them.
+	timeout func(method string) time.Duration
 }
 
 // New creates a client pointed at host:port. name prefixes an RPC error, so a
@@ -58,7 +62,8 @@ func New(name, host string, port int, cookiePath string, opts Options) *Client {
 		baseURL:    fmt.Sprintf("http://%s:%d", host, port),
 		opts:       opts,
 		cookiePath: cookiePath,
-		http:       &http.Client{Timeout: 30 * time.Second},
+		http:       &http.Client{},
+		timeout:    rpc.MethodTimeout,
 	}
 }
 
@@ -102,6 +107,9 @@ func (c *Client) callAt(ctx context.Context, path, method string, params any) (j
 	if err != nil {
 		return nil, fmt.Errorf("marshal %s request: %w", method, err)
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout(method))
+	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
 	if err != nil {

--- a/sidechain-orchestrator/sidechain/corenode/client_test.go
+++ b/sidechain-orchestrator/sidechain/corenode/client_test.go
@@ -8,9 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
 )
 
 type recordedRequest struct {
@@ -184,4 +187,62 @@ func TestFeeEstimateFallsBackWithoutHistory(t *testing.T) {
 	rate, err := clientFor(t, srv, cookieFile(t, "user:pass"), Options{}).EstimateSmartFee(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, FallbackFeeRate, rate)
+}
+
+// slowNode answers after delay. release stops a handler still waiting, so a
+// test that never gets an answer still returns.
+func slowNode(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-time.After(delay):
+		case <-release:
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":true,"error":null}`))
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+	return srv
+}
+
+// connect_block stores the mainchain ancestors of the block before it answers,
+// so it takes a deadline the ordinary calls never get.
+func TestConnectBlockOutlastsAnOrdinaryCall(t *testing.T) {
+	client := clientFor(t, slowNode(t, 200*time.Millisecond), cookieFile(t, "user:pass"), Options{})
+	client.timeout = func(method string) time.Duration {
+		if method == "connect_block" {
+			return 5 * time.Second
+		}
+		return 50 * time.Millisecond
+	}
+
+	connected, err := Decode[bool](context.Background(), client, "connect_block", []any{"{}", "hash"})
+	require.NoError(t, err)
+	assert.True(t, connected)
+
+	_, err = client.GetBlockCount(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getblockcount call")
+}
+
+// The longer deadline still ends the call. A node that hangs must not hold the
+// BMM engine for as long as it runs.
+func TestConnectBlockStopsAtItsOwnDeadline(t *testing.T) {
+	client := clientFor(t, slowNode(t, time.Hour), cookieFile(t, "user:pass"), Options{})
+	client.timeout = func(string) time.Duration { return 100 * time.Millisecond }
+
+	_, err := Decode[bool](context.Background(), client, "connect_block", []any{"{}", "hash"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connect_block call")
+}
+
+func TestMethodTimeoutBindsTheCoreTransport(t *testing.T) {
+	client := New("testchain", "127.0.0.1", 0, "", Options{})
+	assert.Equal(t, rpc.ConnectBlockTimeout, client.timeout("connect_block"))
+	assert.Equal(t, rpc.CallTimeout, client.timeout("getblockcount"))
 }

--- a/sidechain-orchestrator/sidechain/nodes/nodes_test.go
+++ b/sidechain-orchestrator/sidechain/nodes/nodes_test.go
@@ -1,0 +1,47 @@
+package nodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bbc"
+)
+
+// Two transports carry connect_block, and both give it its own deadline. A
+// chain that arrives with a client of its own would cap connect_block at the
+// ordinary 30 seconds, so it fails here first.
+func TestEveryBmmSidechainTakesAnAuditedTransport(t *testing.T) {
+	chains := []struct {
+		name string
+		core bool
+	}{
+		{name: "thunder"},
+		{name: "bitnames"},
+		{name: "bitassets"},
+		{name: "photon"},
+		{name: "coinshift"},
+		{name: "truthcoin"},
+		{name: "zside"},
+		{name: "bbc", core: true},
+	}
+
+	for _, chain := range chains {
+		t.Run(chain.name, func(t *testing.T) {
+			node, err := New(chain.name, "127.0.0.1", 1, chain.core, config.NetworkSignet)
+			require.NoError(t, err)
+
+			bmm, ok := node.(sidechain.BMMNode)
+			require.True(t, ok, "the BMM engine drives this chain")
+
+			switch bmm.(type) {
+			case *sidechain.JSONRPCProxy, *bbc.Client:
+			default:
+				assert.Failf(t, "unaudited transport", "%s takes %T", chain.name, bmm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
connect_block stores the mainchain ancestors of the block inside the call, so it runs for minutes on a node that was offline. One 30 second deadline for every RPC does not fit it.

Both sidechain transports now read one per-method policy: connect_block gets 3 minutes, every other call keeps 30 seconds. Each chain keeps its own client.