### PR TITLE
Quiet the console during a daemon boot

### DIFF
--- a/bitwindow/lib/providers/hd_wallet_provider.dart
+++ b/bitwindow/lib/providers/hd_wallet_provider.dart
@@ -96,12 +96,10 @@ class HDWalletProvider extends ChangeNotifier implements NetworkScoped {
   }
 
   Future<void> _loadMnemonic() async {
-    log.i('HDWalletProvider: _loadMnemonic start');
     try {
       // Use WalletWriterProvider to load L1 mnemonic (supports both old and new structure)
       final walletProvider = GetIt.I.get<WalletWriterProvider>();
       final l1Mnemonic = await walletProvider.getL1Starter();
-      log.i('HDWalletProvider: getL1Starter returned len=${l1Mnemonic?.length ?? -1}');
 
       if (l1Mnemonic == null || l1Mnemonic.isEmpty) {
         // Electrum wallets have no L1 (enforcer) seed, so the HD Explorer has
@@ -237,7 +235,11 @@ class HDWalletProvider extends ChangeNotifier implements NetworkScoped {
         adjustedPath = path.replaceAll("'0'/", "'1'/");
       }
 
-      final mnemonicObj = Mnemonic.fromSentence(mnemonic, Language.english, passphrase: passphrase);
+      final mnemonicObj = Mnemonic.fromSentence(
+        mnemonic,
+        Language.english,
+        passphrase: passphrase,
+      );
       final seedHex = hex.encode(mnemonicObj.seed);
       final chain = Chain.seed(seedHex);
 
@@ -414,7 +416,10 @@ class HDWalletProvider extends ChangeNotifier implements NetworkScoped {
     }
   }
 
-  Future<Map<String, String>> generateWalletXpub(int accountIndex, [bool isMainnet = false]) async {
+  Future<Map<String, String>> generateWalletXpub(
+    int accountIndex, [
+    bool isMainnet = false,
+  ]) async {
     final coinType = isMainnet ? "0'" : "1'";
     final path = "m/84'/$coinType/$accountIndex'";
 
@@ -438,7 +443,10 @@ class HDWalletProvider extends ChangeNotifier implements NetworkScoped {
     );
   }
 
-  Future<Map<String, String>> deriveKeyInfo(String mnemonic, String path) async {
+  Future<Map<String, String>> deriveKeyInfo(
+    String mnemonic,
+    String path,
+  ) async {
     final isMainnet = GetIt.I.get<BitcoinConfProvider>().usesMainnetParams;
     return deriveExtendedKeyInfo(mnemonic, path, isMainnet);
   }

--- a/bitwindow/server/api/server.go
+++ b/bitwindow/server/api/server.go
@@ -22,6 +22,7 @@ import (
 	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/lease"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitassets"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitnames"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/coinshift"
@@ -317,6 +318,8 @@ func (s *Server) Serve(ctx context.Context, address string) error {
 	protocols.SetUnencryptedHTTP2(true)
 	s.server = &http.Server{
 		ConnState: s.leaseConnState,
+		// A dropped HTTP/2 frame is console noise; a handler panic is not.
+		ErrorLog:  logfile.StdLogger(*log, logfile.TransportNoise),
 		Handler:   s.Handler(),
 		Protocols: protocols,
 		HTTP2:     &http.HTTP2Config{SendPingTimeout: 30 * time.Second},

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -550,7 +550,7 @@ func run(cctx *cli.Context) error {
 		// the frontend actually issues and how slow each is. authIC stays
 		// outermost (auth before metering); meterIC times only the post-auth
 		// handler. Logs a per-method summary every coreMeterInterval.
-		const coreMeterInterval = 30 * time.Second
+		const coreMeterInterval = 5 * time.Minute
 		meterIC := rpcmeter.New(ctx, log, coreMeterInterval).Interceptor()
 
 		swappable := newSwappableHandler()

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -176,6 +176,10 @@ func run(cctx *cli.Context) error {
 		Timestamp().
 		Logger()
 
+	// net/http repeats a refused dial and a dropped frame once a second while a
+	// daemon boots. Only those two drop to debug; a handler panic stays at error.
+	transportLog := logfile.StdLogger(log, logfile.TransportNoise)
+
 	dataDir := cctx.String("datadir")
 	network := cctx.String("network")
 	listenAddr := cctx.String("rpclisten")
@@ -396,7 +400,7 @@ func run(cctx *cli.Context) error {
 	if _, ok := orch.Configs()["enforcer"]; ok {
 		// Enforcer passthrough: sidechain apps funnel all enforcer traffic
 		// through drivechaind instead of dialing the enforcer directly.
-		enforcerBridge := enforcerproxy.ConnectDynamic(orch.EnforcerURL)
+		enforcerBridge := enforcerproxy.ConnectDynamic(orch.EnforcerURL, transportLog)
 		for _, svc := range []string{
 			enforcerrpc.ValidatorServiceName,
 			cryptorpc.CryptoServiceName,
@@ -664,6 +668,7 @@ func run(cctx *cli.Context) error {
 
 	srv := &http.Server{
 		ConnState: clients.ConnState,
+		ErrorLog:  transportLog,
 		Handler:   mux,
 		Protocols: protocols,
 		HTTP2:     &http.HTTP2Config{SendPingTimeout: 30 * time.Second},

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -450,17 +450,17 @@ func (m *ConnectionMonitor) StartConnectionTimer(ctx context.Context) {
 	m.mu.Unlock()
 
 	// Dart L307: immediate first ping
-	m.log.Info().Str("binary", m.Name).Msg("checking connection")
+	m.log.Debug().Str("binary", m.Name).Msg("checking connection")
 	m.testConnection(ctx)
 
 	if m.Connected() {
-		m.log.Info().Str("binary", m.Name).Msg("already running")
+		m.log.Debug().Str("binary", m.Name).Msg("already running")
 	} else {
 		m.log.Info().Str("binary", m.Name).Str("error", m.ConnectionError()).Msg("could not connect")
 	}
 
 	// Dart L317: start 1-second periodic timer
-	m.log.Info().Str("binary", m.Name).Msg("starting connection timer")
+	m.log.Debug().Str("binary", m.Name).Msg("starting connection timer")
 	go func() {
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()

--- a/sidechain-orchestrator/enforcerproxy/enforcerproxy.go
+++ b/sidechain-orchestrator/enforcerproxy/enforcerproxy.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	stdlog "log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -23,8 +24,9 @@ const DefaultJSONRPCAddr = "127.0.0.1:8122"
 
 // Connect reverse-proxies Connect/gRPC requests to the enforcer's main
 // gRPC endpoint, preserving the request path. upstream is e.g.
-// "http://127.0.0.1:50051".
-func Connect(upstream string) (http.Handler, error) {
+// "http://127.0.0.1:50051". errorLog takes the transport failures; a nil
+// errorLog sends them to the standard logger.
+func Connect(upstream string, errorLog *stdlog.Logger) (http.Handler, error) {
 	u, err := url.Parse(upstream)
 	if err != nil {
 		return nil, fmt.Errorf("parse enforcer upstream %q: %w", upstream, err)
@@ -48,11 +50,12 @@ func Connect(upstream string) (http.Handler, error) {
 		},
 		Transport:     transport,
 		FlushInterval: -1,
+		ErrorLog:      errorLog,
 	}, nil
 }
 
 // ConnectDynamic resolves the enforcer endpoint for each request.
-func ConnectDynamic(resolve func() (string, error)) http.Handler {
+func ConnectDynamic(resolve func() (string, error), errorLog *stdlog.Logger) http.Handler {
 	var mu sync.Mutex
 	var current string
 	var handler http.Handler
@@ -64,7 +67,7 @@ func ConnectDynamic(resolve func() (string, error)) http.Handler {
 		}
 		mu.Lock()
 		if handler == nil || upstream != current {
-			next, err := Connect(upstream)
+			next, err := Connect(upstream, errorLog)
 			if err != nil {
 				mu.Unlock()
 				http.Error(w, err.Error(), http.StatusBadGateway)

--- a/sidechain-orchestrator/enforcerproxy/remote.go
+++ b/sidechain-orchestrator/enforcerproxy/remote.go
@@ -3,6 +3,7 @@ package enforcerproxy
 import (
 	"errors"
 	"fmt"
+	stdlog "log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -13,6 +14,7 @@ import (
 
 // Remote serves a remote validator through a loopback h2c listener.
 type Remote struct {
+	errorLog  *stdlog.Logger
 	server    *http.Server
 	listener  net.Listener
 	mu        sync.RWMutex
@@ -30,15 +32,15 @@ func closeIdleConnections(handler http.Handler) {
 }
 
 // NewRemote starts a loopback bridge to the remote enforcer URL.
-func NewRemote(upstream string) (*Remote, error) {
-	proxy, err := Connect(upstream)
+func NewRemote(upstream string, errorLog *stdlog.Logger) (*Remote, error) {
+	proxy, err := Connect(upstream, errorLog)
 	if err != nil {
 		return nil, err
 	}
-	return newRemote(proxy)
+	return newRemote(proxy, errorLog)
 }
 
-func newRemote(proxy http.Handler) (*Remote, error) {
+func newRemote(proxy http.Handler, errorLog *stdlog.Logger) (*Remote, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("listen for remote enforcer: %w", err)
@@ -47,6 +49,7 @@ func newRemote(proxy http.Handler) (*Remote, error) {
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
 	r := &Remote{
+		errorLog: errorLog,
 		listener: listener,
 		proxy:    proxy,
 		done:     make(chan error, 1),
@@ -54,6 +57,7 @@ func newRemote(proxy http.Handler) (*Remote, error) {
 	r.server = &http.Server{
 		Handler:   ValidatorOnly(http.HandlerFunc(r.serveHTTP)),
 		Protocols: protocols,
+		ErrorLog:  errorLog,
 	}
 	go func() {
 		r.done <- r.server.Serve(listener)
@@ -70,7 +74,7 @@ func (r *Remote) serveHTTP(w http.ResponseWriter, request *http.Request) {
 
 // SetUpstream changes the validator endpoint without a listener change.
 func (r *Remote) SetUpstream(upstream string) error {
-	handler, err := Connect(upstream)
+	handler, err := Connect(upstream, r.errorLog)
 	if err != nil {
 		return err
 	}

--- a/sidechain-orchestrator/enforcerproxy/remote_test.go
+++ b/sidechain-orchestrator/enforcerproxy/remote_test.go
@@ -63,12 +63,12 @@ func TestRemoteForwardsTLSAndTrailers(t *testing.T) {
 	upstream.StartTLS()
 	defer upstream.Close()
 
-	proxy, err := Connect(upstream.URL + "/enforcer")
+	proxy, err := Connect(upstream.URL+"/enforcer", nil)
 	require.NoError(t, err)
 	roots := x509.NewCertPool()
 	roots.AddCert(upstream.Certificate())
 	proxy.(*httputil.ReverseProxy).Transport.(*http2.Transport).TLSClientConfig = &tls.Config{RootCAs: roots}
-	remote, err := newRemote(proxy)
+	remote, err := newRemote(proxy, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
 
@@ -93,7 +93,7 @@ func TestRemoteBlocksAdminMethods(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer upstream.Close()
-	remote, err := NewRemote(upstream.URL)
+	remote, err := NewRemote(upstream.URL, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
 
@@ -129,7 +129,7 @@ func TestRemoteCloseStopsSubscriptions(t *testing.T) {
 	}))
 	defer upstream.Close()
 	defer close(release)
-	remote, err := NewRemote(upstream.URL)
+	remote, err := NewRemote(upstream.URL, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
 	response, err := testClient(t).Post(remote.URL()+"/cusf.mainchain.v1.ValidatorService/SubscribeEvents", "application/grpc", nil)
@@ -177,7 +177,7 @@ func TestRemoteSetUpstreamKeepsOldStreamUntilClose(t *testing.T) {
 		require.NoError(t, err)
 	}))
 	defer second.Close()
-	remote, err := NewRemote(first.URL)
+	remote, err := NewRemote(first.URL, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
 	endpoint := remote.URL()
@@ -227,7 +227,7 @@ func TestRemoteSetUpstreamDuringRequests(t *testing.T) {
 	first, second := server("first"), server("second")
 	defer first.Close()
 	defer second.Close()
-	remote, err := NewRemote(first.URL)
+	remote, err := NewRemote(first.URL, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
 	client := testClient(t)
@@ -268,7 +268,7 @@ func TestConnectDynamicChangesEndpoint(t *testing.T) {
 	defer second.Close()
 	url := first.URL
 	var resolveErr error
-	handler := ConnectDynamic(func() (string, error) { return url, resolveErr })
+	handler := ConnectDynamic(func() (string, error) { return url, resolveErr }, nil)
 	for _, test := range []struct {
 		url  string
 		body string
@@ -290,7 +290,7 @@ func TestConnectDynamicChangesEndpoint(t *testing.T) {
 
 func TestConnectRejectsInvalidURLs(t *testing.T) {
 	for _, url := range []string{"", "localhost:50051", "ftp://example.com", "https://user:secret@example.com", "https://example.com?token=x"} {
-		_, err := Connect(url)
+		_, err := Connect(url, nil)
 		require.Error(t, err)
 	}
 }

--- a/sidechain-orchestrator/hwi-daemon/hwi_daemon.py
+++ b/sidechain-orchestrator/hwi-daemon/hwi_daemon.py
@@ -82,10 +82,12 @@ def _with_client(req, fn):
 
 def _handle(req):
     cmd = req["cmd"]
-    _log("cmd=%s type=%s path=%r fp=%r pass=%s" % (
-        cmd, req.get("type"), req.get("device_path"), req.get("fingerprint"),
-        "yes" if req.get("passphrase") else "no",
-    ))
+    # The frontend polls enumerate every few seconds, so it stays out of the log.
+    if cmd != "enumerate":
+        _log("cmd=%s type=%s path=%r fp=%r pass=%s" % (
+            cmd, req.get("type"), req.get("device_path"), req.get("fingerprint"),
+            "yes" if req.get("passphrase") else "no",
+        ))
 
     if cmd == "enumerate":
         return commands.enumerate(password=req.get("passphrase") or "")

--- a/sidechain-orchestrator/logfile/stdlog.go
+++ b/sidechain-orchestrator/logfile/stdlog.go
@@ -1,0 +1,38 @@
+package logfile
+
+import (
+	stdlog "log"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// TransportNoise names the net/http lines a booting daemon repeats once a
+// second: a refused dial through the enforcer proxy, and a client that drops
+// an HTTP/2 frame.
+func TransportNoise(line string) bool {
+	return strings.HasPrefix(line, "http: proxy error:") ||
+		strings.HasPrefix(line, "http2: server connection error")
+}
+
+// StdLogger adapts a zerolog logger for net/http, which writes through the
+// standard logger. quiet picks the lines that drop to debug; every other line,
+// a handler panic and its stack included, stays at error.
+func StdLogger(log zerolog.Logger, quiet func(string) bool) *stdlog.Logger {
+	return stdlog.New(levelWriter{log: log, quiet: quiet}, "", 0)
+}
+
+type levelWriter struct {
+	log   zerolog.Logger
+	quiet func(string) bool
+}
+
+func (w levelWriter) Write(p []byte) (int, error) {
+	line := strings.TrimRight(string(p), "\n")
+	level := zerolog.ErrorLevel
+	if w.quiet != nil && w.quiet(line) {
+		level = zerolog.DebugLevel
+	}
+	w.log.WithLevel(level).Msg(line)
+	return len(p), nil
+}

--- a/sidechain-orchestrator/logfile/stdlog_test.go
+++ b/sidechain-orchestrator/logfile/stdlog_test.go
@@ -1,0 +1,60 @@
+package logfile
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// net/http repeats a refused dial once per retry. The bridge holds those lines
+// at debug, so an info console stays clean.
+func TestStdLoggerHoldsTransportNoiseAtDebug(t *testing.T) {
+	var sink bytes.Buffer
+	log := zerolog.New(&sink).Level(zerolog.InfoLevel)
+
+	StdLogger(log, TransportNoise).Printf("http: proxy error: dial tcp 127.0.0.1:50051: connect: connection refused")
+	StdLogger(log, TransportNoise).Printf("http2: server connection error from 127.0.0.1:1: connection error: PROTOCOL_ERROR")
+
+	require.Empty(t, sink.String())
+}
+
+// Server.ErrorLog also carries a handler panic and its stack. Losing that hides
+// a real failure, so every line the filter does not name stays at error.
+func TestStdLoggerKeepsEveryOtherLineAtError(t *testing.T) {
+	var sink bytes.Buffer
+	log := zerolog.New(&sink).Level(zerolog.InfoLevel)
+
+	StdLogger(log, TransportNoise).Printf("http: panic serving 127.0.0.1:1: runtime error: index out of range")
+
+	require.Contains(t, sink.String(), `"level":"error"`)
+	require.Contains(t, sink.String(), "panic serving")
+}
+
+func TestStdLoggerWritesOneLineWithoutTheTrailingNewline(t *testing.T) {
+	var sink bytes.Buffer
+	log := zerolog.New(&sink).Level(zerolog.DebugLevel)
+
+	StdLogger(log, TransportNoise).Printf("http2: server connection error")
+
+	require.Equal(t, `{"level":"debug","message":"http2: server connection error"}`+"\n", sink.String())
+}
+
+// A nil filter must not silence anything.
+func TestStdLoggerWithoutAFilterKeepsEveryLineAtError(t *testing.T) {
+	var sink bytes.Buffer
+	log := zerolog.New(&sink).Level(zerolog.InfoLevel)
+
+	StdLogger(log, nil).Printf("http: proxy error: connection refused")
+
+	require.Contains(t, sink.String(), `"level":"error"`)
+}
+
+func TestTransportNoiseNamesOnlyTheTwoRepeatedLines(t *testing.T) {
+	require.True(t, TransportNoise("http: proxy error: dial tcp: connection refused"))
+	require.True(t, TransportNoise("http2: server connection error from 1.2.3.4:5"))
+	require.False(t, TransportNoise("http: panic serving 127.0.0.1:1"))
+	require.False(t, TransportNoise("http: TLS handshake error"))
+	require.False(t, TransportNoise(""))
+}

--- a/sidechain-orchestrator/remote_enforcer.go
+++ b/sidechain-orchestrator/remote_enforcer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/enforcerproxy"
 	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 )
 
 // EnforcerURL returns the local enforcer URL or the bridge URL for light mode.
@@ -47,7 +48,7 @@ func (o *Orchestrator) EnforcerURL() (string, error) {
 		}
 		o.remoteEnforcer = nil
 	}
-	remote, err := enforcerproxy.NewRemote(upstream)
+	remote, err := enforcerproxy.NewRemote(upstream, logfile.StdLogger(o.log, logfile.TransportNoise))
 	if err != nil {
 		return "", fmt.Errorf("connect to the remote enforcer for %s: %w", network, err)
 	}

--- a/sidechain-orchestrator/remote_enforcer_restart_test.go
+++ b/sidechain-orchestrator/remote_enforcer_restart_test.go
@@ -43,7 +43,7 @@ func TestRemoteSidechainRestartsOwnedOrphans(t *testing.T) {
 				ownThisInstall(t, o)
 			}
 			cfg, env, argsPath := installRemoteTestDaemon(t, o)
-			oldBridge, err := enforcerproxy.NewRemote(server.URL)
+			oldBridge, err := enforcerproxy.NewRemote(server.URL, nil)
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, oldBridge.Close()) })
 			oldArgs := []string{"--headless", "--mainchain-grpc-url=" + oldBridge.URL()}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -108,6 +108,10 @@ type ElectrumBackend struct {
 	subStatus  map[string]string
 	shWallet   map[string]string
 	consumerCh <-chan ElectrumNotification
+
+	// The descriptor build runs on every balance read; the warning is a
+	// property of the wallet, so it reads one time.
+	warnedNoOrigin sync.Map
 }
 
 var (
@@ -1971,6 +1975,11 @@ func (p *ElectrumBackend) multisigSigningDescriptorFor(w *WalletData, onlyXpub s
 		signWithXprv[c.Xpub] = xprv
 	}
 
+	if len(noOrigin) > 0 {
+		if _, seen := p.warnedNoOrigin.LoadOrStore(w.ID, true); seen {
+			noOrigin = nil
+		}
+	}
 	if len(noOrigin) > 0 {
 		p.log.Warn().
 			Str("wallet", w.ID).

--- a/sidechain-orchestrator/wallet/electrum_no_origin_warn_test.go
+++ b/sidechain-orchestrator/wallet/electrum_no_origin_warn_test.go
@@ -1,0 +1,51 @@
+package wallet
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// Every balance read rebuilds the descriptor. The missing origin belongs to
+// the wallet, not to the read, so the console gets it one time.
+func TestNoOriginWarnsOncePerWallet(t *testing.T) {
+	var sink bytes.Buffer
+	p := &ElectrumBackend{
+		log:       zerolog.New(&sink),
+		netParams: StaticParams(&chaincfg.RegressionNetParams),
+	}
+	w := &WalletData{
+		ID: "WALLET-A",
+		Multisig: &MultisigWalletData{
+			M: 1, N: 2,
+			Cosigners: []MultisigCosigner{
+				{Xpub: "xpub-one"},
+				{Xpub: "xpub-two"},
+			},
+		},
+	}
+
+	for range 3 {
+		_, _ = p.multisigSigningDescriptorFor(w, "")
+	}
+
+	require.Equal(t, 1, strings.Count(sink.String(), "cosigner has no key origin"))
+}
+
+func TestNoOriginWarnsForEachWallet(t *testing.T) {
+	var sink bytes.Buffer
+	p := &ElectrumBackend{
+		log:       zerolog.New(&sink),
+		netParams: StaticParams(&chaincfg.RegressionNetParams),
+	}
+	ms := &MultisigWalletData{M: 1, N: 1, Cosigners: []MultisigCosigner{{Xpub: "xpub-one"}}}
+
+	_, _ = p.multisigSigningDescriptorFor(&WalletData{ID: "WALLET-A", Multisig: ms}, "")
+	_, _ = p.multisigSigningDescriptorFor(&WalletData{ID: "WALLET-B", Multisig: ms}, "")
+
+	require.Equal(t, 2, strings.Count(sink.String(), "cosigner has no key origin"))
+}

--- a/sidechain_core/lib/providers/wallet_reader_provider.dart
+++ b/sidechain_core/lib/providers/wallet_reader_provider.dart
@@ -108,10 +108,6 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
     required String? newActiveId,
     required bool newHasWalletOnDisk,
   }) {
-    _logger.i(
-      'WalletReaderProvider: frame wallets=${protoWallets.length} '
-      'active=$newActiveId hasWallet=$newHasWalletOnDisk (current=${wallets.length})',
-    );
     // Reconnecting stream can send an empty initial frame; keep a populated
     // list (a real delete arrives with hasWallet=false).
     if (protoWallets.isEmpty && wallets.isNotEmpty && newHasWalletOnDisk) {
@@ -135,14 +131,18 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
     final previousHasWallet = hasWalletOnDisk;
     hasWalletOnDisk = newHasWalletOnDisk;
     if (previousHasWallet != hasWalletOnDisk) {
-      _logger.i('WalletReaderProvider: hasWalletOnDisk $previousHasWallet -> $hasWalletOnDisk');
+      _logger.i(
+        'WalletReaderProvider: hasWalletOnDisk $previousHasWallet -> $hasWalletOnDisk',
+      );
     }
 
     wallets = protoWallets.map<WalletData>((protoWallet) {
       WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
       if (protoWallet.gradientJson.isNotEmpty) {
         try {
-          final parsed = WalletGradient.fromJsonString(protoWallet.gradientJson);
+          final parsed = WalletGradient.fromJsonString(
+            protoWallet.gradientJson,
+          );
           // Legacy default {"background_svg":""} parses cleanly but would
           // render an empty avatar; keep the deterministic fallback in that
           // case.
@@ -208,7 +208,9 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
     if (!GetIt.I.isRegistered<OrchestratorRPC>()) {
       // bootBackendManagedSidechain calls back into init() once the
       // orchestrator is registered + ready; bail without crashing.
-      _logger.d('WalletReaderProvider: OrchestratorRPC not registered yet, skipping seed');
+      _logger.d(
+        'WalletReaderProvider: OrchestratorRPC not registered yet, skipping seed',
+      );
       return;
     }
     _ensureSupervisor();
@@ -333,7 +335,9 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
         return resp.hasWallet;
       } catch (e) {
         if (attempt == maxAttempts - 1) {
-          _logger.w('WalletReaderProvider.hasWallet: giving up after $maxAttempts attempts: $e');
+          _logger.w(
+            'WalletReaderProvider.hasWallet: giving up after $maxAttempts attempts: $e',
+          );
           return false;
         }
         await Future.delayed(delay);
@@ -362,7 +366,9 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
         await _seedWalletsIfEmpty('unlock');
       }
       if (wallets.isEmpty && !await _waitForWalletState(unlockStateWait)) {
-        _logger.w('WalletReaderProvider: unlock succeeded but wallet state did not load');
+        _logger.w(
+          'WalletReaderProvider: unlock succeeded but wallet state did not load',
+        );
         return false;
       }
       unlockedPassword = password;
@@ -434,7 +440,10 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
 
   /// Resolves whatever the backend needs before a wallet switch — moving onto a
   /// Core wallet can need a datadir this network was never given.
-  Future<String> resolveSwitchRequirements(BuildContext context, String walletId) async {
+  Future<String> resolveSwitchRequirements(
+    BuildContext context,
+    String walletId,
+  ) async {
     if (!GetIt.I.isRegistered<BitcoinConfProvider>()) {
       return '';
     }
@@ -448,7 +457,11 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
     if (!context.mounted) {
       throw NetworkChangeDeclined(conf.network);
     }
-    final dataDir = await conf.resolveNetworkChangePlan(context, plan, conf.network);
+    final dataDir = await conf.resolveNetworkChangePlan(
+      context,
+      plan,
+      conf.network,
+    );
     if (dataDir == null) {
       throw NetworkChangeDeclined(conf.network);
     }


### PR DESCRIPTION
Holds the repeated boot noise at debug: net/http, the connection monitor, the RPC meter, the cosigner warning, the HWI enumerate poll and two Flutter providers.