### PR TITLE
orchestrator: give every bmm slot a coin of its own

### DIFF
--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"slices"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -32,18 +33,59 @@ import (
 // that decided a round the engine slept through.
 const bmmAncestorWalk = 200
 
+const (
+	// bmmSlotCoinRounds is how many rounds one slot coin funds. It sizes each
+	// output of the coin split.
+	bmmSlotCoinRounds = 20
+	// bmmSlotCoinFeeSats is what a slot coin holds over the bid itself, for the
+	// change output every bid adds. The coin split pays it as its fee.
+	bmmSlotCoinFeeSats = 10_000
+	// bmmSplitPatience is how long a split holds the next one back after the
+	// mempool stops naming it. An Electrum wallet broadcasts through Esplora,
+	// and the local node can take a moment to see the transaction.
+	bmmSplitPatience = 10 * time.Minute
+	// noSlot claims no slot, so every live bid counts as another slot's bid.
+	noSlot = -1
+)
+
+// bidWallet is the wallet surface a bid spends through.
+type bidWallet interface {
+	// ResolveWalletID names the wallet an empty id means.
+	ResolveWalletID(walletID string) (string, error)
+	ListUnspent(
+		context.Context, *connect.Request[wpb.ListUnspentRequest],
+	) (*connect.Response[wpb.ListUnspentResponse], error)
+	GetNewAddress(
+		context.Context, *connect.Request[wpb.GetNewAddressRequest],
+	) (*connect.Response[wpb.GetNewAddressResponse], error)
+	SendTransaction(
+		context.Context, *connect.Request[wpb.SendTransactionRequest],
+	) (*connect.Response[wpb.SendTransactionResponse], error)
+}
+
 // BMMHandler serves BMMService. It owns bid assembly; the engine drives it on
 // a loop so both paths build an M8 exactly one way.
 type BMMHandler struct {
 	orch   *orchestrator.Orchestrator
-	wallet *WalletHandler
+	wallet bidWallet
 	engine *engines.BmmEngine
 	// core reads bitcoind. A test supplies its own through SetCoreCaller.
 	core CoreRawCaller
+
+	splitMu sync.Mutex
+	// splits names the coin split each wallet waits for. Bitcoin Core lists no
+	// coin of an unconfirmed split, so this holds a second split back.
+	splits map[string]pendingSplit
 }
 
 func NewBMMHandler(orch *orchestrator.Orchestrator, wallet *WalletHandler) *BMMHandler {
-	return &BMMHandler{orch: orch, wallet: wallet}
+	h := &BMMHandler{orch: orch}
+	// A nil pointer in the interface answers every call, and then panics inside
+	// it. An empty field answers the wallet check below instead.
+	if wallet != nil {
+		h.wallet = wallet
+	}
+	return h
 }
 
 // SetCoreCaller replaces the bitcoind seam.
@@ -121,7 +163,7 @@ func (h *BMMHandler) Start(
 		return nil, err
 	}
 	// Past validation, an engine failure is a storage one, not a client one.
-	if err := h.engine.Start(req.Msg.Sidechain, req.Msg.WalletId,
+	if err := h.engine.Start(ctx, req.Msg.Sidechain, req.Msg.WalletId,
 		req.Msg.MaxBidSats, req.Msg.CapToBlockWorth); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -357,6 +399,12 @@ func (h *BMMHandler) CreateBid(
 		if raised != bidSats {
 			bidSats, byRate = raised, false
 		}
+	} else {
+		coin, err := h.slotCoin(ctx, req.Msg, cfg.Slot, pinSats(bidSats, byRate, req.Msg.FeeRateSatVb))
+		if err != nil {
+			return nil, err
+		}
+		requiredInputs = []*wpb.UnspentOutput{coin}
 	}
 
 	// The M8's OP_RETURN must be output 0 with no value, so the bid only
@@ -506,26 +554,10 @@ func (h *BMMHandler) ListBids(
 
 	var bids []*bmmpb.Bid
 	for txid, entry := range mempool {
-		rawTx, err := h.coreCall(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
-		if err != nil {
-			continue
-		}
-		var tx struct {
-			Vout []struct {
-				ScriptPubKey struct {
-					Hex string `json:"hex"`
-				} `json:"scriptPubKey"`
-			} `json:"vout"`
-		}
-		if err := json.Unmarshal(rawTx, &tx); err != nil || len(tx.Vout) == 0 {
-			continue
-		}
-		script, err := hex.DecodeString(tx.Vout[0].ScriptPubKey.Hex)
-		if err != nil {
-			continue
-		}
-		request := orchestrator.ParseM8BmmRequestScript(script)
-		if request == nil || int(request.Slot) != cfg.Slot {
+		// A transaction can leave the mempool between the two reads, and one the
+		// node cannot name is no competitor of ours.
+		request, err := h.m8Request(ctx, txid)
+		if err != nil || request == nil || int(request.Slot) != cfg.Slot {
 			continue
 		}
 		bids = append(bids, &bmmpb.Bid{
@@ -538,6 +570,391 @@ func (h *BMMHandler) ListBids(
 	sort.Slice(bids, func(i, j int) bool { return bids[i].BidSats > bids[j].BidSats })
 
 	return connect.NewResponse(&bmmpb.ListBidsResponse{Bids: bids}), nil
+}
+
+// mempoolTxids names every transaction the mainchain mempool holds.
+func (h *BMMHandler) mempoolTxids(ctx context.Context) (map[string]bool, error) {
+	raw, err := h.coreCall(ctx, "getrawmempool", "[false]")
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get raw mempool: %w", err))
+	}
+	var txids []string
+	if err := json.Unmarshal(raw, &txids); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("decode mempool: %w", err))
+	}
+	held := make(map[string]bool, len(txids))
+	for _, txid := range txids {
+		held[txid] = true
+	}
+	return held, nil
+}
+
+// m8Request reads the bid a transaction carries, nil when it carries none.
+func (h *BMMHandler) m8Request(ctx context.Context, txid string) (*orchestrator.BmmRequest, error) {
+	raw, err := h.coreCall(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
+	if err != nil {
+		return nil, fmt.Errorf("get raw transaction %s: %w", txid, err)
+	}
+	var tx struct {
+		Vout []struct {
+			ScriptPubKey struct {
+				Hex string `json:"hex"`
+			} `json:"scriptPubKey"`
+		} `json:"vout"`
+	}
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return nil, fmt.Errorf("decode transaction %s: %w", txid, err)
+	}
+	if len(tx.Vout) == 0 {
+		return nil, nil
+	}
+	script, err := hex.DecodeString(tx.Vout[0].ScriptPubKey.Hex)
+	if err != nil {
+		return nil, fmt.Errorf("decode the script of %s: %w", txid, err)
+	}
+	return orchestrator.ParseM8BmmRequestScript(script), nil
+}
+
+// slotCoin picks the coin an opening bid spends, and holds every slot to a coin
+// lineage of its own.
+//
+// One wallet funds all the sidechains. A bid built on another slot's bid change
+// dies the moment that slot replaces its own bid, because a replacement evicts
+// every mempool descendant of the transaction it replaces.
+func (h *BMMHandler) slotCoin(
+	ctx context.Context, req *bmmpb.CreateBidRequest, slot int, bidSats int64,
+) (*wpb.UnspentOutput, error) {
+	coins, err := h.readWalletCoins(ctx, req.WalletId, slot)
+	if err != nil {
+		return nil, err
+	}
+
+	var coin *wpb.UnspentOutput
+	for _, u := range coins.own {
+		if u.AmountSats < bidSats+bmmSlotCoinFeeSats {
+			continue
+		}
+		if coin == nil || u.AmountSats > coin.AmountSats {
+			coin = u
+		}
+	}
+	if coin == nil {
+		// PrepareBMM pays the missing coins. The engine opens the round again on
+		// the next tick, once one of them lands.
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"the wallet holds no coin of its own for slot %d", slot))
+	}
+	return coin, nil
+}
+
+// PrepareBMM gives every bidding sidechain a coin of its own, and splits one
+// large coin when a wallet holds too few.
+func (h *BMMHandler) PrepareBMM(
+	ctx context.Context, req *connect.Request[bmmpb.PrepareBMMRequest],
+) (*connect.Response[bmmpb.PrepareBMMResponse], error) {
+	if err := h.requireBMMAvailable(); err != nil {
+		return nil, err
+	}
+	if len(req.Msg.Targets) == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("targets must name a sidechain"))
+	}
+	if h.wallet == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no wallet is wired"))
+	}
+
+	// Two targets can name one wallet, by its id and by the empty active id, and
+	// both then bid from the same coins.
+	type want struct {
+		sidechains int32
+		maxBidSats int64
+	}
+	wants := make(map[string]*want, len(req.Msg.Targets))
+	var order []string
+	for _, target := range req.Msg.Targets {
+		if target.MaxBidSats <= 0 {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("max_bid_sats must be positive"))
+		}
+		walletID, err := h.wallet.ResolveWalletID(target.WalletId)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		}
+		w, ok := wants[walletID]
+		if !ok {
+			w = &want{}
+			wants[walletID] = w
+			order = append(order, walletID)
+		}
+		w.sidechains++
+		if target.MaxBidSats > w.maxBidSats {
+			w.maxBidSats = target.MaxBidSats
+		}
+	}
+
+	out := &bmmpb.PrepareBMMResponse{}
+	var failure error
+	for _, walletID := range order {
+		w := wants[walletID]
+		state, err := h.prepareWallet(ctx, walletID, w.sidechains, w.maxBidSats)
+		if err != nil {
+			// One wallet that cannot pay must not hold back the coins of the next
+			// one, which the engine counts again only on the next block.
+			if failure == nil {
+				failure = err
+			}
+			continue
+		}
+		out.Wallets = append(out.Wallets, state)
+	}
+	if failure != nil {
+		return nil, failure
+	}
+	return connect.NewResponse(out), nil
+}
+
+// prepareWallet counts the coins one wallet can bid from, and pays the missing
+// ones out of its largest coin.
+func (h *BMMHandler) prepareWallet(
+	ctx context.Context, walletID string, sidechains int32, maxBidSats int64,
+) (*bmmpb.PrepareBMMWallet, error) {
+	coins, err := h.readWalletCoins(ctx, walletID, noSlot)
+	if err != nil {
+		return nil, err
+	}
+
+	workingSats := slotCoinSats(maxBidSats)
+	// A coin a live bid created counts: that slot bids from it again, and its
+	// replacement respends the same inputs.
+	usable := lo.Filter(coins.all, func(u *wpb.UnspentOutput, _ int) bool {
+		return u.AmountSats >= workingSats
+	})
+
+	out := &bmmpb.PrepareBMMWallet{
+		WalletId:    walletID,
+		UsableCoins: int32(len(usable)),
+		WantedCoins: sidechains,
+	}
+	if int32(len(usable)) >= sidechains {
+		h.splitLanded(walletID)
+		return out, nil
+	}
+	// A split still in the mempool pays coins that a second split would spend
+	// again.
+	if h.pendingSplitTxid(walletID) != "" {
+		return out, nil
+	}
+
+	source := largestCoin(coins.free)
+	missing := int(sidechains) - len(usable)
+	// The split spends its source, so a source that counts as usable pays itself
+	// back as one more coin.
+	if source != nil && source.AmountSats >= workingSats {
+		missing++
+	}
+
+	txid, err := h.splitBMMCoins(ctx, walletID, source, missing, workingSats)
+	if err != nil {
+		return nil, err
+	}
+	h.holdSplit(walletID, txid)
+	out.SplitTxid = txid
+	return out, nil
+}
+
+// walletCoins is what one wallet holds for a bid.
+type walletCoins struct {
+	// all holds every coin the wallet can sign. A coin a live bid created still
+	// belongs to the slot that made it, and that slot bids from it again.
+	all []*wpb.UnspentOutput
+	// own holds the coins a bid for the named slot may spend.
+	own []*wpb.UnspentOutput
+	// free holds the coins no live bid created, which a split may spend.
+	free []*wpb.UnspentOutput
+	// held names every transaction the mainchain mempool holds.
+	held map[string]bool
+}
+
+// readWalletCoins sorts the coins of the wallet by the slot that may spend
+// them. A bid over another slot's bid change dies with the replacement that
+// slot broadcasts, because a replacement evicts every mempool descendant.
+//
+// A block already took a confirmed coin out of reach of a replacement, so only
+// an unconfirmed coin costs a read. An unconfirmed coin the node cannot name
+// waits: an Electrum wallet lists its own change before Core sees the bid that
+// paid it.
+func (h *BMMHandler) readWalletCoins(
+	ctx context.Context, walletID string, slot int,
+) (*walletCoins, error) {
+	if h.wallet == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no wallet is wired"))
+	}
+	resolved, err := h.wallet.ResolveWalletID(walletID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	unspent, err := h.wallet.ListUnspent(ctx, connect.NewRequest(&wpb.ListUnspentRequest{
+		WalletId: resolved,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	held, err := h.mempoolTxids(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &walletCoins{held: held}
+	for _, u := range unspent.Msg.Utxos {
+		if !u.Spendable {
+			continue
+		}
+		if u.Confirmations > 0 {
+			out.all = append(out.all, u)
+			out.own = append(out.own, u)
+			out.free = append(out.free, u)
+			continue
+		}
+		request, err := h.m8Request(ctx, u.Txid)
+		if err != nil {
+			zerolog.Ctx(ctx).Debug().Err(err).Str("txid", u.Txid).Msg("read the parent of a wallet coin")
+			continue
+		}
+		out.all = append(out.all, u)
+		if request == nil {
+			out.own = append(out.own, u)
+			out.free = append(out.free, u)
+			continue
+		}
+		if int(request.Slot) == slot {
+			out.own = append(out.own, u)
+		}
+	}
+	h.clearSplitWhenDone(resolved, out.all, held)
+	return out, nil
+}
+
+// splitBMMCoins pays count coins to the wallet itself, out of the source coin.
+// It spends that one coin alone, so the coins the other slots bid from stay
+// where they are.
+func (h *BMMHandler) splitBMMCoins(
+	ctx context.Context, walletID string, source *wpb.UnspentOutput, count int, coinSats int64,
+) (string, error) {
+	want := int64(count)*coinSats + bmmSlotCoinFeeSats
+	if source == nil || source.AmountSats < want {
+		return "", connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"no coin holds the %d sats that %d more bmm coins cost", want, count))
+	}
+
+	destinations := make(map[string]int64, count)
+	for range count {
+		addr, err := h.wallet.GetNewAddress(ctx, connect.NewRequest(&wpb.GetNewAddressRequest{
+			WalletId: walletID,
+		}))
+		if err != nil {
+			return "", err
+		}
+		destinations[addr.Msg.Address] = coinSats
+	}
+	if len(destinations) != count {
+		return "", connect.NewError(connect.CodeInternal, fmt.Errorf(
+			"the wallet named %d addresses for %d bmm coins", len(destinations), count))
+	}
+
+	send, err := h.wallet.SendTransaction(ctx, connect.NewRequest(&wpb.SendTransactionRequest{
+		WalletId:       walletID,
+		Destinations:   destinations,
+		RequiredInputs: []*wpb.UnspentOutput{source},
+		// The source pays this exact fee, or coin selection reaches for a second
+		// coin and puts the split on another slot's lineage.
+		FixedFeeSats: bmmSlotCoinFeeSats,
+	}))
+	if err != nil {
+		return "", err
+	}
+	return send.Msg.Txid, nil
+}
+
+// pendingSplit is a coin split a wallet waits for.
+type pendingSplit struct {
+	txid string
+	at   time.Time
+}
+
+// largestCoin names the coin that pays for a split, nil when the wallet holds
+// none.
+func largestCoin(coins []*wpb.UnspentOutput) *wpb.UnspentOutput {
+	var largest *wpb.UnspentOutput
+	for _, u := range coins {
+		if largest == nil || u.AmountSats > largest.AmountSats {
+			largest = u
+		}
+	}
+	return largest
+}
+
+// pinSats is what the pinned coin has to cover. A bid sized at a rate carries
+// no amount yet, and a coin under what that rate costs makes the wallet reach
+// for a coin of another slot.
+func pinSats(bidSats int64, byRate bool, rateSatVb float64) int64 {
+	if !byRate {
+		return bidSats
+	}
+	return int64(math.Ceil(rateSatVb * nominalBidVsize))
+}
+
+// slotCoinSats is the balance one slot works from: enough for many rounds at
+// the ceiling the operator set, plus the change of each bid.
+func slotCoinSats(maxBidSats int64) int64 {
+	return maxBidSats*bmmSlotCoinRounds + bmmSlotCoinFeeSats
+}
+
+// pendingSplitTxid names the split the wallet waits for, empty when it waits
+// for none.
+func (h *BMMHandler) pendingSplitTxid(walletID string) string {
+	h.splitMu.Lock()
+	defer h.splitMu.Unlock()
+	return h.splits[walletID].txid
+}
+
+func (h *BMMHandler) holdSplit(walletID, txid string) {
+	h.splitMu.Lock()
+	defer h.splitMu.Unlock()
+	if h.splits == nil {
+		h.splits = make(map[string]pendingSplit)
+	}
+	h.splits[walletID] = pendingSplit{txid: txid, at: time.Now()}
+}
+
+// clearSplitWhenDone drops the hold once the split paid a coin the wallet can
+// name. A hold the mempool stopped naming waits out the propagation gap first,
+// and then goes, or a split the node dropped holds the next one back forever.
+func (h *BMMHandler) clearSplitWhenDone(
+	walletID string, coins []*wpb.UnspentOutput, held map[string]bool,
+) {
+	h.splitMu.Lock()
+	defer h.splitMu.Unlock()
+
+	split, ok := h.splits[walletID]
+	if !ok {
+		return
+	}
+	for _, u := range coins {
+		if u.Txid == split.txid {
+			delete(h.splits, walletID)
+			return
+		}
+	}
+	if held[split.txid] || time.Since(split.at) < bmmSplitPatience {
+		return
+	}
+	delete(h.splits, walletID)
+}
+
+// splitLanded drops the hold, because a wallet with a coin for every sidechain
+// waits for nothing.
+func (h *BMMHandler) splitLanded(walletID string) {
+	h.splitMu.Lock()
+	defer h.splitMu.Unlock()
+	delete(h.splits, walletID)
 }
 
 // bidFeeSats reads what a broadcast bid paid, from the mempool entry Core

--- a/sidechain-orchestrator/api/bmm_mode_test.go
+++ b/sidechain-orchestrator/api/bmm_mode_test.go
@@ -87,7 +87,7 @@ func TestBMMFullModeReadsCore(t *testing.T) {
 func TestBMMLightModeKeepsStopAndPaidHistory(t *testing.T) {
 	h, store := newBMMModeHandler(t)
 	sidechain := pb.BinaryType_BINARY_TYPE_THUNDER
-	require.NoError(t, h.engine.Start(sidechain, "wallet", 10000, false))
+	require.NoError(t, h.engine.Start(context.Background(), sidechain, "wallet", 10000, false))
 	round := bmmstate.Round{Sidechain: int32(sidechain), PrevMainHash: "paid", Result: engines.ResultWon, WinnerBidSats: 1000}
 	require.NoError(t, store.Save(round))
 	require.NoError(t, orchestrator.WriteNodeMode(h.orch.BitwindowDir, orchestrator.NodeModeLight))

--- a/sidechain-orchestrator/api/bmm_slot_coin_test.go
+++ b/sidechain-orchestrator/api/bmm_slot_coin_test.go
@@ -1,0 +1,604 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
+	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+)
+
+// fakeSlotMempool answers the two Core reads the coin choice makes.
+type fakeSlotMempool struct {
+	// slots names the slot each mempool bid claims, by txid.
+	slots map[string]int
+	// plain names the mempool transactions that carry no bid.
+	plain []string
+	// unreadable names the mempool transactions the node refuses to read.
+	unreadable []string
+}
+
+func (m *fakeSlotMempool) call(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
+	switch method {
+	case "getrawmempool":
+		txids := make([]string, 0, len(m.slots)+len(m.plain)+len(m.unreadable))
+		for txid := range m.slots {
+			txids = append(txids, txid)
+		}
+		txids = append(txids, m.plain...)
+		txids = append(txids, m.unreadable...)
+		if paramsJSON == "[false]" {
+			return json.Marshal(txids)
+		}
+		entries := map[string]any{}
+		for _, txid := range txids {
+			entries[txid] = map[string]any{"fees": map[string]any{"base": 0.0001}}
+		}
+		return json.Marshal(entries)
+
+	case "getrawtransaction":
+		var params []any
+		if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+			return nil, err
+		}
+		txid, _ := params[0].(string)
+		if slices.Contains(m.unreadable, txid) {
+			return nil, fmt.Errorf("no transaction %s", txid)
+		}
+		slot, ok := m.slots[txid]
+		if !ok {
+			if !slices.Contains(m.plain, txid) {
+				// Without a txindex, Core reads no transaction outside its mempool.
+				return nil, fmt.Errorf("no transaction %s", txid)
+			}
+			// A transaction that is no bid carries a script the M8 parser refuses.
+			return json.Marshal(map[string]any{"vout": []map[string]any{{
+				"scriptPubKey": map[string]any{"hex": "51"},
+			}}})
+		}
+		script, err := orchestrator.M8BmmRequestScript(
+			uint8(slot), strings.Repeat("ab", 32), strings.Repeat("cd", 32))
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(map[string]any{"vout": []map[string]any{{
+			"scriptPubKey": map[string]any{"hex": hex.EncodeToString(script)},
+		}}})
+	}
+	return nil, fmt.Errorf("the coin choice called %s", method)
+}
+
+// fakeBidWallet stands in for the wallet the bid spends through.
+type fakeBidWallet struct {
+	utxos []*wpb.UnspentOutput
+	// byWallet holds the coins of each wallet, for a test that names more than
+	// one. It comes before utxos.
+	byWallet  map[string][]*wpb.UnspentOutput
+	addresses int
+	sends     []*wpb.SendTransactionRequest
+	sendTxid  string
+}
+
+func (w *fakeBidWallet) ResolveWalletID(walletID string) (string, error) {
+	if walletID == "" {
+		return "active", nil
+	}
+	return walletID, nil
+}
+
+func (w *fakeBidWallet) ListUnspent(
+	_ context.Context, req *connect.Request[wpb.ListUnspentRequest],
+) (*connect.Response[wpb.ListUnspentResponse], error) {
+	utxos := w.utxos
+	if w.byWallet != nil {
+		utxos = w.byWallet[req.Msg.WalletId]
+	}
+	return connect.NewResponse(&wpb.ListUnspentResponse{Utxos: utxos}), nil
+}
+
+func (w *fakeBidWallet) GetNewAddress(
+	_ context.Context, _ *connect.Request[wpb.GetNewAddressRequest],
+) (*connect.Response[wpb.GetNewAddressResponse], error) {
+	w.addresses++
+	return connect.NewResponse(&wpb.GetNewAddressResponse{
+		Address: fmt.Sprintf("address-%d", w.addresses),
+	}), nil
+}
+
+func (w *fakeBidWallet) SendTransaction(
+	_ context.Context, req *connect.Request[wpb.SendTransactionRequest],
+) (*connect.Response[wpb.SendTransactionResponse], error) {
+	w.sends = append(w.sends, req.Msg)
+	return connect.NewResponse(&wpb.SendTransactionResponse{Txid: w.sendTxid}), nil
+}
+
+func slotCoinHandler(t *testing.T, mempool *fakeSlotMempool, wallet *fakeBidWallet) *BMMHandler {
+	t.Helper()
+	h, _ := newBMMModeHandler(t)
+	h.wallet = wallet
+	h.SetCoreCaller(mempool.call)
+	return h
+}
+
+func bidRequest() *bmmpb.CreateBidRequest {
+	return &bmmpb.CreateBidRequest{WalletId: "bidder", MaxBidSats: 30_000, FeeRateSatVb: 2}
+}
+
+// The change of another slot's bid is that slot's next coin. A bid that spends
+// it dies when that slot replaces its own bid, because a replacement evicts
+// every mempool descendant of the transaction it replaces.
+func TestSlotCoinSkipsAnotherSlotsBidChange(t *testing.T) {
+	const otherBid = "1111111111111111111111111111111111111111111111111111111111111111"
+	const free = "2222222222222222222222222222222222222222222222222222222222222222"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: otherBid, Vout: 1, AmountSats: 1_000_000, Spendable: true},
+		{Txid: free, Vout: 0, AmountSats: 500_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{slots: map[string]int{otherBid: 9}}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, free, coin.Txid, "the larger coin belongs to slot 9")
+	assert.Empty(t, wallet.sends, "a free coin needs no split")
+}
+
+// The bid pins one coin, and that coin covers the bid. Coin selection then adds
+// no other coin, so the bid stays on its own lineage.
+func TestSlotCoinPinsOneCoinThatCoversTheBid(t *testing.T) {
+	const small = "3333333333333333333333333333333333333333333333333333333333333333"
+	const large = "4444444444444444444444444444444444444444444444444444444444444444"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: small, Vout: 0, AmountSats: 12_000, Spendable: true, Confirmations: 6},
+		{Txid: large, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, large, coin.Txid)
+	assert.GreaterOrEqual(t, coin.AmountSats, int64(10_000+bmmSlotCoinFeeSats))
+}
+
+// A coin under the bid plus its change cannot fund the bid alone, and the
+// wallet would fill the rest from a coin another slot owns. The bid waits for
+// PrepareBMM instead.
+func TestSlotCoinRefusesWhenEveryCoinIsTooSmall(t *testing.T) {
+	const tiny = "5555555555555555555555555555555555555555555555555555555555555555"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{{Txid: tiny, Vout: 0, AmountSats: 11_000, Spendable: true, Confirmations: 6}}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	_, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"the engine opens the round again on the next tick")
+	assert.Empty(t, wallet.sends, "the bid path never splits")
+}
+
+// Two slots take two coins, so a replacement of one slot's bid respends coins
+// the other slot never touched. The other bid stays in the mempool.
+func TestSlotCoinGivesTwoSlotsTwoCoins(t *testing.T) {
+	const first = "8888888888888888888888888888888888888888888888888888888888888888"
+	const second = "9999999999999999999999999999999999999999999999999999999999999999"
+	const bidOfFirstSlot = "aaaa111111111111111111111111111111111111111111111111111111111111"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: first, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+		{Txid: second, Vout: 0, AmountSats: 2_000_000, Spendable: true, Confirmations: 6},
+	}}
+	mempool := &fakeSlotMempool{}
+	h := slotCoinHandler(t, mempool, wallet)
+
+	ctx := context.Background()
+	coinOne, err := h.slotCoin(ctx, bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+	require.Equal(t, first, coinOne.Txid)
+
+	// Slot 1 spends its coin, so the wallet now holds that bid's change.
+	mempool.slots = map[string]int{bidOfFirstSlot: 1}
+	wallet.utxos = []*wpb.UnspentOutput{
+		{Txid: bidOfFirstSlot, Vout: 1, AmountSats: 2_990_000, Spendable: true},
+		{Txid: second, Vout: 0, AmountSats: 2_000_000, Spendable: true, Confirmations: 6},
+	}
+
+	coinTwo, err := h.slotCoin(ctx, bidRequest(), 2, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, second, coinTwo.Txid)
+	assert.NotEqual(t, coinOne.Txid, coinTwo.Txid, "the two slots spend separate coins")
+	assert.Empty(t, wallet.sends, "two free coins need no split")
+}
+
+func prepareRequest(sidechains int) *connect.Request[bmmpb.PrepareBMMRequest] {
+	targets := make([]*bmmpb.PrepareBMMTarget, 0, sidechains)
+	for range sidechains {
+		targets = append(targets, &bmmpb.PrepareBMMTarget{WalletId: "bidder", MaxBidSats: 30_000})
+	}
+	return connect.NewRequest(&bmmpb.PrepareBMMRequest{Targets: targets})
+}
+
+// prepared reads the one wallet the tests below prepare.
+func prepared(t *testing.T, resp *connect.Response[bmmpb.PrepareBMMResponse]) *bmmpb.PrepareBMMWallet {
+	t.Helper()
+	require.Len(t, resp.Msg.Wallets, 1)
+	return resp.Msg.Wallets[0]
+}
+
+// workingSats is the balance one sidechain bids many rounds from.
+const workingSats = 30_000*bmmSlotCoinRounds + bmmSlotCoinFeeSats
+
+// Five sidechains bid from one wallet, so the wallet needs five coins. The
+// split pays the missing ones out of the largest coin, and leaves the coins the
+// other slots already bid from alone.
+func TestPrepareBMMSplitsWhenCoinsAreMissing(t *testing.T) {
+	const held = "1111222222222222222222222222222222222222222222222222222222222222"
+	const large = "2222333333333333333333333333333333333333333333333333333333333333"
+
+	wallet := &fakeBidWallet{
+		utxos: []*wpb.UnspentOutput{
+			{Txid: held, Vout: 0, AmountSats: workingSats, Spendable: true, Confirmations: 6},
+			{Txid: large, Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6},
+		},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	resp, err := h.PrepareBMM(context.Background(), prepareRequest(5))
+	require.NoError(t, err)
+
+	wallet0 := prepared(t, resp)
+	assert.Equal(t, int32(2), wallet0.UsableCoins)
+	assert.Equal(t, int32(5), wallet0.WantedCoins)
+	assert.Equal(t, "split-txid", wallet0.SplitTxid)
+
+	require.Len(t, wallet.sends, 1)
+	split := wallet.sends[0]
+	assert.Len(t, split.Destinations, 4,
+		"three coins are missing, and the split pays back the coin it spends")
+	for address, sats := range split.Destinations {
+		assert.Equal(t, int64(workingSats), sats, "coin %s funds many rounds", address)
+	}
+	require.Len(t, split.RequiredInputs, 1)
+	assert.Equal(t, large, split.RequiredInputs[0].Txid,
+		"the split spends the largest coin alone, so the other slots keep theirs")
+}
+
+// A wallet that already holds one coin per sidechain needs no split, and a
+// split would spend the coins the slots bid from.
+func TestPrepareBMMLeavesAFullWalletAlone(t *testing.T) {
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: "aaaa", Vout: 0, AmountSats: workingSats, Spendable: true, Confirmations: 6},
+		{Txid: "bbbb", Vout: 0, AmountSats: workingSats, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	resp, err := h.PrepareBMM(context.Background(), prepareRequest(2))
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), prepared(t, resp).UsableCoins)
+	assert.Empty(t, prepared(t, resp).SplitTxid)
+	assert.Empty(t, wallet.sends)
+}
+
+// A coin under the working balance funds a few rounds and then leaves its slot
+// with nothing, so the guard counts it as missing.
+func TestPrepareBMMCountsASmallCoinAsMissing(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos: []*wpb.UnspentOutput{
+			{Txid: "aaaa", Vout: 0, AmountSats: workingSats - 1, Spendable: true, Confirmations: 6},
+			{Txid: "bbbb", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6},
+		},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	resp, err := h.PrepareBMM(context.Background(), prepareRequest(2))
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), prepared(t, resp).UsableCoins, "only the large coin can work")
+	require.Len(t, wallet.sends, 1)
+	assert.Len(t, wallet.sends[0].Destinations, 2,
+		"one coin is missing, and the split pays back the coin it spends")
+}
+
+// The Electrum scan carries an unconfirmed coin, Bitcoin Core does not. A
+// second split would spend the same coin again.
+func TestPrepareBMMSplitsOnlyOnce(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos:    []*wpb.UnspentOutput{{Txid: "aaaa", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6}},
+		sendTxid: "split-txid",
+	}
+	mempool := &fakeSlotMempool{}
+	h := slotCoinHandler(t, mempool, wallet)
+
+	ctx := context.Background()
+	_, err := h.PrepareBMM(ctx, prepareRequest(5))
+	require.NoError(t, err)
+	require.Len(t, wallet.sends, 1)
+
+	mempool.plain = append(mempool.plain, wallet.sendTxid)
+	resp, err := h.PrepareBMM(ctx, prepareRequest(5))
+	require.NoError(t, err)
+
+	assert.Empty(t, prepared(t, resp).SplitTxid, "the wallet waits for the first split")
+	assert.Len(t, wallet.sends, 1)
+}
+
+// The local node can take a moment to see a split an Electrum wallet broadcast
+// through Esplora. A hold that drops at once pays for a second split.
+func TestPrepareBMMHoldsASplitTheNodeHasNotSeen(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos:    []*wpb.UnspentOutput{{Txid: "aaaa", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6}},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	ctx := context.Background()
+	_, err := h.PrepareBMM(ctx, prepareRequest(5))
+	require.NoError(t, err)
+	require.Len(t, wallet.sends, 1)
+
+	resp, err := h.PrepareBMM(ctx, prepareRequest(5))
+	require.NoError(t, err)
+
+	assert.Empty(t, prepared(t, resp).SplitTxid, "the wallet waits out the propagation gap")
+	assert.Len(t, wallet.sends, 1)
+}
+
+// A split the mempool dropped must not hold the next one back forever.
+func TestPrepareBMMSplitsAgainOnceTheFirstSplitIsGone(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos:    []*wpb.UnspentOutput{{Txid: "aaaa", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6}},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	ctx := context.Background()
+	_, err := h.PrepareBMM(ctx, prepareRequest(5))
+	require.NoError(t, err)
+
+	// The node named no such transaction for longer than the propagation gap.
+	h.splitMu.Lock()
+	h.splits["bidder"] = pendingSplit{txid: wallet.sendTxid, at: time.Now().Add(-2 * bmmSplitPatience)}
+	h.splitMu.Unlock()
+
+	resp, err := h.PrepareBMM(ctx, prepareRequest(5))
+	require.NoError(t, err)
+
+	assert.Equal(t, "split-txid", prepared(t, resp).SplitTxid)
+	assert.Len(t, wallet.sends, 2)
+}
+
+// A wallet too small for the coins says so, rather than broadcasting a split
+// that spends more than it holds.
+func TestPrepareBMMRefusesAWalletThatCannotPay(t *testing.T) {
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{{Txid: "aaaa", Vout: 0, AmountSats: 5_000, Spendable: true, Confirmations: 6}}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	_, err := h.PrepareBMM(context.Background(), prepareRequest(5))
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Empty(t, wallet.sends)
+}
+
+// A parent the node cannot read may hold another slot's bid. A bid over its
+// change would then die with the replacement that slot broadcasts.
+func TestSlotCoinSkipsACoinItCannotRead(t *testing.T) {
+	const unreadable = "cccc111111111111111111111111111111111111111111111111111111111111"
+	const free = "dddd222222222222222222222222222222222222222222222222222222222222"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: unreadable, Vout: 1, AmountSats: 3_000_000, Spendable: true},
+		{Txid: free, Vout: 0, AmountSats: 500_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{unreadable: []string{unreadable}}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, free, coin.Txid, "the coin the node can name is the safe one")
+}
+
+// A watch-only coin cannot sign a bid, so counting it would leave a slot with
+// an opening bid that always fails.
+func TestSlotCoinSkipsAWatchOnlyCoin(t *testing.T) {
+	const watched = "eeee111111111111111111111111111111111111111111111111111111111111"
+	const own = "ffff222222222222222222222222222222222222222222222222222222222222"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: watched, Vout: 0, AmountSats: 9_000_000, Spendable: false},
+		{Txid: own, Vout: 0, AmountSats: 500_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, own, coin.Txid, "only a coin the wallet signs can pay a bid")
+}
+
+// One target names the wallet by its id, another leaves it empty for the active
+// wallet. Both bid from the same coins, so both count toward one wallet.
+func TestPrepareBMMJoinsTheAliasesOfOneWallet(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos:    []*wpb.UnspentOutput{{Txid: "aaaa", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6}},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	resp, err := h.PrepareBMM(context.Background(), connect.NewRequest(&bmmpb.PrepareBMMRequest{
+		Targets: []*bmmpb.PrepareBMMTarget{
+			{WalletId: "", MaxBidSats: 30_000},
+			{WalletId: "active", MaxBidSats: 45_000},
+		},
+	}))
+	require.NoError(t, err)
+
+	only := prepared(t, resp)
+	assert.Equal(t, "active", only.WalletId)
+	assert.Equal(t, int32(2), only.WantedCoins, "two sidechains spend one wallet")
+
+	require.Len(t, wallet.sends, 1)
+	for _, sats := range wallet.sends[0].Destinations {
+		assert.Equal(t, int64(45_000*bmmSlotCoinRounds+bmmSlotCoinFeeSats), sats,
+			"the coin covers the highest ceiling either sidechain bids to")
+	}
+}
+
+// The split spends its source. A source that counted as usable therefore has to
+// pay itself back, or the wallet ends the split one coin short.
+func TestPrepareBMMPaysBackTheCoinTheSplitSpends(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos: []*wpb.UnspentOutput{
+			{Txid: "aaaa", Vout: 0, AmountSats: 3 * workingSats, Spendable: true, Confirmations: 6},
+		},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	resp, err := h.PrepareBMM(context.Background(), prepareRequest(2))
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), prepared(t, resp).UsableCoins)
+	require.Len(t, wallet.sends, 1)
+	assert.Len(t, wallet.sends[0].Destinations, 2,
+		"two sidechains bid, and the one usable coin pays for both")
+}
+
+// One wallet that cannot pay must not hold back the coins of the next one. The
+// engine counts again only on the next block, so that slot would miss the whole
+// round.
+func TestPrepareBMMPreparesEveryWalletAfterAFailure(t *testing.T) {
+	wallet := &fakeBidWallet{
+		byWallet: map[string][]*wpb.UnspentOutput{
+			"poor": {{Txid: "aaaa", Vout: 0, AmountSats: 5_000, Spendable: true, Confirmations: 6}},
+			"rich": {{Txid: "bbbb", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6}},
+		},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	_, err := h.PrepareBMM(context.Background(), connect.NewRequest(&bmmpb.PrepareBMMRequest{
+		Targets: []*bmmpb.PrepareBMMTarget{
+			{WalletId: "poor", MaxBidSats: 30_000},
+			{WalletId: "rich", MaxBidSats: 30_000},
+			{WalletId: "rich", MaxBidSats: 30_000},
+		},
+	}))
+
+	require.Error(t, err, "the poor wallet cannot pay for its coin")
+	require.Len(t, wallet.sends, 1, "the rich wallet still gets its coins")
+	assert.Equal(t, "bbbb", wallet.sends[0].RequiredInputs[0].Txid)
+}
+
+// A bid sized at a rate carries no amount yet. A coin under what the rate costs
+// makes the wallet reach for the coin of another slot.
+func TestPinSatsCoversARateSizedBid(t *testing.T) {
+	assert.Equal(t, int64(12_000), pinSats(12_000, false, 50),
+		"an amount names what the bid pays")
+	assert.Equal(t, int64(50*nominalBidVsize), pinSats(0, true, 50),
+		"a rate names it by the size the wallet builds")
+}
+
+// An Electrum wallet lists its own change before Core sees the bid that pays
+// it. A coin the node cannot name may be another slot's change, and a bid over
+// it dies with that slot's replacement.
+func TestSlotCoinWaitsForACoinTheNodeCannotName(t *testing.T) {
+	const fresh = "cccc333333333333333333333333333333333333333333333333333333333333"
+	const confirmed = "dddd444444444444444444444444444444444444444444444444444444444444"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: fresh, Vout: 1, AmountSats: 3_000_000, Spendable: true},
+		{Txid: confirmed, Vout: 0, AmountSats: 500_000, Spendable: true, Confirmations: 1},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, confirmed, coin.Txid, "a block put the confirmed coin out of reach")
+}
+
+// A coin a live bid created still belongs to the slot that made it, and that
+// slot bids from it again. Counting it as missing pays for a split the wallet
+// does not need.
+func TestPrepareBMMCountsTheCoinOfALiveBid(t *testing.T) {
+	const bidOfSlotNine = "eeee999999999999999999999999999999999999999999999999999999999999"
+
+	wallet := &fakeBidWallet{
+		utxos: []*wpb.UnspentOutput{
+			{Txid: bidOfSlotNine, Vout: 1, AmountSats: workingSats, Spendable: true},
+			{Txid: "ffff", Vout: 0, AmountSats: workingSats, Spendable: true, Confirmations: 6},
+		},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{slots: map[string]int{bidOfSlotNine: 9}}, wallet)
+
+	resp, err := h.PrepareBMM(context.Background(), prepareRequest(2))
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), prepared(t, resp).UsableCoins, "slot 9 bids from its own change again")
+	assert.Empty(t, wallet.sends, "a full wallet needs no split")
+}
+
+// A split spends a coin no live bid created, or a replacement on that slot
+// evicts the split and every coin it pays.
+func TestPrepareBMMNeverSplitsTheCoinOfALiveBid(t *testing.T) {
+	const bidOfSlotNine = "aaaa888888888888888888888888888888888888888888888888888888888888"
+
+	wallet := &fakeBidWallet{
+		utxos: []*wpb.UnspentOutput{
+			{Txid: bidOfSlotNine, Vout: 1, AmountSats: 499_485_401, Spendable: true},
+			{Txid: "bbbb", Vout: 0, AmountSats: 5_000, Spendable: true, Confirmations: 6},
+		},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{slots: map[string]int{bidOfSlotNine: 9}}, wallet)
+
+	_, err := h.PrepareBMM(context.Background(), prepareRequest(5))
+
+	require.Error(t, err)
+	assert.Empty(t, wallet.sends)
+}
+
+// The split paid its coins, so the wallet waits for nothing. A hold that stays
+// on keeps a sidechain that starts later out of the round.
+func TestPrepareBMMDropsTheHoldOnceTheSplitPaid(t *testing.T) {
+	wallet := &fakeBidWallet{
+		utxos:    []*wpb.UnspentOutput{{Txid: "aaaa", Vout: 0, AmountSats: 499_485_401, Spendable: true, Confirmations: 6}},
+		sendTxid: "split-txid",
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	ctx := context.Background()
+	_, err := h.PrepareBMM(ctx, prepareRequest(2))
+	require.NoError(t, err)
+	require.Len(t, wallet.sends, 1)
+
+	// The split confirmed, and one more sidechain now bids.
+	wallet.utxos = append(wallet.utxos, &wpb.UnspentOutput{
+		Txid: "split-txid", Vout: 0, AmountSats: workingSats, Spendable: true, Confirmations: 1,
+	})
+	resp, err := h.PrepareBMM(ctx, prepareRequest(4))
+	require.NoError(t, err)
+
+	assert.Equal(t, "split-txid", prepared(t, resp).SplitTxid, "the wallet pays the coins it still needs")
+	assert.Len(t, wallet.sends, 2)
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -676,6 +676,15 @@ func (h *WalletHandler) EstimateFee(ctx context.Context, req *connect.Request[pb
 // Core wallet management RPCs
 // ============================================================================
 
+// ResolveWalletID names the wallet an id means. An empty id means the active
+// wallet.
+func (h *WalletHandler) ResolveWalletID(walletID string) (string, error) {
+	if err := h.requireEngine(); err != nil {
+		return "", err
+	}
+	return h.engine.ResolveWalletID(walletID)
+}
+
 func (h *WalletHandler) requireEngine() error {
 	if h.engine == nil {
 		return fmt.Errorf("bitcoin Core RPC not configured")

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -29,6 +29,9 @@ const (
 	// connect. Its header names one mainchain block, so the sidechain refuses a
 	// tip older than this and no number of attempts changes that.
 	bmmConnectHorizon = 10
+	// bmmPrepareTries bounds the coin counts one mainchain block pays for. A
+	// count on every tick would scan the wallet 30 times a minute.
+	bmmPrepareTries = 3
 )
 
 // Round result values.
@@ -74,6 +77,7 @@ type BmmBackend interface {
 	CreateBid(context.Context, *connect.Request[bmmpb.CreateBidRequest]) (*connect.Response[bmmpb.CreateBidResponse], error)
 	ConnectBid(context.Context, *connect.Request[bmmpb.ConnectBidRequest]) (*connect.Response[bmmpb.ConnectBidResponse], error)
 	ListBids(context.Context, *connect.Request[bmmpb.ListBidsRequest]) (*connect.Response[bmmpb.ListBidsResponse], error)
+	PrepareBMM(context.Context, *connect.Request[bmmpb.PrepareBMMRequest]) (*connect.Response[bmmpb.PrepareBMMResponse], error)
 	// Commitment reports the sidechain block hash a mainchain block committed
 	// to for this sidechain, empty when it carried none.
 	Commitment(ctx context.Context, sidechain pb.BinaryType, mainBlockHash string) (string, error)
@@ -120,6 +124,11 @@ type BmmEngine struct {
 	// yet. Giving up here would forfeit a block we already paid for.
 	unconnected map[pb.BinaryType][]*bmmstate.Round
 	subs        map[chan struct{}]struct{}
+	// preparedTip is the mainchain tip the wallet was last given bid coins for.
+	// One scan per block keeps the count current without a scan every tick.
+	preparedTip string
+	// prepareTries counts the coin counts preparedTip already paid for.
+	prepareTries int
 
 	wake chan struct{}
 }
@@ -145,7 +154,7 @@ func NewBmmEngine(
 // Start bids for sidechain on every new mainchain tip until Stop, raising
 // toward maxBidSats when outbid. walletID funds every bid.
 func (e *BmmEngine) Start(
-	sidechain pb.BinaryType, walletID string, maxBidSats int64, capToBlockWorth bool,
+	ctx context.Context, sidechain pb.BinaryType, walletID string, maxBidSats int64, capToBlockWorth bool,
 ) error {
 	if maxBidSats <= 0 {
 		return fmt.Errorf("max_bid_sats must be positive")
@@ -190,9 +199,90 @@ func (e *BmmEngine) Start(
 	e.log.Info().Stringer("sidechain", sidechain).
 		Int64("max_bid_sats", maxBidSats).
 		Bool("cap_to_block_worth", capToBlockWorth).Msg("bmm started")
+	// The new sidechain bids on the tip in play, so it needs a coin of its own
+	// before the next tick rather than after the next block. The tip counts
+	// again when this one fails.
+	e.resetPrepare()
+	e.prepareCoins(ctx)
 	e.notify()
 	e.poke()
 	return nil
+}
+
+// prepareCoins asks the backend for one bid coin per sidechain, per wallet. A
+// bid over another slot's bid change dies when that slot replaces its own bid,
+// so each slot spends a coin of its own.
+func (e *BmmEngine) prepareCoins(ctx context.Context) bool {
+	e.mu.Lock()
+	targets := make([]*bmmpb.PrepareBMMTarget, 0, len(e.targets))
+	for _, target := range e.targets {
+		targets = append(targets, &bmmpb.PrepareBMMTarget{
+			WalletId:   target.walletID,
+			MaxBidSats: target.maxBidSats,
+		})
+	}
+	e.mu.Unlock()
+
+	if len(targets) == 0 {
+		return false
+	}
+	resp, err := e.backend.PrepareBMM(ctx, connect.NewRequest(&bmmpb.PrepareBMMRequest{Targets: targets}))
+	if err != nil {
+		// A wallet that cannot make the coins still bids: every round that finds
+		// no coin of its own says so on the round itself.
+		e.log.Warn().Err(err).Msg("prepare the bmm coins")
+		return false
+	}
+	ready := true
+	for _, w := range resp.Msg.Wallets {
+		if w.UsableCoins < w.WantedCoins {
+			// A split the mempool drops leaves the wallet short again, so the tip
+			// counts once more.
+			ready = false
+		}
+		if w.SplitTxid == "" {
+			continue
+		}
+		e.log.Info().Str("wallet", w.WalletId).Str("txid", w.SplitTxid).
+			Int32("usable_coins", w.UsableCoins).Int32("wanted_coins", w.WantedCoins).
+			Msg("the wallet pays one bmm coin to each sidechain")
+	}
+	return ready
+}
+
+// needsPrepare claims one coin count for this tip. It reports false once the
+// count answered, or once the tip spent its attempts on a backend that fails.
+func (e *BmmEngine) needsPrepare(tip string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.preparedTip != tip {
+		e.preparedTip = tip
+		e.prepareTries = 0
+	}
+	if e.prepareTries >= bmmPrepareTries {
+		return false
+	}
+	e.prepareTries++
+	return true
+}
+
+// resetPrepare gives the tip its counts back, because the sidechains that bid
+// changed.
+func (e *BmmEngine) resetPrepare() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.prepareTries = 0
+}
+
+// prepareDone ends the counts for this tip, because one of them answered.
+func (e *BmmEngine) prepareDone(tip string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.preparedTip == tip {
+		e.prepareTries = bmmPrepareTries
+	}
 }
 
 // Stop ends automated bidding. Bids already broadcast still settle.
@@ -479,6 +569,13 @@ func (e *BmmEngine) tick(ctx context.Context) {
 		if round := e.Current(sidechain); round != nil && round.PrevMainHash != tip {
 			e.settleRound(ctx, sidechain, tip, height)
 		}
+	}
+
+	// The coin count can fall at any time: a coin drains, an operator starts one
+	// more sidechain, or another send spends one. One check per block keeps it
+	// current, and a check every tick would scan the wallet 30 times a minute.
+	if len(targets) > 0 && e.needsPrepare(tip) && e.prepareCoins(ctx) {
+		e.prepareDone(tip)
 	}
 
 	for sidechain, target := range targets {

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -11,6 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/rs/zerolog"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,6 +32,11 @@ type fakeBackend struct {
 	noInclusion       bool
 	lastMainBlockHash string
 	bidErr            error
+	prepares          int
+	lastPrepare       *bmmpb.PrepareBMMRequest
+	prepareErr        error
+	splitTxid         string
+	shortCoins        bool
 	feesSats          int64
 	others            []*bmmpb.Bid
 	commitment        string
@@ -115,6 +121,31 @@ func (f *fakeBackend) ListBids(
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return connect.NewResponse(&bmmpb.ListBidsResponse{Bids: f.others}), nil
+}
+
+func (f *fakeBackend) PrepareBMM(
+	_ context.Context, req *connect.Request[bmmpb.PrepareBMMRequest],
+) (*connect.Response[bmmpb.PrepareBMMResponse], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.prepares++
+	f.lastPrepare = req.Msg
+	if f.prepareErr != nil {
+		return nil, f.prepareErr
+	}
+	wanted := int32(len(req.Msg.Targets))
+	usable := wanted
+	if f.shortCoins {
+		usable = wanted - 1
+	}
+	return connect.NewResponse(&bmmpb.PrepareBMMResponse{
+		Wallets: []*bmmpb.PrepareBMMWallet{{
+			WalletId:    req.Msg.Targets[0].WalletId,
+			UsableCoins: usable,
+			WantedCoins: wanted,
+			SplitTxid:   f.splitTxid,
+		}},
+	}), nil
 }
 
 func (f *fakeBackend) Commitment(_ context.Context, _ pb.BinaryType, main string) (string, error) {
@@ -211,7 +242,7 @@ func TestBmmEngineIdleUntilStarted(t *testing.T) {
 // Only a new tip opens a round, so a repeated tip must not bid again.
 func TestBmmEngineOpensOneRoundPerTip(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -228,12 +259,12 @@ func TestBmmEngineBidsForASidechainStartedMidBlock(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	ctx := context.Background()
 
-	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
 	engine.tick(ctx)
 	require.Equal(t, 1, backend.bids)
 
 	const other = pb.BinaryType_BINARY_TYPE_BITNAMES
-	require.NoError(t, engine.Start(other, "", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), other, "", 20_000, false))
 	engine.tick(ctx)
 
 	assert.Equal(t, 2, backend.bids, "the newly started sidechain bids on the current tip")
@@ -245,7 +276,7 @@ func TestBmmEngineBidsForASidechainStartedMidBlock(t *testing.T) {
 func TestBmmEngineKeepsCompetitorsAfterTheRoundCloses(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	backend.others = []*bmmpb.Bid{{Txid: "rival", CriticalHash: "rival-h", BidSats: 9000}}
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -264,7 +295,7 @@ func TestBmmEngineKeepsCompetitorsAfterTheRoundCloses(t *testing.T) {
 
 func TestBmmEngineSettlesAWonRound(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -287,7 +318,7 @@ func TestBmmEngineSettlesAWonRound(t *testing.T) {
 func TestBmmEngineSettlesALostRound(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	backend.others = []*bmmpb.Bid{{Txid: "rival", CriticalHash: "rival-h", BidSats: 30_000}}
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -309,7 +340,7 @@ func TestBmmEngineSettlesALostRound(t *testing.T) {
 func TestBmmEngineRaisesWhenOutbid(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "", 30_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -333,7 +364,7 @@ func TestBmmEngineRaisesWhenOutbid(t *testing.T) {
 func TestBmmEngineBidsFromTheNamedWallet(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "wallet-b", 30_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "wallet-b", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -355,12 +386,12 @@ func TestBmmEngineBidsFromTheNamedWallet(t *testing.T) {
 func TestBmmEngineRaisesFromTheWalletThatFundedTheBid(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "wallet-b", 30_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "wallet-b", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
 
-	require.NoError(t, engine.Start(testSidechain, "wallet-c", 30_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "wallet-c", 30_000, false))
 	backend.others = []*bmmpb.Bid{{Txid: "rival", BidSats: 12_000}}
 	engine.tick(ctx)
 
@@ -372,7 +403,7 @@ func TestBmmEngineRaisesFromTheWalletThatFundedTheBid(t *testing.T) {
 func TestBmmEngineNeverRaisesAboveMax(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 90_000
-	require.NoError(t, engine.Start(testSidechain, "", 12_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 12_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -388,7 +419,7 @@ func TestBmmEngineNeverRaisesAboveMax(t *testing.T) {
 func TestBmmEngineHoldsTheCapWhenTheOperatorAsks(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 12_500
-	require.NoError(t, engine.Start(testSidechain, "", 100_000, true))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 100_000, true))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -404,7 +435,7 @@ func TestBmmEngineHoldsTheCapWhenTheOperatorAsks(t *testing.T) {
 func TestBmmEngineRaisesPastTheBlockWorth(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 1_000
-	require.NoError(t, engine.Start(testSidechain, "", 100_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 100_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -418,7 +449,7 @@ func TestBmmEngineRaisesPastTheBlockWorth(t *testing.T) {
 func TestBmmEngineRecordsAFailedBid(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.bidErr = errors.New("no block template")
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
@@ -430,7 +461,7 @@ func TestBmmEngineRecordsAFailedBid(t *testing.T) {
 
 func TestBmmEngineStopEndsBidding(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -447,8 +478,8 @@ func TestBmmEngineStopEndsBidding(t *testing.T) {
 
 func TestBmmEngineRejectsBadBounds(t *testing.T) {
 	engine, _, _, _ := newEngine(t)
-	require.Error(t, engine.Start(testSidechain, "", 0, false), "a ceiling of zero bids nothing")
-	require.Error(t, engine.Start(testSidechain, "", -1, false), "a negative ceiling is not a bid")
+	require.Error(t, engine.Start(context.Background(), testSidechain, "", 0, false), "a ceiling of zero bids nothing")
+	require.Error(t, engine.Start(context.Background(), testSidechain, "", -1, false), "a negative ceiling is not a bid")
 }
 
 // Core names the rate, so a caller that wants a cheaper bid cannot have one.
@@ -476,7 +507,7 @@ func TestBmmEngineOpensAtTheRelayMinimumWithoutAnEstimate(t *testing.T) {
 func TestBmmEngineOpensByRateNotByAmount(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
 	engine.fee.(*fakeFee).set(42)
-	require.NoError(t, engine.Start(testSidechain, "", 100_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 100_000, false))
 	tip.set("main-1")
 
 	engine.tick(context.Background())
@@ -490,7 +521,7 @@ func TestBmmEngineOpensByRateNotByAmount(t *testing.T) {
 // mainchain block carried the commitment. We must name that block.
 func TestBmmEngineNamesTheMainBlockOnConnect(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -508,7 +539,7 @@ func TestBmmEngineNamesTheMainBlockOnConnect(t *testing.T) {
 // connect on that block, not on the tip.
 func TestBmmEngineWinsARoundTheTipOutran(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -531,7 +562,7 @@ func TestBmmEngineWinsARoundTheTipOutran(t *testing.T) {
 // written down, so a restart can still resume it.
 func TestBmmEngineHoldsAnUndecidableRound(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -552,7 +583,7 @@ func TestBmmEngineHoldsAnUndecidableRound(t *testing.T) {
 // the bid, not connected blind on whatever the tip is by then.
 func TestBmmEngineDecidesAParkedRoundOnRetry(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -575,7 +606,7 @@ func TestBmmEngineDecidesAParkedRoundOnRetry(t *testing.T) {
 // must never be written down as a loss.
 func TestBmmEngineNeverCallsAnUndecidableRoundLost(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -596,7 +627,7 @@ func TestBmmEngineNeverCallsAnUndecidableRoundLost(t *testing.T) {
 // History is on disk, so a restart keeps what past rounds cost and earned.
 func TestBmmEngineHistorySurvivesRestart(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -619,7 +650,7 @@ func TestBmmEngineHistorySurvivesRestart(t *testing.T) {
 // stalls until somebody notices and starts it by hand.
 func TestBmmEngineResumesItsTargetAfterRestart(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "spender", 10_000, true))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "spender", 10_000, true))
 
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
 	running, _, _ := restarted.Running(testSidechain)
@@ -638,7 +669,7 @@ func TestBmmEngineResumesItsTargetAfterRestart(t *testing.T) {
 // Stop is a decision, so it must outlive the process too.
 func TestBmmEngineForgetsAStoppedTargetAfterRestart(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 	require.NoError(t, engine.Stop(testSidechain))
 
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
@@ -652,7 +683,7 @@ func TestBmmEngineForgetsAStoppedTargetAfterRestart(t *testing.T) {
 
 func TestBmmEngineClearHistory(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -680,7 +711,7 @@ func mustHistory(t *testing.T, engine *BmmEngine) []bmmstate.Round {
 // the connect back up rather than forfeit it.
 func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -709,7 +740,7 @@ func TestBmmEngineResumesAWonBlockThatNeverConnected(t *testing.T) {
 
 func TestBmmEngineRecordsBlockHeights(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -733,7 +764,7 @@ func TestBmmEngineIgnoresBidsFromAnotherRound(t *testing.T) {
 	backend.others = []*bmmpb.Bid{
 		{Txid: "stale", CriticalHash: "stale-h", BidSats: 80_000, PrevMainHash: "block-0"},
 	}
-	require.NoError(t, engine.Start(testSidechain, "", 50_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 50_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -747,7 +778,7 @@ func TestBmmEngineIgnoresBidsFromAnotherRound(t *testing.T) {
 // not caught up cannot spend on an already-dead round.
 func TestBmmEngineNamesTheTipItExpects(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
@@ -759,7 +790,7 @@ func TestBmmEngineNamesTheTipItExpects(t *testing.T) {
 func TestBmmEngineCapsTheOpeningBidToBlockWorth(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 8_000
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, true))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, true))
 
 	engine.tick(context.Background())
 
@@ -771,7 +802,7 @@ func TestBmmEngineCapsTheOpeningBidToBlockWorth(t *testing.T) {
 func TestBmmEngineOpensAtTheCeilingWithNoCap(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.feesSats = 8_000
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
@@ -781,7 +812,7 @@ func TestBmmEngineOpensAtTheCeilingWithNoCap(t *testing.T) {
 // Stop ends bidding, but a bid already broadcast still has to settle.
 func TestBmmEngineSettlesAfterStop(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -801,14 +832,14 @@ func TestBmmEngineSettlesAfterStop(t *testing.T) {
 // Restarting must not re-open a round already in play and double-bid it.
 func TestBmmEngineRestartDoesNotDoubleBidTheSameRound(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
 	require.Equal(t, 1, backend.bids)
 
 	require.NoError(t, engine.Stop(testSidechain))
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 	engine.tick(ctx)
 
 	assert.Equal(t, 1, backend.bids, "same tip, still one bid")
@@ -818,7 +849,7 @@ func TestBmmEngineRestartDoesNotDoubleBidTheSameRound(t *testing.T) {
 // stop us connecting a block we may already have paid for.
 func TestBmmEngineKeepsRoundPendingWhenTheCommitmentCannotBeRead(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -844,7 +875,7 @@ func TestBmmEngineKeepsRoundPendingWhenTheCommitmentCannotBeRead(t *testing.T) {
 func TestBmmEngineCurrentIsADeepCopy(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.others = []*bmmpb.Bid{{Txid: "rival", BidSats: 5_000, PrevMainHash: "block-1"}}
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	engine.tick(context.Background())
 
@@ -872,7 +903,7 @@ func roundOn(t *testing.T, engine *BmmEngine, tip string) bmmstate.Round {
 // the bid we already broadcast can still win.
 func TestBmmEngineDoesNotSettleAnOpenRoundOnStop(t *testing.T) {
 	engine, _, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -894,7 +925,7 @@ func TestBmmEngineDoesNotSettleAnOpenRoundOnStop(t *testing.T) {
 func TestBmmEngineRetriesAfterAPreconditionRefusal(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.bidErr = connect.NewError(connect.CodeFailedPrecondition, errors.New("enforcer is still syncing"))
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -914,7 +945,7 @@ func TestBmmEngineRetriesAfterAPreconditionRefusal(t *testing.T) {
 func TestBmmEngineDoesNotRetryOtherFailures(t *testing.T) {
 	engine, backend, _, _ := newEngine(t)
 	backend.bidErr = errors.New("no block template")
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -932,7 +963,7 @@ func TestBmmEngineDoesNotRetryOtherFailures(t *testing.T) {
 // spends its change inherits that. The next opening bid must replace it.
 func TestBmmEngineReplacesAStrandedBid(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -957,7 +988,7 @@ func TestBmmEngineReplacesWithTheFundingWallet(t *testing.T) {
 	for _, walletID := range []string{"core-wallet", "electrum-wallet"} {
 		t.Run(walletID, func(t *testing.T) {
 			engine, backend, tip, _ := newEngine(t)
-			require.NoError(t, engine.Start(testSidechain, walletID, 20_000, false))
+			require.NoError(t, engine.Start(context.Background(), testSidechain, walletID, 20_000, false))
 
 			ctx := context.Background()
 			engine.tick(ctx)
@@ -980,7 +1011,7 @@ func TestBmmEngineReplacesWithTheFundingWallet(t *testing.T) {
 // rather than respend inputs that are already gone.
 func TestBmmEngineOpensFreelyWhenNoBidIsStranded(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -998,7 +1029,7 @@ func TestBmmEngineOpensFreelyWhenNoBidIsStranded(t *testing.T) {
 // leave it looking live.
 func TestBmmEngineRecordsAStrandedBidAsReplaced(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1031,7 +1062,7 @@ func TestBmmEngineRecordsAStrandedBidAsReplaced(t *testing.T) {
 // which evicts every bid chained to it.
 func TestBmmEngineReplacesAStrandedBidAfterRestart(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "core-wallet", 20_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "core-wallet", 20_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1052,7 +1083,7 @@ func TestBmmEngineReplacesAStrandedBidAfterRestart(t *testing.T) {
 	backend.mu.Unlock()
 
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
-	require.NoError(t, restarted.Start(testSidechain, "core-wallet", 20_000, false))
+	require.NoError(t, restarted.Start(context.Background(), testSidechain, "core-wallet", 20_000, false))
 
 	tip.set("block-4")
 	restarted.tick(ctx)
@@ -1206,7 +1237,7 @@ func TestBmmEngineBoundsARepeatedRefusal(t *testing.T) {
 // get the whole bound for the connect, or one wait forfeits a paid block.
 func TestBmmEngineGivesAWonRoundAFreshBudget(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1288,7 +1319,7 @@ func pendingCount(engine *BmmEngine) int {
 // on that tip pays twice, and the engine then raises against its own bid.
 func TestBmmEngineResumesWithoutBiddingTwiceOnTheSameTip(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1310,7 +1341,7 @@ func TestBmmEngineResumesWithoutBiddingTwiceOnTheSameTip(t *testing.T) {
 func TestBmmEngineSavesARaise(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
 	backend.feesSats = 50_000
-	require.NoError(t, engine.Start(testSidechain, "", 30_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 30_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1329,7 +1360,7 @@ func TestBmmEngineSavesARaise(t *testing.T) {
 // the whole budget before the tip moves, and the engine forgets a paid block.
 func TestBmmEngineResumesTheLiveRoundAsCurrent(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 	engine.tick(context.Background())
 
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, tip, newFakeFee(), store)
@@ -1346,7 +1377,7 @@ func TestBmmEngineResumesTheLiveRoundAsCurrent(t *testing.T) {
 // with no tip, and its next tick would bid a second time on the same parent.
 func TestBmmEngineKeepsTheLiveRoundThroughClearHistory(t *testing.T) {
 	engine, backend, tip, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1370,11 +1401,11 @@ func TestBmmEngineKeepsTheLiveRoundThroughClearHistory(t *testing.T) {
 // not stop the bidding the operator already asked for.
 func TestBmmEngineKeepsBiddingWhenAnUpdateCannotBeSaved(t *testing.T) {
 	engine, backend, _, store := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "first", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "first", 10_000, false))
 
 	// A directory that does not exist makes every later write fail.
 	store.Rebind(filepath.Join(t.TempDir(), "gone"))
-	require.Error(t, engine.Start(testSidechain, "second", 20_000, false))
+	require.Error(t, engine.Start(context.Background(), testSidechain, "second", 20_000, false))
 
 	running, wallet, maxBid := engine.Running(testSidechain)
 	assert.True(t, running, "an update that cannot be saved leaves the old target bidding")
@@ -1389,7 +1420,7 @@ func TestBmmEngineKeepsBiddingWhenAnUpdateCannotBeSaved(t *testing.T) {
 // The target leaves memory before the disk write, so no window stays open.
 func TestBmmEngineStopsBeforeTheDiskWrite(t *testing.T) {
 	engine, backend, tip, _ := newEngine(t)
-	require.NoError(t, engine.Start(testSidechain, "", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
 
 	ctx := context.Background()
 	engine.tick(ctx)
@@ -1409,7 +1440,7 @@ func TestBmmEngineKeepsBiddingWhenAStopCannotBeSaved(t *testing.T) {
 	engine, _, _, store := newEngine(t)
 	dir := t.TempDir()
 	store.Rebind(dir)
-	require.NoError(t, engine.Start(testSidechain, "spender", 10_000, false))
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "spender", 10_000, false))
 
 	// The target is on disk and in the store's cache. Taking the directory
 	// away makes the delete fail on its write.
@@ -1419,4 +1450,135 @@ func TestBmmEngineKeepsBiddingWhenAStopCannotBeSaved(t *testing.T) {
 	running, wallet, _ := engine.Running(testSidechain)
 	assert.True(t, running, "the stop never reached the disk, so nothing changed")
 	assert.Equal(t, "spender", wallet)
+}
+
+// The wallet must hold one bid coin per sidechain before the round opens, so a
+// new sidechain gets its coin at once rather than after the next block.
+func TestBmmEngineStartPreparesTheCoins(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "spender", 20_000, false))
+
+	assert.Equal(t, 1, backend.prepares)
+	require.NotNil(t, backend.lastPrepare)
+	require.Len(t, backend.lastPrepare.Targets, 1)
+	assert.Equal(t, "spender", backend.lastPrepare.Targets[0].WalletId)
+	assert.Equal(t, int64(20_000), backend.lastPrepare.Targets[0].MaxBidSats)
+}
+
+// The coin count can fall at any time, so the engine counts again on every new
+// tip. A count on every tick would scan the wallet 30 times a minute.
+func TestBmmEnginePreparesTheCoinsOncePerTip(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	ctx := context.Background()
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 20_000, false))
+	backend.prepares = 0
+
+	engine.tick(ctx)
+	engine.tick(ctx)
+	assert.Equal(t, 1, backend.prepares, "the same tip counts once")
+
+	tip.set("block-2")
+	engine.tick(ctx)
+	assert.Equal(t, 2, backend.prepares, "a new tip counts again")
+}
+
+// Every sidechain that bids names its wallet and its ceiling, so the handler
+// can join the targets that spend one wallet.
+func TestBmmEngineNamesEverySidechainThatBids(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	ctx := context.Background()
+
+	require.NoError(t, engine.Start(ctx, testSidechain, "shared", 20_000, false))
+	require.NoError(t, engine.Start(ctx, pb.BinaryType_BINARY_TYPE_BITNAMES, "shared", 45_000, false))
+
+	require.NotNil(t, backend.lastPrepare)
+	require.Len(t, backend.lastPrepare.Targets, 2)
+	ceilings := lo.Map(backend.lastPrepare.Targets, func(t *bmmpb.PrepareBMMTarget, _ int) int64 {
+		return t.MaxBidSats
+	})
+	assert.ElementsMatch(t, []int64{20_000, 45_000}, ceilings)
+}
+
+// A stopped engine spends nothing, so it must not scan the wallet either.
+func TestBmmEngineNeverPreparesWithoutATarget(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	ctx := context.Background()
+
+	engine.tick(ctx)
+	tip.set("block-2")
+	engine.tick(ctx)
+
+	assert.Zero(t, backend.prepares)
+}
+
+// A wallet the backend cannot prepare still bids: every round that finds no
+// coin of its own says so on the round.
+func TestBmmEngineKeepsBiddingWhenPrepareFails(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.prepareErr = errors.New("core is unreachable")
+	ctx := context.Background()
+
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 20_000, false))
+	engine.tick(ctx)
+
+	assert.Equal(t, 1, backend.bids)
+}
+
+// A backend that fails one count must not cost the sidechains the whole block.
+// The engine counts again on the same tip, a bounded number of times.
+func TestBmmEngineRetriesAFailedPrepareOnTheSameTip(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.prepareErr = errors.New("core is unreachable")
+	ctx := context.Background()
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 20_000, false))
+	require.Equal(t, 1, backend.prepares, "the start counts once")
+
+	engine.tick(ctx)
+	assert.Equal(t, 2, backend.prepares, "a failed count runs again on the same tip")
+
+	for range 5 {
+		engine.tick(ctx)
+	}
+	assert.Equal(t, 1+bmmPrepareTries, backend.prepares,
+		"the start counts once, and the tip pays for a bounded number more")
+
+	backend.mu.Lock()
+	backend.prepareErr = nil
+	backend.mu.Unlock()
+	engine.tick(ctx)
+	assert.Equal(t, 1+bmmPrepareTries, backend.prepares, "the tip spent its counts")
+}
+
+// A split the mempool drops leaves the wallet short again. The tip counts once
+// more rather than waiting for the next block.
+func TestBmmEngineCountsAgainWhileTheWalletIsShort(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.shortCoins = true
+	ctx := context.Background()
+
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 20_000, false))
+	require.Equal(t, 1, backend.prepares, "the start counts once")
+
+	engine.tick(ctx)
+	assert.Equal(t, 2, backend.prepares, "a wallet short of coins counts again")
+}
+
+// A sidechain that starts mid-block gets its coin count, even when the tip
+// already spent its counts on the sidechains that bid before it.
+func TestBmmEngineStartGivesTheTipItsCountsBack(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	ctx := context.Background()
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 20_000, false))
+	engine.tick(ctx)
+	before := backend.prepares
+
+	require.NoError(t, engine.Start(ctx, pb.BinaryType_BINARY_TYPE_BITNAMES, "", 20_000, false))
+	assert.Equal(t, before+1, backend.prepares, "the new sidechain counts at once")
+
+	backend.mu.Lock()
+	backend.prepareErr = errors.New("core is unreachable")
+	backend.mu.Unlock()
+	engine.tick(ctx)
+	assert.Equal(t, before+2, backend.prepares, "the tip counts again after the start")
 }

--- a/sidechain-orchestrator/engines/bmm_mode_test.go
+++ b/sidechain-orchestrator/engines/bmm_mode_test.go
@@ -17,8 +17,8 @@ func TestBmmEnginePausesWhenBackendIsUnavailable(t *testing.T) {
 			engine, backend, tip, store := newEngine(t)
 			fee := newFakeFee()
 			engine.fee = fee
-			require.NoError(t, engine.Start(testSidechain, "wallet", 20000, false))
 			ctx := context.Background()
+			require.NoError(t, engine.Start(ctx, testSidechain, "wallet", 20000, false))
 			engine.tick(ctx)
 			backend.commitment = "critical"
 			backend.noInclusion = true

--- a/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
+++ b/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
@@ -1202,6 +1202,222 @@ func (x *ListBidsResponse) GetBids() []*Bid {
 	return nil
 }
 
+type PrepareBMMRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The sidechains that bid now. Each one needs a coin of its own.
+	Targets       []*PrepareBMMTarget `protobuf:"bytes,1,rep,name=targets,proto3" json:"targets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareBMMRequest) Reset() {
+	*x = PrepareBMMRequest{}
+	mi := &file_bmm_v1_bmm_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareBMMRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareBMMRequest) ProtoMessage() {}
+
+func (x *PrepareBMMRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bmm_v1_bmm_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareBMMRequest.ProtoReflect.Descriptor instead.
+func (*PrepareBMMRequest) Descriptor() ([]byte, []int) {
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *PrepareBMMRequest) GetTargets() []*PrepareBMMTarget {
+	if x != nil {
+		return x.Targets
+	}
+	return nil
+}
+
+// PrepareBMMTarget is one sidechain that bids.
+type PrepareBMMTarget struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Wallet that funds its bids. Empty uses the active wallet.
+	WalletId string `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	// Ceiling one of its bids may pay, in sats. It sizes the coin.
+	MaxBidSats    int64 `protobuf:"varint,2,opt,name=max_bid_sats,json=maxBidSats,proto3" json:"max_bid_sats,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareBMMTarget) Reset() {
+	*x = PrepareBMMTarget{}
+	mi := &file_bmm_v1_bmm_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareBMMTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareBMMTarget) ProtoMessage() {}
+
+func (x *PrepareBMMTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_bmm_v1_bmm_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareBMMTarget.ProtoReflect.Descriptor instead.
+func (*PrepareBMMTarget) Descriptor() ([]byte, []int) {
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *PrepareBMMTarget) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *PrepareBMMTarget) GetMaxBidSats() int64 {
+	if x != nil {
+		return x.MaxBidSats
+	}
+	return 0
+}
+
+type PrepareBMMResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// One entry per wallet the targets name, with aliases of one wallet joined.
+	Wallets       []*PrepareBMMWallet `protobuf:"bytes,1,rep,name=wallets,proto3" json:"wallets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareBMMResponse) Reset() {
+	*x = PrepareBMMResponse{}
+	mi := &file_bmm_v1_bmm_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareBMMResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareBMMResponse) ProtoMessage() {}
+
+func (x *PrepareBMMResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bmm_v1_bmm_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareBMMResponse.ProtoReflect.Descriptor instead.
+func (*PrepareBMMResponse) Descriptor() ([]byte, []int) {
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *PrepareBMMResponse) GetWallets() []*PrepareBMMWallet {
+	if x != nil {
+		return x.Wallets
+	}
+	return nil
+}
+
+type PrepareBMMWallet struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	WalletId string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	// Coins the wallet holds that a sidechain can bid many rounds from.
+	UsableCoins int32 `protobuf:"varint,2,opt,name=usable_coins,json=usableCoins,proto3" json:"usable_coins,omitempty"`
+	// Coins the sidechains that spend this wallet need, one each.
+	WantedCoins int32 `protobuf:"varint,3,opt,name=wanted_coins,json=wantedCoins,proto3" json:"wanted_coins,omitempty"`
+	// Transaction that pays the missing coins. Empty when none was necessary.
+	SplitTxid     string `protobuf:"bytes,4,opt,name=split_txid,json=splitTxid,proto3" json:"split_txid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareBMMWallet) Reset() {
+	*x = PrepareBMMWallet{}
+	mi := &file_bmm_v1_bmm_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareBMMWallet) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareBMMWallet) ProtoMessage() {}
+
+func (x *PrepareBMMWallet) ProtoReflect() protoreflect.Message {
+	mi := &file_bmm_v1_bmm_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareBMMWallet.ProtoReflect.Descriptor instead.
+func (*PrepareBMMWallet) Descriptor() ([]byte, []int) {
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *PrepareBMMWallet) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *PrepareBMMWallet) GetUsableCoins() int32 {
+	if x != nil {
+		return x.UsableCoins
+	}
+	return 0
+}
+
+func (x *PrepareBMMWallet) GetWantedCoins() int32 {
+	if x != nil {
+		return x.WantedCoins
+	}
+	return 0
+}
+
+func (x *PrepareBMMWallet) GetSplitTxid() string {
+	if x != nil {
+		return x.SplitTxid
+	}
+	return ""
+}
+
 var File_bmm_v1_bmm_proto protoreflect.FileDescriptor
 
 const file_bmm_v1_bmm_proto_rawDesc = "" +
@@ -1294,7 +1510,21 @@ const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\x0fListBidsRequest\x129\n" +
 	"\tsidechain\x18\x01 \x01(\x0e2\x1b.orchestrator.v1.BinaryTypeR\tsidechain\"3\n" +
 	"\x10ListBidsResponse\x12\x1f\n" +
-	"\x04bids\x18\x01 \x03(\v2\v.bmm.v1.BidR\x04bids2\x89\x04\n" +
+	"\x04bids\x18\x01 \x03(\v2\v.bmm.v1.BidR\x04bids\"G\n" +
+	"\x11PrepareBMMRequest\x122\n" +
+	"\atargets\x18\x01 \x03(\v2\x18.bmm.v1.PrepareBMMTargetR\atargets\"Q\n" +
+	"\x10PrepareBMMTarget\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12 \n" +
+	"\fmax_bid_sats\x18\x02 \x01(\x03R\n" +
+	"maxBidSats\"H\n" +
+	"\x12PrepareBMMResponse\x122\n" +
+	"\awallets\x18\x01 \x03(\v2\x18.bmm.v1.PrepareBMMWalletR\awallets\"\x94\x01\n" +
+	"\x10PrepareBMMWallet\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12!\n" +
+	"\fusable_coins\x18\x02 \x01(\x05R\vusableCoins\x12!\n" +
+	"\fwanted_coins\x18\x03 \x01(\x05R\vwantedCoins\x12\x1d\n" +
+	"\n" +
+	"split_txid\x18\x04 \x01(\tR\tsplitTxid2\xce\x04\n" +
 	"\n" +
 	"BMMService\x124\n" +
 	"\x05Start\x12\x14.bmm.v1.StartRequest\x1a\x15.bmm.v1.StartResponse\x121\n" +
@@ -1305,7 +1535,9 @@ const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\tCreateBid\x12\x18.bmm.v1.CreateBidRequest\x1a\x19.bmm.v1.CreateBidResponse\x12C\n" +
 	"\n" +
 	"ConnectBid\x12\x19.bmm.v1.ConnectBidRequest\x1a\x1a.bmm.v1.ConnectBidResponse\x12=\n" +
-	"\bListBids\x12\x17.bmm.v1.ListBidsRequest\x1a\x18.bmm.v1.ListBidsResponseB\x9a\x01\n" +
+	"\bListBids\x12\x17.bmm.v1.ListBidsRequest\x1a\x18.bmm.v1.ListBidsResponse\x12C\n" +
+	"\n" +
+	"PrepareBMM\x12\x19.bmm.v1.PrepareBMMRequest\x1a\x1a.bmm.v1.PrepareBMMResponseB\x9a\x01\n" +
 	"\n" +
 	"com.bmm.v1B\bBmmProtoP\x01ZIgithub.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1;bmmv1\xa2\x02\x03BXX\xaa\x02\x06Bmm.V1\xca\x02\x06Bmm\\V1\xe2\x02\x12Bmm\\V1\\GPBMetadata\xea\x02\aBmm::V1b\x06proto3"
 
@@ -1321,7 +1553,7 @@ func file_bmm_v1_bmm_proto_rawDescGZIP() []byte {
 	return file_bmm_v1_bmm_proto_rawDescData
 }
 
-var file_bmm_v1_bmm_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_bmm_v1_bmm_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_bmm_v1_bmm_proto_goTypes = []any{
 	(*StartRequest)(nil),         // 0: bmm.v1.StartRequest
 	(*StartResponse)(nil),        // 1: bmm.v1.StartResponse
@@ -1341,44 +1573,52 @@ var file_bmm_v1_bmm_proto_goTypes = []any{
 	(*ConnectBidResponse)(nil),   // 15: bmm.v1.ConnectBidResponse
 	(*ListBidsRequest)(nil),      // 16: bmm.v1.ListBidsRequest
 	(*ListBidsResponse)(nil),     // 17: bmm.v1.ListBidsResponse
-	(v1.BinaryType)(0),           // 18: orchestrator.v1.BinaryType
+	(*PrepareBMMRequest)(nil),    // 18: bmm.v1.PrepareBMMRequest
+	(*PrepareBMMTarget)(nil),     // 19: bmm.v1.PrepareBMMTarget
+	(*PrepareBMMResponse)(nil),   // 20: bmm.v1.PrepareBMMResponse
+	(*PrepareBMMWallet)(nil),     // 21: bmm.v1.PrepareBMMWallet
+	(v1.BinaryType)(0),           // 22: orchestrator.v1.BinaryType
 }
 var file_bmm_v1_bmm_proto_depIdxs = []int32{
-	18, // 0: bmm.v1.StartRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	18, // 1: bmm.v1.StopRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	18, // 2: bmm.v1.ClearHistoryRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	18, // 3: bmm.v1.WatchRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 0: bmm.v1.StartRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 1: bmm.v1.StopRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 2: bmm.v1.ClearHistoryRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 3: bmm.v1.WatchRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	8,  // 4: bmm.v1.WatchResponse.current:type_name -> bmm.v1.Round
 	8,  // 5: bmm.v1.WatchResponse.history:type_name -> bmm.v1.Round
 	9,  // 6: bmm.v1.Round.our_bids:type_name -> bmm.v1.Bid
 	9,  // 7: bmm.v1.Round.other_bids:type_name -> bmm.v1.Bid
-	18, // 8: bmm.v1.GetRoundBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 8: bmm.v1.GetRoundBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	8,  // 9: bmm.v1.GetRoundBidsResponse.round:type_name -> bmm.v1.Round
-	18, // 10: bmm.v1.CreateBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	18, // 11: bmm.v1.ConnectBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	18, // 12: bmm.v1.ListBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 10: bmm.v1.CreateBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 11: bmm.v1.ConnectBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	22, // 12: bmm.v1.ListBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	9,  // 13: bmm.v1.ListBidsResponse.bids:type_name -> bmm.v1.Bid
-	0,  // 14: bmm.v1.BMMService.Start:input_type -> bmm.v1.StartRequest
-	2,  // 15: bmm.v1.BMMService.Stop:input_type -> bmm.v1.StopRequest
-	4,  // 16: bmm.v1.BMMService.ClearHistory:input_type -> bmm.v1.ClearHistoryRequest
-	6,  // 17: bmm.v1.BMMService.Watch:input_type -> bmm.v1.WatchRequest
-	10, // 18: bmm.v1.BMMService.GetRoundBids:input_type -> bmm.v1.GetRoundBidsRequest
-	12, // 19: bmm.v1.BMMService.CreateBid:input_type -> bmm.v1.CreateBidRequest
-	14, // 20: bmm.v1.BMMService.ConnectBid:input_type -> bmm.v1.ConnectBidRequest
-	16, // 21: bmm.v1.BMMService.ListBids:input_type -> bmm.v1.ListBidsRequest
-	1,  // 22: bmm.v1.BMMService.Start:output_type -> bmm.v1.StartResponse
-	3,  // 23: bmm.v1.BMMService.Stop:output_type -> bmm.v1.StopResponse
-	5,  // 24: bmm.v1.BMMService.ClearHistory:output_type -> bmm.v1.ClearHistoryResponse
-	7,  // 25: bmm.v1.BMMService.Watch:output_type -> bmm.v1.WatchResponse
-	11, // 26: bmm.v1.BMMService.GetRoundBids:output_type -> bmm.v1.GetRoundBidsResponse
-	13, // 27: bmm.v1.BMMService.CreateBid:output_type -> bmm.v1.CreateBidResponse
-	15, // 28: bmm.v1.BMMService.ConnectBid:output_type -> bmm.v1.ConnectBidResponse
-	17, // 29: bmm.v1.BMMService.ListBids:output_type -> bmm.v1.ListBidsResponse
-	22, // [22:30] is the sub-list for method output_type
-	14, // [14:22] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	19, // 14: bmm.v1.PrepareBMMRequest.targets:type_name -> bmm.v1.PrepareBMMTarget
+	21, // 15: bmm.v1.PrepareBMMResponse.wallets:type_name -> bmm.v1.PrepareBMMWallet
+	0,  // 16: bmm.v1.BMMService.Start:input_type -> bmm.v1.StartRequest
+	2,  // 17: bmm.v1.BMMService.Stop:input_type -> bmm.v1.StopRequest
+	4,  // 18: bmm.v1.BMMService.ClearHistory:input_type -> bmm.v1.ClearHistoryRequest
+	6,  // 19: bmm.v1.BMMService.Watch:input_type -> bmm.v1.WatchRequest
+	10, // 20: bmm.v1.BMMService.GetRoundBids:input_type -> bmm.v1.GetRoundBidsRequest
+	12, // 21: bmm.v1.BMMService.CreateBid:input_type -> bmm.v1.CreateBidRequest
+	14, // 22: bmm.v1.BMMService.ConnectBid:input_type -> bmm.v1.ConnectBidRequest
+	16, // 23: bmm.v1.BMMService.ListBids:input_type -> bmm.v1.ListBidsRequest
+	18, // 24: bmm.v1.BMMService.PrepareBMM:input_type -> bmm.v1.PrepareBMMRequest
+	1,  // 25: bmm.v1.BMMService.Start:output_type -> bmm.v1.StartResponse
+	3,  // 26: bmm.v1.BMMService.Stop:output_type -> bmm.v1.StopResponse
+	5,  // 27: bmm.v1.BMMService.ClearHistory:output_type -> bmm.v1.ClearHistoryResponse
+	7,  // 28: bmm.v1.BMMService.Watch:output_type -> bmm.v1.WatchResponse
+	11, // 29: bmm.v1.BMMService.GetRoundBids:output_type -> bmm.v1.GetRoundBidsResponse
+	13, // 30: bmm.v1.BMMService.CreateBid:output_type -> bmm.v1.CreateBidResponse
+	15, // 31: bmm.v1.BMMService.ConnectBid:output_type -> bmm.v1.ConnectBidResponse
+	17, // 32: bmm.v1.BMMService.ListBids:output_type -> bmm.v1.ListBidsResponse
+	20, // 33: bmm.v1.BMMService.PrepareBMM:output_type -> bmm.v1.PrepareBMMResponse
+	25, // [25:34] is the sub-list for method output_type
+	16, // [16:25] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_bmm_v1_bmm_proto_init() }
@@ -1392,7 +1632,7 @@ func file_bmm_v1_bmm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bmm_v1_bmm_proto_rawDesc), len(file_bmm_v1_bmm_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/bmm/v1/bmmv1connect/bmm.connect.go
+++ b/sidechain-orchestrator/gen/bmm/v1/bmmv1connect/bmm.connect.go
@@ -49,6 +49,8 @@ const (
 	BMMServiceConnectBidProcedure = "/bmm.v1.BMMService/ConnectBid"
 	// BMMServiceListBidsProcedure is the fully-qualified name of the BMMService's ListBids RPC.
 	BMMServiceListBidsProcedure = "/bmm.v1.BMMService/ListBids"
+	// BMMServicePrepareBMMProcedure is the fully-qualified name of the BMMService's PrepareBMM RPC.
+	BMMServicePrepareBMMProcedure = "/bmm.v1.BMMService/PrepareBMM"
 )
 
 // BMMServiceClient is a client for the bmm.v1.BMMService service.
@@ -75,6 +77,11 @@ type BMMServiceClient interface {
 	// ListBids reads the competing bids for the slot out of the mainchain
 	// mempool, highest bid first.
 	ListBids(context.Context, *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error)
+	// PrepareBMM gives every bidding sidechain a coin of its own to bid from,
+	// and splits one large coin when the wallet holds too few. One wallet funds
+	// them all, and a bid over another slot's bid change dies when that slot
+	// replaces its own bid.
+	PrepareBMM(context.Context, *connect.Request[v1.PrepareBMMRequest]) (*connect.Response[v1.PrepareBMMResponse], error)
 }
 
 // NewBMMServiceClient constructs a client for the bmm.v1.BMMService service. By default, it uses
@@ -136,6 +143,12 @@ func NewBMMServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 			connect.WithSchema(bMMServiceMethods.ByName("ListBids")),
 			connect.WithClientOptions(opts...),
 		),
+		prepareBMM: connect.NewClient[v1.PrepareBMMRequest, v1.PrepareBMMResponse](
+			httpClient,
+			baseURL+BMMServicePrepareBMMProcedure,
+			connect.WithSchema(bMMServiceMethods.ByName("PrepareBMM")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -149,6 +162,7 @@ type bMMServiceClient struct {
 	createBid    *connect.Client[v1.CreateBidRequest, v1.CreateBidResponse]
 	connectBid   *connect.Client[v1.ConnectBidRequest, v1.ConnectBidResponse]
 	listBids     *connect.Client[v1.ListBidsRequest, v1.ListBidsResponse]
+	prepareBMM   *connect.Client[v1.PrepareBMMRequest, v1.PrepareBMMResponse]
 }
 
 // Start calls bmm.v1.BMMService.Start.
@@ -191,6 +205,11 @@ func (c *bMMServiceClient) ListBids(ctx context.Context, req *connect.Request[v1
 	return c.listBids.CallUnary(ctx, req)
 }
 
+// PrepareBMM calls bmm.v1.BMMService.PrepareBMM.
+func (c *bMMServiceClient) PrepareBMM(ctx context.Context, req *connect.Request[v1.PrepareBMMRequest]) (*connect.Response[v1.PrepareBMMResponse], error) {
+	return c.prepareBMM.CallUnary(ctx, req)
+}
+
 // BMMServiceHandler is an implementation of the bmm.v1.BMMService service.
 type BMMServiceHandler interface {
 	// Start bids on every new mainchain tip and connects the blocks miners take,
@@ -215,6 +234,11 @@ type BMMServiceHandler interface {
 	// ListBids reads the competing bids for the slot out of the mainchain
 	// mempool, highest bid first.
 	ListBids(context.Context, *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error)
+	// PrepareBMM gives every bidding sidechain a coin of its own to bid from,
+	// and splits one large coin when the wallet holds too few. One wallet funds
+	// them all, and a bid over another slot's bid change dies when that slot
+	// replaces its own bid.
+	PrepareBMM(context.Context, *connect.Request[v1.PrepareBMMRequest]) (*connect.Response[v1.PrepareBMMResponse], error)
 }
 
 // NewBMMServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -272,6 +296,12 @@ func NewBMMServiceHandler(svc BMMServiceHandler, opts ...connect.HandlerOption) 
 		connect.WithSchema(bMMServiceMethods.ByName("ListBids")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bMMServicePrepareBMMHandler := connect.NewUnaryHandler(
+		BMMServicePrepareBMMProcedure,
+		svc.PrepareBMM,
+		connect.WithSchema(bMMServiceMethods.ByName("PrepareBMM")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/bmm.v1.BMMService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case BMMServiceStartProcedure:
@@ -290,6 +320,8 @@ func NewBMMServiceHandler(svc BMMServiceHandler, opts ...connect.HandlerOption) 
 			bMMServiceConnectBidHandler.ServeHTTP(w, r)
 		case BMMServiceListBidsProcedure:
 			bMMServiceListBidsHandler.ServeHTTP(w, r)
+		case BMMServicePrepareBMMProcedure:
+			bMMServicePrepareBMMHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -329,4 +361,8 @@ func (UnimplementedBMMServiceHandler) ConnectBid(context.Context, *connect.Reque
 
 func (UnimplementedBMMServiceHandler) ListBids(context.Context, *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bmm.v1.BMMService.ListBids is not implemented"))
+}
+
+func (UnimplementedBMMServiceHandler) PrepareBMM(context.Context, *connect.Request[v1.PrepareBMMRequest]) (*connect.Response[v1.PrepareBMMResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bmm.v1.BMMService.PrepareBMM is not implemented"))
 }

--- a/sidechain-orchestrator/proto/bmm/v1/bmm.proto
+++ b/sidechain-orchestrator/proto/bmm/v1/bmm.proto
@@ -37,6 +37,12 @@ service BMMService {
   // ListBids reads the competing bids for the slot out of the mainchain
   // mempool, highest bid first.
   rpc ListBids(ListBidsRequest) returns (ListBidsResponse);
+
+  // PrepareBMM gives every bidding sidechain a coin of its own to bid from,
+  // and splits one large coin when the wallet holds too few. One wallet funds
+  // them all, and a bid over another slot's bid change dies when that slot
+  // replaces its own bid.
+  rpc PrepareBMM(PrepareBMMRequest) returns (PrepareBMMResponse);
 }
 
 message StartRequest {
@@ -204,4 +210,32 @@ message ListBidsRequest {
 message ListBidsResponse {
   // Highest bid first.
   repeated Bid bids = 1;
+}
+
+message PrepareBMMRequest {
+  // The sidechains that bid now. Each one needs a coin of its own.
+  repeated PrepareBMMTarget targets = 1;
+}
+
+// PrepareBMMTarget is one sidechain that bids.
+message PrepareBMMTarget {
+  // Wallet that funds its bids. Empty uses the active wallet.
+  string wallet_id = 1;
+  // Ceiling one of its bids may pay, in sats. It sizes the coin.
+  int64 max_bid_sats = 2;
+}
+
+message PrepareBMMResponse {
+  // One entry per wallet the targets name, with aliases of one wallet joined.
+  repeated PrepareBMMWallet wallets = 1;
+}
+
+message PrepareBMMWallet {
+  string wallet_id = 1;
+  // Coins the wallet holds that a sidechain can bid many rounds from.
+  int32 usable_coins = 2;
+  // Coins the sidechains that spend this wallet need, one each.
+  int32 wanted_coins = 3;
+  // Transaction that pays the missing coins. Empty when none was necessary.
+  string split_txid = 4;
 }

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -3258,3 +3258,91 @@ func TestReplacedChainIgnoresAnOrdinarySend(t *testing.T) {
 	_, _, ok := replacedChain(scan, []RequiredInput{{TxID: "aa", Vout: 0}})
 	assert.False(t, ok)
 }
+
+// A BMM bid pins the coin of its own sidechain slot. The pin only isolates the
+// slot when selection adds no other coin, because a second coin puts the bid on
+// another slot's lineage and a replacement there evicts it.
+func TestElectrumSendAddsNoCoinBesideACoveringPin(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const slotCoin = "4444444444444444444444444444444444444444444444444444444444444444"
+	const siblingCoin = "5555555555555555555555555555555555555555555555555555555555555555"
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 2, FundedTxoSum: 3_100_000, TxCount: 2},
+	}
+	fake.utxos[addr] = []EsploraUTXO{
+		{TxID: slotCoin, Vout: 0, Value: 100_000, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}},
+		{TxID: siblingCoin, Vout: 0, Value: 3_000_000, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}},
+	}
+
+	txid, err := p.Send(ctx, w.ID, SendRequest{
+		RawOutputs:     []TxOutSpec{{RawScriptHex: "6a04deadbeef", AmountSats: 0}},
+		FixedFeeSats:   10_000,
+		RequiredInputs: []RequiredInput{{TxID: slotCoin, Vout: 0}},
+		Replaceable:    true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "broadcasttxid", txid)
+	require.Len(t, fake.broadcast, 1)
+
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+
+	require.Len(t, tx.TxIn, 1, "the pinned coin covers the bid, so no other coin joins it")
+	assert.Equal(t, slotCoin, tx.TxIn[0].PreviousOutPoint.Hash.String())
+}
+
+// Each BMM slot bids from a coin of its own. A replacement on one slot then
+// respends coins the other slot never touched, so the other slot's bid stays in
+// the mempool and its round runs on.
+func TestElectrumReplacementSparesASiblingOnAnotherCoin(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const (
+		coinOfSlotOne = "1111111111111111111111111111111111111111111111111111111111111111"
+		coinOfSlotTwo = "2222222222222222222222222222222222222222222222222222222222222222"
+		bidOfSlotOne  = "3333333333333333333333333333333333333333333333333333333333333333"
+		bidOfSlotTwo  = "4444444444444444444444444444444444444444444444444444444444444444"
+	)
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 2, FundedTxoSum: 400_000, TxCount: 2},
+	}
+	fake.utxos[addr] = nil
+	fake.txs[addr] = []EsploraTx{
+		{
+			TxID:   bidOfSlotOne,
+			Vin:    []EsploraVin{{TxID: coinOfSlotOne, Vout: 0}},
+			Vout:   []EsploraVout{{ScriptPubKeyAddress: addr, Value: 199_000}},
+			Status: EsploraStatus{Confirmed: false},
+		},
+		{
+			TxID:   bidOfSlotTwo,
+			Vin:    []EsploraVin{{TxID: coinOfSlotTwo, Vout: 0}},
+			Vout:   []EsploraVout{{ScriptPubKeyAddress: addr, Value: 198_000}},
+			Status: EsploraStatus{Confirmed: false},
+		},
+	}
+
+	_, _, err := p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	p.mu.Lock()
+	scan := p.warmScan[w.ID]
+	p.mu.Unlock()
+	require.NotNil(t, scan)
+
+	root, evicted, ok := replacedChain(scan, []RequiredInput{{TxID: coinOfSlotOne, Vout: 0}})
+
+	require.True(t, ok, "the raise replaces the bid over that coin")
+	assert.Equal(t, bidOfSlotOne, root)
+	for _, u := range evicted {
+		assert.NotEqual(t, bidOfSlotTwo, u.txid, "the other slot bids from a coin of its own")
+	}
+}


### PR DESCRIPTION
One wallet funds the bids of five sidechains, and every bid spent the change of the bid before it. A replacement on one slot, from a raise or from a stranded-bid replacement, then evicted the live bids of all the other slots. On the alphanet server four sidechains lost whole rounds this way.

`PrepareBMM` is a new BMM step. It counts the coins one sidechain can bid many rounds from, and pays the missing ones out of the largest coin. It spends that one coin alone, so the coins the other slots bid from stay where they are. It holds a second split back while the first one sits in the mempool.

The engine calls it when a sidechain starts, and one time per new mainchain tip. The coin count can fall at any time: a coin drains, an operator starts one more sidechain, or another send spends one.

`CreateBid` only pins. An opening bid takes the largest coin of its own slot, skips every coin another slot's live M8 created, and passes it as the single required input. Coin selection then adds no other coin. When it finds no coin of its own it answers FailedPrecondition, and the engine opens the round again on the next tick.

A raise keeps the inputs of the transaction it replaces, so that path does not change.