### PR TITLE
Name a lost BMM bid, and let the user cancel it

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_overview.dart
+++ b/bitwindow/lib/pages/wallet/wallet_overview.dart
@@ -143,7 +143,19 @@ const double bumpFeeColumnWidth = 104;
 /// Only a transaction that waits for a block can carry a replacement. Whether
 /// this wallet signs its inputs comes from the backend preview, because a
 /// self-send and a consolidation both read as amount zero here.
-bool canBumpFee(WalletTransaction tx) => tx.confirmationTime.height == 0;
+bool canBumpFee(WalletTransaction tx) => tx.confirmationTime.height == 0 && !canCancelBid(tx);
+
+/// A lost bid names a mainchain block the chain already built past, so no miner
+/// can take it. A replacement is the only way back to the coins.
+bool canCancelBid(WalletTransaction tx) => tx.hasBmmBid() && tx.bmmBid.lost;
+
+/// What the status column says about one transaction.
+String transactionStatus(WalletTransaction tx) {
+  if (tx.hasBmmBid()) {
+    return tx.bmmBid.lost ? 'BMM bid \u00b7 lost' : 'BMM bid \u00b7 slot ${tx.bmmBid.slot}';
+  }
+  return tx.confirmationTime.height == 0 ? 'Unconfirmed' : 'Confirmed';
+}
 
 class TransactionTable extends StatefulWidget {
   final Widget searchWidget;
@@ -296,6 +308,7 @@ class _TransactionTableState extends State<TransactionTable> {
                         final entry = entries[row];
                         final unconfirmed = entry.confirmationTime.height == 0;
                         final replaceable = canBumpFee(entry);
+                        final cancellable = canCancelBid(entry);
 
                         // Calculate amount and determine sign
                         final amountDiff = entry.receivedSatoshi - entry.sentSatoshi;
@@ -317,7 +330,7 @@ class _TransactionTableState extends State<TransactionTable> {
                             value: entry.note,
                           ),
                           SailTableCell(
-                            value: unconfirmed ? 'Unconfirmed' : 'Confirmed',
+                            value: transactionStatus(entry),
                             textColor: unconfirmed ? context.sailTheme.colors.orange : null,
                           ),
                           SailTableCell(
@@ -325,10 +338,20 @@ class _TransactionTableState extends State<TransactionTable> {
                             monospace: true,
                           ),
                           SailTableCell(
-                            value: replaceable ? 'Bump fee' : '',
+                            value: cancellable
+                                ? 'Cancel bid'
+                                : replaceable
+                                ? 'Bump fee'
+                                : '',
                             width: bumpFeeColumnWidth,
                             alignment: Alignment.centerRight,
-                            child: replaceable
+                            child: cancellable
+                                ? SailButton(
+                                    label: 'Cancel bid',
+                                    onPressed: () async => widget.model.cancelBid(context, entry),
+                                    insideTable: true,
+                                  )
+                                : replaceable
                                 ? SailButton(
                                     label: 'Bump fee',
                                     onPressed: () async => widget.model.openBumpFee(context, entry),
@@ -378,6 +401,14 @@ class _TransactionTableState extends State<TransactionTable> {
                             },
                             child: SailText.primary12(entry.note.isEmpty ? 'Add Note' : 'Update Note'),
                           ),
+                          if (canCancelBid(entry))
+                            SailMenuItem(
+                              closeOnSelect: false,
+                              onSelected: () async {
+                                await widget.model.cancelBid(context, entry);
+                              },
+                              child: SailText.primary12('Cancel bid'),
+                            ),
                           if (canBumpFee(entry))
                             SailMenuItem(
                               closeOnSelect: false,
@@ -437,6 +468,7 @@ class OverviewViewModel extends BaseViewModel with ChangeTrackingMixin {
   final TransactionProvider _txProvider = GetIt.I<TransactionProvider>();
   final BitwindowRPC _bitwindowRPC = GetIt.I<BitwindowRPC>();
   final OrchestratorWalletRPC _orchestratorWallet = GetIt.I<OrchestratorRPC>().wallet;
+  final OrchestratorBmmRPC _orchestratorBmm = GetIt.I<OrchestratorRPC>().bmm;
   final EnforcerRPC _enforcerRPC = GetIt.I<EnforcerRPC>();
   final BalanceProvider _balanceProvider = GetIt.I<BalanceProvider>();
   WalletReaderProvider get _walletReader => GetIt.I<WalletReaderProvider>();
@@ -654,6 +686,33 @@ class OverviewViewModel extends BaseViewModel with ChangeTrackingMixin {
     );
     if (outcome == BumpFeeOutcome.accelerate && context.mounted) {
       await accelerateCpfp(context, tx);
+    }
+  }
+
+  /// Replaces a lost bid with a payment back to this wallet.
+  Future<void> cancelBid(BuildContext context, WalletTransaction tx) async {
+    final log = GetIt.I<Logger>();
+    try {
+      final result = await _orchestratorBmm.cancelBid(
+        txid: tx.txid,
+        walletId: _walletReader.activeWalletId,
+      );
+      log.i('cancelled bid ${tx.txid} with ${result.replacementTxid}');
+      if (context.mounted) {
+        showSailToast(
+          context,
+          'Cancelled. ${result.recoveredSats} sats come back in ${result.replacementTxid}',
+          variant: SailToastVariant.success,
+        );
+      }
+      // The network holds the replacement already. A refresh that fails changes
+      // nothing about that.
+      unawaited(_txProvider.fetch());
+    } catch (e) {
+      log.e('failed to cancel bid ${tx.txid}: $e');
+      if (context.mounted) {
+        showSailToast(context, 'Failed to cancel the bid: $e');
+      }
     }
   }
 

--- a/bitwindow/lib/providers/transactions_provider.dart
+++ b/bitwindow/lib/providers/transactions_provider.dart
@@ -19,6 +19,13 @@ import 'package:sidechain_core/rpcs/bitwindow_api.dart';
 import 'package:sidechain_core/rpcs/orchestrator_rpc.dart';
 import 'package:sidechain_core/rpcs/orchestrator_wallet_rpc.dart';
 
+BmmBid _bmmBid(wmpb.BmmBid bid) => BmmBid(
+  slot: bid.slot,
+  criticalHash: bid.criticalHash,
+  prevMainHash: bid.prevMainHash,
+  lost: bid.lost,
+);
+
 // because the class extends ChangeNotifier, any subscribers
 // to this class will be notified of changes to new transactions
 class TransactionProvider extends ChangeNotifier implements NetworkScoped {
@@ -172,6 +179,7 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
                       // sort to the top and show immediately.
                       timestamp: Timestamp(seconds: tx.blockTime != Int64.ZERO ? tx.blockTime : tx.time),
                     ),
+                    bmmBid: tx.hasBmmBid() ? _bmmBid(tx.bmmBid) : null,
                   ),
                 )
                 .toList();

--- a/bitwindow/server/gen/wallet/v1/wallet.pb.go
+++ b/bitwindow/server/gen/wallet/v1/wallet.pb.go
@@ -1114,8 +1114,10 @@ type WalletTransaction struct {
 	AddressLabel     string                 `protobuf:"bytes,6,opt,name=address_label,json=addressLabel,proto3" json:"address_label,omitempty"`
 	Note             string                 `protobuf:"bytes,7,opt,name=note,proto3" json:"note,omitempty"`
 	ConfirmationTime *Confirmation          `protobuf:"bytes,8,opt,name=confirmation_time,json=confirmationTime,proto3" json:"confirmation_time,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Set when output 0 carries a BMM request. Unset for every other transaction.
+	BmmBid        *BmmBid `protobuf:"bytes,9,opt,name=bmm_bid,json=bmmBid,proto3" json:"bmm_bid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WalletTransaction) Reset() {
@@ -1204,6 +1206,85 @@ func (x *WalletTransaction) GetConfirmationTime() *Confirmation {
 	return nil
 }
 
+func (x *WalletTransaction) GetBmmBid() *BmmBid {
+	if x != nil {
+		return x.BmmBid
+	}
+	return nil
+}
+
+// BmmBid names the BMM request one wallet transaction carries.
+type BmmBid struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Slot         uint32                 `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	CriticalHash string                 `protobuf:"bytes,2,opt,name=critical_hash,json=criticalHash,proto3" json:"critical_hash,omitempty"`
+	// The mainchain block the sidechain block builds on. The bid reaches only
+	// the block after it.
+	PrevMainHash string `protobuf:"bytes,3,opt,name=prev_main_hash,json=prevMainHash,proto3" json:"prev_main_hash,omitempty"`
+	// True when the mainchain tip moved past prev_main_hash.
+	Lost          bool `protobuf:"varint,4,opt,name=lost,proto3" json:"lost,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BmmBid) Reset() {
+	*x = BmmBid{}
+	mi := &file_wallet_v1_wallet_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BmmBid) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BmmBid) ProtoMessage() {}
+
+func (x *BmmBid) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_v1_wallet_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BmmBid.ProtoReflect.Descriptor instead.
+func (*BmmBid) Descriptor() ([]byte, []int) {
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *BmmBid) GetSlot() uint32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *BmmBid) GetCriticalHash() string {
+	if x != nil {
+		return x.CriticalHash
+	}
+	return ""
+}
+
+func (x *BmmBid) GetPrevMainHash() string {
+	if x != nil {
+		return x.PrevMainHash
+	}
+	return ""
+}
+
+func (x *BmmBid) GetLost() bool {
+	if x != nil {
+		return x.Lost
+	}
+	return false
+}
+
 type ListSidechainDepositsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
@@ -1214,7 +1295,7 @@ type ListSidechainDepositsRequest struct {
 
 func (x *ListSidechainDepositsRequest) Reset() {
 	*x = ListSidechainDepositsRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[17]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1226,7 +1307,7 @@ func (x *ListSidechainDepositsRequest) String() string {
 func (*ListSidechainDepositsRequest) ProtoMessage() {}
 
 func (x *ListSidechainDepositsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[17]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1239,7 +1320,7 @@ func (x *ListSidechainDepositsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSidechainDepositsRequest.ProtoReflect.Descriptor instead.
 func (*ListSidechainDepositsRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{17}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListSidechainDepositsRequest) GetWalletId() string {
@@ -1265,7 +1346,7 @@ type ListSidechainDepositsResponse struct {
 
 func (x *ListSidechainDepositsResponse) Reset() {
 	*x = ListSidechainDepositsResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[18]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1277,7 +1358,7 @@ func (x *ListSidechainDepositsResponse) String() string {
 func (*ListSidechainDepositsResponse) ProtoMessage() {}
 
 func (x *ListSidechainDepositsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[18]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1290,7 +1371,7 @@ func (x *ListSidechainDepositsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSidechainDepositsResponse.ProtoReflect.Descriptor instead.
 func (*ListSidechainDepositsResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{18}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListSidechainDepositsResponse) GetDeposits() []*ListSidechainDepositsResponse_SidechainDeposit {
@@ -1317,7 +1398,7 @@ type CreateSidechainDepositRequest struct {
 
 func (x *CreateSidechainDepositRequest) Reset() {
 	*x = CreateSidechainDepositRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[19]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1329,7 +1410,7 @@ func (x *CreateSidechainDepositRequest) String() string {
 func (*CreateSidechainDepositRequest) ProtoMessage() {}
 
 func (x *CreateSidechainDepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[19]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1342,7 +1423,7 @@ func (x *CreateSidechainDepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSidechainDepositRequest.ProtoReflect.Descriptor instead.
 func (*CreateSidechainDepositRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{19}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CreateSidechainDepositRequest) GetWalletId() string {
@@ -1389,7 +1470,7 @@ type CreateSidechainDepositResponse struct {
 
 func (x *CreateSidechainDepositResponse) Reset() {
 	*x = CreateSidechainDepositResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[20]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1401,7 +1482,7 @@ func (x *CreateSidechainDepositResponse) String() string {
 func (*CreateSidechainDepositResponse) ProtoMessage() {}
 
 func (x *CreateSidechainDepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[20]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1414,7 +1495,7 @@ func (x *CreateSidechainDepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSidechainDepositResponse.ProtoReflect.Descriptor instead.
 func (*CreateSidechainDepositResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{20}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CreateSidechainDepositResponse) GetTxid() string {
@@ -1436,7 +1517,7 @@ type SignMessageRequest struct {
 
 func (x *SignMessageRequest) Reset() {
 	*x = SignMessageRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[21]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1448,7 +1529,7 @@ func (x *SignMessageRequest) String() string {
 func (*SignMessageRequest) ProtoMessage() {}
 
 func (x *SignMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[21]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1461,7 +1542,7 @@ func (x *SignMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignMessageRequest.ProtoReflect.Descriptor instead.
 func (*SignMessageRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{21}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SignMessageRequest) GetWalletId() string {
@@ -1494,7 +1575,7 @@ type SignMessageResponse struct {
 
 func (x *SignMessageResponse) Reset() {
 	*x = SignMessageResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[22]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1506,7 +1587,7 @@ func (x *SignMessageResponse) String() string {
 func (*SignMessageResponse) ProtoMessage() {}
 
 func (x *SignMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[22]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1519,7 +1600,7 @@ func (x *SignMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignMessageResponse.ProtoReflect.Descriptor instead.
 func (*SignMessageResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{22}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SignMessageResponse) GetSignature() string {
@@ -1541,7 +1622,7 @@ type VerifyMessageRequest struct {
 
 func (x *VerifyMessageRequest) Reset() {
 	*x = VerifyMessageRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[23]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1634,7 @@ func (x *VerifyMessageRequest) String() string {
 func (*VerifyMessageRequest) ProtoMessage() {}
 
 func (x *VerifyMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[23]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1647,7 @@ func (x *VerifyMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyMessageRequest.ProtoReflect.Descriptor instead.
 func (*VerifyMessageRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{23}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *VerifyMessageRequest) GetWalletId() string {
@@ -1606,7 +1687,7 @@ type VerifyMessageResponse struct {
 
 func (x *VerifyMessageResponse) Reset() {
 	*x = VerifyMessageResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[24]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1618,7 +1699,7 @@ func (x *VerifyMessageResponse) String() string {
 func (*VerifyMessageResponse) ProtoMessage() {}
 
 func (x *VerifyMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[24]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1631,7 +1712,7 @@ func (x *VerifyMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyMessageResponse.ProtoReflect.Descriptor instead.
 func (*VerifyMessageResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{24}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *VerifyMessageResponse) GetValid() bool {
@@ -1660,7 +1741,7 @@ type GetStatsResponse struct {
 
 func (x *GetStatsResponse) Reset() {
 	*x = GetStatsResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[25]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1672,7 +1753,7 @@ func (x *GetStatsResponse) String() string {
 func (*GetStatsResponse) ProtoMessage() {}
 
 func (x *GetStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[25]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1685,7 +1766,7 @@ func (x *GetStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetStatsResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{25}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetStatsResponse) GetUtxosCurrent() uint64 {
@@ -1761,7 +1842,7 @@ type UnlockWalletRequest struct {
 
 func (x *UnlockWalletRequest) Reset() {
 	*x = UnlockWalletRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[26]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1773,7 +1854,7 @@ func (x *UnlockWalletRequest) String() string {
 func (*UnlockWalletRequest) ProtoMessage() {}
 
 func (x *UnlockWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[26]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1786,7 +1867,7 @@ func (x *UnlockWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockWalletRequest.ProtoReflect.Descriptor instead.
 func (*UnlockWalletRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{26}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *UnlockWalletRequest) GetPassword() string {
@@ -1807,7 +1888,7 @@ type CreateChequeRequest struct {
 
 func (x *CreateChequeRequest) Reset() {
 	*x = CreateChequeRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[27]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1819,7 +1900,7 @@ func (x *CreateChequeRequest) String() string {
 func (*CreateChequeRequest) ProtoMessage() {}
 
 func (x *CreateChequeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[27]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1832,7 +1913,7 @@ func (x *CreateChequeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateChequeRequest.ProtoReflect.Descriptor instead.
 func (*CreateChequeRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{27}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *CreateChequeRequest) GetWalletId() string {
@@ -1860,7 +1941,7 @@ type CreateChequeResponse struct {
 
 func (x *CreateChequeResponse) Reset() {
 	*x = CreateChequeResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[28]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1872,7 +1953,7 @@ func (x *CreateChequeResponse) String() string {
 func (*CreateChequeResponse) ProtoMessage() {}
 
 func (x *CreateChequeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[28]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1885,7 +1966,7 @@ func (x *CreateChequeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateChequeResponse.ProtoReflect.Descriptor instead.
 func (*CreateChequeResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{28}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *CreateChequeResponse) GetId() int64 {
@@ -1919,7 +2000,7 @@ type GetChequeRequest struct {
 
 func (x *GetChequeRequest) Reset() {
 	*x = GetChequeRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[29]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1931,7 +2012,7 @@ func (x *GetChequeRequest) String() string {
 func (*GetChequeRequest) ProtoMessage() {}
 
 func (x *GetChequeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[29]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1944,7 +2025,7 @@ func (x *GetChequeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChequeRequest.ProtoReflect.Descriptor instead.
 func (*GetChequeRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{29}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetChequeRequest) GetWalletId() string {
@@ -1970,7 +2051,7 @@ type GetChequeResponse struct {
 
 func (x *GetChequeResponse) Reset() {
 	*x = GetChequeResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[30]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1982,7 +2063,7 @@ func (x *GetChequeResponse) String() string {
 func (*GetChequeResponse) ProtoMessage() {}
 
 func (x *GetChequeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[30]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1995,7 +2076,7 @@ func (x *GetChequeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChequeResponse.ProtoReflect.Descriptor instead.
 func (*GetChequeResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{30}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetChequeResponse) GetCheque() *Cheque {
@@ -2015,7 +2096,7 @@ type GetChequePrivateKeyRequest struct {
 
 func (x *GetChequePrivateKeyRequest) Reset() {
 	*x = GetChequePrivateKeyRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[31]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2027,7 +2108,7 @@ func (x *GetChequePrivateKeyRequest) String() string {
 func (*GetChequePrivateKeyRequest) ProtoMessage() {}
 
 func (x *GetChequePrivateKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[31]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2040,7 +2121,7 @@ func (x *GetChequePrivateKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChequePrivateKeyRequest.ProtoReflect.Descriptor instead.
 func (*GetChequePrivateKeyRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{31}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetChequePrivateKeyRequest) GetWalletId() string {
@@ -2066,7 +2147,7 @@ type GetChequePrivateKeyResponse struct {
 
 func (x *GetChequePrivateKeyResponse) Reset() {
 	*x = GetChequePrivateKeyResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[32]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2078,7 +2159,7 @@ func (x *GetChequePrivateKeyResponse) String() string {
 func (*GetChequePrivateKeyResponse) ProtoMessage() {}
 
 func (x *GetChequePrivateKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[32]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2091,7 +2172,7 @@ func (x *GetChequePrivateKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChequePrivateKeyResponse.ProtoReflect.Descriptor instead.
 func (*GetChequePrivateKeyResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{32}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetChequePrivateKeyResponse) GetPrivateKeyWif() string {
@@ -2121,7 +2202,7 @@ type Cheque struct {
 
 func (x *Cheque) Reset() {
 	*x = Cheque{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[33]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2133,7 +2214,7 @@ func (x *Cheque) String() string {
 func (*Cheque) ProtoMessage() {}
 
 func (x *Cheque) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[33]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2146,7 +2227,7 @@ func (x *Cheque) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Cheque.ProtoReflect.Descriptor instead.
 func (*Cheque) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{33}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Cheque) GetId() int64 {
@@ -2242,7 +2323,7 @@ type ListChequesRequest struct {
 
 func (x *ListChequesRequest) Reset() {
 	*x = ListChequesRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[34]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2254,7 +2335,7 @@ func (x *ListChequesRequest) String() string {
 func (*ListChequesRequest) ProtoMessage() {}
 
 func (x *ListChequesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[34]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2267,7 +2348,7 @@ func (x *ListChequesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListChequesRequest.ProtoReflect.Descriptor instead.
 func (*ListChequesRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{34}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListChequesRequest) GetWalletId() string {
@@ -2286,7 +2367,7 @@ type ListChequesResponse struct {
 
 func (x *ListChequesResponse) Reset() {
 	*x = ListChequesResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[35]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2298,7 +2379,7 @@ func (x *ListChequesResponse) String() string {
 func (*ListChequesResponse) ProtoMessage() {}
 
 func (x *ListChequesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[35]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2311,7 +2392,7 @@ func (x *ListChequesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListChequesResponse.ProtoReflect.Descriptor instead.
 func (*ListChequesResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{35}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ListChequesResponse) GetCheques() []*Cheque {
@@ -2331,7 +2412,7 @@ type CheckChequeFundingRequest struct {
 
 func (x *CheckChequeFundingRequest) Reset() {
 	*x = CheckChequeFundingRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[36]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2343,7 +2424,7 @@ func (x *CheckChequeFundingRequest) String() string {
 func (*CheckChequeFundingRequest) ProtoMessage() {}
 
 func (x *CheckChequeFundingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[36]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2356,7 +2437,7 @@ func (x *CheckChequeFundingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckChequeFundingRequest.ProtoReflect.Descriptor instead.
 func (*CheckChequeFundingRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{36}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CheckChequeFundingRequest) GetWalletId() string {
@@ -2386,7 +2467,7 @@ type CheckChequeFundingResponse struct {
 
 func (x *CheckChequeFundingResponse) Reset() {
 	*x = CheckChequeFundingResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[37]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2398,7 +2479,7 @@ func (x *CheckChequeFundingResponse) String() string {
 func (*CheckChequeFundingResponse) ProtoMessage() {}
 
 func (x *CheckChequeFundingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[37]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2411,7 +2492,7 @@ func (x *CheckChequeFundingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckChequeFundingResponse.ProtoReflect.Descriptor instead.
 func (*CheckChequeFundingResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{37}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CheckChequeFundingResponse) GetFunded() bool {
@@ -2460,7 +2541,7 @@ type PreviewSweepRequest struct {
 
 func (x *PreviewSweepRequest) Reset() {
 	*x = PreviewSweepRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[38]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2472,7 +2553,7 @@ func (x *PreviewSweepRequest) String() string {
 func (*PreviewSweepRequest) ProtoMessage() {}
 
 func (x *PreviewSweepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[38]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2485,7 +2566,7 @@ func (x *PreviewSweepRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewSweepRequest.ProtoReflect.Descriptor instead.
 func (*PreviewSweepRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{38}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *PreviewSweepRequest) GetPrivateKeyWif() string {
@@ -2520,7 +2601,7 @@ type PreviewSweepResponse struct {
 
 func (x *PreviewSweepResponse) Reset() {
 	*x = PreviewSweepResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[39]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2532,7 +2613,7 @@ func (x *PreviewSweepResponse) String() string {
 func (*PreviewSweepResponse) ProtoMessage() {}
 
 func (x *PreviewSweepResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[39]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2545,7 +2626,7 @@ func (x *PreviewSweepResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewSweepResponse.ProtoReflect.Descriptor instead.
 func (*PreviewSweepResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{39}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *PreviewSweepResponse) GetAddress() string {
@@ -2609,7 +2690,7 @@ type SweepChequeRequest struct {
 
 func (x *SweepChequeRequest) Reset() {
 	*x = SweepChequeRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[40]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2621,7 +2702,7 @@ func (x *SweepChequeRequest) String() string {
 func (*SweepChequeRequest) ProtoMessage() {}
 
 func (x *SweepChequeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[40]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2634,7 +2715,7 @@ func (x *SweepChequeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepChequeRequest.ProtoReflect.Descriptor instead.
 func (*SweepChequeRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{40}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *SweepChequeRequest) GetWalletId() string {
@@ -2678,7 +2759,7 @@ type SweepChequeResponse struct {
 
 func (x *SweepChequeResponse) Reset() {
 	*x = SweepChequeResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[41]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2690,7 +2771,7 @@ func (x *SweepChequeResponse) String() string {
 func (*SweepChequeResponse) ProtoMessage() {}
 
 func (x *SweepChequeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[41]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2703,7 +2784,7 @@ func (x *SweepChequeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepChequeResponse.ProtoReflect.Descriptor instead.
 func (*SweepChequeResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{41}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SweepChequeResponse) GetTxid() string {
@@ -2737,7 +2818,7 @@ type DeleteChequeRequest struct {
 
 func (x *DeleteChequeRequest) Reset() {
 	*x = DeleteChequeRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[42]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2749,7 +2830,7 @@ func (x *DeleteChequeRequest) String() string {
 func (*DeleteChequeRequest) ProtoMessage() {}
 
 func (x *DeleteChequeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[42]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2762,7 +2843,7 @@ func (x *DeleteChequeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteChequeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteChequeRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{42}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *DeleteChequeRequest) GetWalletId() string {
@@ -2792,7 +2873,7 @@ type CreateBitcoinCoreWalletRequest struct {
 
 func (x *CreateBitcoinCoreWalletRequest) Reset() {
 	*x = CreateBitcoinCoreWalletRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[43]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2804,7 +2885,7 @@ func (x *CreateBitcoinCoreWalletRequest) String() string {
 func (*CreateBitcoinCoreWalletRequest) ProtoMessage() {}
 
 func (x *CreateBitcoinCoreWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[43]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2817,7 +2898,7 @@ func (x *CreateBitcoinCoreWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBitcoinCoreWalletRequest.ProtoReflect.Descriptor instead.
 func (*CreateBitcoinCoreWalletRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{43}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CreateBitcoinCoreWalletRequest) GetSeedHex() string {
@@ -2848,7 +2929,7 @@ type CreateBitcoinCoreWalletResponse struct {
 
 func (x *CreateBitcoinCoreWalletResponse) Reset() {
 	*x = CreateBitcoinCoreWalletResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[44]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2860,7 +2941,7 @@ func (x *CreateBitcoinCoreWalletResponse) String() string {
 func (*CreateBitcoinCoreWalletResponse) ProtoMessage() {}
 
 func (x *CreateBitcoinCoreWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[44]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2873,7 +2954,7 @@ func (x *CreateBitcoinCoreWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBitcoinCoreWalletResponse.ProtoReflect.Descriptor instead.
 func (*CreateBitcoinCoreWalletResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{44}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *CreateBitcoinCoreWalletResponse) GetWalletId() string {
@@ -2909,7 +2990,7 @@ type UTXOMetadata struct {
 
 func (x *UTXOMetadata) Reset() {
 	*x = UTXOMetadata{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[45]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2921,7 +3002,7 @@ func (x *UTXOMetadata) String() string {
 func (*UTXOMetadata) ProtoMessage() {}
 
 func (x *UTXOMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[45]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2934,7 +3015,7 @@ func (x *UTXOMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UTXOMetadata.ProtoReflect.Descriptor instead.
 func (*UTXOMetadata) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{45}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *UTXOMetadata) GetOutpoint() string {
@@ -2969,7 +3050,7 @@ type SetUTXOMetadataRequest struct {
 
 func (x *SetUTXOMetadataRequest) Reset() {
 	*x = SetUTXOMetadataRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[46]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2981,7 +3062,7 @@ func (x *SetUTXOMetadataRequest) String() string {
 func (*SetUTXOMetadataRequest) ProtoMessage() {}
 
 func (x *SetUTXOMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[46]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2994,7 +3075,7 @@ func (x *SetUTXOMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetUTXOMetadataRequest.ProtoReflect.Descriptor instead.
 func (*SetUTXOMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{46}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *SetUTXOMetadataRequest) GetOutpoint() string {
@@ -3027,7 +3108,7 @@ type GetUTXOMetadataRequest struct {
 
 func (x *GetUTXOMetadataRequest) Reset() {
 	*x = GetUTXOMetadataRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[47]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3039,7 +3120,7 @@ func (x *GetUTXOMetadataRequest) String() string {
 func (*GetUTXOMetadataRequest) ProtoMessage() {}
 
 func (x *GetUTXOMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[47]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3052,7 +3133,7 @@ func (x *GetUTXOMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUTXOMetadataRequest.ProtoReflect.Descriptor instead.
 func (*GetUTXOMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{47}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetUTXOMetadataRequest) GetOutpoints() []string {
@@ -3071,7 +3152,7 @@ type GetUTXOMetadataResponse struct {
 
 func (x *GetUTXOMetadataResponse) Reset() {
 	*x = GetUTXOMetadataResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[48]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3083,7 +3164,7 @@ func (x *GetUTXOMetadataResponse) String() string {
 func (*GetUTXOMetadataResponse) ProtoMessage() {}
 
 func (x *GetUTXOMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[48]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3096,7 +3177,7 @@ func (x *GetUTXOMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUTXOMetadataResponse.ProtoReflect.Descriptor instead.
 func (*GetUTXOMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{48}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetUTXOMetadataResponse) GetMetadata() map[string]*UTXOMetadata {
@@ -3115,7 +3196,7 @@ type SetCoinSelectionStrategyRequest struct {
 
 func (x *SetCoinSelectionStrategyRequest) Reset() {
 	*x = SetCoinSelectionStrategyRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[49]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3127,7 +3208,7 @@ func (x *SetCoinSelectionStrategyRequest) String() string {
 func (*SetCoinSelectionStrategyRequest) ProtoMessage() {}
 
 func (x *SetCoinSelectionStrategyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[49]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3140,7 +3221,7 @@ func (x *SetCoinSelectionStrategyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoinSelectionStrategyRequest.ProtoReflect.Descriptor instead.
 func (*SetCoinSelectionStrategyRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{49}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SetCoinSelectionStrategyRequest) GetStrategy() CoinSelectionStrategy {
@@ -3159,7 +3240,7 @@ type GetCoinSelectionStrategyResponse struct {
 
 func (x *GetCoinSelectionStrategyResponse) Reset() {
 	*x = GetCoinSelectionStrategyResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[50]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3171,7 +3252,7 @@ func (x *GetCoinSelectionStrategyResponse) String() string {
 func (*GetCoinSelectionStrategyResponse) ProtoMessage() {}
 
 func (x *GetCoinSelectionStrategyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[50]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3184,7 +3265,7 @@ func (x *GetCoinSelectionStrategyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoinSelectionStrategyResponse.ProtoReflect.Descriptor instead.
 func (*GetCoinSelectionStrategyResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{50}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GetCoinSelectionStrategyResponse) GetStrategy() CoinSelectionStrategy {
@@ -3204,7 +3285,7 @@ type GetTransactionDetailsRequest struct {
 
 func (x *GetTransactionDetailsRequest) Reset() {
 	*x = GetTransactionDetailsRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[51]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3216,7 +3297,7 @@ func (x *GetTransactionDetailsRequest) String() string {
 func (*GetTransactionDetailsRequest) ProtoMessage() {}
 
 func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[51]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3229,7 +3310,7 @@ func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{51}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetTransactionDetailsRequest) GetTxid() string {
@@ -3269,7 +3350,7 @@ type GetTransactionDetailsResponse struct {
 
 func (x *GetTransactionDetailsResponse) Reset() {
 	*x = GetTransactionDetailsResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[52]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3281,7 +3362,7 @@ func (x *GetTransactionDetailsResponse) String() string {
 func (*GetTransactionDetailsResponse) ProtoMessage() {}
 
 func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[52]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3375,7 @@ func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{52}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *GetTransactionDetailsResponse) GetTxid() string {
@@ -3429,7 +3510,7 @@ type TransactionInput struct {
 
 func (x *TransactionInput) Reset() {
 	*x = TransactionInput{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[53]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3441,7 +3522,7 @@ func (x *TransactionInput) String() string {
 func (*TransactionInput) ProtoMessage() {}
 
 func (x *TransactionInput) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[53]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3454,7 +3535,7 @@ func (x *TransactionInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionInput.ProtoReflect.Descriptor instead.
 func (*TransactionInput) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{53}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *TransactionInput) GetIndex() int32 {
@@ -3541,7 +3622,7 @@ type TransactionOutput struct {
 
 func (x *TransactionOutput) Reset() {
 	*x = TransactionOutput{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[54]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3553,7 +3634,7 @@ func (x *TransactionOutput) String() string {
 func (*TransactionOutput) ProtoMessage() {}
 
 func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[54]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3566,7 +3647,7 @@ func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionOutput.ProtoReflect.Descriptor instead.
 func (*TransactionOutput) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{54}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *TransactionOutput) GetIndex() int32 {
@@ -3622,7 +3703,7 @@ type GetUTXODistributionRequest struct {
 
 func (x *GetUTXODistributionRequest) Reset() {
 	*x = GetUTXODistributionRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[55]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3634,7 +3715,7 @@ func (x *GetUTXODistributionRequest) String() string {
 func (*GetUTXODistributionRequest) ProtoMessage() {}
 
 func (x *GetUTXODistributionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[55]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3647,7 +3728,7 @@ func (x *GetUTXODistributionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUTXODistributionRequest.ProtoReflect.Descriptor instead.
 func (*GetUTXODistributionRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{55}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetUTXODistributionRequest) GetWalletId() string {
@@ -3673,7 +3754,7 @@ type GetUTXODistributionResponse struct {
 
 func (x *GetUTXODistributionResponse) Reset() {
 	*x = GetUTXODistributionResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[56]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3685,7 +3766,7 @@ func (x *GetUTXODistributionResponse) String() string {
 func (*GetUTXODistributionResponse) ProtoMessage() {}
 
 func (x *GetUTXODistributionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[56]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3698,7 +3779,7 @@ func (x *GetUTXODistributionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUTXODistributionResponse.ProtoReflect.Descriptor instead.
 func (*GetUTXODistributionResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{56}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetUTXODistributionResponse) GetBuckets() []*UTXOBucket {
@@ -3720,7 +3801,7 @@ type UTXOBucket struct {
 
 func (x *UTXOBucket) Reset() {
 	*x = UTXOBucket{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[57]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3732,7 +3813,7 @@ func (x *UTXOBucket) String() string {
 func (*UTXOBucket) ProtoMessage() {}
 
 func (x *UTXOBucket) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[57]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3745,7 +3826,7 @@ func (x *UTXOBucket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UTXOBucket.ProtoReflect.Descriptor instead.
 func (*UTXOBucket) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{57}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *UTXOBucket) GetLabel() string {
@@ -3786,7 +3867,7 @@ type BumpFeeRequest struct {
 
 func (x *BumpFeeRequest) Reset() {
 	*x = BumpFeeRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[58]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3798,7 +3879,7 @@ func (x *BumpFeeRequest) String() string {
 func (*BumpFeeRequest) ProtoMessage() {}
 
 func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[58]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3811,7 +3892,7 @@ func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{58}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *BumpFeeRequest) GetTxid() string {
@@ -3832,7 +3913,7 @@ type BumpFeeResponse struct {
 
 func (x *BumpFeeResponse) Reset() {
 	*x = BumpFeeResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[59]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3844,7 +3925,7 @@ func (x *BumpFeeResponse) String() string {
 func (*BumpFeeResponse) ProtoMessage() {}
 
 func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[59]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3857,7 +3938,7 @@ func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{59}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *BumpFeeResponse) GetTxid() string {
@@ -3897,7 +3978,7 @@ type SelectCoinsRequest struct {
 
 func (x *SelectCoinsRequest) Reset() {
 	*x = SelectCoinsRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[60]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3909,7 +3990,7 @@ func (x *SelectCoinsRequest) String() string {
 func (*SelectCoinsRequest) ProtoMessage() {}
 
 func (x *SelectCoinsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[60]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3922,7 +4003,7 @@ func (x *SelectCoinsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectCoinsRequest.ProtoReflect.Descriptor instead.
 func (*SelectCoinsRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{60}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *SelectCoinsRequest) GetWalletId() string {
@@ -3986,7 +4067,7 @@ type SelectCoinsResponse struct {
 
 func (x *SelectCoinsResponse) Reset() {
 	*x = SelectCoinsResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[61]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3998,7 +4079,7 @@ func (x *SelectCoinsResponse) String() string {
 func (*SelectCoinsResponse) ProtoMessage() {}
 
 func (x *SelectCoinsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[61]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4011,7 +4092,7 @@ func (x *SelectCoinsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectCoinsResponse.ProtoReflect.Descriptor instead.
 func (*SelectCoinsResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{61}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *SelectCoinsResponse) GetSelectedUtxos() []*UnspentOutput {
@@ -4055,7 +4136,7 @@ type CreateBackupResponse struct {
 
 func (x *CreateBackupResponse) Reset() {
 	*x = CreateBackupResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[62]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4067,7 +4148,7 @@ func (x *CreateBackupResponse) String() string {
 func (*CreateBackupResponse) ProtoMessage() {}
 
 func (x *CreateBackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[62]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4080,7 +4161,7 @@ func (x *CreateBackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBackupResponse.ProtoReflect.Descriptor instead.
 func (*CreateBackupResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{62}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *CreateBackupResponse) GetBackupData() []byte {
@@ -4109,7 +4190,7 @@ type RestoreBackupRequest struct {
 
 func (x *RestoreBackupRequest) Reset() {
 	*x = RestoreBackupRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[63]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4121,7 +4202,7 @@ func (x *RestoreBackupRequest) String() string {
 func (*RestoreBackupRequest) ProtoMessage() {}
 
 func (x *RestoreBackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[63]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4134,7 +4215,7 @@ func (x *RestoreBackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreBackupRequest.ProtoReflect.Descriptor instead.
 func (*RestoreBackupRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{63}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *RestoreBackupRequest) GetBackupData() []byte {
@@ -4163,7 +4244,7 @@ type ValidateBackupRequest struct {
 
 func (x *ValidateBackupRequest) Reset() {
 	*x = ValidateBackupRequest{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[64]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4175,7 +4256,7 @@ func (x *ValidateBackupRequest) String() string {
 func (*ValidateBackupRequest) ProtoMessage() {}
 
 func (x *ValidateBackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[64]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4188,7 +4269,7 @@ func (x *ValidateBackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateBackupRequest.ProtoReflect.Descriptor instead.
 func (*ValidateBackupRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{64}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ValidateBackupRequest) GetBackupData() []byte {
@@ -4219,7 +4300,7 @@ type ValidateBackupResponse struct {
 
 func (x *ValidateBackupResponse) Reset() {
 	*x = ValidateBackupResponse{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[65]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4231,7 +4312,7 @@ func (x *ValidateBackupResponse) String() string {
 func (*ValidateBackupResponse) ProtoMessage() {}
 
 func (x *ValidateBackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[65]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4244,7 +4325,7 @@ func (x *ValidateBackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateBackupResponse.ProtoReflect.Descriptor instead.
 func (*ValidateBackupResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{65}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ValidateBackupResponse) GetValid() bool {
@@ -4294,7 +4375,7 @@ type ListSidechainDepositsResponse_SidechainDeposit struct {
 
 func (x *ListSidechainDepositsResponse_SidechainDeposit) Reset() {
 	*x = ListSidechainDepositsResponse_SidechainDeposit{}
-	mi := &file_wallet_v1_wallet_proto_msgTypes[67]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4306,7 +4387,7 @@ func (x *ListSidechainDepositsResponse_SidechainDeposit) String() string {
 func (*ListSidechainDepositsResponse_SidechainDeposit) ProtoMessage() {}
 
 func (x *ListSidechainDepositsResponse_SidechainDeposit) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_v1_wallet_proto_msgTypes[67]
+	mi := &file_wallet_v1_wallet_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4319,7 +4400,7 @@ func (x *ListSidechainDepositsResponse_SidechainDeposit) ProtoReflect() protoref
 
 // Deprecated: Use ListSidechainDepositsResponse_SidechainDeposit.ProtoReflect.Descriptor instead.
 func (*ListSidechainDepositsResponse_SidechainDeposit) Descriptor() ([]byte, []int) {
-	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{18, 0}
+	return file_wallet_v1_wallet_proto_rawDescGZIP(), []int{19, 0}
 }
 
 func (x *ListSidechainDepositsResponse_SidechainDeposit) GetTxid() string {
@@ -4423,7 +4504,7 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"\x0fderivation_path\x18\x06 \x01(\tR\x0ederivationPath\"`\n" +
 	"\fConfirmation\x12\x16\n" +
 	"\x06height\x18\x01 \x01(\rR\x06height\x128\n" +
-	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xa9\x02\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xd5\x02\n" +
 	"\x11WalletTransaction\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x19\n" +
 	"\bfee_sats\x18\x02 \x01(\x04R\afeeSats\x12)\n" +
@@ -4432,7 +4513,13 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"\aaddress\x18\x05 \x01(\tR\aaddress\x12#\n" +
 	"\raddress_label\x18\x06 \x01(\tR\faddressLabel\x12\x12\n" +
 	"\x04note\x18\a \x01(\tR\x04note\x12D\n" +
-	"\x11confirmation_time\x18\b \x01(\v2\x17.wallet.v1.ConfirmationR\x10confirmationTime\"O\n" +
+	"\x11confirmation_time\x18\b \x01(\v2\x17.wallet.v1.ConfirmationR\x10confirmationTime\x12*\n" +
+	"\abmm_bid\x18\t \x01(\v2\x11.wallet.v1.BmmBidR\x06bmmBid\"{\n" +
+	"\x06BmmBid\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\rR\x04slot\x12#\n" +
+	"\rcritical_hash\x18\x02 \x01(\tR\fcriticalHash\x12$\n" +
+	"\x0eprev_main_hash\x18\x03 \x01(\tR\fprevMainHash\x12\x12\n" +
+	"\x04lost\x18\x04 \x01(\bR\x04lost\"O\n" +
 	"\x1cListSidechainDepositsRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x12\n" +
 	"\x04slot\x18\x02 \x01(\x05R\x04slot\"\xee\x01\n" +
@@ -4752,7 +4839,7 @@ func file_wallet_v1_wallet_proto_rawDescGZIP() []byte {
 }
 
 var file_wallet_v1_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_wallet_v1_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
+var file_wallet_v1_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
 var file_wallet_v1_wallet_proto_goTypes = []any{
 	(AddressType)(0),                                       // 0: wallet.v1.AddressType
 	(SweepAddressKind)(0),                                  // 1: wallet.v1.SweepAddressKind
@@ -4774,165 +4861,167 @@ var file_wallet_v1_wallet_proto_goTypes = []any{
 	(*ReceiveAddress)(nil),                                 // 17: wallet.v1.ReceiveAddress
 	(*Confirmation)(nil),                                   // 18: wallet.v1.Confirmation
 	(*WalletTransaction)(nil),                              // 19: wallet.v1.WalletTransaction
-	(*ListSidechainDepositsRequest)(nil),                   // 20: wallet.v1.ListSidechainDepositsRequest
-	(*ListSidechainDepositsResponse)(nil),                  // 21: wallet.v1.ListSidechainDepositsResponse
-	(*CreateSidechainDepositRequest)(nil),                  // 22: wallet.v1.CreateSidechainDepositRequest
-	(*CreateSidechainDepositResponse)(nil),                 // 23: wallet.v1.CreateSidechainDepositResponse
-	(*SignMessageRequest)(nil),                             // 24: wallet.v1.SignMessageRequest
-	(*SignMessageResponse)(nil),                            // 25: wallet.v1.SignMessageResponse
-	(*VerifyMessageRequest)(nil),                           // 26: wallet.v1.VerifyMessageRequest
-	(*VerifyMessageResponse)(nil),                          // 27: wallet.v1.VerifyMessageResponse
-	(*GetStatsResponse)(nil),                               // 28: wallet.v1.GetStatsResponse
-	(*UnlockWalletRequest)(nil),                            // 29: wallet.v1.UnlockWalletRequest
-	(*CreateChequeRequest)(nil),                            // 30: wallet.v1.CreateChequeRequest
-	(*CreateChequeResponse)(nil),                           // 31: wallet.v1.CreateChequeResponse
-	(*GetChequeRequest)(nil),                               // 32: wallet.v1.GetChequeRequest
-	(*GetChequeResponse)(nil),                              // 33: wallet.v1.GetChequeResponse
-	(*GetChequePrivateKeyRequest)(nil),                     // 34: wallet.v1.GetChequePrivateKeyRequest
-	(*GetChequePrivateKeyResponse)(nil),                    // 35: wallet.v1.GetChequePrivateKeyResponse
-	(*Cheque)(nil),                                         // 36: wallet.v1.Cheque
-	(*ListChequesRequest)(nil),                             // 37: wallet.v1.ListChequesRequest
-	(*ListChequesResponse)(nil),                            // 38: wallet.v1.ListChequesResponse
-	(*CheckChequeFundingRequest)(nil),                      // 39: wallet.v1.CheckChequeFundingRequest
-	(*CheckChequeFundingResponse)(nil),                     // 40: wallet.v1.CheckChequeFundingResponse
-	(*PreviewSweepRequest)(nil),                            // 41: wallet.v1.PreviewSweepRequest
-	(*PreviewSweepResponse)(nil),                           // 42: wallet.v1.PreviewSweepResponse
-	(*SweepChequeRequest)(nil),                             // 43: wallet.v1.SweepChequeRequest
-	(*SweepChequeResponse)(nil),                            // 44: wallet.v1.SweepChequeResponse
-	(*DeleteChequeRequest)(nil),                            // 45: wallet.v1.DeleteChequeRequest
-	(*CreateBitcoinCoreWalletRequest)(nil),                 // 46: wallet.v1.CreateBitcoinCoreWalletRequest
-	(*CreateBitcoinCoreWalletResponse)(nil),                // 47: wallet.v1.CreateBitcoinCoreWalletResponse
-	(*UTXOMetadata)(nil),                                   // 48: wallet.v1.UTXOMetadata
-	(*SetUTXOMetadataRequest)(nil),                         // 49: wallet.v1.SetUTXOMetadataRequest
-	(*GetUTXOMetadataRequest)(nil),                         // 50: wallet.v1.GetUTXOMetadataRequest
-	(*GetUTXOMetadataResponse)(nil),                        // 51: wallet.v1.GetUTXOMetadataResponse
-	(*SetCoinSelectionStrategyRequest)(nil),                // 52: wallet.v1.SetCoinSelectionStrategyRequest
-	(*GetCoinSelectionStrategyResponse)(nil),               // 53: wallet.v1.GetCoinSelectionStrategyResponse
-	(*GetTransactionDetailsRequest)(nil),                   // 54: wallet.v1.GetTransactionDetailsRequest
-	(*GetTransactionDetailsResponse)(nil),                  // 55: wallet.v1.GetTransactionDetailsResponse
-	(*TransactionInput)(nil),                               // 56: wallet.v1.TransactionInput
-	(*TransactionOutput)(nil),                              // 57: wallet.v1.TransactionOutput
-	(*GetUTXODistributionRequest)(nil),                     // 58: wallet.v1.GetUTXODistributionRequest
-	(*GetUTXODistributionResponse)(nil),                    // 59: wallet.v1.GetUTXODistributionResponse
-	(*UTXOBucket)(nil),                                     // 60: wallet.v1.UTXOBucket
-	(*BumpFeeRequest)(nil),                                 // 61: wallet.v1.BumpFeeRequest
-	(*BumpFeeResponse)(nil),                                // 62: wallet.v1.BumpFeeResponse
-	(*SelectCoinsRequest)(nil),                             // 63: wallet.v1.SelectCoinsRequest
-	(*SelectCoinsResponse)(nil),                            // 64: wallet.v1.SelectCoinsResponse
-	(*CreateBackupResponse)(nil),                           // 65: wallet.v1.CreateBackupResponse
-	(*RestoreBackupRequest)(nil),                           // 66: wallet.v1.RestoreBackupRequest
-	(*ValidateBackupRequest)(nil),                          // 67: wallet.v1.ValidateBackupRequest
-	(*ValidateBackupResponse)(nil),                         // 68: wallet.v1.ValidateBackupResponse
-	nil,                                                    // 69: wallet.v1.SendTransactionRequest.DestinationsEntry
-	(*ListSidechainDepositsResponse_SidechainDeposit)(nil), // 70: wallet.v1.ListSidechainDepositsResponse.SidechainDeposit
-	nil,                           // 71: wallet.v1.GetUTXOMetadataResponse.MetadataEntry
-	(*timestamppb.Timestamp)(nil), // 72: google.protobuf.Timestamp
-	(*v1.DenialInfo)(nil),         // 73: bitwindowd.v1.DenialInfo
-	(*emptypb.Empty)(nil),         // 74: google.protobuf.Empty
+	(*BmmBid)(nil),                                         // 20: wallet.v1.BmmBid
+	(*ListSidechainDepositsRequest)(nil),                   // 21: wallet.v1.ListSidechainDepositsRequest
+	(*ListSidechainDepositsResponse)(nil),                  // 22: wallet.v1.ListSidechainDepositsResponse
+	(*CreateSidechainDepositRequest)(nil),                  // 23: wallet.v1.CreateSidechainDepositRequest
+	(*CreateSidechainDepositResponse)(nil),                 // 24: wallet.v1.CreateSidechainDepositResponse
+	(*SignMessageRequest)(nil),                             // 25: wallet.v1.SignMessageRequest
+	(*SignMessageResponse)(nil),                            // 26: wallet.v1.SignMessageResponse
+	(*VerifyMessageRequest)(nil),                           // 27: wallet.v1.VerifyMessageRequest
+	(*VerifyMessageResponse)(nil),                          // 28: wallet.v1.VerifyMessageResponse
+	(*GetStatsResponse)(nil),                               // 29: wallet.v1.GetStatsResponse
+	(*UnlockWalletRequest)(nil),                            // 30: wallet.v1.UnlockWalletRequest
+	(*CreateChequeRequest)(nil),                            // 31: wallet.v1.CreateChequeRequest
+	(*CreateChequeResponse)(nil),                           // 32: wallet.v1.CreateChequeResponse
+	(*GetChequeRequest)(nil),                               // 33: wallet.v1.GetChequeRequest
+	(*GetChequeResponse)(nil),                              // 34: wallet.v1.GetChequeResponse
+	(*GetChequePrivateKeyRequest)(nil),                     // 35: wallet.v1.GetChequePrivateKeyRequest
+	(*GetChequePrivateKeyResponse)(nil),                    // 36: wallet.v1.GetChequePrivateKeyResponse
+	(*Cheque)(nil),                                         // 37: wallet.v1.Cheque
+	(*ListChequesRequest)(nil),                             // 38: wallet.v1.ListChequesRequest
+	(*ListChequesResponse)(nil),                            // 39: wallet.v1.ListChequesResponse
+	(*CheckChequeFundingRequest)(nil),                      // 40: wallet.v1.CheckChequeFundingRequest
+	(*CheckChequeFundingResponse)(nil),                     // 41: wallet.v1.CheckChequeFundingResponse
+	(*PreviewSweepRequest)(nil),                            // 42: wallet.v1.PreviewSweepRequest
+	(*PreviewSweepResponse)(nil),                           // 43: wallet.v1.PreviewSweepResponse
+	(*SweepChequeRequest)(nil),                             // 44: wallet.v1.SweepChequeRequest
+	(*SweepChequeResponse)(nil),                            // 45: wallet.v1.SweepChequeResponse
+	(*DeleteChequeRequest)(nil),                            // 46: wallet.v1.DeleteChequeRequest
+	(*CreateBitcoinCoreWalletRequest)(nil),                 // 47: wallet.v1.CreateBitcoinCoreWalletRequest
+	(*CreateBitcoinCoreWalletResponse)(nil),                // 48: wallet.v1.CreateBitcoinCoreWalletResponse
+	(*UTXOMetadata)(nil),                                   // 49: wallet.v1.UTXOMetadata
+	(*SetUTXOMetadataRequest)(nil),                         // 50: wallet.v1.SetUTXOMetadataRequest
+	(*GetUTXOMetadataRequest)(nil),                         // 51: wallet.v1.GetUTXOMetadataRequest
+	(*GetUTXOMetadataResponse)(nil),                        // 52: wallet.v1.GetUTXOMetadataResponse
+	(*SetCoinSelectionStrategyRequest)(nil),                // 53: wallet.v1.SetCoinSelectionStrategyRequest
+	(*GetCoinSelectionStrategyResponse)(nil),               // 54: wallet.v1.GetCoinSelectionStrategyResponse
+	(*GetTransactionDetailsRequest)(nil),                   // 55: wallet.v1.GetTransactionDetailsRequest
+	(*GetTransactionDetailsResponse)(nil),                  // 56: wallet.v1.GetTransactionDetailsResponse
+	(*TransactionInput)(nil),                               // 57: wallet.v1.TransactionInput
+	(*TransactionOutput)(nil),                              // 58: wallet.v1.TransactionOutput
+	(*GetUTXODistributionRequest)(nil),                     // 59: wallet.v1.GetUTXODistributionRequest
+	(*GetUTXODistributionResponse)(nil),                    // 60: wallet.v1.GetUTXODistributionResponse
+	(*UTXOBucket)(nil),                                     // 61: wallet.v1.UTXOBucket
+	(*BumpFeeRequest)(nil),                                 // 62: wallet.v1.BumpFeeRequest
+	(*BumpFeeResponse)(nil),                                // 63: wallet.v1.BumpFeeResponse
+	(*SelectCoinsRequest)(nil),                             // 64: wallet.v1.SelectCoinsRequest
+	(*SelectCoinsResponse)(nil),                            // 65: wallet.v1.SelectCoinsResponse
+	(*CreateBackupResponse)(nil),                           // 66: wallet.v1.CreateBackupResponse
+	(*RestoreBackupRequest)(nil),                           // 67: wallet.v1.RestoreBackupRequest
+	(*ValidateBackupRequest)(nil),                          // 68: wallet.v1.ValidateBackupRequest
+	(*ValidateBackupResponse)(nil),                         // 69: wallet.v1.ValidateBackupResponse
+	nil,                                                    // 70: wallet.v1.SendTransactionRequest.DestinationsEntry
+	(*ListSidechainDepositsResponse_SidechainDeposit)(nil), // 71: wallet.v1.ListSidechainDepositsResponse.SidechainDeposit
+	nil,                           // 72: wallet.v1.GetUTXOMetadataResponse.MetadataEntry
+	(*timestamppb.Timestamp)(nil), // 73: google.protobuf.Timestamp
+	(*v1.DenialInfo)(nil),         // 74: bitwindowd.v1.DenialInfo
+	(*emptypb.Empty)(nil),         // 75: google.protobuf.Empty
 }
 var file_wallet_v1_wallet_proto_depIdxs = []int32{
 	0,  // 0: wallet.v1.GetNewAddressRequest.address_type:type_name -> wallet.v1.AddressType
-	69, // 1: wallet.v1.SendTransactionRequest.destinations:type_name -> wallet.v1.SendTransactionRequest.DestinationsEntry
+	70, // 1: wallet.v1.SendTransactionRequest.destinations:type_name -> wallet.v1.SendTransactionRequest.DestinationsEntry
 	14, // 2: wallet.v1.SendTransactionRequest.required_inputs:type_name -> wallet.v1.UnspentOutput
 	19, // 3: wallet.v1.ListTransactionsResponse.transactions:type_name -> wallet.v1.WalletTransaction
-	72, // 4: wallet.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
-	73, // 5: wallet.v1.UnspentOutput.denial_info:type_name -> bitwindowd.v1.DenialInfo
+	73, // 4: wallet.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
+	74, // 5: wallet.v1.UnspentOutput.denial_info:type_name -> bitwindowd.v1.DenialInfo
 	14, // 6: wallet.v1.ListUnspentResponse.utxos:type_name -> wallet.v1.UnspentOutput
 	17, // 7: wallet.v1.ListReceiveAddressesResponse.addresses:type_name -> wallet.v1.ReceiveAddress
-	72, // 8: wallet.v1.ReceiveAddress.last_used_at:type_name -> google.protobuf.Timestamp
-	72, // 9: wallet.v1.Confirmation.timestamp:type_name -> google.protobuf.Timestamp
+	73, // 8: wallet.v1.ReceiveAddress.last_used_at:type_name -> google.protobuf.Timestamp
+	73, // 9: wallet.v1.Confirmation.timestamp:type_name -> google.protobuf.Timestamp
 	18, // 10: wallet.v1.WalletTransaction.confirmation_time:type_name -> wallet.v1.Confirmation
-	70, // 11: wallet.v1.ListSidechainDepositsResponse.deposits:type_name -> wallet.v1.ListSidechainDepositsResponse.SidechainDeposit
-	72, // 12: wallet.v1.GetStatsResponse.last_tx_at:type_name -> google.protobuf.Timestamp
-	36, // 13: wallet.v1.GetChequeResponse.cheque:type_name -> wallet.v1.Cheque
-	72, // 14: wallet.v1.Cheque.created_at:type_name -> google.protobuf.Timestamp
-	72, // 15: wallet.v1.Cheque.funded_at:type_name -> google.protobuf.Timestamp
-	72, // 16: wallet.v1.Cheque.swept_at:type_name -> google.protobuf.Timestamp
-	36, // 17: wallet.v1.ListChequesResponse.cheques:type_name -> wallet.v1.Cheque
-	72, // 18: wallet.v1.CheckChequeFundingResponse.funded_at:type_name -> google.protobuf.Timestamp
-	1,  // 19: wallet.v1.PreviewSweepResponse.address_kind:type_name -> wallet.v1.SweepAddressKind
-	71, // 20: wallet.v1.GetUTXOMetadataResponse.metadata:type_name -> wallet.v1.GetUTXOMetadataResponse.MetadataEntry
-	2,  // 21: wallet.v1.SetCoinSelectionStrategyRequest.strategy:type_name -> wallet.v1.CoinSelectionStrategy
-	2,  // 22: wallet.v1.GetCoinSelectionStrategyResponse.strategy:type_name -> wallet.v1.CoinSelectionStrategy
-	56, // 23: wallet.v1.GetTransactionDetailsResponse.inputs:type_name -> wallet.v1.TransactionInput
-	57, // 24: wallet.v1.GetTransactionDetailsResponse.outputs:type_name -> wallet.v1.TransactionOutput
-	60, // 25: wallet.v1.GetUTXODistributionResponse.buckets:type_name -> wallet.v1.UTXOBucket
-	2,  // 26: wallet.v1.SelectCoinsRequest.strategy:type_name -> wallet.v1.CoinSelectionStrategy
-	14, // 27: wallet.v1.SelectCoinsResponse.selected_utxos:type_name -> wallet.v1.UnspentOutput
-	48, // 28: wallet.v1.GetUTXOMetadataResponse.MetadataEntry.value:type_name -> wallet.v1.UTXOMetadata
-	46, // 29: wallet.v1.WalletService.CreateBitcoinCoreWallet:input_type -> wallet.v1.CreateBitcoinCoreWalletRequest
-	10, // 30: wallet.v1.WalletService.SendTransaction:input_type -> wallet.v1.SendTransactionRequest
-	3,  // 31: wallet.v1.WalletService.GetBalance:input_type -> wallet.v1.GetBalanceRequest
-	4,  // 32: wallet.v1.WalletService.GetNewAddress:input_type -> wallet.v1.GetNewAddressRequest
-	6,  // 33: wallet.v1.WalletService.ListTransactions:input_type -> wallet.v1.ListTransactionsRequest
-	7,  // 34: wallet.v1.WalletService.ListUnspent:input_type -> wallet.v1.ListUnspentRequest
-	8,  // 35: wallet.v1.WalletService.ListReceiveAddresses:input_type -> wallet.v1.ListReceiveAddressesRequest
-	20, // 36: wallet.v1.WalletService.ListSidechainDeposits:input_type -> wallet.v1.ListSidechainDepositsRequest
-	22, // 37: wallet.v1.WalletService.CreateSidechainDeposit:input_type -> wallet.v1.CreateSidechainDepositRequest
-	24, // 38: wallet.v1.WalletService.SignMessage:input_type -> wallet.v1.SignMessageRequest
-	26, // 39: wallet.v1.WalletService.VerifyMessage:input_type -> wallet.v1.VerifyMessageRequest
-	9,  // 40: wallet.v1.WalletService.GetStats:input_type -> wallet.v1.GetStatsRequest
-	29, // 41: wallet.v1.WalletService.UnlockWallet:input_type -> wallet.v1.UnlockWalletRequest
-	74, // 42: wallet.v1.WalletService.LockWallet:input_type -> google.protobuf.Empty
-	74, // 43: wallet.v1.WalletService.IsWalletUnlocked:input_type -> google.protobuf.Empty
-	30, // 44: wallet.v1.WalletService.CreateCheque:input_type -> wallet.v1.CreateChequeRequest
-	32, // 45: wallet.v1.WalletService.GetCheque:input_type -> wallet.v1.GetChequeRequest
-	34, // 46: wallet.v1.WalletService.GetChequePrivateKey:input_type -> wallet.v1.GetChequePrivateKeyRequest
-	37, // 47: wallet.v1.WalletService.ListCheques:input_type -> wallet.v1.ListChequesRequest
-	39, // 48: wallet.v1.WalletService.CheckChequeFunding:input_type -> wallet.v1.CheckChequeFundingRequest
-	41, // 49: wallet.v1.WalletService.PreviewSweep:input_type -> wallet.v1.PreviewSweepRequest
-	43, // 50: wallet.v1.WalletService.SweepCheque:input_type -> wallet.v1.SweepChequeRequest
-	45, // 51: wallet.v1.WalletService.DeleteCheque:input_type -> wallet.v1.DeleteChequeRequest
-	49, // 52: wallet.v1.WalletService.SetUTXOMetadata:input_type -> wallet.v1.SetUTXOMetadataRequest
-	50, // 53: wallet.v1.WalletService.GetUTXOMetadata:input_type -> wallet.v1.GetUTXOMetadataRequest
-	52, // 54: wallet.v1.WalletService.SetCoinSelectionStrategy:input_type -> wallet.v1.SetCoinSelectionStrategyRequest
-	74, // 55: wallet.v1.WalletService.GetCoinSelectionStrategy:input_type -> google.protobuf.Empty
-	54, // 56: wallet.v1.WalletService.GetTransactionDetails:input_type -> wallet.v1.GetTransactionDetailsRequest
-	58, // 57: wallet.v1.WalletService.GetUTXODistribution:input_type -> wallet.v1.GetUTXODistributionRequest
-	61, // 58: wallet.v1.WalletService.BumpFee:input_type -> wallet.v1.BumpFeeRequest
-	63, // 59: wallet.v1.WalletService.SelectCoins:input_type -> wallet.v1.SelectCoinsRequest
-	74, // 60: wallet.v1.WalletService.CreateBackup:input_type -> google.protobuf.Empty
-	66, // 61: wallet.v1.WalletService.RestoreBackup:input_type -> wallet.v1.RestoreBackupRequest
-	67, // 62: wallet.v1.WalletService.ValidateBackup:input_type -> wallet.v1.ValidateBackupRequest
-	47, // 63: wallet.v1.WalletService.CreateBitcoinCoreWallet:output_type -> wallet.v1.CreateBitcoinCoreWalletResponse
-	11, // 64: wallet.v1.WalletService.SendTransaction:output_type -> wallet.v1.SendTransactionResponse
-	12, // 65: wallet.v1.WalletService.GetBalance:output_type -> wallet.v1.GetBalanceResponse
-	5,  // 66: wallet.v1.WalletService.GetNewAddress:output_type -> wallet.v1.GetNewAddressResponse
-	13, // 67: wallet.v1.WalletService.ListTransactions:output_type -> wallet.v1.ListTransactionsResponse
-	15, // 68: wallet.v1.WalletService.ListUnspent:output_type -> wallet.v1.ListUnspentResponse
-	16, // 69: wallet.v1.WalletService.ListReceiveAddresses:output_type -> wallet.v1.ListReceiveAddressesResponse
-	21, // 70: wallet.v1.WalletService.ListSidechainDeposits:output_type -> wallet.v1.ListSidechainDepositsResponse
-	23, // 71: wallet.v1.WalletService.CreateSidechainDeposit:output_type -> wallet.v1.CreateSidechainDepositResponse
-	25, // 72: wallet.v1.WalletService.SignMessage:output_type -> wallet.v1.SignMessageResponse
-	27, // 73: wallet.v1.WalletService.VerifyMessage:output_type -> wallet.v1.VerifyMessageResponse
-	28, // 74: wallet.v1.WalletService.GetStats:output_type -> wallet.v1.GetStatsResponse
-	74, // 75: wallet.v1.WalletService.UnlockWallet:output_type -> google.protobuf.Empty
-	74, // 76: wallet.v1.WalletService.LockWallet:output_type -> google.protobuf.Empty
-	74, // 77: wallet.v1.WalletService.IsWalletUnlocked:output_type -> google.protobuf.Empty
-	31, // 78: wallet.v1.WalletService.CreateCheque:output_type -> wallet.v1.CreateChequeResponse
-	33, // 79: wallet.v1.WalletService.GetCheque:output_type -> wallet.v1.GetChequeResponse
-	35, // 80: wallet.v1.WalletService.GetChequePrivateKey:output_type -> wallet.v1.GetChequePrivateKeyResponse
-	38, // 81: wallet.v1.WalletService.ListCheques:output_type -> wallet.v1.ListChequesResponse
-	40, // 82: wallet.v1.WalletService.CheckChequeFunding:output_type -> wallet.v1.CheckChequeFundingResponse
-	42, // 83: wallet.v1.WalletService.PreviewSweep:output_type -> wallet.v1.PreviewSweepResponse
-	44, // 84: wallet.v1.WalletService.SweepCheque:output_type -> wallet.v1.SweepChequeResponse
-	74, // 85: wallet.v1.WalletService.DeleteCheque:output_type -> google.protobuf.Empty
-	74, // 86: wallet.v1.WalletService.SetUTXOMetadata:output_type -> google.protobuf.Empty
-	51, // 87: wallet.v1.WalletService.GetUTXOMetadata:output_type -> wallet.v1.GetUTXOMetadataResponse
-	74, // 88: wallet.v1.WalletService.SetCoinSelectionStrategy:output_type -> google.protobuf.Empty
-	53, // 89: wallet.v1.WalletService.GetCoinSelectionStrategy:output_type -> wallet.v1.GetCoinSelectionStrategyResponse
-	55, // 90: wallet.v1.WalletService.GetTransactionDetails:output_type -> wallet.v1.GetTransactionDetailsResponse
-	59, // 91: wallet.v1.WalletService.GetUTXODistribution:output_type -> wallet.v1.GetUTXODistributionResponse
-	62, // 92: wallet.v1.WalletService.BumpFee:output_type -> wallet.v1.BumpFeeResponse
-	64, // 93: wallet.v1.WalletService.SelectCoins:output_type -> wallet.v1.SelectCoinsResponse
-	65, // 94: wallet.v1.WalletService.CreateBackup:output_type -> wallet.v1.CreateBackupResponse
-	74, // 95: wallet.v1.WalletService.RestoreBackup:output_type -> google.protobuf.Empty
-	68, // 96: wallet.v1.WalletService.ValidateBackup:output_type -> wallet.v1.ValidateBackupResponse
-	63, // [63:97] is the sub-list for method output_type
-	29, // [29:63] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	20, // 11: wallet.v1.WalletTransaction.bmm_bid:type_name -> wallet.v1.BmmBid
+	71, // 12: wallet.v1.ListSidechainDepositsResponse.deposits:type_name -> wallet.v1.ListSidechainDepositsResponse.SidechainDeposit
+	73, // 13: wallet.v1.GetStatsResponse.last_tx_at:type_name -> google.protobuf.Timestamp
+	37, // 14: wallet.v1.GetChequeResponse.cheque:type_name -> wallet.v1.Cheque
+	73, // 15: wallet.v1.Cheque.created_at:type_name -> google.protobuf.Timestamp
+	73, // 16: wallet.v1.Cheque.funded_at:type_name -> google.protobuf.Timestamp
+	73, // 17: wallet.v1.Cheque.swept_at:type_name -> google.protobuf.Timestamp
+	37, // 18: wallet.v1.ListChequesResponse.cheques:type_name -> wallet.v1.Cheque
+	73, // 19: wallet.v1.CheckChequeFundingResponse.funded_at:type_name -> google.protobuf.Timestamp
+	1,  // 20: wallet.v1.PreviewSweepResponse.address_kind:type_name -> wallet.v1.SweepAddressKind
+	72, // 21: wallet.v1.GetUTXOMetadataResponse.metadata:type_name -> wallet.v1.GetUTXOMetadataResponse.MetadataEntry
+	2,  // 22: wallet.v1.SetCoinSelectionStrategyRequest.strategy:type_name -> wallet.v1.CoinSelectionStrategy
+	2,  // 23: wallet.v1.GetCoinSelectionStrategyResponse.strategy:type_name -> wallet.v1.CoinSelectionStrategy
+	57, // 24: wallet.v1.GetTransactionDetailsResponse.inputs:type_name -> wallet.v1.TransactionInput
+	58, // 25: wallet.v1.GetTransactionDetailsResponse.outputs:type_name -> wallet.v1.TransactionOutput
+	61, // 26: wallet.v1.GetUTXODistributionResponse.buckets:type_name -> wallet.v1.UTXOBucket
+	2,  // 27: wallet.v1.SelectCoinsRequest.strategy:type_name -> wallet.v1.CoinSelectionStrategy
+	14, // 28: wallet.v1.SelectCoinsResponse.selected_utxos:type_name -> wallet.v1.UnspentOutput
+	49, // 29: wallet.v1.GetUTXOMetadataResponse.MetadataEntry.value:type_name -> wallet.v1.UTXOMetadata
+	47, // 30: wallet.v1.WalletService.CreateBitcoinCoreWallet:input_type -> wallet.v1.CreateBitcoinCoreWalletRequest
+	10, // 31: wallet.v1.WalletService.SendTransaction:input_type -> wallet.v1.SendTransactionRequest
+	3,  // 32: wallet.v1.WalletService.GetBalance:input_type -> wallet.v1.GetBalanceRequest
+	4,  // 33: wallet.v1.WalletService.GetNewAddress:input_type -> wallet.v1.GetNewAddressRequest
+	6,  // 34: wallet.v1.WalletService.ListTransactions:input_type -> wallet.v1.ListTransactionsRequest
+	7,  // 35: wallet.v1.WalletService.ListUnspent:input_type -> wallet.v1.ListUnspentRequest
+	8,  // 36: wallet.v1.WalletService.ListReceiveAddresses:input_type -> wallet.v1.ListReceiveAddressesRequest
+	21, // 37: wallet.v1.WalletService.ListSidechainDeposits:input_type -> wallet.v1.ListSidechainDepositsRequest
+	23, // 38: wallet.v1.WalletService.CreateSidechainDeposit:input_type -> wallet.v1.CreateSidechainDepositRequest
+	25, // 39: wallet.v1.WalletService.SignMessage:input_type -> wallet.v1.SignMessageRequest
+	27, // 40: wallet.v1.WalletService.VerifyMessage:input_type -> wallet.v1.VerifyMessageRequest
+	9,  // 41: wallet.v1.WalletService.GetStats:input_type -> wallet.v1.GetStatsRequest
+	30, // 42: wallet.v1.WalletService.UnlockWallet:input_type -> wallet.v1.UnlockWalletRequest
+	75, // 43: wallet.v1.WalletService.LockWallet:input_type -> google.protobuf.Empty
+	75, // 44: wallet.v1.WalletService.IsWalletUnlocked:input_type -> google.protobuf.Empty
+	31, // 45: wallet.v1.WalletService.CreateCheque:input_type -> wallet.v1.CreateChequeRequest
+	33, // 46: wallet.v1.WalletService.GetCheque:input_type -> wallet.v1.GetChequeRequest
+	35, // 47: wallet.v1.WalletService.GetChequePrivateKey:input_type -> wallet.v1.GetChequePrivateKeyRequest
+	38, // 48: wallet.v1.WalletService.ListCheques:input_type -> wallet.v1.ListChequesRequest
+	40, // 49: wallet.v1.WalletService.CheckChequeFunding:input_type -> wallet.v1.CheckChequeFundingRequest
+	42, // 50: wallet.v1.WalletService.PreviewSweep:input_type -> wallet.v1.PreviewSweepRequest
+	44, // 51: wallet.v1.WalletService.SweepCheque:input_type -> wallet.v1.SweepChequeRequest
+	46, // 52: wallet.v1.WalletService.DeleteCheque:input_type -> wallet.v1.DeleteChequeRequest
+	50, // 53: wallet.v1.WalletService.SetUTXOMetadata:input_type -> wallet.v1.SetUTXOMetadataRequest
+	51, // 54: wallet.v1.WalletService.GetUTXOMetadata:input_type -> wallet.v1.GetUTXOMetadataRequest
+	53, // 55: wallet.v1.WalletService.SetCoinSelectionStrategy:input_type -> wallet.v1.SetCoinSelectionStrategyRequest
+	75, // 56: wallet.v1.WalletService.GetCoinSelectionStrategy:input_type -> google.protobuf.Empty
+	55, // 57: wallet.v1.WalletService.GetTransactionDetails:input_type -> wallet.v1.GetTransactionDetailsRequest
+	59, // 58: wallet.v1.WalletService.GetUTXODistribution:input_type -> wallet.v1.GetUTXODistributionRequest
+	62, // 59: wallet.v1.WalletService.BumpFee:input_type -> wallet.v1.BumpFeeRequest
+	64, // 60: wallet.v1.WalletService.SelectCoins:input_type -> wallet.v1.SelectCoinsRequest
+	75, // 61: wallet.v1.WalletService.CreateBackup:input_type -> google.protobuf.Empty
+	67, // 62: wallet.v1.WalletService.RestoreBackup:input_type -> wallet.v1.RestoreBackupRequest
+	68, // 63: wallet.v1.WalletService.ValidateBackup:input_type -> wallet.v1.ValidateBackupRequest
+	48, // 64: wallet.v1.WalletService.CreateBitcoinCoreWallet:output_type -> wallet.v1.CreateBitcoinCoreWalletResponse
+	11, // 65: wallet.v1.WalletService.SendTransaction:output_type -> wallet.v1.SendTransactionResponse
+	12, // 66: wallet.v1.WalletService.GetBalance:output_type -> wallet.v1.GetBalanceResponse
+	5,  // 67: wallet.v1.WalletService.GetNewAddress:output_type -> wallet.v1.GetNewAddressResponse
+	13, // 68: wallet.v1.WalletService.ListTransactions:output_type -> wallet.v1.ListTransactionsResponse
+	15, // 69: wallet.v1.WalletService.ListUnspent:output_type -> wallet.v1.ListUnspentResponse
+	16, // 70: wallet.v1.WalletService.ListReceiveAddresses:output_type -> wallet.v1.ListReceiveAddressesResponse
+	22, // 71: wallet.v1.WalletService.ListSidechainDeposits:output_type -> wallet.v1.ListSidechainDepositsResponse
+	24, // 72: wallet.v1.WalletService.CreateSidechainDeposit:output_type -> wallet.v1.CreateSidechainDepositResponse
+	26, // 73: wallet.v1.WalletService.SignMessage:output_type -> wallet.v1.SignMessageResponse
+	28, // 74: wallet.v1.WalletService.VerifyMessage:output_type -> wallet.v1.VerifyMessageResponse
+	29, // 75: wallet.v1.WalletService.GetStats:output_type -> wallet.v1.GetStatsResponse
+	75, // 76: wallet.v1.WalletService.UnlockWallet:output_type -> google.protobuf.Empty
+	75, // 77: wallet.v1.WalletService.LockWallet:output_type -> google.protobuf.Empty
+	75, // 78: wallet.v1.WalletService.IsWalletUnlocked:output_type -> google.protobuf.Empty
+	32, // 79: wallet.v1.WalletService.CreateCheque:output_type -> wallet.v1.CreateChequeResponse
+	34, // 80: wallet.v1.WalletService.GetCheque:output_type -> wallet.v1.GetChequeResponse
+	36, // 81: wallet.v1.WalletService.GetChequePrivateKey:output_type -> wallet.v1.GetChequePrivateKeyResponse
+	39, // 82: wallet.v1.WalletService.ListCheques:output_type -> wallet.v1.ListChequesResponse
+	41, // 83: wallet.v1.WalletService.CheckChequeFunding:output_type -> wallet.v1.CheckChequeFundingResponse
+	43, // 84: wallet.v1.WalletService.PreviewSweep:output_type -> wallet.v1.PreviewSweepResponse
+	45, // 85: wallet.v1.WalletService.SweepCheque:output_type -> wallet.v1.SweepChequeResponse
+	75, // 86: wallet.v1.WalletService.DeleteCheque:output_type -> google.protobuf.Empty
+	75, // 87: wallet.v1.WalletService.SetUTXOMetadata:output_type -> google.protobuf.Empty
+	52, // 88: wallet.v1.WalletService.GetUTXOMetadata:output_type -> wallet.v1.GetUTXOMetadataResponse
+	75, // 89: wallet.v1.WalletService.SetCoinSelectionStrategy:output_type -> google.protobuf.Empty
+	54, // 90: wallet.v1.WalletService.GetCoinSelectionStrategy:output_type -> wallet.v1.GetCoinSelectionStrategyResponse
+	56, // 91: wallet.v1.WalletService.GetTransactionDetails:output_type -> wallet.v1.GetTransactionDetailsResponse
+	60, // 92: wallet.v1.WalletService.GetUTXODistribution:output_type -> wallet.v1.GetUTXODistributionResponse
+	63, // 93: wallet.v1.WalletService.BumpFee:output_type -> wallet.v1.BumpFeeResponse
+	65, // 94: wallet.v1.WalletService.SelectCoins:output_type -> wallet.v1.SelectCoinsResponse
+	66, // 95: wallet.v1.WalletService.CreateBackup:output_type -> wallet.v1.CreateBackupResponse
+	75, // 96: wallet.v1.WalletService.RestoreBackup:output_type -> google.protobuf.Empty
+	69, // 97: wallet.v1.WalletService.ValidateBackup:output_type -> wallet.v1.ValidateBackupResponse
+	64, // [64:98] is the sub-list for method output_type
+	30, // [30:64] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_wallet_v1_wallet_proto_init() }
@@ -4941,16 +5030,16 @@ func file_wallet_v1_wallet_proto_init() {
 		return
 	}
 	file_wallet_v1_wallet_proto_msgTypes[11].OneofWrappers = []any{}
-	file_wallet_v1_wallet_proto_msgTypes[33].OneofWrappers = []any{}
-	file_wallet_v1_wallet_proto_msgTypes[37].OneofWrappers = []any{}
-	file_wallet_v1_wallet_proto_msgTypes[46].OneofWrappers = []any{}
+	file_wallet_v1_wallet_proto_msgTypes[34].OneofWrappers = []any{}
+	file_wallet_v1_wallet_proto_msgTypes[38].OneofWrappers = []any{}
+	file_wallet_v1_wallet_proto_msgTypes[47].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_v1_wallet_proto_rawDesc), len(file_wallet_v1_wallet_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   69,
+			NumMessages:   70,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/bitwindow/server/proto/wallet/v1/wallet.proto
+++ b/bitwindow/server/proto/wallet/v1/wallet.proto
@@ -200,6 +200,19 @@ message WalletTransaction {
   string note = 7;
 
   Confirmation confirmation_time = 8;
+  // Set when output 0 carries a BMM request. Unset for every other transaction.
+  BmmBid bmm_bid = 9;
+}
+
+// BmmBid names the BMM request one wallet transaction carries.
+message BmmBid {
+  uint32 slot = 1;
+  string critical_hash = 2;
+  // The mainchain block the sidechain block builds on. The bid reaches only
+  // the block after it.
+  string prev_main_hash = 3;
+  // True when the mainchain tip moved past prev_main_hash.
+  bool lost = 4;
 }
 
 message ListSidechainDepositsRequest {

--- a/bitwindow/test/bmm_bid_row_test.dart
+++ b/bitwindow/test/bmm_bid_row_test.dart
@@ -1,0 +1,49 @@
+import 'package:bitwindow/pages/wallet/wallet_overview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+WalletTransaction _tx({int height = 0, BmmBid? bid}) {
+  return WalletTransaction(
+    txid: 'abc',
+    confirmationTime: Confirmation(height: height),
+    bmmBid: bid,
+  );
+}
+
+BmmBid _bid({required bool lost, int slot = 9}) {
+  return BmmBid(slot: slot, criticalHash: 'aa', prevMainHash: 'bb', lost: lost);
+}
+
+void main() {
+  group('transactionStatus', () {
+    test('a plain transaction keeps the two words it always had', () {
+      expect(transactionStatus(_tx()), 'Unconfirmed');
+      expect(transactionStatus(_tx(height: 3)), 'Confirmed');
+    });
+
+    test('a live bid names the slot it bids for', () {
+      expect(transactionStatus(_tx(bid: _bid(lost: false, slot: 4))), 'BMM bid · slot 4');
+    });
+
+    test('a stranded bid says it lost', () {
+      expect(transactionStatus(_tx(bid: _bid(lost: true))), 'BMM bid · lost');
+    });
+  });
+
+  group('canCancelBid', () {
+    test('only a lost bid offers the cancel', () {
+      expect(canCancelBid(_tx(bid: _bid(lost: true))), isTrue);
+      expect(canCancelBid(_tx(bid: _bid(lost: false))), isFalse);
+      expect(canCancelBid(_tx()), isFalse);
+    });
+  });
+
+  group('canBumpFee', () {
+    // A raise rebuilds the M8 for a live round. A lost bid has no round left,
+    // so the row offers the cancel in its place.
+    test('a lost bid offers the cancel rather than the bump', () {
+      expect(canBumpFee(_tx(bid: _bid(lost: true))), isFalse);
+      expect(canBumpFee(_tx(bid: _bid(lost: false))), isTrue);
+    });
+  });
+}

--- a/sidechain-orchestrator/api/bmm_cancel.go
+++ b/sidechain-orchestrator/api/bmm_cancel.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"connectrpc.com/connect"
+
+	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
+	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+)
+
+// cancelDustSats is the smallest payment the wallet accepts. Coins under the
+// replacement fee plus this cannot come back.
+const cancelDustSats = 546
+
+// CancelBid replaces a stranded bid with a payment back to its own wallet.
+//
+// The replacement respends the coins under the whole unconfirmed bid chain, so
+// it evicts every bid that sits on them, and it pays more than all of them
+// together. It carries no M8, so the mempool drops the request and the coins
+// come back.
+func (h *BMMHandler) CancelBid(
+	ctx context.Context, req *connect.Request[bmmpb.CancelBidRequest],
+) (*connect.Response[bmmpb.CancelBidResponse], error) {
+	if err := h.requireBMMAvailable(); err != nil {
+		return nil, err
+	}
+	if h.wallet == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no wallet is loaded"))
+	}
+	if req.Msg.Txid == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name the bid to cancel"))
+	}
+	walletID, err := h.wallet.ResolveWalletID(req.Msg.WalletId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	tip, err := coreTipHash(ctx, h.coreCall)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, err)
+	}
+	if err := h.requireStrandedBid(ctx, req.Msg.Txid, tip); err != nil {
+		return nil, err
+	}
+
+	inputs, roots, err := h.bidInputs(ctx, req.Msg.Txid)
+	if err != nil {
+		return nil, err
+	}
+	evicted := h.evictedByReplacement(ctx, roots)
+	if err := h.requireNoLiveBid(ctx, evicted, tip, req.Msg.Txid); err != nil {
+		return nil, err
+	}
+
+	evictedSats, err := h.evictedFeeSats(ctx, roots)
+	if err != nil {
+		return nil, err
+	}
+	vsize, err := h.cancelVsize(ctx, roots, len(inputs))
+	if err != nil {
+		return nil, err
+	}
+	incrementalSatPerKvB, err := incrementalRelayFeeSatPerKvB(ctx, h.coreCall)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, err)
+	}
+	feeSats := cancelFeeSats(evictedSats, vsize, incrementalSatPerKvB)
+
+	totalSats, err := h.inputValueSats(ctx, inputs)
+	if err != nil {
+		return nil, err
+	}
+	recoveredSats := totalSats - feeSats
+	if recoveredSats < cancelDustSats {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"the coins under %s hold %d sats, under the %d sat replacement fee plus dust",
+			req.Msg.Txid, totalSats, feeSats))
+	}
+
+	address, err := h.wallet.GetNewAddress(ctx, connect.NewRequest(&wpb.GetNewAddressRequest{
+		WalletId: walletID,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	send, err := h.wallet.SendTransaction(ctx, connect.NewRequest(&wpb.SendTransactionRequest{
+		WalletId:       walletID,
+		Destinations:   map[string]int64{address.Msg.Address: recoveredSats},
+		RequiredInputs: inputs,
+		FixedFeeSats:   feeSats,
+		Replaceable:    true,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&bmmpb.CancelBidResponse{
+		ReplacementTxid: send.Msg.Txid,
+		RecoveredSats:   recoveredSats,
+		FeeSats:         feeSats,
+		CancelledTxids:  evicted,
+	}), nil
+}
+
+// requireStrandedBid refuses a bid the next block can still take. Cancelling
+// one throws away a round the wallet already paid for.
+func (h *BMMHandler) requireStrandedBid(ctx context.Context, txid, tip string) error {
+	if !h.pendingBid(ctx, txid) {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"%s is not an unconfirmed BMM bid", txid))
+	}
+	if !inMempool(ctx, h.coreCall, txid) {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"bid %s is not in the mempool", txid))
+	}
+	script, err := firstOutputScript(ctx, h.coreCall, txid)
+	if err != nil {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	bid := BidLabel(script, tip)
+	if bid == nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s is not a BMM bid", txid))
+	}
+	if !bid.Lost {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"bid %s builds on the current tip and can still win", txid))
+	}
+	return nil
+}
+
+// cancelFeeSats is what a cancel of vsize vbytes pays to evict evictedSats of
+// fees, by BIP125 rules 3 and 4.
+func cancelFeeSats(evictedSats, vsize, incrementalSatPerKvB int64) int64 {
+	feeSats := evictedSats + (incrementalSatPerKvB*vsize+999)/1000
+	// A chain the mempool forgot evicts nothing, and a cancel still pays a miner.
+	return max(feeSats, replacementBumpSats)
+}
+
+// cancelVsize bounds the size of the cancel. It spends only coins the roots
+// spend, through one output, so only a longer signature makes it larger.
+func (h *BMMHandler) cancelVsize(ctx context.Context, roots []string, inputCount int) (int64, error) {
+	var total int64
+	for _, root := range roots {
+		raw, err := h.coreCall(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", root))
+		if err != nil {
+			return 0, connect.NewError(connect.CodeNotFound, fmt.Errorf("read bid %s: %w", root, err))
+		}
+		var tx struct {
+			Vsize int64 `json:"vsize"`
+		}
+		if err := json.Unmarshal(raw, &tx); err != nil {
+			return 0, connect.NewError(connect.CodeInternal, fmt.Errorf("decode bid %s: %w", root, err))
+		}
+		if tx.Vsize <= 0 {
+			return 0, connect.NewError(connect.CodeInternal, fmt.Errorf("bid %s reports no size", root))
+		}
+		total += tx.Vsize
+	}
+	return total + int64(inputCount), nil
+}
+
+// incrementalRelayFeeSatPerKvB reads the rate a replacement pays on its own
+// size, over the fees it evicts.
+func incrementalRelayFeeSatPerKvB(ctx context.Context, call coreReader) (int64, error) {
+	raw, err := call(ctx, "getnetworkinfo", "[]")
+	if err != nil {
+		return 0, fmt.Errorf("read the incremental relay fee: %w", err)
+	}
+	var info struct {
+		IncrementalFee *float64 `json:"incrementalfee"`
+	}
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return 0, fmt.Errorf("decode the incremental relay fee: %w", err)
+	}
+	if info.IncrementalFee == nil {
+		return 0, fmt.Errorf("the node reports no incremental relay fee")
+	}
+	return int64(math.Round(*info.IncrementalFee * 1e8)), nil
+}
+
+// evictedByReplacement names every transaction the replacement removes: each
+// root of the chain and everything the mempool holds over it.
+func (h *BMMHandler) evictedByReplacement(ctx context.Context, roots []string) []string {
+	seen := make(map[string]bool)
+	var all []string
+	for _, root := range roots {
+		for _, txid := range append([]string{root}, h.mempoolDescendants(ctx, root)...) {
+			if seen[txid] {
+				continue
+			}
+			seen[txid] = true
+			all = append(all, txid)
+		}
+	}
+	return all
+}
+
+// requireNoLiveBid refuses a cancel that would take this round's bid with it.
+// One wallet funds every slot, so a live bid of another slot can sit on the
+// same coins.
+func (h *BMMHandler) requireNoLiveBid(ctx context.Context, evicted []string, tip, cancelling string) error {
+	for _, txid := range evicted {
+		if txid == cancelling {
+			continue
+		}
+		req, err := h.m8Request(ctx, txid)
+		if err != nil || req == nil {
+			continue
+		}
+		if req.PrevMainHash == tip {
+			return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+				"cancelling %s would evict the live bid %s", cancelling, txid))
+		}
+	}
+	return nil
+}
+
+// inputValueSats totals what the named outpoints hold. It reads each parent
+// transaction one time, because a bid chain shares its parents.
+func (h *BMMHandler) inputValueSats(ctx context.Context, inputs []*wpb.UnspentOutput) (int64, error) {
+	values := make(map[string][]int64, len(inputs))
+	var total int64
+	for _, in := range inputs {
+		outs, ok := values[in.Txid]
+		if !ok {
+			var err error
+			outs, err = outputValuesSats(ctx, h.coreCall, in.Txid)
+			if err != nil {
+				return 0, connect.NewError(connect.CodeInternal, err)
+			}
+			values[in.Txid] = outs
+		}
+		if int(in.Vout) >= len(outs) {
+			return 0, connect.NewError(connect.CodeInternal, fmt.Errorf(
+				"transaction %s has no output %d", in.Txid, in.Vout))
+		}
+		total += outs[in.Vout]
+	}
+	return total, nil
+}
+
+// outputValuesSats reads what every output of one transaction holds.
+func outputValuesSats(ctx context.Context, call coreReader, txid string) ([]int64, error) {
+	raw, err := call(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
+	if err != nil {
+		return nil, fmt.Errorf("read transaction %s: %w", txid, err)
+	}
+	var tx struct {
+		Vout []struct {
+			Value float64 `json:"value"`
+		} `json:"vout"`
+	}
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return nil, fmt.Errorf("decode transaction %s: %w", txid, err)
+	}
+	values := make([]int64, len(tx.Vout))
+	for i, out := range tx.Vout {
+		values[i] = int64(math.Round(out.Value * 1e8))
+	}
+	return values, nil
+}

--- a/sidechain-orchestrator/api/bmm_cancel_test.go
+++ b/sidechain-orchestrator/api/bmm_cancel_test.go
@@ -1,0 +1,333 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
+)
+
+const (
+	cancelTip    = "aaaa000000000000000000000000000000000000000000000000000000000000"
+	cancelOldTip = "bbbb000000000000000000000000000000000000000000000000000000000000"
+)
+
+// cancelTx names one transaction the fake node holds.
+type cancelTx struct {
+	// vin names what the transaction spends, as "txid:vout".
+	vin []string
+	// values holds what each output carries, in sats.
+	values []int64
+	// slot marks a bid for that sidechain. A zero slot names no bid.
+	slot int
+	// prevMain is the block the bid builds on.
+	prevMain string
+	// confirmations above zero says a block carries it.
+	confirmations int
+	// feeSats is what the mempool reports the transaction pays.
+	feeSats int64
+	// descendants names the transactions the mempool holds over this one.
+	descendants []string
+	// replaced says a replacement took it out of the mempool.
+	replaced bool
+	// vsize is its size in vbytes. Zero reads as a one input bid.
+	vsize int64
+}
+
+// cancelNode answers every Core read the cancel makes.
+type cancelNode struct {
+	txs map[string]cancelTx
+	tip string
+	// incrementalFee is the incremental relay fee, in BTC/kvB.
+	incrementalFee float64
+}
+
+func (n *cancelNode) call(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
+	var params []any
+	if paramsJSON != "" {
+		if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+			return nil, err
+		}
+	}
+	txid := ""
+	if len(params) > 0 {
+		txid, _ = params[0].(string)
+	}
+
+	switch method {
+	case "getbestblockhash":
+		return json.Marshal(n.tip)
+	case "getmempooldescendants":
+		return json.Marshal(n.txs[txid].descendants)
+	case "getnetworkinfo":
+		return json.Marshal(map[string]any{"incrementalfee": n.incrementalFee})
+	case "getmempoolentry":
+		tx, ok := n.txs[txid]
+		if !ok || tx.replaced {
+			return nil, fmt.Errorf("transaction %s not in mempool", txid)
+		}
+		return json.Marshal(map[string]any{
+			"fees": map[string]any{"modified": float64(tx.feeSats) / 1e8},
+		})
+	case "getrawtransaction":
+		tx, ok := n.txs[txid]
+		if !ok {
+			return nil, fmt.Errorf("no transaction %s", txid)
+		}
+		return json.Marshal(n.rawTx(tx))
+	}
+	return nil, fmt.Errorf("the cancel called %s", method)
+}
+
+func (n *cancelNode) rawTx(tx cancelTx) map[string]any {
+	vsize := tx.vsize
+	if vsize == 0 {
+		vsize = nominalBidVsize
+	}
+	out := map[string]any{"confirmations": tx.confirmations, "vsize": vsize}
+	vin := make([]map[string]any, 0, len(tx.vin))
+	for _, in := range tx.vin {
+		parts := strings.Split(in, ":")
+		var vout int
+		_, _ = fmt.Sscanf(parts[1], "%d", &vout)
+		vin = append(vin, map[string]any{"txid": parts[0], "vout": vout})
+	}
+	out["vin"] = vin
+
+	vout := make([]map[string]any, 0, len(tx.values))
+	for i, value := range tx.values {
+		entry := map[string]any{"value": float64(value) / 1e8, "scriptPubKey": map[string]any{"hex": ""}}
+		if i == 0 && tx.slot > 0 {
+			script, err := orchestrator.M8BmmRequestScript(uint8(tx.slot), strings.Repeat("ab", 32), tx.prevMain)
+			if err == nil {
+				entry["scriptPubKey"] = map[string]any{"hex": hex.EncodeToString(script)}
+			}
+		}
+		vout = append(vout, entry)
+	}
+	out["vout"] = vout
+	return out
+}
+
+// strandedNode holds one confirmed coin of 1 BTC under one lost bid.
+func strandedNode() *cancelNode {
+	return &cancelNode{
+		tip:            cancelTip,
+		incrementalFee: 0.00001,
+		txs: map[string]cancelTx{
+			"coin": {confirmations: 6, values: []int64{0, 100_000_000}},
+			"lost": {
+				vin:      []string{"coin:1"},
+				values:   []int64{0, 99_990_000},
+				slot:     9,
+				prevMain: cancelOldTip,
+				feeSats:  10_000,
+			},
+		},
+	}
+}
+
+func cancelHandler(t *testing.T, node *cancelNode, w *fakeBidWallet) *BMMHandler {
+	t.Helper()
+	h, _ := newBMMModeHandler(t)
+	h.wallet = w
+	h.SetCoreCaller(node.call)
+	return h
+}
+
+func cancel(t *testing.T, node *cancelNode, w *fakeBidWallet, txid string) (*bmmpb.CancelBidResponse, error) {
+	t.Helper()
+	resp, err := cancelHandler(t, node, w).CancelBid(
+		context.Background(), connect.NewRequest(&bmmpb.CancelBidRequest{Txid: txid}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+func TestCancelBidPaysTheCoinsBackToItsOwnWallet(t *testing.T) {
+	node := strandedNode()
+	w := &fakeBidWallet{sendTxid: "replacement"}
+
+	got, err := cancel(t, node, w, "lost")
+	require.NoError(t, err)
+
+	require.Equal(t, "replacement", got.ReplacementTxid)
+	require.Equal(t, int64(10_189), got.FeeSats, "the evicted fee plus 1 sat/vB on 189 vB")
+	require.Equal(t, int64(100_000_000-10_189), got.RecoveredSats)
+	require.Equal(t, []string{"lost"}, got.CancelledTxids)
+
+	require.Len(t, w.sends, 1)
+	send := w.sends[0]
+	require.Equal(t, map[string]int64{"address-1": 99_989_811}, send.Destinations)
+	require.Equal(t, int64(10_189), send.FixedFeeSats)
+	require.True(t, send.Replaceable)
+	require.Zero(t, send.FeeRateSatPerVbyte, "a rate beside a fixed fee is refused")
+	require.False(t, send.SubtractFeeFromAmount, "Core ignores it beside a fixed fee")
+	require.Empty(t, send.RawOutputs, "no M8, or the replacement bids again")
+	require.Len(t, send.RequiredInputs, 1)
+	require.Equal(t, "coin", send.RequiredInputs[0].Txid)
+}
+
+// The M8 reaches only the block after the one it names. A bid on the tip can
+// still win, and cancelling it throws away a round the wallet paid for.
+func TestCancelBidRefusesABidThatCanStillWin(t *testing.T) {
+	node := strandedNode()
+	live := node.txs["lost"]
+	live.prevMain = cancelTip
+	node.txs["lost"] = live
+
+	_, err := cancel(t, node, &fakeBidWallet{}, "lost")
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "can still win")
+}
+
+// One wallet funds every slot, so another slot's live bid can sit on the same
+// coins. The replacement would take it too.
+func TestCancelBidRefusesToEvictALiveBid(t *testing.T) {
+	node := strandedNode()
+	lost := node.txs["lost"]
+	lost.descendants = []string{"live"}
+	node.txs["lost"] = lost
+	node.txs["live"] = cancelTx{
+		vin:      []string{"lost:1"},
+		values:   []int64{0, 99_980_000},
+		slot:     4,
+		prevMain: cancelTip,
+		feeSats:  10_000,
+	}
+
+	_, err := cancel(t, node, &fakeBidWallet{}, "lost")
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "live bid live")
+}
+
+func TestCancelBidRefusesAPlainPayment(t *testing.T) {
+	node := &cancelNode{tip: cancelTip, txs: map[string]cancelTx{
+		"coin":    {confirmations: 6, values: []int64{100_000_000}},
+		"payment": {vin: []string{"coin:0"}, values: []int64{99_990_000}},
+	}}
+
+	_, err := cancel(t, node, &fakeBidWallet{}, "payment")
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "not an unconfirmed BMM bid")
+}
+
+func TestCancelBidRefusesAnEmptyTxid(t *testing.T) {
+	_, err := cancel(t, strandedNode(), &fakeBidWallet{}, "")
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// A coin under the fee cannot come back, and a send would fail on dust.
+func TestCancelBidRefusesACoinUnderTheFee(t *testing.T) {
+	node := strandedNode()
+	coin := node.txs["coin"]
+	coin.values = []int64{0, 5_000}
+	node.txs["coin"] = coin
+
+	_, err := cancel(t, node, &fakeBidWallet{}, "lost")
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "under the")
+}
+
+// A node that forgot the chain reports no fee, and a free replacement reaches
+// no miner.
+func TestCancelBidPaysTheBumpWhenTheMempoolForgotTheChain(t *testing.T) {
+	node := strandedNode()
+	lost := node.txs["lost"]
+	lost.feeSats = 0
+	node.txs["lost"] = lost
+	w := &fakeBidWallet{sendTxid: "replacement"}
+
+	got, err := cancel(t, node, w, "lost")
+
+	require.NoError(t, err)
+	require.Equal(t, int64(replacementBumpSats), got.FeeSats)
+}
+
+// The chain shares one parent, so a deep chain still reads it one time.
+func TestCancelBidRespendsTheWholeChain(t *testing.T) {
+	node := &cancelNode{tip: cancelTip, incrementalFee: 0.00001, txs: map[string]cancelTx{
+		"coin": {confirmations: 6, values: []int64{0, 100_000_000}},
+		"root": {vin: []string{"coin:1"}, values: []int64{0, 99_990_000}, slot: 9, prevMain: cancelOldTip, feeSats: 10_000, descendants: []string{"top"}},
+		"top":  {vin: []string{"root:1"}, values: []int64{0, 99_980_000}, slot: 9, prevMain: cancelOldTip, feeSats: 10_000},
+	}}
+	w := &fakeBidWallet{sendTxid: "replacement"}
+
+	got, err := cancel(t, node, w, "top")
+
+	require.NoError(t, err)
+	require.Equal(t, int64(20_189), got.FeeSats, "both bids plus 1 sat/vB on the root's size")
+	require.ElementsMatch(t, []string{"root", "top"}, got.CancelledTxids)
+	require.Len(t, w.sends[0].RequiredInputs, 1)
+	require.Equal(t, "coin", w.sends[0].RequiredInputs[0].Txid)
+}
+
+// An RBF raise leaves the replaced bid in the wallet with no confirmations. The
+// live bid conflicts with it and does not descend from it, so no descendant read
+// finds the live bid.
+func TestCancelBidRefusesAReplacedBid(t *testing.T) {
+	node := strandedNode()
+	replaced := node.txs["lost"]
+	replaced.replaced = true
+	node.txs["lost"] = replaced
+	node.txs["live"] = cancelTx{
+		vin:      []string{"coin:1"},
+		values:   []int64{0, 99_980_000},
+		slot:     9,
+		prevMain: cancelTip,
+		feeSats:  20_000,
+	}
+	w := &fakeBidWallet{sendTxid: "replacement"}
+
+	_, err := cancel(t, node, w, "lost")
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.Contains(t, err.Error(), "not in the mempool")
+	require.Empty(t, w.sends)
+}
+
+// The node wants the incremental relay fee on every vbyte of the cancel, over
+// the fees it evicts. A bid over many coins makes a large cancel.
+func TestCancelBidPaysTheIncrementalRelayFeeOnItsSize(t *testing.T) {
+	const coins = 30
+	node := strandedNode()
+	node.incrementalFee = 0.00002
+	coin := cancelTx{confirmations: 6}
+	lost := node.txs["lost"]
+	lost.vin = nil
+	lost.vsize = 2_100
+	for i := range coins {
+		coin.values = append(coin.values, 1_000_000)
+		lost.vin = append(lost.vin, fmt.Sprintf("coin:%d", i))
+	}
+	node.txs["coin"] = coin
+	node.txs["lost"] = lost
+	w := &fakeBidWallet{sendTxid: "replacement"}
+
+	got, err := cancel(t, node, w, "lost")
+
+	require.NoError(t, err)
+	require.Len(t, w.sends[0].RequiredInputs, coins)
+	require.Equal(t, int64(10_000+2*(2_100+coins)), got.FeeSats,
+		"the evicted fee plus 2 sat/vB on the largest the cancel can be")
+}

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -1075,6 +1075,16 @@ func (h *BMMHandler) sidechainConfig(binary pb.BinaryType) (orchestrator.BinaryC
 //
 // A transaction the mempool no longer holds needs no floor at all.
 func (h *BMMHandler) replacementFloorSats(ctx context.Context, roots []string) (int64, error) {
+	total, err := h.evictedFeeSats(ctx, roots)
+	if err != nil || total == 0 {
+		return 0, err
+	}
+	return total + replacementBumpSats, nil
+}
+
+// evictedFeeSats totals the modified fees of every mempool transaction a
+// replacement of roots evicts.
+func (h *BMMHandler) evictedFeeSats(ctx context.Context, roots []string) (int64, error) {
 	// One chain can carry two roots, and a bid over both of them belongs to
 	// each root's descendants. So each transaction counts one time, by txid.
 	counted := make(map[string]bool)
@@ -1097,10 +1107,7 @@ func (h *BMMHandler) replacementFloorSats(ctx context.Context, roots []string) (
 	// A node that deprioritised the chain reports a fee far below zero, and a
 	// replacement then beats it at any price. Core compares the same modified
 	// fees, so this is the number its own rule reads.
-	if total <= 0 {
-		return 0, nil
-	}
-	return total + replacementBumpSats, nil
+	return max(total, 0), nil
 }
 
 // mempoolDescendants names every transaction the mempool holds over one

--- a/sidechain-orchestrator/api/bmm_label.go
+++ b/sidechain-orchestrator/api/bmm_label.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+)
+
+// coreReader calls one mainchain Core RPC method.
+type coreReader func(ctx context.Context, method, paramsJSON string) (json.RawMessage, error)
+
+// BidLabel reads a BMM request from an output's scriptPubKey and says whether
+// the bid can still win. tipHash is the current mainchain tip. It returns nil
+// for every other script.
+func BidLabel(scriptHex, tipHash string) *wpb.BmmBid {
+	script, err := hex.DecodeString(scriptHex)
+	if err != nil {
+		return nil
+	}
+	req := orchestrator.ParseM8BmmRequestScript(script)
+	if req == nil {
+		return nil
+	}
+	return &wpb.BmmBid{
+		Slot:         uint32(req.Slot),
+		CriticalHash: req.CriticalHash,
+		PrevMainHash: req.PrevMainHash,
+		// A bid names one parent block, so a moved tip strands it. An unknown
+		// tip leaves the bid live rather than calling a winnable bid lost.
+		Lost: tipHash != "" && tipHash != req.PrevMainHash,
+	}
+}
+
+// BidLabels names the BMM request each mempool transaction carries. A
+// transaction the node cannot read, or the mempool does not hold, gets no label.
+func BidLabels(ctx context.Context, call coreReader, txids []string) map[string]*wpb.BmmBid {
+	if len(txids) == 0 {
+		return nil
+	}
+	tip, err := coreTipHash(ctx, call)
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]*wpb.BmmBid, len(txids))
+	for _, txid := range txids {
+		if _, done := out[txid]; done {
+			continue
+		}
+		script, err := firstOutputScript(ctx, call, txid)
+		if err != nil {
+			continue
+		}
+		if bid := BidLabel(script, tip); bid != nil && inMempool(ctx, call, txid) {
+			out[txid] = bid
+		}
+	}
+	return out
+}
+
+// inMempool says whether the mempool holds txid. A replaced bid stays in the
+// wallet with no confirmations, but the mempool drops it.
+func inMempool(ctx context.Context, call coreReader, txid string) bool {
+	_, err := call(ctx, "getmempoolentry", fmt.Sprintf("[%q]", txid))
+	return err == nil
+}
+
+func coreTipHash(ctx context.Context, call coreReader) (string, error) {
+	raw, err := call(ctx, "getbestblockhash", "[]")
+	if err != nil {
+		return "", fmt.Errorf("read the mainchain tip: %w", err)
+	}
+	var hash string
+	if err := json.Unmarshal(raw, &hash); err != nil {
+		return "", fmt.Errorf("decode the mainchain tip: %w", err)
+	}
+	return hash, nil
+}
+
+func firstOutputScript(ctx context.Context, call coreReader, txid string) (string, error) {
+	raw, err := call(ctx, "getrawtransaction", fmt.Sprintf("[%q,true]", txid))
+	if err != nil {
+		return "", fmt.Errorf("read transaction %s: %w", txid, err)
+	}
+	var tx struct {
+		Vout []struct {
+			ScriptPubKey struct {
+				Hex string `json:"hex"`
+			} `json:"scriptPubKey"`
+		} `json:"vout"`
+	}
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return "", fmt.Errorf("decode transaction %s: %w", txid, err)
+	}
+	if len(tx.Vout) == 0 {
+		return "", fmt.Errorf("transaction %s has no outputs", txid)
+	}
+	return tx.Vout[0].ScriptPubKey.Hex, nil
+}

--- a/sidechain-orchestrator/api/bmm_label_test.go
+++ b/sidechain-orchestrator/api/bmm_label_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+)
+
+const (
+	labelTip      = "00000000000000000000a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f6"
+	labelOldTip   = "00000000000000000000ffeeddccbbaa99887766554433221100ffeeddccbbaa"
+	labelCritical = "1111111111111111111111111111111111111111111111111111111111111111"
+)
+
+func bidScriptHex(t *testing.T, slot uint8, prevMain string) string {
+	t.Helper()
+	script, err := orchestrator.M8BmmRequestScript(slot, labelCritical, prevMain)
+	require.NoError(t, err)
+	return hex.EncodeToString(script)
+}
+
+func TestBidLabelReadsALiveBid(t *testing.T) {
+	bid := BidLabel(bidScriptHex(t, 9, labelTip), labelTip)
+
+	require.NotNil(t, bid)
+	require.Equal(t, uint32(9), bid.Slot)
+	require.Equal(t, labelCritical, bid.CriticalHash)
+	require.Equal(t, labelTip, bid.PrevMainHash)
+	require.False(t, bid.Lost)
+}
+
+// The tip moved past the block the bid names, so no miner can take it.
+func TestBidLabelCallsAStrandedBidLost(t *testing.T) {
+	bid := BidLabel(bidScriptHex(t, 9, labelOldTip), labelTip)
+
+	require.NotNil(t, bid)
+	require.True(t, bid.Lost)
+}
+
+// A read that misses the tip must not call a winnable bid lost.
+func TestBidLabelKeepsABidLiveWithoutATip(t *testing.T) {
+	bid := BidLabel(bidScriptHex(t, 9, labelOldTip), "")
+
+	require.NotNil(t, bid)
+	require.False(t, bid.Lost)
+}
+
+func TestBidLabelIgnoresEveryOtherScript(t *testing.T) {
+	for name, scriptHex := range map[string]string{
+		"a payment":          "0014c0ffee0000000000000000000000000000000000",
+		"a plain op_return":  "6a0b68656c6c6f20776f726c64",
+		"an empty script":    "",
+		"a broken hex":       "zz",
+		"a short bmm script": "6a0300bf00",
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Nil(t, BidLabel(scriptHex, labelTip))
+		})
+	}
+}
+
+// fakeCore answers the reads BidLabels makes, and counts every call.
+type fakeCore struct {
+	tip     string
+	scripts map[string]string
+	// dropped names the transactions the mempool does not hold.
+	dropped map[string]bool
+	calls   int
+	tipErr  error
+}
+
+func (f *fakeCore) call(_ context.Context, method, params string) (json.RawMessage, error) {
+	f.calls++
+	switch method {
+	case "getbestblockhash":
+		if f.tipErr != nil {
+			return nil, f.tipErr
+		}
+		return json.Marshal(f.tip)
+	case "getrawtransaction":
+		var args []any
+		if err := json.Unmarshal([]byte(params), &args); err != nil {
+			return nil, err
+		}
+		txid, _ := args[0].(string)
+		script, ok := f.scripts[txid]
+		if !ok {
+			return nil, fmt.Errorf("no such transaction %s", txid)
+		}
+		return json.Marshal(map[string]any{
+			"vout": []map[string]any{{"scriptPubKey": map[string]any{"hex": script}}},
+		})
+	case "getmempoolentry":
+		var args []any
+		if err := json.Unmarshal([]byte(params), &args); err != nil {
+			return nil, err
+		}
+		txid, _ := args[0].(string)
+		if f.dropped[txid] {
+			return nil, fmt.Errorf("transaction %s not in mempool", txid)
+		}
+		return json.Marshal(map[string]any{})
+	}
+	return nil, fmt.Errorf("unexpected method %s", method)
+}
+
+func TestBidLabelsNamesOnlyTheBids(t *testing.T) {
+	core := &fakeCore{
+		tip: labelTip,
+		scripts: map[string]string{
+			"live":    bidScriptHex(t, 9, labelTip),
+			"lost":    bidScriptHex(t, 9, labelOldTip),
+			"payment": "0014c0ffee0000000000000000000000000000000000",
+		},
+	}
+
+	bids := BidLabels(context.Background(), core.call, []string{"live", "lost", "payment", "missing"})
+
+	require.Len(t, bids, 2)
+	require.False(t, bids["live"].Lost)
+	require.True(t, bids["lost"].Lost)
+}
+
+func TestBidLabelsReadsEachTxidOneTime(t *testing.T) {
+	core := &fakeCore{tip: labelTip, scripts: map[string]string{"live": bidScriptHex(t, 9, labelTip)}}
+
+	bids := BidLabels(context.Background(), core.call, []string{"live", "live", "live"})
+
+	require.Len(t, bids, 1)
+	require.Equal(t, 3, core.calls, "one tip read, one transaction read and one mempool read")
+}
+
+// An RBF raise leaves the replaced bid in the wallet with no confirmations. A
+// cancel of it can evict the live bid, so it gets no label.
+func TestBidLabelsSkipsAReplacedBid(t *testing.T) {
+	core := &fakeCore{
+		tip: labelTip,
+		scripts: map[string]string{
+			"replaced": bidScriptHex(t, 9, labelOldTip),
+			"live":     bidScriptHex(t, 9, labelTip),
+		},
+		dropped: map[string]bool{"replaced": true},
+	}
+
+	bids := BidLabels(context.Background(), core.call, []string{"replaced", "live"})
+
+	require.Len(t, bids, 1)
+	require.Contains(t, bids, "live")
+}
+
+func TestBidLabelsCallsNothingWithoutATxid(t *testing.T) {
+	core := &fakeCore{tip: labelTip}
+
+	require.Nil(t, BidLabels(context.Background(), core.call, nil))
+	require.Zero(t, core.calls)
+}
+
+// A node that cannot name its tip leaves every row unlabelled.
+func TestBidLabelsStopsWhenTheTipReadFails(t *testing.T) {
+	core := &fakeCore{tipErr: fmt.Errorf("no node")}
+
+	require.Nil(t, BidLabels(context.Background(), core.call, []string{"live"}))
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -945,9 +945,33 @@ func (h *WalletHandler) ListTransactions(ctx context.Context, req *connect.Reque
 		}
 	})
 
+	bids := h.bidLabels(ctx, pbTxs)
+	for _, entry := range pbTxs {
+		entry.BmmBid = bids[entry.Txid]
+	}
+
 	return connect.NewResponse(&pb.ListTransactionsResponse{
 		Transactions: pbTxs,
 	}), nil
+}
+
+// bidLabels names the BMM request each unconfirmed transaction carries. A
+// confirmed transaction cannot be a live bid, so a settled wallet costs no
+// Core call.
+func (h *WalletHandler) bidLabels(ctx context.Context, entries []*pb.TransactionEntry) map[string]*pb.BmmBid {
+	if h.orch == nil {
+		return nil
+	}
+	pending := lo.FilterMap(entries, func(e *pb.TransactionEntry, _ int) (string, bool) {
+		return e.Txid, e.Confirmations == 0
+	})
+	if len(pending) == 0 {
+		return nil
+	}
+	core := NewHandler(h.orch)
+	return BidLabels(ctx, func(ctx context.Context, method, paramsJSON string) (json.RawMessage, error) {
+		return core.RawCoreCall(ctx, method, paramsJSON, "")
+	}, lo.Uniq(pending))
 }
 
 func (h *WalletHandler) ListUnspent(ctx context.Context, req *connect.Request[pb.ListUnspentRequest]) (*connect.Response[pb.ListUnspentResponse], error) {

--- a/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
+++ b/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
@@ -897,6 +897,132 @@ func (x *CreateBidRequest) GetMaxBidSats() int64 {
 	return 0
 }
 
+type CancelBidRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Wallet that funds the replacement. Empty uses the active wallet.
+	WalletId string `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	// The stranded M8 transaction.
+	Txid          string `protobuf:"bytes,2,opt,name=txid,proto3" json:"txid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelBidRequest) Reset() {
+	*x = CancelBidRequest{}
+	mi := &file_bmm_v1_bmm_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelBidRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelBidRequest) ProtoMessage() {}
+
+func (x *CancelBidRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bmm_v1_bmm_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelBidRequest.ProtoReflect.Descriptor instead.
+func (*CancelBidRequest) Descriptor() ([]byte, []int) {
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CancelBidRequest) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *CancelBidRequest) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+type CancelBidResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The replacement transaction.
+	ReplacementTxid string `protobuf:"bytes,1,opt,name=replacement_txid,json=replacementTxid,proto3" json:"replacement_txid,omitempty"`
+	// What the fresh address receives.
+	RecoveredSats int64 `protobuf:"varint,2,opt,name=recovered_sats,json=recoveredSats,proto3" json:"recovered_sats,omitempty"`
+	// What the replacement pays the miner to evict the chain.
+	FeeSats int64 `protobuf:"varint,3,opt,name=fee_sats,json=feeSats,proto3" json:"fee_sats,omitempty"`
+	// Every bid the replacement evicts, the named one included.
+	CancelledTxids []string `protobuf:"bytes,4,rep,name=cancelled_txids,json=cancelledTxids,proto3" json:"cancelled_txids,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CancelBidResponse) Reset() {
+	*x = CancelBidResponse{}
+	mi := &file_bmm_v1_bmm_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelBidResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelBidResponse) ProtoMessage() {}
+
+func (x *CancelBidResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bmm_v1_bmm_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelBidResponse.ProtoReflect.Descriptor instead.
+func (*CancelBidResponse) Descriptor() ([]byte, []int) {
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *CancelBidResponse) GetReplacementTxid() string {
+	if x != nil {
+		return x.ReplacementTxid
+	}
+	return ""
+}
+
+func (x *CancelBidResponse) GetRecoveredSats() int64 {
+	if x != nil {
+		return x.RecoveredSats
+	}
+	return 0
+}
+
+func (x *CancelBidResponse) GetFeeSats() int64 {
+	if x != nil {
+		return x.FeeSats
+	}
+	return 0
+}
+
+func (x *CancelBidResponse) GetCancelledTxids() []string {
+	if x != nil {
+		return x.CancelledTxids
+	}
+	return nil
+}
+
 type CreateBidResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Sidechain block hash committed to by the bid.
@@ -917,7 +1043,7 @@ type CreateBidResponse struct {
 
 func (x *CreateBidResponse) Reset() {
 	*x = CreateBidResponse{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[13]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -929,7 +1055,7 @@ func (x *CreateBidResponse) String() string {
 func (*CreateBidResponse) ProtoMessage() {}
 
 func (x *CreateBidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[13]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -942,7 +1068,7 @@ func (x *CreateBidResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBidResponse.ProtoReflect.Descriptor instead.
 func (*CreateBidResponse) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{13}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateBidResponse) GetCriticalHash() string {
@@ -1003,7 +1129,7 @@ type ConnectBidRequest struct {
 
 func (x *ConnectBidRequest) Reset() {
 	*x = ConnectBidRequest{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[14]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1015,7 +1141,7 @@ func (x *ConnectBidRequest) String() string {
 func (*ConnectBidRequest) ProtoMessage() {}
 
 func (x *ConnectBidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[14]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1028,7 +1154,7 @@ func (x *ConnectBidRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectBidRequest.ProtoReflect.Descriptor instead.
 func (*ConnectBidRequest) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{14}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ConnectBidRequest) GetSidechain() v1.BinaryType {
@@ -1071,7 +1197,7 @@ type ConnectBidResponse struct {
 
 func (x *ConnectBidResponse) Reset() {
 	*x = ConnectBidResponse{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[15]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1083,7 +1209,7 @@ func (x *ConnectBidResponse) String() string {
 func (*ConnectBidResponse) ProtoMessage() {}
 
 func (x *ConnectBidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[15]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1096,7 +1222,7 @@ func (x *ConnectBidResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectBidResponse.ProtoReflect.Descriptor instead.
 func (*ConnectBidResponse) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{15}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ConnectBidResponse) GetConnected() bool {
@@ -1122,7 +1248,7 @@ type ListBidsRequest struct {
 
 func (x *ListBidsRequest) Reset() {
 	*x = ListBidsRequest{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[16]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1134,7 +1260,7 @@ func (x *ListBidsRequest) String() string {
 func (*ListBidsRequest) ProtoMessage() {}
 
 func (x *ListBidsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[16]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1147,7 +1273,7 @@ func (x *ListBidsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBidsRequest.ProtoReflect.Descriptor instead.
 func (*ListBidsRequest) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{16}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListBidsRequest) GetSidechain() v1.BinaryType {
@@ -1167,7 +1293,7 @@ type ListBidsResponse struct {
 
 func (x *ListBidsResponse) Reset() {
 	*x = ListBidsResponse{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[17]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1179,7 +1305,7 @@ func (x *ListBidsResponse) String() string {
 func (*ListBidsResponse) ProtoMessage() {}
 
 func (x *ListBidsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[17]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1192,7 +1318,7 @@ func (x *ListBidsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBidsResponse.ProtoReflect.Descriptor instead.
 func (*ListBidsResponse) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{17}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListBidsResponse) GetBids() []*Bid {
@@ -1212,7 +1338,7 @@ type PrepareBMMRequest struct {
 
 func (x *PrepareBMMRequest) Reset() {
 	*x = PrepareBMMRequest{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[18]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1224,7 +1350,7 @@ func (x *PrepareBMMRequest) String() string {
 func (*PrepareBMMRequest) ProtoMessage() {}
 
 func (x *PrepareBMMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[18]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1237,7 +1363,7 @@ func (x *PrepareBMMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBMMRequest.ProtoReflect.Descriptor instead.
 func (*PrepareBMMRequest) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{18}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *PrepareBMMRequest) GetTargets() []*PrepareBMMTarget {
@@ -1260,7 +1386,7 @@ type PrepareBMMTarget struct {
 
 func (x *PrepareBMMTarget) Reset() {
 	*x = PrepareBMMTarget{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[19]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1272,7 +1398,7 @@ func (x *PrepareBMMTarget) String() string {
 func (*PrepareBMMTarget) ProtoMessage() {}
 
 func (x *PrepareBMMTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[19]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1285,7 +1411,7 @@ func (x *PrepareBMMTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBMMTarget.ProtoReflect.Descriptor instead.
 func (*PrepareBMMTarget) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{19}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *PrepareBMMTarget) GetWalletId() string {
@@ -1312,7 +1438,7 @@ type PrepareBMMResponse struct {
 
 func (x *PrepareBMMResponse) Reset() {
 	*x = PrepareBMMResponse{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[20]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1324,7 +1450,7 @@ func (x *PrepareBMMResponse) String() string {
 func (*PrepareBMMResponse) ProtoMessage() {}
 
 func (x *PrepareBMMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[20]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1337,7 +1463,7 @@ func (x *PrepareBMMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBMMResponse.ProtoReflect.Descriptor instead.
 func (*PrepareBMMResponse) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{20}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *PrepareBMMResponse) GetWallets() []*PrepareBMMWallet {
@@ -1362,7 +1488,7 @@ type PrepareBMMWallet struct {
 
 func (x *PrepareBMMWallet) Reset() {
 	*x = PrepareBMMWallet{}
-	mi := &file_bmm_v1_bmm_proto_msgTypes[21]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1374,7 +1500,7 @@ func (x *PrepareBMMWallet) String() string {
 func (*PrepareBMMWallet) ProtoMessage() {}
 
 func (x *PrepareBMMWallet) ProtoReflect() protoreflect.Message {
-	mi := &file_bmm_v1_bmm_proto_msgTypes[21]
+	mi := &file_bmm_v1_bmm_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1387,7 +1513,7 @@ func (x *PrepareBMMWallet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBMMWallet.ProtoReflect.Descriptor instead.
 func (*PrepareBMMWallet) Descriptor() ([]byte, []int) {
-	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{21}
+	return file_bmm_v1_bmm_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PrepareBMMWallet) GetWalletId() string {
@@ -1489,7 +1615,15 @@ const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\x12cap_to_block_worth\x18\x06 \x01(\bR\x0fcapToBlockWorth\x12%\n" +
 	"\x0ffee_rate_sat_vb\x18\a \x01(\x01R\ffeeRateSatVb\x12 \n" +
 	"\fmax_bid_sats\x18\b \x01(\x03R\n" +
-	"maxBidSats\"\xd0\x01\n" +
+	"maxBidSats\"C\n" +
+	"\x10CancelBidRequest\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x12\n" +
+	"\x04txid\x18\x02 \x01(\tR\x04txid\"\xa9\x01\n" +
+	"\x11CancelBidResponse\x12)\n" +
+	"\x10replacement_txid\x18\x01 \x01(\tR\x0freplacementTxid\x12%\n" +
+	"\x0erecovered_sats\x18\x02 \x01(\x03R\rrecoveredSats\x12\x19\n" +
+	"\bfee_sats\x18\x03 \x01(\x03R\afeeSats\x12'\n" +
+	"\x0fcancelled_txids\x18\x04 \x03(\tR\x0ecancelledTxids\"\xd0\x01\n" +
 	"\x11CreateBidResponse\x12#\n" +
 	"\rcritical_hash\x18\x01 \x01(\tR\fcriticalHash\x12\x19\n" +
 	"\bbmm_txid\x18\x02 \x01(\tR\abmmTxid\x12\x1b\n" +
@@ -1524,7 +1658,7 @@ const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\fusable_coins\x18\x02 \x01(\x05R\vusableCoins\x12!\n" +
 	"\fwanted_coins\x18\x03 \x01(\x05R\vwantedCoins\x12\x1d\n" +
 	"\n" +
-	"split_txid\x18\x04 \x01(\tR\tsplitTxid2\xce\x04\n" +
+	"split_txid\x18\x04 \x01(\tR\tsplitTxid2\x90\x05\n" +
 	"\n" +
 	"BMMService\x124\n" +
 	"\x05Start\x12\x14.bmm.v1.StartRequest\x1a\x15.bmm.v1.StartResponse\x121\n" +
@@ -1534,7 +1668,8 @@ const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\fGetRoundBids\x12\x1b.bmm.v1.GetRoundBidsRequest\x1a\x1c.bmm.v1.GetRoundBidsResponse\x12@\n" +
 	"\tCreateBid\x12\x18.bmm.v1.CreateBidRequest\x1a\x19.bmm.v1.CreateBidResponse\x12C\n" +
 	"\n" +
-	"ConnectBid\x12\x19.bmm.v1.ConnectBidRequest\x1a\x1a.bmm.v1.ConnectBidResponse\x12=\n" +
+	"ConnectBid\x12\x19.bmm.v1.ConnectBidRequest\x1a\x1a.bmm.v1.ConnectBidResponse\x12@\n" +
+	"\tCancelBid\x12\x18.bmm.v1.CancelBidRequest\x1a\x19.bmm.v1.CancelBidResponse\x12=\n" +
 	"\bListBids\x12\x17.bmm.v1.ListBidsRequest\x1a\x18.bmm.v1.ListBidsResponse\x12C\n" +
 	"\n" +
 	"PrepareBMM\x12\x19.bmm.v1.PrepareBMMRequest\x1a\x1a.bmm.v1.PrepareBMMResponseB\x9a\x01\n" +
@@ -1553,7 +1688,7 @@ func file_bmm_v1_bmm_proto_rawDescGZIP() []byte {
 	return file_bmm_v1_bmm_proto_rawDescData
 }
 
-var file_bmm_v1_bmm_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_bmm_v1_bmm_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_bmm_v1_bmm_proto_goTypes = []any{
 	(*StartRequest)(nil),         // 0: bmm.v1.StartRequest
 	(*StartResponse)(nil),        // 1: bmm.v1.StartResponse
@@ -1568,54 +1703,58 @@ var file_bmm_v1_bmm_proto_goTypes = []any{
 	(*GetRoundBidsRequest)(nil),  // 10: bmm.v1.GetRoundBidsRequest
 	(*GetRoundBidsResponse)(nil), // 11: bmm.v1.GetRoundBidsResponse
 	(*CreateBidRequest)(nil),     // 12: bmm.v1.CreateBidRequest
-	(*CreateBidResponse)(nil),    // 13: bmm.v1.CreateBidResponse
-	(*ConnectBidRequest)(nil),    // 14: bmm.v1.ConnectBidRequest
-	(*ConnectBidResponse)(nil),   // 15: bmm.v1.ConnectBidResponse
-	(*ListBidsRequest)(nil),      // 16: bmm.v1.ListBidsRequest
-	(*ListBidsResponse)(nil),     // 17: bmm.v1.ListBidsResponse
-	(*PrepareBMMRequest)(nil),    // 18: bmm.v1.PrepareBMMRequest
-	(*PrepareBMMTarget)(nil),     // 19: bmm.v1.PrepareBMMTarget
-	(*PrepareBMMResponse)(nil),   // 20: bmm.v1.PrepareBMMResponse
-	(*PrepareBMMWallet)(nil),     // 21: bmm.v1.PrepareBMMWallet
-	(v1.BinaryType)(0),           // 22: orchestrator.v1.BinaryType
+	(*CancelBidRequest)(nil),     // 13: bmm.v1.CancelBidRequest
+	(*CancelBidResponse)(nil),    // 14: bmm.v1.CancelBidResponse
+	(*CreateBidResponse)(nil),    // 15: bmm.v1.CreateBidResponse
+	(*ConnectBidRequest)(nil),    // 16: bmm.v1.ConnectBidRequest
+	(*ConnectBidResponse)(nil),   // 17: bmm.v1.ConnectBidResponse
+	(*ListBidsRequest)(nil),      // 18: bmm.v1.ListBidsRequest
+	(*ListBidsResponse)(nil),     // 19: bmm.v1.ListBidsResponse
+	(*PrepareBMMRequest)(nil),    // 20: bmm.v1.PrepareBMMRequest
+	(*PrepareBMMTarget)(nil),     // 21: bmm.v1.PrepareBMMTarget
+	(*PrepareBMMResponse)(nil),   // 22: bmm.v1.PrepareBMMResponse
+	(*PrepareBMMWallet)(nil),     // 23: bmm.v1.PrepareBMMWallet
+	(v1.BinaryType)(0),           // 24: orchestrator.v1.BinaryType
 }
 var file_bmm_v1_bmm_proto_depIdxs = []int32{
-	22, // 0: bmm.v1.StartRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	22, // 1: bmm.v1.StopRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	22, // 2: bmm.v1.ClearHistoryRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	22, // 3: bmm.v1.WatchRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 0: bmm.v1.StartRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 1: bmm.v1.StopRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 2: bmm.v1.ClearHistoryRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 3: bmm.v1.WatchRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	8,  // 4: bmm.v1.WatchResponse.current:type_name -> bmm.v1.Round
 	8,  // 5: bmm.v1.WatchResponse.history:type_name -> bmm.v1.Round
 	9,  // 6: bmm.v1.Round.our_bids:type_name -> bmm.v1.Bid
 	9,  // 7: bmm.v1.Round.other_bids:type_name -> bmm.v1.Bid
-	22, // 8: bmm.v1.GetRoundBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 8: bmm.v1.GetRoundBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	8,  // 9: bmm.v1.GetRoundBidsResponse.round:type_name -> bmm.v1.Round
-	22, // 10: bmm.v1.CreateBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	22, // 11: bmm.v1.ConnectBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	22, // 12: bmm.v1.ListBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 10: bmm.v1.CreateBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 11: bmm.v1.ConnectBidRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	24, // 12: bmm.v1.ListBidsRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	9,  // 13: bmm.v1.ListBidsResponse.bids:type_name -> bmm.v1.Bid
-	19, // 14: bmm.v1.PrepareBMMRequest.targets:type_name -> bmm.v1.PrepareBMMTarget
-	21, // 15: bmm.v1.PrepareBMMResponse.wallets:type_name -> bmm.v1.PrepareBMMWallet
+	21, // 14: bmm.v1.PrepareBMMRequest.targets:type_name -> bmm.v1.PrepareBMMTarget
+	23, // 15: bmm.v1.PrepareBMMResponse.wallets:type_name -> bmm.v1.PrepareBMMWallet
 	0,  // 16: bmm.v1.BMMService.Start:input_type -> bmm.v1.StartRequest
 	2,  // 17: bmm.v1.BMMService.Stop:input_type -> bmm.v1.StopRequest
 	4,  // 18: bmm.v1.BMMService.ClearHistory:input_type -> bmm.v1.ClearHistoryRequest
 	6,  // 19: bmm.v1.BMMService.Watch:input_type -> bmm.v1.WatchRequest
 	10, // 20: bmm.v1.BMMService.GetRoundBids:input_type -> bmm.v1.GetRoundBidsRequest
 	12, // 21: bmm.v1.BMMService.CreateBid:input_type -> bmm.v1.CreateBidRequest
-	14, // 22: bmm.v1.BMMService.ConnectBid:input_type -> bmm.v1.ConnectBidRequest
-	16, // 23: bmm.v1.BMMService.ListBids:input_type -> bmm.v1.ListBidsRequest
-	18, // 24: bmm.v1.BMMService.PrepareBMM:input_type -> bmm.v1.PrepareBMMRequest
-	1,  // 25: bmm.v1.BMMService.Start:output_type -> bmm.v1.StartResponse
-	3,  // 26: bmm.v1.BMMService.Stop:output_type -> bmm.v1.StopResponse
-	5,  // 27: bmm.v1.BMMService.ClearHistory:output_type -> bmm.v1.ClearHistoryResponse
-	7,  // 28: bmm.v1.BMMService.Watch:output_type -> bmm.v1.WatchResponse
-	11, // 29: bmm.v1.BMMService.GetRoundBids:output_type -> bmm.v1.GetRoundBidsResponse
-	13, // 30: bmm.v1.BMMService.CreateBid:output_type -> bmm.v1.CreateBidResponse
-	15, // 31: bmm.v1.BMMService.ConnectBid:output_type -> bmm.v1.ConnectBidResponse
-	17, // 32: bmm.v1.BMMService.ListBids:output_type -> bmm.v1.ListBidsResponse
-	20, // 33: bmm.v1.BMMService.PrepareBMM:output_type -> bmm.v1.PrepareBMMResponse
-	25, // [25:34] is the sub-list for method output_type
-	16, // [16:25] is the sub-list for method input_type
+	16, // 22: bmm.v1.BMMService.ConnectBid:input_type -> bmm.v1.ConnectBidRequest
+	13, // 23: bmm.v1.BMMService.CancelBid:input_type -> bmm.v1.CancelBidRequest
+	18, // 24: bmm.v1.BMMService.ListBids:input_type -> bmm.v1.ListBidsRequest
+	20, // 25: bmm.v1.BMMService.PrepareBMM:input_type -> bmm.v1.PrepareBMMRequest
+	1,  // 26: bmm.v1.BMMService.Start:output_type -> bmm.v1.StartResponse
+	3,  // 27: bmm.v1.BMMService.Stop:output_type -> bmm.v1.StopResponse
+	5,  // 28: bmm.v1.BMMService.ClearHistory:output_type -> bmm.v1.ClearHistoryResponse
+	7,  // 29: bmm.v1.BMMService.Watch:output_type -> bmm.v1.WatchResponse
+	11, // 30: bmm.v1.BMMService.GetRoundBids:output_type -> bmm.v1.GetRoundBidsResponse
+	15, // 31: bmm.v1.BMMService.CreateBid:output_type -> bmm.v1.CreateBidResponse
+	17, // 32: bmm.v1.BMMService.ConnectBid:output_type -> bmm.v1.ConnectBidResponse
+	14, // 33: bmm.v1.BMMService.CancelBid:output_type -> bmm.v1.CancelBidResponse
+	19, // 34: bmm.v1.BMMService.ListBids:output_type -> bmm.v1.ListBidsResponse
+	22, // 35: bmm.v1.BMMService.PrepareBMM:output_type -> bmm.v1.PrepareBMMResponse
+	26, // [26:36] is the sub-list for method output_type
+	16, // [16:26] is the sub-list for method input_type
 	16, // [16:16] is the sub-list for extension type_name
 	16, // [16:16] is the sub-list for extension extendee
 	0,  // [0:16] is the sub-list for field type_name
@@ -1632,7 +1771,7 @@ func file_bmm_v1_bmm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bmm_v1_bmm_proto_rawDesc), len(file_bmm_v1_bmm_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/bmm/v1/bmmv1connect/bmm.connect.go
+++ b/sidechain-orchestrator/gen/bmm/v1/bmmv1connect/bmm.connect.go
@@ -47,6 +47,8 @@ const (
 	BMMServiceCreateBidProcedure = "/bmm.v1.BMMService/CreateBid"
 	// BMMServiceConnectBidProcedure is the fully-qualified name of the BMMService's ConnectBid RPC.
 	BMMServiceConnectBidProcedure = "/bmm.v1.BMMService/ConnectBid"
+	// BMMServiceCancelBidProcedure is the fully-qualified name of the BMMService's CancelBid RPC.
+	BMMServiceCancelBidProcedure = "/bmm.v1.BMMService/CancelBid"
 	// BMMServiceListBidsProcedure is the fully-qualified name of the BMMService's ListBids RPC.
 	BMMServiceListBidsProcedure = "/bmm.v1.BMMService/ListBids"
 	// BMMServicePrepareBMMProcedure is the fully-qualified name of the BMMService's PrepareBMM RPC.
@@ -74,6 +76,9 @@ type BMMServiceClient interface {
 	// drive a single attempt by hand; Start does both on a loop.
 	CreateBid(context.Context, *connect.Request[v1.CreateBidRequest]) (*connect.Response[v1.CreateBidResponse], error)
 	ConnectBid(context.Context, *connect.Request[v1.ConnectBidRequest]) (*connect.Response[v1.ConnectBidResponse], error)
+	// CancelBid replaces a stranded bid with a payment back to its own wallet,
+	// so the coins under it come back. A bid that can still win is refused.
+	CancelBid(context.Context, *connect.Request[v1.CancelBidRequest]) (*connect.Response[v1.CancelBidResponse], error)
 	// ListBids reads the competing bids for the slot out of the mainchain
 	// mempool, highest bid first.
 	ListBids(context.Context, *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error)
@@ -137,6 +142,12 @@ func NewBMMServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 			connect.WithSchema(bMMServiceMethods.ByName("ConnectBid")),
 			connect.WithClientOptions(opts...),
 		),
+		cancelBid: connect.NewClient[v1.CancelBidRequest, v1.CancelBidResponse](
+			httpClient,
+			baseURL+BMMServiceCancelBidProcedure,
+			connect.WithSchema(bMMServiceMethods.ByName("CancelBid")),
+			connect.WithClientOptions(opts...),
+		),
 		listBids: connect.NewClient[v1.ListBidsRequest, v1.ListBidsResponse](
 			httpClient,
 			baseURL+BMMServiceListBidsProcedure,
@@ -161,6 +172,7 @@ type bMMServiceClient struct {
 	getRoundBids *connect.Client[v1.GetRoundBidsRequest, v1.GetRoundBidsResponse]
 	createBid    *connect.Client[v1.CreateBidRequest, v1.CreateBidResponse]
 	connectBid   *connect.Client[v1.ConnectBidRequest, v1.ConnectBidResponse]
+	cancelBid    *connect.Client[v1.CancelBidRequest, v1.CancelBidResponse]
 	listBids     *connect.Client[v1.ListBidsRequest, v1.ListBidsResponse]
 	prepareBMM   *connect.Client[v1.PrepareBMMRequest, v1.PrepareBMMResponse]
 }
@@ -200,6 +212,11 @@ func (c *bMMServiceClient) ConnectBid(ctx context.Context, req *connect.Request[
 	return c.connectBid.CallUnary(ctx, req)
 }
 
+// CancelBid calls bmm.v1.BMMService.CancelBid.
+func (c *bMMServiceClient) CancelBid(ctx context.Context, req *connect.Request[v1.CancelBidRequest]) (*connect.Response[v1.CancelBidResponse], error) {
+	return c.cancelBid.CallUnary(ctx, req)
+}
+
 // ListBids calls bmm.v1.BMMService.ListBids.
 func (c *bMMServiceClient) ListBids(ctx context.Context, req *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error) {
 	return c.listBids.CallUnary(ctx, req)
@@ -231,6 +248,9 @@ type BMMServiceHandler interface {
 	// drive a single attempt by hand; Start does both on a loop.
 	CreateBid(context.Context, *connect.Request[v1.CreateBidRequest]) (*connect.Response[v1.CreateBidResponse], error)
 	ConnectBid(context.Context, *connect.Request[v1.ConnectBidRequest]) (*connect.Response[v1.ConnectBidResponse], error)
+	// CancelBid replaces a stranded bid with a payment back to its own wallet,
+	// so the coins under it come back. A bid that can still win is refused.
+	CancelBid(context.Context, *connect.Request[v1.CancelBidRequest]) (*connect.Response[v1.CancelBidResponse], error)
 	// ListBids reads the competing bids for the slot out of the mainchain
 	// mempool, highest bid first.
 	ListBids(context.Context, *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error)
@@ -290,6 +310,12 @@ func NewBMMServiceHandler(svc BMMServiceHandler, opts ...connect.HandlerOption) 
 		connect.WithSchema(bMMServiceMethods.ByName("ConnectBid")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bMMServiceCancelBidHandler := connect.NewUnaryHandler(
+		BMMServiceCancelBidProcedure,
+		svc.CancelBid,
+		connect.WithSchema(bMMServiceMethods.ByName("CancelBid")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bMMServiceListBidsHandler := connect.NewUnaryHandler(
 		BMMServiceListBidsProcedure,
 		svc.ListBids,
@@ -318,6 +344,8 @@ func NewBMMServiceHandler(svc BMMServiceHandler, opts ...connect.HandlerOption) 
 			bMMServiceCreateBidHandler.ServeHTTP(w, r)
 		case BMMServiceConnectBidProcedure:
 			bMMServiceConnectBidHandler.ServeHTTP(w, r)
+		case BMMServiceCancelBidProcedure:
+			bMMServiceCancelBidHandler.ServeHTTP(w, r)
 		case BMMServiceListBidsProcedure:
 			bMMServiceListBidsHandler.ServeHTTP(w, r)
 		case BMMServicePrepareBMMProcedure:
@@ -357,6 +385,10 @@ func (UnimplementedBMMServiceHandler) CreateBid(context.Context, *connect.Reques
 
 func (UnimplementedBMMServiceHandler) ConnectBid(context.Context, *connect.Request[v1.ConnectBidRequest]) (*connect.Response[v1.ConnectBidResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bmm.v1.BMMService.ConnectBid is not implemented"))
+}
+
+func (UnimplementedBMMServiceHandler) CancelBid(context.Context, *connect.Request[v1.CancelBidRequest]) (*connect.Response[v1.CancelBidResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bmm.v1.BMMService.CancelBid is not implemented"))
 }
 
 func (UnimplementedBMMServiceHandler) ListBids(context.Context, *connect.Request[v1.ListBidsRequest]) (*connect.Response[v1.ListBidsResponse], error) {

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -6712,8 +6712,10 @@ type TransactionEntry struct {
 	Fee            float64                `protobuf:"fixed64,11,opt,name=fee,proto3" json:"fee,omitempty"`
 	ReplacedByTxid bool                   `protobuf:"varint,12,opt,name=replaced_by_txid,json=replacedByTxid,proto3" json:"replaced_by_txid,omitempty"`
 	WalletId       string                 `protobuf:"bytes,13,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Set when output 0 carries a BMM request. Unset for every other transaction.
+	BmmBid        *BmmBid `protobuf:"bytes,14,opt,name=bmm_bid,json=bmmBid,proto3" json:"bmm_bid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TransactionEntry) Reset() {
@@ -6837,6 +6839,85 @@ func (x *TransactionEntry) GetWalletId() string {
 	return ""
 }
 
+func (x *TransactionEntry) GetBmmBid() *BmmBid {
+	if x != nil {
+		return x.BmmBid
+	}
+	return nil
+}
+
+// BmmBid names the BMM request one wallet transaction carries.
+type BmmBid struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Slot         uint32                 `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	CriticalHash string                 `protobuf:"bytes,2,opt,name=critical_hash,json=criticalHash,proto3" json:"critical_hash,omitempty"`
+	// The mainchain block the sidechain block builds on. The bid reaches only
+	// the block after it.
+	PrevMainHash string `protobuf:"bytes,3,opt,name=prev_main_hash,json=prevMainHash,proto3" json:"prev_main_hash,omitempty"`
+	// True when the mainchain tip moved past prev_main_hash.
+	Lost          bool `protobuf:"varint,4,opt,name=lost,proto3" json:"lost,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BmmBid) Reset() {
+	*x = BmmBid{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BmmBid) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BmmBid) ProtoMessage() {}
+
+func (x *BmmBid) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BmmBid.ProtoReflect.Descriptor instead.
+func (*BmmBid) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{117}
+}
+
+func (x *BmmBid) GetSlot() uint32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *BmmBid) GetCriticalHash() string {
+	if x != nil {
+		return x.CriticalHash
+	}
+	return ""
+}
+
+func (x *BmmBid) GetPrevMainHash() string {
+	if x != nil {
+		return x.PrevMainHash
+	}
+	return ""
+}
+
+func (x *BmmBid) GetLost() bool {
+	if x != nil {
+		return x.Lost
+	}
+	return false
+}
+
 type ListTransactionsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Transactions  []*TransactionEntry    `protobuf:"bytes,1,rep,name=transactions,proto3" json:"transactions,omitempty"`
@@ -6846,7 +6927,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6858,7 +6939,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6871,7 +6952,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{117}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionEntry {
@@ -6890,7 +6971,7 @@ type ListUnspentRequest struct {
 
 func (x *ListUnspentRequest) Reset() {
 	*x = ListUnspentRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6902,7 +6983,7 @@ func (x *ListUnspentRequest) String() string {
 func (*ListUnspentRequest) ProtoMessage() {}
 
 func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6915,7 +6996,7 @@ func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentRequest.ProtoReflect.Descriptor instead.
 func (*ListUnspentRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{118}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *ListUnspentRequest) GetWalletId() string {
@@ -6956,7 +7037,7 @@ type UnspentOutput struct {
 
 func (x *UnspentOutput) Reset() {
 	*x = UnspentOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6968,7 +7049,7 @@ func (x *UnspentOutput) String() string {
 func (*UnspentOutput) ProtoMessage() {}
 
 func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6981,7 +7062,7 @@ func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnspentOutput.ProtoReflect.Descriptor instead.
 func (*UnspentOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{119}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *UnspentOutput) GetTxid() string {
@@ -7091,7 +7172,7 @@ type ListUnspentResponse struct {
 
 func (x *ListUnspentResponse) Reset() {
 	*x = ListUnspentResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7103,7 +7184,7 @@ func (x *ListUnspentResponse) String() string {
 func (*ListUnspentResponse) ProtoMessage() {}
 
 func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7116,7 +7197,7 @@ func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentResponse.ProtoReflect.Descriptor instead.
 func (*ListUnspentResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{120}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *ListUnspentResponse) GetUtxos() []*UnspentOutput {
@@ -7135,7 +7216,7 @@ type ListReceiveAddressesRequest struct {
 
 func (x *ListReceiveAddressesRequest) Reset() {
 	*x = ListReceiveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7147,7 +7228,7 @@ func (x *ListReceiveAddressesRequest) String() string {
 func (*ListReceiveAddressesRequest) ProtoMessage() {}
 
 func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7160,7 +7241,7 @@ func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{121}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *ListReceiveAddressesRequest) GetWalletId() string {
@@ -7187,7 +7268,7 @@ type ReceiveAddress struct {
 
 func (x *ReceiveAddress) Reset() {
 	*x = ReceiveAddress{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7199,7 +7280,7 @@ func (x *ReceiveAddress) String() string {
 func (*ReceiveAddress) ProtoMessage() {}
 
 func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7212,7 +7293,7 @@ func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAddress.ProtoReflect.Descriptor instead.
 func (*ReceiveAddress) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{122}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *ReceiveAddress) GetAddress() string {
@@ -7273,7 +7354,7 @@ type ListReceiveAddressesResponse struct {
 
 func (x *ListReceiveAddressesResponse) Reset() {
 	*x = ListReceiveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7285,7 +7366,7 @@ func (x *ListReceiveAddressesResponse) String() string {
 func (*ListReceiveAddressesResponse) ProtoMessage() {}
 
 func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7298,7 +7379,7 @@ func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{123}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *ListReceiveAddressesResponse) GetAddresses() []*ReceiveAddress {
@@ -7318,7 +7399,7 @@ type GetTransactionDetailsRequest struct {
 
 func (x *GetTransactionDetailsRequest) Reset() {
 	*x = GetTransactionDetailsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7330,7 +7411,7 @@ func (x *GetTransactionDetailsRequest) String() string {
 func (*GetTransactionDetailsRequest) ProtoMessage() {}
 
 func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7343,7 +7424,7 @@ func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{124}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *GetTransactionDetailsRequest) GetWalletId() string {
@@ -7384,7 +7465,7 @@ type GetTransactionDetailsResponse struct {
 
 func (x *GetTransactionDetailsResponse) Reset() {
 	*x = GetTransactionDetailsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7396,7 +7477,7 @@ func (x *GetTransactionDetailsResponse) String() string {
 func (*GetTransactionDetailsResponse) ProtoMessage() {}
 
 func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7409,7 +7490,7 @@ func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{125}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *GetTransactionDetailsResponse) GetTransaction() *TransactionEntry {
@@ -7542,7 +7623,7 @@ type TransactionInput struct {
 
 func (x *TransactionInput) Reset() {
 	*x = TransactionInput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7554,7 +7635,7 @@ func (x *TransactionInput) String() string {
 func (*TransactionInput) ProtoMessage() {}
 
 func (x *TransactionInput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7567,7 +7648,7 @@ func (x *TransactionInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionInput.ProtoReflect.Descriptor instead.
 func (*TransactionInput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{126}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *TransactionInput) GetIndex() int32 {
@@ -7657,7 +7738,7 @@ type TransactionOutput struct {
 
 func (x *TransactionOutput) Reset() {
 	*x = TransactionOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7669,7 +7750,7 @@ func (x *TransactionOutput) String() string {
 func (*TransactionOutput) ProtoMessage() {}
 
 func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7682,7 +7763,7 @@ func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionOutput.ProtoReflect.Descriptor instead.
 func (*TransactionOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{127}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *TransactionOutput) GetIndex() int32 {
@@ -7751,7 +7832,7 @@ type DecodeTransactionRequest struct {
 
 func (x *DecodeTransactionRequest) Reset() {
 	*x = DecodeTransactionRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7763,7 +7844,7 @@ func (x *DecodeTransactionRequest) String() string {
 func (*DecodeTransactionRequest) ProtoMessage() {}
 
 func (x *DecodeTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7776,7 +7857,7 @@ func (x *DecodeTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecodeTransactionRequest.ProtoReflect.Descriptor instead.
 func (*DecodeTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{128}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *DecodeTransactionRequest) GetInput() string {
@@ -7822,7 +7903,7 @@ type DecodeTransactionResponse struct {
 
 func (x *DecodeTransactionResponse) Reset() {
 	*x = DecodeTransactionResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7834,7 +7915,7 @@ func (x *DecodeTransactionResponse) String() string {
 func (*DecodeTransactionResponse) ProtoMessage() {}
 
 func (x *DecodeTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7847,7 +7928,7 @@ func (x *DecodeTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecodeTransactionResponse.ProtoReflect.Descriptor instead.
 func (*DecodeTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{129}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *DecodeTransactionResponse) GetForm() DecodedForm {
@@ -7990,7 +8071,7 @@ type BumpFeeRequest struct {
 
 func (x *BumpFeeRequest) Reset() {
 	*x = BumpFeeRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8002,7 +8083,7 @@ func (x *BumpFeeRequest) String() string {
 func (*BumpFeeRequest) ProtoMessage() {}
 
 func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8015,7 +8096,7 @@ func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{130}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *BumpFeeRequest) GetWalletId() string {
@@ -8056,7 +8137,7 @@ type BumpFeeResponse struct {
 
 func (x *BumpFeeResponse) Reset() {
 	*x = BumpFeeResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8068,7 +8149,7 @@ func (x *BumpFeeResponse) String() string {
 func (*BumpFeeResponse) ProtoMessage() {}
 
 func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8081,7 +8162,7 @@ func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{131}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *BumpFeeResponse) GetNewTxid() string {
@@ -8110,7 +8191,7 @@ type PreviewBumpFeeRequest struct {
 
 func (x *PreviewBumpFeeRequest) Reset() {
 	*x = PreviewBumpFeeRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8122,7 +8203,7 @@ func (x *PreviewBumpFeeRequest) String() string {
 func (*PreviewBumpFeeRequest) ProtoMessage() {}
 
 func (x *PreviewBumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8135,7 +8216,7 @@ func (x *PreviewBumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewBumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*PreviewBumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{132}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *PreviewBumpFeeRequest) GetWalletId() string {
@@ -8195,7 +8276,7 @@ type PreviewBumpFeeResponse struct {
 
 func (x *PreviewBumpFeeResponse) Reset() {
 	*x = PreviewBumpFeeResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8207,7 +8288,7 @@ func (x *PreviewBumpFeeResponse) String() string {
 func (*PreviewBumpFeeResponse) ProtoMessage() {}
 
 func (x *PreviewBumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8220,7 +8301,7 @@ func (x *PreviewBumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewBumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*PreviewBumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{133}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *PreviewBumpFeeResponse) GetInputCount() int32 {
@@ -8319,7 +8400,7 @@ type BumpFeeOutput struct {
 
 func (x *BumpFeeOutput) Reset() {
 	*x = BumpFeeOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8331,7 +8412,7 @@ func (x *BumpFeeOutput) String() string {
 func (*BumpFeeOutput) ProtoMessage() {}
 
 func (x *BumpFeeOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8344,7 +8425,7 @@ func (x *BumpFeeOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeOutput.ProtoReflect.Descriptor instead.
 func (*BumpFeeOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{134}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *BumpFeeOutput) GetVout() int32 {
@@ -8411,7 +8492,7 @@ type BumpFeePlan struct {
 
 func (x *BumpFeePlan) Reset() {
 	*x = BumpFeePlan{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8423,7 +8504,7 @@ func (x *BumpFeePlan) String() string {
 func (*BumpFeePlan) ProtoMessage() {}
 
 func (x *BumpFeePlan) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8436,7 +8517,7 @@ func (x *BumpFeePlan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeePlan.ProtoReflect.Descriptor instead.
 func (*BumpFeePlan) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{135}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *BumpFeePlan) GetOldFeeSats() int64 {
@@ -8514,7 +8595,7 @@ type CreateCpfpRequest struct {
 
 func (x *CreateCpfpRequest) Reset() {
 	*x = CreateCpfpRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8526,7 +8607,7 @@ func (x *CreateCpfpRequest) String() string {
 func (*CreateCpfpRequest) ProtoMessage() {}
 
 func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8539,7 +8620,7 @@ func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpRequest.ProtoReflect.Descriptor instead.
 func (*CreateCpfpRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{136}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *CreateCpfpRequest) GetWalletId() string {
@@ -8579,7 +8660,7 @@ type CreateCpfpResponse struct {
 
 func (x *CreateCpfpResponse) Reset() {
 	*x = CreateCpfpResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8591,7 +8672,7 @@ func (x *CreateCpfpResponse) String() string {
 func (*CreateCpfpResponse) ProtoMessage() {}
 
 func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8604,7 +8685,7 @@ func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpResponse.ProtoReflect.Descriptor instead.
 func (*CreateCpfpResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{137}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *CreateCpfpResponse) GetChildTxid() string {
@@ -8625,7 +8706,7 @@ type DeriveAddressesRequest struct {
 
 func (x *DeriveAddressesRequest) Reset() {
 	*x = DeriveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8637,7 +8718,7 @@ func (x *DeriveAddressesRequest) String() string {
 func (*DeriveAddressesRequest) ProtoMessage() {}
 
 func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8650,7 +8731,7 @@ func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{138}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *DeriveAddressesRequest) GetWalletId() string {
@@ -8683,7 +8764,7 @@ type DeriveAddressesResponse struct {
 
 func (x *DeriveAddressesResponse) Reset() {
 	*x = DeriveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8695,7 +8776,7 @@ func (x *DeriveAddressesResponse) String() string {
 func (*DeriveAddressesResponse) ProtoMessage() {}
 
 func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8708,7 +8789,7 @@ func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{139}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *DeriveAddressesResponse) GetAddresses() []string {
@@ -8739,7 +8820,7 @@ type PreviewWalletFromEntropyRequest struct {
 
 func (x *PreviewWalletFromEntropyRequest) Reset() {
 	*x = PreviewWalletFromEntropyRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8751,7 +8832,7 @@ func (x *PreviewWalletFromEntropyRequest) String() string {
 func (*PreviewWalletFromEntropyRequest) ProtoMessage() {}
 
 func (x *PreviewWalletFromEntropyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8764,7 +8845,7 @@ func (x *PreviewWalletFromEntropyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewWalletFromEntropyRequest.ProtoReflect.Descriptor instead.
 func (*PreviewWalletFromEntropyRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{140}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *PreviewWalletFromEntropyRequest) GetEntropy() []byte {
@@ -8820,7 +8901,7 @@ type PreviewWalletFromEntropyResponse struct {
 
 func (x *PreviewWalletFromEntropyResponse) Reset() {
 	*x = PreviewWalletFromEntropyResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8832,7 +8913,7 @@ func (x *PreviewWalletFromEntropyResponse) String() string {
 func (*PreviewWalletFromEntropyResponse) ProtoMessage() {}
 
 func (x *PreviewWalletFromEntropyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8845,7 +8926,7 @@ func (x *PreviewWalletFromEntropyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewWalletFromEntropyResponse.ProtoReflect.Descriptor instead.
 func (*PreviewWalletFromEntropyResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{141}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *PreviewWalletFromEntropyResponse) GetEntropyHex() string {
@@ -8913,7 +8994,7 @@ type GetWalletSeedRequest struct {
 
 func (x *GetWalletSeedRequest) Reset() {
 	*x = GetWalletSeedRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8925,7 +9006,7 @@ func (x *GetWalletSeedRequest) String() string {
 func (*GetWalletSeedRequest) ProtoMessage() {}
 
 func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8938,7 +9019,7 @@ func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{142}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *GetWalletSeedRequest) GetWalletId() string {
@@ -8959,7 +9040,7 @@ type GetWalletSeedResponse struct {
 
 func (x *GetWalletSeedResponse) Reset() {
 	*x = GetWalletSeedResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8971,7 +9052,7 @@ func (x *GetWalletSeedResponse) String() string {
 func (*GetWalletSeedResponse) ProtoMessage() {}
 
 func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8984,7 +9065,7 @@ func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{143}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *GetWalletSeedResponse) GetSeedHex() string {
@@ -9009,7 +9090,7 @@ type ListCoreVariantsRequest struct {
 
 func (x *ListCoreVariantsRequest) Reset() {
 	*x = ListCoreVariantsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9021,7 +9102,7 @@ func (x *ListCoreVariantsRequest) String() string {
 func (*ListCoreVariantsRequest) ProtoMessage() {}
 
 func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9034,7 +9115,7 @@ func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsRequest.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{144}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{145}
 }
 
 type CoreVariant struct {
@@ -9048,7 +9129,7 @@ type CoreVariant struct {
 
 func (x *CoreVariant) Reset() {
 	*x = CoreVariant{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9060,7 +9141,7 @@ func (x *CoreVariant) String() string {
 func (*CoreVariant) ProtoMessage() {}
 
 func (x *CoreVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9073,7 +9154,7 @@ func (x *CoreVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreVariant.ProtoReflect.Descriptor instead.
 func (*CoreVariant) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{145}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *CoreVariant) GetId() string {
@@ -9107,7 +9188,7 @@ type ListCoreVariantsResponse struct {
 
 func (x *ListCoreVariantsResponse) Reset() {
 	*x = ListCoreVariantsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9119,7 +9200,7 @@ func (x *ListCoreVariantsResponse) String() string {
 func (*ListCoreVariantsResponse) ProtoMessage() {}
 
 func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9132,7 +9213,7 @@ func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsResponse.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{146}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *ListCoreVariantsResponse) GetVariants() []*CoreVariant {
@@ -9157,7 +9238,7 @@ type GetCoreVariantRequest struct {
 
 func (x *GetCoreVariantRequest) Reset() {
 	*x = GetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9169,7 +9250,7 @@ func (x *GetCoreVariantRequest) String() string {
 func (*GetCoreVariantRequest) ProtoMessage() {}
 
 func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9182,7 +9263,7 @@ func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{147}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{148}
 }
 
 type GetCoreVariantResponse struct {
@@ -9194,7 +9275,7 @@ type GetCoreVariantResponse struct {
 
 func (x *GetCoreVariantResponse) Reset() {
 	*x = GetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9206,7 +9287,7 @@ func (x *GetCoreVariantResponse) String() string {
 func (*GetCoreVariantResponse) ProtoMessage() {}
 
 func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9219,7 +9300,7 @@ func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{148}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *GetCoreVariantResponse) GetId() string {
@@ -9238,7 +9319,7 @@ type SetCoreVariantRequest struct {
 
 func (x *SetCoreVariantRequest) Reset() {
 	*x = SetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9250,7 +9331,7 @@ func (x *SetCoreVariantRequest) String() string {
 func (*SetCoreVariantRequest) ProtoMessage() {}
 
 func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9263,7 +9344,7 @@ func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{149}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *SetCoreVariantRequest) GetId() string {
@@ -9281,7 +9362,7 @@ type SetCoreVariantResponse struct {
 
 func (x *SetCoreVariantResponse) Reset() {
 	*x = SetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9293,7 +9374,7 @@ func (x *SetCoreVariantResponse) String() string {
 func (*SetCoreVariantResponse) ProtoMessage() {}
 
 func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9306,7 +9387,7 @@ func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{150}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{151}
 }
 
 type GetElectrumServerRequest struct {
@@ -9317,7 +9398,7 @@ type GetElectrumServerRequest struct {
 
 func (x *GetElectrumServerRequest) Reset() {
 	*x = GetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9329,7 +9410,7 @@ func (x *GetElectrumServerRequest) String() string {
 func (*GetElectrumServerRequest) ProtoMessage() {}
 
 func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9342,7 +9423,7 @@ func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{151}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{152}
 }
 
 type GetElectrumServerResponse struct {
@@ -9359,7 +9440,7 @@ type GetElectrumServerResponse struct {
 
 func (x *GetElectrumServerResponse) Reset() {
 	*x = GetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9371,7 +9452,7 @@ func (x *GetElectrumServerResponse) String() string {
 func (*GetElectrumServerResponse) ProtoMessage() {}
 
 func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9384,7 +9465,7 @@ func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{152}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *GetElectrumServerResponse) GetUrl() string {
@@ -9418,7 +9499,7 @@ type SetElectrumServerRequest struct {
 
 func (x *SetElectrumServerRequest) Reset() {
 	*x = SetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9430,7 +9511,7 @@ func (x *SetElectrumServerRequest) String() string {
 func (*SetElectrumServerRequest) ProtoMessage() {}
 
 func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9443,7 +9524,7 @@ func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{153}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *SetElectrumServerRequest) GetUrl() string {
@@ -9465,7 +9546,7 @@ type SetElectrumServerResponse struct {
 
 func (x *SetElectrumServerResponse) Reset() {
 	*x = SetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9477,7 +9558,7 @@ func (x *SetElectrumServerResponse) String() string {
 func (*SetElectrumServerResponse) ProtoMessage() {}
 
 func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9490,7 +9571,7 @@ func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{154}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *SetElectrumServerResponse) GetUrl() string {
@@ -9515,7 +9596,7 @@ type GetTorConfigRequest struct {
 
 func (x *GetTorConfigRequest) Reset() {
 	*x = GetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9527,7 +9608,7 @@ func (x *GetTorConfigRequest) String() string {
 func (*GetTorConfigRequest) ProtoMessage() {}
 
 func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9540,7 +9621,7 @@ func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{155}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{156}
 }
 
 type GetTorConfigResponse struct {
@@ -9557,7 +9638,7 @@ type GetTorConfigResponse struct {
 
 func (x *GetTorConfigResponse) Reset() {
 	*x = GetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9569,7 +9650,7 @@ func (x *GetTorConfigResponse) String() string {
 func (*GetTorConfigResponse) ProtoMessage() {}
 
 func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9582,7 +9663,7 @@ func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{156}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *GetTorConfigResponse) GetEnabled() bool {
@@ -9618,7 +9699,7 @@ type SetTorConfigRequest struct {
 
 func (x *SetTorConfigRequest) Reset() {
 	*x = SetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9630,7 +9711,7 @@ func (x *SetTorConfigRequest) String() string {
 func (*SetTorConfigRequest) ProtoMessage() {}
 
 func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9643,7 +9724,7 @@ func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{157}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *SetTorConfigRequest) GetEnabled() bool {
@@ -9673,7 +9754,7 @@ type SetTorConfigResponse struct {
 
 func (x *SetTorConfigResponse) Reset() {
 	*x = SetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9685,7 +9766,7 @@ func (x *SetTorConfigResponse) String() string {
 func (*SetTorConfigResponse) ProtoMessage() {}
 
 func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9698,7 +9779,7 @@ func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*SetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{158}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *SetTorConfigResponse) GetEnabled() bool {
@@ -9747,7 +9828,7 @@ type WatchWalletDataResponse struct {
 
 func (x *WatchWalletDataResponse) Reset() {
 	*x = WatchWalletDataResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9759,7 +9840,7 @@ func (x *WatchWalletDataResponse) String() string {
 func (*WatchWalletDataResponse) ProtoMessage() {}
 
 func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9772,7 +9853,7 @@ func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchWalletDataResponse.ProtoReflect.Descriptor instead.
 func (*WatchWalletDataResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{159}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *WatchWalletDataResponse) GetHasWallet() bool {
@@ -9856,7 +9937,7 @@ type CreateDepositRequest struct {
 
 func (x *CreateDepositRequest) Reset() {
 	*x = CreateDepositRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9868,7 +9949,7 @@ func (x *CreateDepositRequest) String() string {
 func (*CreateDepositRequest) ProtoMessage() {}
 
 func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9881,7 +9962,7 @@ func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositRequest.ProtoReflect.Descriptor instead.
 func (*CreateDepositRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{160}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *CreateDepositRequest) GetSlot() int32 {
@@ -9930,7 +10011,7 @@ type CreateDepositResponse struct {
 
 func (x *CreateDepositResponse) Reset() {
 	*x = CreateDepositResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9942,7 +10023,7 @@ func (x *CreateDepositResponse) String() string {
 func (*CreateDepositResponse) ProtoMessage() {}
 
 func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9955,7 +10036,7 @@ func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositResponse.ProtoReflect.Descriptor instead.
 func (*CreateDepositResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{161}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *CreateDepositResponse) GetTxid() string {
@@ -10443,7 +10524,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"descriptor\"L\n" +
 	"\x17ListTransactionsRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x14\n" +
-	"\x05count\x18\x02 \x01(\x05R\x05count\"\xf1\x02\n" +
+	"\x05count\x18\x02 \x01(\x05R\x05count\"\xa4\x03\n" +
 	"\x10TransactionEntry\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
 	"\x04vout\x18\x02 \x01(\x05R\x04vout\x12\x18\n" +
@@ -10460,7 +10541,13 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	" \x01(\tR\x05label\x12\x10\n" +
 	"\x03fee\x18\v \x01(\x01R\x03fee\x12(\n" +
 	"\x10replaced_by_txid\x18\f \x01(\bR\x0ereplacedByTxid\x12\x1b\n" +
-	"\twallet_id\x18\r \x01(\tR\bwalletId\"b\n" +
+	"\twallet_id\x18\r \x01(\tR\bwalletId\x121\n" +
+	"\abmm_bid\x18\x0e \x01(\v2\x18.walletmanager.v1.BmmBidR\x06bmmBid\"{\n" +
+	"\x06BmmBid\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\rR\x04slot\x12#\n" +
+	"\rcritical_hash\x18\x02 \x01(\tR\fcriticalHash\x12$\n" +
+	"\x0eprev_main_hash\x18\x03 \x01(\tR\fprevMainHash\x12\x12\n" +
+	"\x04lost\x18\x04 \x01(\bR\x04lost\"b\n" +
 	"\x18ListTransactionsResponse\x12F\n" +
 	"\ftransactions\x18\x01 \x03(\v2\".walletmanager.v1.TransactionEntryR\ftransactions\"1\n" +
 	"\x12ListUnspentRequest\x12\x1b\n" +
@@ -10844,7 +10931,7 @@ func file_walletmanager_v1_walletmanager_proto_rawDescGZIP() []byte {
 }
 
 var file_walletmanager_v1_walletmanager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 164)
+var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 165)
 var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(NodeMode)(0),                                // 0: walletmanager.v1.NodeMode
 	(WalletType)(0),                              // 1: walletmanager.v1.WalletType
@@ -10968,56 +11055,57 @@ var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(*DeriveKeystoreResponse)(nil),               // 119: walletmanager.v1.DeriveKeystoreResponse
 	(*ListTransactionsRequest)(nil),              // 120: walletmanager.v1.ListTransactionsRequest
 	(*TransactionEntry)(nil),                     // 121: walletmanager.v1.TransactionEntry
-	(*ListTransactionsResponse)(nil),             // 122: walletmanager.v1.ListTransactionsResponse
-	(*ListUnspentRequest)(nil),                   // 123: walletmanager.v1.ListUnspentRequest
-	(*UnspentOutput)(nil),                        // 124: walletmanager.v1.UnspentOutput
-	(*ListUnspentResponse)(nil),                  // 125: walletmanager.v1.ListUnspentResponse
-	(*ListReceiveAddressesRequest)(nil),          // 126: walletmanager.v1.ListReceiveAddressesRequest
-	(*ReceiveAddress)(nil),                       // 127: walletmanager.v1.ReceiveAddress
-	(*ListReceiveAddressesResponse)(nil),         // 128: walletmanager.v1.ListReceiveAddressesResponse
-	(*GetTransactionDetailsRequest)(nil),         // 129: walletmanager.v1.GetTransactionDetailsRequest
-	(*GetTransactionDetailsResponse)(nil),        // 130: walletmanager.v1.GetTransactionDetailsResponse
-	(*TransactionInput)(nil),                     // 131: walletmanager.v1.TransactionInput
-	(*TransactionOutput)(nil),                    // 132: walletmanager.v1.TransactionOutput
-	(*DecodeTransactionRequest)(nil),             // 133: walletmanager.v1.DecodeTransactionRequest
-	(*DecodeTransactionResponse)(nil),            // 134: walletmanager.v1.DecodeTransactionResponse
-	(*BumpFeeRequest)(nil),                       // 135: walletmanager.v1.BumpFeeRequest
-	(*BumpFeeResponse)(nil),                      // 136: walletmanager.v1.BumpFeeResponse
-	(*PreviewBumpFeeRequest)(nil),                // 137: walletmanager.v1.PreviewBumpFeeRequest
-	(*PreviewBumpFeeResponse)(nil),               // 138: walletmanager.v1.PreviewBumpFeeResponse
-	(*BumpFeeOutput)(nil),                        // 139: walletmanager.v1.BumpFeeOutput
-	(*BumpFeePlan)(nil),                          // 140: walletmanager.v1.BumpFeePlan
-	(*CreateCpfpRequest)(nil),                    // 141: walletmanager.v1.CreateCpfpRequest
-	(*CreateCpfpResponse)(nil),                   // 142: walletmanager.v1.CreateCpfpResponse
-	(*DeriveAddressesRequest)(nil),               // 143: walletmanager.v1.DeriveAddressesRequest
-	(*DeriveAddressesResponse)(nil),              // 144: walletmanager.v1.DeriveAddressesResponse
-	(*PreviewWalletFromEntropyRequest)(nil),      // 145: walletmanager.v1.PreviewWalletFromEntropyRequest
-	(*PreviewWalletFromEntropyResponse)(nil),     // 146: walletmanager.v1.PreviewWalletFromEntropyResponse
-	(*GetWalletSeedRequest)(nil),                 // 147: walletmanager.v1.GetWalletSeedRequest
-	(*GetWalletSeedResponse)(nil),                // 148: walletmanager.v1.GetWalletSeedResponse
-	(*ListCoreVariantsRequest)(nil),              // 149: walletmanager.v1.ListCoreVariantsRequest
-	(*CoreVariant)(nil),                          // 150: walletmanager.v1.CoreVariant
-	(*ListCoreVariantsResponse)(nil),             // 151: walletmanager.v1.ListCoreVariantsResponse
-	(*GetCoreVariantRequest)(nil),                // 152: walletmanager.v1.GetCoreVariantRequest
-	(*GetCoreVariantResponse)(nil),               // 153: walletmanager.v1.GetCoreVariantResponse
-	(*SetCoreVariantRequest)(nil),                // 154: walletmanager.v1.SetCoreVariantRequest
-	(*SetCoreVariantResponse)(nil),               // 155: walletmanager.v1.SetCoreVariantResponse
-	(*GetElectrumServerRequest)(nil),             // 156: walletmanager.v1.GetElectrumServerRequest
-	(*GetElectrumServerResponse)(nil),            // 157: walletmanager.v1.GetElectrumServerResponse
-	(*SetElectrumServerRequest)(nil),             // 158: walletmanager.v1.SetElectrumServerRequest
-	(*SetElectrumServerResponse)(nil),            // 159: walletmanager.v1.SetElectrumServerResponse
-	(*GetTorConfigRequest)(nil),                  // 160: walletmanager.v1.GetTorConfigRequest
-	(*GetTorConfigResponse)(nil),                 // 161: walletmanager.v1.GetTorConfigResponse
-	(*SetTorConfigRequest)(nil),                  // 162: walletmanager.v1.SetTorConfigRequest
-	(*SetTorConfigResponse)(nil),                 // 163: walletmanager.v1.SetTorConfigResponse
-	(*WatchWalletDataResponse)(nil),              // 164: walletmanager.v1.WatchWalletDataResponse
-	(*CreateDepositRequest)(nil),                 // 165: walletmanager.v1.CreateDepositRequest
-	(*CreateDepositResponse)(nil),                // 166: walletmanager.v1.CreateDepositResponse
-	nil,                                          // 167: walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	nil,                                          // 168: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	(v1.BinaryType)(0),                           // 169: orchestrator.v1.BinaryType
-	(*timestamppb.Timestamp)(nil),                // 170: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                        // 171: google.protobuf.Empty
+	(*BmmBid)(nil),                               // 122: walletmanager.v1.BmmBid
+	(*ListTransactionsResponse)(nil),             // 123: walletmanager.v1.ListTransactionsResponse
+	(*ListUnspentRequest)(nil),                   // 124: walletmanager.v1.ListUnspentRequest
+	(*UnspentOutput)(nil),                        // 125: walletmanager.v1.UnspentOutput
+	(*ListUnspentResponse)(nil),                  // 126: walletmanager.v1.ListUnspentResponse
+	(*ListReceiveAddressesRequest)(nil),          // 127: walletmanager.v1.ListReceiveAddressesRequest
+	(*ReceiveAddress)(nil),                       // 128: walletmanager.v1.ReceiveAddress
+	(*ListReceiveAddressesResponse)(nil),         // 129: walletmanager.v1.ListReceiveAddressesResponse
+	(*GetTransactionDetailsRequest)(nil),         // 130: walletmanager.v1.GetTransactionDetailsRequest
+	(*GetTransactionDetailsResponse)(nil),        // 131: walletmanager.v1.GetTransactionDetailsResponse
+	(*TransactionInput)(nil),                     // 132: walletmanager.v1.TransactionInput
+	(*TransactionOutput)(nil),                    // 133: walletmanager.v1.TransactionOutput
+	(*DecodeTransactionRequest)(nil),             // 134: walletmanager.v1.DecodeTransactionRequest
+	(*DecodeTransactionResponse)(nil),            // 135: walletmanager.v1.DecodeTransactionResponse
+	(*BumpFeeRequest)(nil),                       // 136: walletmanager.v1.BumpFeeRequest
+	(*BumpFeeResponse)(nil),                      // 137: walletmanager.v1.BumpFeeResponse
+	(*PreviewBumpFeeRequest)(nil),                // 138: walletmanager.v1.PreviewBumpFeeRequest
+	(*PreviewBumpFeeResponse)(nil),               // 139: walletmanager.v1.PreviewBumpFeeResponse
+	(*BumpFeeOutput)(nil),                        // 140: walletmanager.v1.BumpFeeOutput
+	(*BumpFeePlan)(nil),                          // 141: walletmanager.v1.BumpFeePlan
+	(*CreateCpfpRequest)(nil),                    // 142: walletmanager.v1.CreateCpfpRequest
+	(*CreateCpfpResponse)(nil),                   // 143: walletmanager.v1.CreateCpfpResponse
+	(*DeriveAddressesRequest)(nil),               // 144: walletmanager.v1.DeriveAddressesRequest
+	(*DeriveAddressesResponse)(nil),              // 145: walletmanager.v1.DeriveAddressesResponse
+	(*PreviewWalletFromEntropyRequest)(nil),      // 146: walletmanager.v1.PreviewWalletFromEntropyRequest
+	(*PreviewWalletFromEntropyResponse)(nil),     // 147: walletmanager.v1.PreviewWalletFromEntropyResponse
+	(*GetWalletSeedRequest)(nil),                 // 148: walletmanager.v1.GetWalletSeedRequest
+	(*GetWalletSeedResponse)(nil),                // 149: walletmanager.v1.GetWalletSeedResponse
+	(*ListCoreVariantsRequest)(nil),              // 150: walletmanager.v1.ListCoreVariantsRequest
+	(*CoreVariant)(nil),                          // 151: walletmanager.v1.CoreVariant
+	(*ListCoreVariantsResponse)(nil),             // 152: walletmanager.v1.ListCoreVariantsResponse
+	(*GetCoreVariantRequest)(nil),                // 153: walletmanager.v1.GetCoreVariantRequest
+	(*GetCoreVariantResponse)(nil),               // 154: walletmanager.v1.GetCoreVariantResponse
+	(*SetCoreVariantRequest)(nil),                // 155: walletmanager.v1.SetCoreVariantRequest
+	(*SetCoreVariantResponse)(nil),               // 156: walletmanager.v1.SetCoreVariantResponse
+	(*GetElectrumServerRequest)(nil),             // 157: walletmanager.v1.GetElectrumServerRequest
+	(*GetElectrumServerResponse)(nil),            // 158: walletmanager.v1.GetElectrumServerResponse
+	(*SetElectrumServerRequest)(nil),             // 159: walletmanager.v1.SetElectrumServerRequest
+	(*SetElectrumServerResponse)(nil),            // 160: walletmanager.v1.SetElectrumServerResponse
+	(*GetTorConfigRequest)(nil),                  // 161: walletmanager.v1.GetTorConfigRequest
+	(*GetTorConfigResponse)(nil),                 // 162: walletmanager.v1.GetTorConfigResponse
+	(*SetTorConfigRequest)(nil),                  // 163: walletmanager.v1.SetTorConfigRequest
+	(*SetTorConfigResponse)(nil),                 // 164: walletmanager.v1.SetTorConfigResponse
+	(*WatchWalletDataResponse)(nil),              // 165: walletmanager.v1.WatchWalletDataResponse
+	(*CreateDepositRequest)(nil),                 // 166: walletmanager.v1.CreateDepositRequest
+	(*CreateDepositResponse)(nil),                // 167: walletmanager.v1.CreateDepositResponse
+	nil,                                          // 168: walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	nil,                                          // 169: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	(v1.BinaryType)(0),                           // 170: orchestrator.v1.BinaryType
+	(*timestamppb.Timestamp)(nil),                // 171: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                        // 172: google.protobuf.Empty
 }
 var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	8,   // 0: walletmanager.v1.ListSidechainDepositsResponse.deposits:type_name -> walletmanager.v1.SidechainDeposit
@@ -11029,9 +11117,9 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	3,   // 6: walletmanager.v1.WalletMetadata.receive_address_types:type_name -> walletmanager.v1.AddressType
 	30,  // 7: walletmanager.v1.MultisigInfo.cosigners:type_name -> walletmanager.v1.MultisigCosignerInfo
 	28,  // 8: walletmanager.v1.ListWalletsResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	169, // 9: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
-	170, // 10: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
-	170, // 11: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
+	170, // 9: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
+	171, // 10: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
+	171, // 11: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
 	43,  // 12: walletmanager.v1.WalletBackup.wallets:type_name -> walletmanager.v1.BackupWalletSummary
 	42,  // 13: walletmanager.v1.WalletBackup.latest_known_balance:type_name -> walletmanager.v1.BalanceSnapshot
 	44,  // 14: walletmanager.v1.ListWalletBackupsResponse.backups:type_name -> walletmanager.v1.WalletBackup
@@ -11043,12 +11131,12 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	66,  // 20: walletmanager.v1.ListDerivationPathsResponse.options:type_name -> walletmanager.v1.DerivationPathOption
 	60,  // 21: walletmanager.v1.ValidateDescriptorResponse.keys:type_name -> walletmanager.v1.ParsedCosigner
 	3,   // 22: walletmanager.v1.GetNewAddressRequest.address_type:type_name -> walletmanager.v1.AddressType
-	167, // 23: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	124, // 24: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	168, // 23: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	125, // 24: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
 	83,  // 25: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
 	84,  // 26: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
-	168, // 27: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	124, // 28: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	169, // 27: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	125, // 28: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
 	83,  // 29: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
 	84,  // 30: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
 	100, // 31: walletmanager.v1.GetAddressUnspentResponse.utxos:type_name -> walletmanager.v1.AddressUnspentOutput
@@ -11059,164 +11147,165 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	105, // 36: walletmanager.v1.SendDevicePinRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
 	105, // 37: walletmanager.v1.CloseDeviceRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
 	105, // 38: walletmanager.v1.DeriveKeystoreRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	121, // 39: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
-	170, // 40: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
-	124, // 41: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
-	127, // 42: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
-	121, // 43: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
-	131, // 44: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	132, // 45: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	4,   // 46: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
-	131, // 47: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	132, // 48: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	140, // 49: walletmanager.v1.BumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
-	139, // 50: walletmanager.v1.PreviewBumpFeeResponse.outputs:type_name -> walletmanager.v1.BumpFeeOutput
-	140, // 51: walletmanager.v1.PreviewBumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
-	150, // 52: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
-	28,  // 53: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	5,   // 54: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
-	7,   // 55: walletmanager.v1.WalletManagerService.ListSidechainDeposits:input_type -> walletmanager.v1.ListSidechainDepositsRequest
-	10,  // 56: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:input_type -> walletmanager.v1.GetSidechainDepositTotalsRequest
-	12,  // 57: walletmanager.v1.WalletManagerService.GetNodeMode:input_type -> walletmanager.v1.GetNodeModeRequest
-	14,  // 58: walletmanager.v1.WalletManagerService.SetNodeMode:input_type -> walletmanager.v1.SetNodeModeRequest
-	16,  // 59: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
-	18,  // 60: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
-	20,  // 61: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
-	22,  // 62: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
-	24,  // 63: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
-	26,  // 64: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
-	32,  // 65: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
-	34,  // 66: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
-	36,  // 67: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
-	38,  // 68: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
-	40,  // 69: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
-	45,  // 70: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
-	47,  // 71: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	47,  // 72: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	52,  // 73: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
-	54,  // 74: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
-	57,  // 75: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
-	59,  // 76: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
-	62,  // 77: walletmanager.v1.WalletManagerService.ValidateDescriptor:input_type -> walletmanager.v1.ValidateDescriptorRequest
-	63,  // 78: walletmanager.v1.WalletManagerService.ValidateDerivationPath:input_type -> walletmanager.v1.ValidateDerivationPathRequest
-	65,  // 79: walletmanager.v1.WalletManagerService.ListDerivationPaths:input_type -> walletmanager.v1.ListDerivationPathsRequest
-	69,  // 80: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
-	71,  // 81: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
-	73,  // 82: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
-	74,  // 83: walletmanager.v1.WalletManagerService.RescanWallet:input_type -> walletmanager.v1.RescanWalletRequest
-	76,  // 84: walletmanager.v1.WalletManagerService.EstimateFee:input_type -> walletmanager.v1.EstimateFeeRequest
-	79,  // 85: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
-	81,  // 86: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
-	165, // 87: walletmanager.v1.WalletManagerService.CreateDeposit:input_type -> walletmanager.v1.CreateDepositRequest
-	120, // 88: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
-	123, // 89: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
-	126, // 90: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
-	129, // 91: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
-	133, // 92: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
-	135, // 93: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
-	137, // 94: walletmanager.v1.WalletManagerService.PreviewBumpFee:input_type -> walletmanager.v1.PreviewBumpFeeRequest
-	141, // 95: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
-	143, // 96: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
-	85,  // 97: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
-	87,  // 98: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
-	89,  // 99: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
-	91,  // 100: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
-	93,  // 101: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
-	95,  // 102: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
-	97,  // 103: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
-	99,  // 104: walletmanager.v1.WalletManagerService.GetAddressUnspent:input_type -> walletmanager.v1.GetAddressUnspentRequest
-	102, // 105: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:input_type -> walletmanager.v1.BroadcastElectrumTransactionRequest
-	106, // 106: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:input_type -> walletmanager.v1.EnumerateHardwareDevicesRequest
-	108, // 107: walletmanager.v1.WalletManagerService.GetHardwareXpub:input_type -> walletmanager.v1.GetHardwareXpubRequest
-	110, // 108: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:input_type -> walletmanager.v1.SignPsbtWithDeviceRequest
-	112, // 109: walletmanager.v1.WalletManagerService.PromptDevicePin:input_type -> walletmanager.v1.PromptDevicePinRequest
-	114, // 110: walletmanager.v1.WalletManagerService.SendDevicePin:input_type -> walletmanager.v1.SendDevicePinRequest
-	116, // 111: walletmanager.v1.WalletManagerService.CloseDevice:input_type -> walletmanager.v1.CloseDeviceRequest
-	118, // 112: walletmanager.v1.WalletManagerService.DeriveKeystore:input_type -> walletmanager.v1.DeriveKeystoreRequest
-	145, // 113: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:input_type -> walletmanager.v1.PreviewWalletFromEntropyRequest
-	147, // 114: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
-	149, // 115: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
-	152, // 116: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
-	154, // 117: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
-	156, // 118: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
-	158, // 119: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
-	160, // 120: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
-	162, // 121: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
-	171, // 122: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
-	6,   // 123: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
-	9,   // 124: walletmanager.v1.WalletManagerService.ListSidechainDeposits:output_type -> walletmanager.v1.ListSidechainDepositsResponse
-	11,  // 125: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:output_type -> walletmanager.v1.GetSidechainDepositTotalsResponse
-	13,  // 126: walletmanager.v1.WalletManagerService.GetNodeMode:output_type -> walletmanager.v1.GetNodeModeResponse
-	15,  // 127: walletmanager.v1.WalletManagerService.SetNodeMode:output_type -> walletmanager.v1.SetNodeModeResponse
-	17,  // 128: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
-	19,  // 129: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
-	21,  // 130: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
-	23,  // 131: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
-	25,  // 132: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
-	27,  // 133: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
-	33,  // 134: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
-	35,  // 135: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
-	37,  // 136: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
-	39,  // 137: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
-	41,  // 138: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
-	46,  // 139: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
-	48,  // 140: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
-	51,  // 141: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
-	53,  // 142: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
-	55,  // 143: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
-	58,  // 144: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
-	61,  // 145: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
-	68,  // 146: walletmanager.v1.WalletManagerService.ValidateDescriptor:output_type -> walletmanager.v1.ValidateDescriptorResponse
-	64,  // 147: walletmanager.v1.WalletManagerService.ValidateDerivationPath:output_type -> walletmanager.v1.ValidateDerivationPathResponse
-	67,  // 148: walletmanager.v1.WalletManagerService.ListDerivationPaths:output_type -> walletmanager.v1.ListDerivationPathsResponse
-	70,  // 149: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
-	72,  // 150: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
-	78,  // 151: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
-	75,  // 152: walletmanager.v1.WalletManagerService.RescanWallet:output_type -> walletmanager.v1.RescanWalletResponse
-	77,  // 153: walletmanager.v1.WalletManagerService.EstimateFee:output_type -> walletmanager.v1.EstimateFeeResponse
-	80,  // 154: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
-	82,  // 155: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
-	166, // 156: walletmanager.v1.WalletManagerService.CreateDeposit:output_type -> walletmanager.v1.CreateDepositResponse
-	122, // 157: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
-	125, // 158: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
-	128, // 159: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
-	130, // 160: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
-	134, // 161: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
-	136, // 162: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
-	138, // 163: walletmanager.v1.WalletManagerService.PreviewBumpFee:output_type -> walletmanager.v1.PreviewBumpFeeResponse
-	142, // 164: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
-	144, // 165: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
-	86,  // 166: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
-	88,  // 167: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
-	90,  // 168: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
-	92,  // 169: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
-	94,  // 170: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
-	96,  // 171: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
-	98,  // 172: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
-	101, // 173: walletmanager.v1.WalletManagerService.GetAddressUnspent:output_type -> walletmanager.v1.GetAddressUnspentResponse
-	103, // 174: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:output_type -> walletmanager.v1.BroadcastElectrumTransactionResponse
-	107, // 175: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:output_type -> walletmanager.v1.EnumerateHardwareDevicesResponse
-	109, // 176: walletmanager.v1.WalletManagerService.GetHardwareXpub:output_type -> walletmanager.v1.GetHardwareXpubResponse
-	111, // 177: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:output_type -> walletmanager.v1.SignPsbtWithDeviceResponse
-	113, // 178: walletmanager.v1.WalletManagerService.PromptDevicePin:output_type -> walletmanager.v1.PromptDevicePinResponse
-	115, // 179: walletmanager.v1.WalletManagerService.SendDevicePin:output_type -> walletmanager.v1.SendDevicePinResponse
-	117, // 180: walletmanager.v1.WalletManagerService.CloseDevice:output_type -> walletmanager.v1.CloseDeviceResponse
-	119, // 181: walletmanager.v1.WalletManagerService.DeriveKeystore:output_type -> walletmanager.v1.DeriveKeystoreResponse
-	146, // 182: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:output_type -> walletmanager.v1.PreviewWalletFromEntropyResponse
-	148, // 183: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
-	151, // 184: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
-	153, // 185: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
-	155, // 186: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
-	157, // 187: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
-	159, // 188: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
-	161, // 189: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
-	163, // 190: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
-	164, // 191: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
-	123, // [123:192] is the sub-list for method output_type
-	54,  // [54:123] is the sub-list for method input_type
-	54,  // [54:54] is the sub-list for extension type_name
-	54,  // [54:54] is the sub-list for extension extendee
-	0,   // [0:54] is the sub-list for field type_name
+	122, // 39: walletmanager.v1.TransactionEntry.bmm_bid:type_name -> walletmanager.v1.BmmBid
+	121, // 40: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
+	171, // 41: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
+	125, // 42: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
+	128, // 43: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
+	121, // 44: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
+	132, // 45: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	133, // 46: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	4,   // 47: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
+	132, // 48: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	133, // 49: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	141, // 50: walletmanager.v1.BumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
+	140, // 51: walletmanager.v1.PreviewBumpFeeResponse.outputs:type_name -> walletmanager.v1.BumpFeeOutput
+	141, // 52: walletmanager.v1.PreviewBumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
+	151, // 53: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
+	28,  // 54: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
+	5,   // 55: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
+	7,   // 56: walletmanager.v1.WalletManagerService.ListSidechainDeposits:input_type -> walletmanager.v1.ListSidechainDepositsRequest
+	10,  // 57: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:input_type -> walletmanager.v1.GetSidechainDepositTotalsRequest
+	12,  // 58: walletmanager.v1.WalletManagerService.GetNodeMode:input_type -> walletmanager.v1.GetNodeModeRequest
+	14,  // 59: walletmanager.v1.WalletManagerService.SetNodeMode:input_type -> walletmanager.v1.SetNodeModeRequest
+	16,  // 60: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
+	18,  // 61: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
+	20,  // 62: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
+	22,  // 63: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
+	24,  // 64: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
+	26,  // 65: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
+	32,  // 66: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
+	34,  // 67: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
+	36,  // 68: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
+	38,  // 69: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
+	40,  // 70: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
+	45,  // 71: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
+	47,  // 72: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	47,  // 73: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	52,  // 74: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
+	54,  // 75: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
+	57,  // 76: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
+	59,  // 77: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
+	62,  // 78: walletmanager.v1.WalletManagerService.ValidateDescriptor:input_type -> walletmanager.v1.ValidateDescriptorRequest
+	63,  // 79: walletmanager.v1.WalletManagerService.ValidateDerivationPath:input_type -> walletmanager.v1.ValidateDerivationPathRequest
+	65,  // 80: walletmanager.v1.WalletManagerService.ListDerivationPaths:input_type -> walletmanager.v1.ListDerivationPathsRequest
+	69,  // 81: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
+	71,  // 82: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
+	73,  // 83: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
+	74,  // 84: walletmanager.v1.WalletManagerService.RescanWallet:input_type -> walletmanager.v1.RescanWalletRequest
+	76,  // 85: walletmanager.v1.WalletManagerService.EstimateFee:input_type -> walletmanager.v1.EstimateFeeRequest
+	79,  // 86: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
+	81,  // 87: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
+	166, // 88: walletmanager.v1.WalletManagerService.CreateDeposit:input_type -> walletmanager.v1.CreateDepositRequest
+	120, // 89: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
+	124, // 90: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
+	127, // 91: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
+	130, // 92: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
+	134, // 93: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
+	136, // 94: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
+	138, // 95: walletmanager.v1.WalletManagerService.PreviewBumpFee:input_type -> walletmanager.v1.PreviewBumpFeeRequest
+	142, // 96: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
+	144, // 97: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
+	85,  // 98: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
+	87,  // 99: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
+	89,  // 100: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
+	91,  // 101: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
+	93,  // 102: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
+	95,  // 103: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
+	97,  // 104: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
+	99,  // 105: walletmanager.v1.WalletManagerService.GetAddressUnspent:input_type -> walletmanager.v1.GetAddressUnspentRequest
+	102, // 106: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:input_type -> walletmanager.v1.BroadcastElectrumTransactionRequest
+	106, // 107: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:input_type -> walletmanager.v1.EnumerateHardwareDevicesRequest
+	108, // 108: walletmanager.v1.WalletManagerService.GetHardwareXpub:input_type -> walletmanager.v1.GetHardwareXpubRequest
+	110, // 109: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:input_type -> walletmanager.v1.SignPsbtWithDeviceRequest
+	112, // 110: walletmanager.v1.WalletManagerService.PromptDevicePin:input_type -> walletmanager.v1.PromptDevicePinRequest
+	114, // 111: walletmanager.v1.WalletManagerService.SendDevicePin:input_type -> walletmanager.v1.SendDevicePinRequest
+	116, // 112: walletmanager.v1.WalletManagerService.CloseDevice:input_type -> walletmanager.v1.CloseDeviceRequest
+	118, // 113: walletmanager.v1.WalletManagerService.DeriveKeystore:input_type -> walletmanager.v1.DeriveKeystoreRequest
+	146, // 114: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:input_type -> walletmanager.v1.PreviewWalletFromEntropyRequest
+	148, // 115: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
+	150, // 116: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
+	153, // 117: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
+	155, // 118: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
+	157, // 119: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
+	159, // 120: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
+	161, // 121: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
+	163, // 122: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
+	172, // 123: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
+	6,   // 124: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
+	9,   // 125: walletmanager.v1.WalletManagerService.ListSidechainDeposits:output_type -> walletmanager.v1.ListSidechainDepositsResponse
+	11,  // 126: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:output_type -> walletmanager.v1.GetSidechainDepositTotalsResponse
+	13,  // 127: walletmanager.v1.WalletManagerService.GetNodeMode:output_type -> walletmanager.v1.GetNodeModeResponse
+	15,  // 128: walletmanager.v1.WalletManagerService.SetNodeMode:output_type -> walletmanager.v1.SetNodeModeResponse
+	17,  // 129: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
+	19,  // 130: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
+	21,  // 131: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
+	23,  // 132: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
+	25,  // 133: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
+	27,  // 134: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
+	33,  // 135: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
+	35,  // 136: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
+	37,  // 137: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
+	39,  // 138: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
+	41,  // 139: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
+	46,  // 140: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
+	48,  // 141: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
+	51,  // 142: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
+	53,  // 143: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
+	55,  // 144: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
+	58,  // 145: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
+	61,  // 146: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
+	68,  // 147: walletmanager.v1.WalletManagerService.ValidateDescriptor:output_type -> walletmanager.v1.ValidateDescriptorResponse
+	64,  // 148: walletmanager.v1.WalletManagerService.ValidateDerivationPath:output_type -> walletmanager.v1.ValidateDerivationPathResponse
+	67,  // 149: walletmanager.v1.WalletManagerService.ListDerivationPaths:output_type -> walletmanager.v1.ListDerivationPathsResponse
+	70,  // 150: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
+	72,  // 151: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
+	78,  // 152: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
+	75,  // 153: walletmanager.v1.WalletManagerService.RescanWallet:output_type -> walletmanager.v1.RescanWalletResponse
+	77,  // 154: walletmanager.v1.WalletManagerService.EstimateFee:output_type -> walletmanager.v1.EstimateFeeResponse
+	80,  // 155: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
+	82,  // 156: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
+	167, // 157: walletmanager.v1.WalletManagerService.CreateDeposit:output_type -> walletmanager.v1.CreateDepositResponse
+	123, // 158: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
+	126, // 159: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
+	129, // 160: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
+	131, // 161: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
+	135, // 162: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
+	137, // 163: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
+	139, // 164: walletmanager.v1.WalletManagerService.PreviewBumpFee:output_type -> walletmanager.v1.PreviewBumpFeeResponse
+	143, // 165: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
+	145, // 166: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
+	86,  // 167: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
+	88,  // 168: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
+	90,  // 169: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
+	92,  // 170: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
+	94,  // 171: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
+	96,  // 172: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
+	98,  // 173: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
+	101, // 174: walletmanager.v1.WalletManagerService.GetAddressUnspent:output_type -> walletmanager.v1.GetAddressUnspentResponse
+	103, // 175: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:output_type -> walletmanager.v1.BroadcastElectrumTransactionResponse
+	107, // 176: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:output_type -> walletmanager.v1.EnumerateHardwareDevicesResponse
+	109, // 177: walletmanager.v1.WalletManagerService.GetHardwareXpub:output_type -> walletmanager.v1.GetHardwareXpubResponse
+	111, // 178: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:output_type -> walletmanager.v1.SignPsbtWithDeviceResponse
+	113, // 179: walletmanager.v1.WalletManagerService.PromptDevicePin:output_type -> walletmanager.v1.PromptDevicePinResponse
+	115, // 180: walletmanager.v1.WalletManagerService.SendDevicePin:output_type -> walletmanager.v1.SendDevicePinResponse
+	117, // 181: walletmanager.v1.WalletManagerService.CloseDevice:output_type -> walletmanager.v1.CloseDeviceResponse
+	119, // 182: walletmanager.v1.WalletManagerService.DeriveKeystore:output_type -> walletmanager.v1.DeriveKeystoreResponse
+	147, // 183: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:output_type -> walletmanager.v1.PreviewWalletFromEntropyResponse
+	149, // 184: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
+	152, // 185: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
+	154, // 186: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
+	156, // 187: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
+	158, // 188: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
+	160, // 189: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
+	162, // 190: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
+	164, // 191: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
+	165, // 192: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
+	124, // [124:193] is the sub-list for method output_type
+	55,  // [55:124] is the sub-list for method input_type
+	55,  // [55:55] is the sub-list for extension type_name
+	55,  // [55:55] is the sub-list for extension extendee
+	0,   // [0:55] is the sub-list for field type_name
 }
 
 func init() { file_walletmanager_v1_walletmanager_proto_init() }
@@ -11224,16 +11313,16 @@ func file_walletmanager_v1_walletmanager_proto_init() {
 	if File_walletmanager_v1_walletmanager_proto != nil {
 		return
 	}
-	file_walletmanager_v1_walletmanager_proto_msgTypes[119].OneofWrappers = []any{}
-	file_walletmanager_v1_walletmanager_proto_msgTypes[130].OneofWrappers = []any{}
-	file_walletmanager_v1_walletmanager_proto_msgTypes[132].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[120].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[131].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[133].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_walletmanager_v1_walletmanager_proto_rawDesc), len(file_walletmanager_v1_walletmanager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   164,
+			NumMessages:   165,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/proto/bmm/v1/bmm.proto
+++ b/sidechain-orchestrator/proto/bmm/v1/bmm.proto
@@ -34,6 +34,9 @@ service BMMService {
   // drive a single attempt by hand; Start does both on a loop.
   rpc CreateBid(CreateBidRequest) returns (CreateBidResponse);
   rpc ConnectBid(ConnectBidRequest) returns (ConnectBidResponse);
+  // CancelBid replaces a stranded bid with a payment back to its own wallet,
+  // so the coins under it come back. A bid that can still win is refused.
+  rpc CancelBid(CancelBidRequest) returns (CancelBidResponse);
   // ListBids reads the competing bids for the slot out of the mainchain
   // mempool, highest bid first.
   rpc ListBids(ListBidsRequest) returns (ListBidsResponse);
@@ -168,6 +171,24 @@ message CreateBidRequest {
   double fee_rate_sat_vb = 7;
   // Highest the bid may go, in sats. Zero sets no ceiling.
   int64 max_bid_sats = 8;
+}
+
+message CancelBidRequest {
+  // Wallet that funds the replacement. Empty uses the active wallet.
+  string wallet_id = 1;
+  // The stranded M8 transaction.
+  string txid = 2;
+}
+
+message CancelBidResponse {
+  // The replacement transaction.
+  string replacement_txid = 1;
+  // What the fresh address receives.
+  int64 recovered_sats = 2;
+  // What the replacement pays the miner to evict the chain.
+  int64 fee_sats = 3;
+  // Every bid the replacement evicts, the named one included.
+  repeated string cancelled_txids = 4;
 }
 
 message CreateBidResponse {

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -918,6 +918,19 @@ message TransactionEntry {
   double fee = 11;
   bool replaced_by_txid = 12;
   string wallet_id = 13;
+  // Set when output 0 carries a BMM request. Unset for every other transaction.
+  BmmBid bmm_bid = 14;
+}
+
+// BmmBid names the BMM request one wallet transaction carries.
+message BmmBid {
+  uint32 slot = 1;
+  string critical_hash = 2;
+  // The mainchain block the sidechain block builds on. The bid reaches only
+  // the block after it.
+  string prev_main_hash = 3;
+  // True when the mainchain tip moved past prev_main_hash.
+  bool lost = 4;
 }
 
 message ListTransactionsResponse {

--- a/sidechain_core/lib/gen/bmm/v1/bmm.connect.client.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.connect.client.dart
@@ -145,6 +145,25 @@ extension type BMMServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// CancelBid replaces a stranded bid with a payment back to its own wallet,
+  /// so the coins under it come back. A bid that can still win is refused.
+  Future<bmmv1bmm.CancelBidResponse> cancelBid(
+    bmmv1bmm.CancelBidRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.BMMService.cancelBid,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// ListBids reads the competing bids for the slot out of the mainchain
   /// mempool, highest bid first.
   Future<bmmv1bmm.ListBidsResponse> listBids(
@@ -156,6 +175,27 @@ extension type BMMServiceClient (connect.Transport _transport) {
   }) {
     return connect.Client(_transport).unary(
       specs.BMMService.listBids,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// PrepareBMM gives every bidding sidechain a coin of its own to bid from,
+  /// and splits one large coin when the wallet holds too few. One wallet funds
+  /// them all, and a bid over another slot's bid change dies when that slot
+  /// replaces its own bid.
+  Future<bmmv1bmm.PrepareBMMResponse> prepareBMM(
+    bmmv1bmm.PrepareBMMRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.BMMService.prepareBMM,
       input,
       signal: signal,
       headers: headers,

--- a/sidechain_core/lib/gen/bmm/v1/bmm.connect.spec.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.connect.spec.dart
@@ -77,6 +77,15 @@ abstract final class BMMService {
     bmmv1bmm.ConnectBidResponse.new,
   );
 
+  /// CancelBid replaces a stranded bid with a payment back to its own wallet,
+  /// so the coins under it come back. A bid that can still win is refused.
+  static const cancelBid = connect.Spec(
+    '/$name/CancelBid',
+    connect.StreamType.unary,
+    bmmv1bmm.CancelBidRequest.new,
+    bmmv1bmm.CancelBidResponse.new,
+  );
+
   /// ListBids reads the competing bids for the slot out of the mainchain
   /// mempool, highest bid first.
   static const listBids = connect.Spec(
@@ -84,5 +93,16 @@ abstract final class BMMService {
     connect.StreamType.unary,
     bmmv1bmm.ListBidsRequest.new,
     bmmv1bmm.ListBidsResponse.new,
+  );
+
+  /// PrepareBMM gives every bidding sidechain a coin of its own to bid from,
+  /// and splits one large coin when the wallet holds too few. One wallet funds
+  /// them all, and a bid over another slot's bid change dies when that slot
+  /// replaces its own bid.
+  static const prepareBMM = connect.Spec(
+    '/$name/PrepareBMM',
+    connect.StreamType.unary,
+    bmmv1bmm.PrepareBMMRequest.new,
+    bmmv1bmm.PrepareBMMResponse.new,
   );
 }

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pb.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pb.dart
@@ -1142,6 +1142,162 @@ class CreateBidRequest extends $pb.GeneratedMessage {
   void clearMaxBidSats() => clearField(8);
 }
 
+class CancelBidRequest extends $pb.GeneratedMessage {
+  factory CancelBidRequest({
+    $core.String? walletId,
+    $core.String? txid,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    return $result;
+  }
+  CancelBidRequest._() : super();
+  factory CancelBidRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CancelBidRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CancelBidRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aOS(2, _omitFieldNames ? '' : 'txid')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CancelBidRequest clone() => CancelBidRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CancelBidRequest copyWith(void Function(CancelBidRequest) updates) => super.copyWith((message) => updates(message as CancelBidRequest)) as CancelBidRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CancelBidRequest create() => CancelBidRequest._();
+  CancelBidRequest createEmptyInstance() => create();
+  static $pb.PbList<CancelBidRequest> createRepeated() => $pb.PbList<CancelBidRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CancelBidRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CancelBidRequest>(create);
+  static CancelBidRequest? _defaultInstance;
+
+  /// Wallet that funds the replacement. Empty uses the active wallet.
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  /// The stranded M8 transaction.
+  @$pb.TagNumber(2)
+  $core.String get txid => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set txid($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxid() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxid() => clearField(2);
+}
+
+class CancelBidResponse extends $pb.GeneratedMessage {
+  factory CancelBidResponse({
+    $core.String? replacementTxid,
+    $fixnum.Int64? recoveredSats,
+    $fixnum.Int64? feeSats,
+    $core.Iterable<$core.String>? cancelledTxids,
+  }) {
+    final $result = create();
+    if (replacementTxid != null) {
+      $result.replacementTxid = replacementTxid;
+    }
+    if (recoveredSats != null) {
+      $result.recoveredSats = recoveredSats;
+    }
+    if (feeSats != null) {
+      $result.feeSats = feeSats;
+    }
+    if (cancelledTxids != null) {
+      $result.cancelledTxids.addAll(cancelledTxids);
+    }
+    return $result;
+  }
+  CancelBidResponse._() : super();
+  factory CancelBidResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CancelBidResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CancelBidResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'replacementTxid')
+    ..aInt64(2, _omitFieldNames ? '' : 'recoveredSats')
+    ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
+    ..pPS(4, _omitFieldNames ? '' : 'cancelledTxids')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CancelBidResponse clone() => CancelBidResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CancelBidResponse copyWith(void Function(CancelBidResponse) updates) => super.copyWith((message) => updates(message as CancelBidResponse)) as CancelBidResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CancelBidResponse create() => CancelBidResponse._();
+  CancelBidResponse createEmptyInstance() => create();
+  static $pb.PbList<CancelBidResponse> createRepeated() => $pb.PbList<CancelBidResponse>();
+  @$core.pragma('dart2js:noInline')
+  static CancelBidResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CancelBidResponse>(create);
+  static CancelBidResponse? _defaultInstance;
+
+  /// The replacement transaction.
+  @$pb.TagNumber(1)
+  $core.String get replacementTxid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set replacementTxid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasReplacementTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearReplacementTxid() => clearField(1);
+
+  /// What the fresh address receives.
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get recoveredSats => $_getI64(1);
+  @$pb.TagNumber(2)
+  set recoveredSats($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRecoveredSats() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRecoveredSats() => clearField(2);
+
+  /// What the replacement pays the miner to evict the chain.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get feeSats => $_getI64(2);
+  @$pb.TagNumber(3)
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFeeSats() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFeeSats() => clearField(3);
+
+  /// Every bid the replacement evicts, the named one included.
+  @$pb.TagNumber(4)
+  $core.List<$core.String> get cancelledTxids => $_getList(3);
+}
+
 class CreateBidResponse extends $pb.GeneratedMessage {
   factory CreateBidResponse({
     $core.String? criticalHash,
@@ -1525,6 +1681,258 @@ class ListBidsResponse extends $pb.GeneratedMessage {
   $core.List<Bid> get bids => $_getList(0);
 }
 
+class PrepareBMMRequest extends $pb.GeneratedMessage {
+  factory PrepareBMMRequest({
+    $core.Iterable<PrepareBMMTarget>? targets,
+  }) {
+    final $result = create();
+    if (targets != null) {
+      $result.targets.addAll(targets);
+    }
+    return $result;
+  }
+  PrepareBMMRequest._() : super();
+  factory PrepareBMMRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrepareBMMRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrepareBMMRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
+    ..pc<PrepareBMMTarget>(1, _omitFieldNames ? '' : 'targets', $pb.PbFieldType.PM, subBuilder: PrepareBMMTarget.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrepareBMMRequest clone() => PrepareBMMRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrepareBMMRequest copyWith(void Function(PrepareBMMRequest) updates) => super.copyWith((message) => updates(message as PrepareBMMRequest)) as PrepareBMMRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMRequest create() => PrepareBMMRequest._();
+  PrepareBMMRequest createEmptyInstance() => create();
+  static $pb.PbList<PrepareBMMRequest> createRepeated() => $pb.PbList<PrepareBMMRequest>();
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrepareBMMRequest>(create);
+  static PrepareBMMRequest? _defaultInstance;
+
+  /// The sidechains that bid now. Each one needs a coin of its own.
+  @$pb.TagNumber(1)
+  $core.List<PrepareBMMTarget> get targets => $_getList(0);
+}
+
+/// PrepareBMMTarget is one sidechain that bids.
+class PrepareBMMTarget extends $pb.GeneratedMessage {
+  factory PrepareBMMTarget({
+    $core.String? walletId,
+    $fixnum.Int64? maxBidSats,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (maxBidSats != null) {
+      $result.maxBidSats = maxBidSats;
+    }
+    return $result;
+  }
+  PrepareBMMTarget._() : super();
+  factory PrepareBMMTarget.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrepareBMMTarget.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrepareBMMTarget', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aInt64(2, _omitFieldNames ? '' : 'maxBidSats')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrepareBMMTarget clone() => PrepareBMMTarget()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrepareBMMTarget copyWith(void Function(PrepareBMMTarget) updates) => super.copyWith((message) => updates(message as PrepareBMMTarget)) as PrepareBMMTarget;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMTarget create() => PrepareBMMTarget._();
+  PrepareBMMTarget createEmptyInstance() => create();
+  static $pb.PbList<PrepareBMMTarget> createRepeated() => $pb.PbList<PrepareBMMTarget>();
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMTarget getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrepareBMMTarget>(create);
+  static PrepareBMMTarget? _defaultInstance;
+
+  /// Wallet that funds its bids. Empty uses the active wallet.
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  /// Ceiling one of its bids may pay, in sats. It sizes the coin.
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get maxBidSats => $_getI64(1);
+  @$pb.TagNumber(2)
+  set maxBidSats($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMaxBidSats() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMaxBidSats() => clearField(2);
+}
+
+class PrepareBMMResponse extends $pb.GeneratedMessage {
+  factory PrepareBMMResponse({
+    $core.Iterable<PrepareBMMWallet>? wallets,
+  }) {
+    final $result = create();
+    if (wallets != null) {
+      $result.wallets.addAll(wallets);
+    }
+    return $result;
+  }
+  PrepareBMMResponse._() : super();
+  factory PrepareBMMResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrepareBMMResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrepareBMMResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
+    ..pc<PrepareBMMWallet>(1, _omitFieldNames ? '' : 'wallets', $pb.PbFieldType.PM, subBuilder: PrepareBMMWallet.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrepareBMMResponse clone() => PrepareBMMResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrepareBMMResponse copyWith(void Function(PrepareBMMResponse) updates) => super.copyWith((message) => updates(message as PrepareBMMResponse)) as PrepareBMMResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMResponse create() => PrepareBMMResponse._();
+  PrepareBMMResponse createEmptyInstance() => create();
+  static $pb.PbList<PrepareBMMResponse> createRepeated() => $pb.PbList<PrepareBMMResponse>();
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrepareBMMResponse>(create);
+  static PrepareBMMResponse? _defaultInstance;
+
+  /// One entry per wallet the targets name, with aliases of one wallet joined.
+  @$pb.TagNumber(1)
+  $core.List<PrepareBMMWallet> get wallets => $_getList(0);
+}
+
+class PrepareBMMWallet extends $pb.GeneratedMessage {
+  factory PrepareBMMWallet({
+    $core.String? walletId,
+    $core.int? usableCoins,
+    $core.int? wantedCoins,
+    $core.String? splitTxid,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (usableCoins != null) {
+      $result.usableCoins = usableCoins;
+    }
+    if (wantedCoins != null) {
+      $result.wantedCoins = wantedCoins;
+    }
+    if (splitTxid != null) {
+      $result.splitTxid = splitTxid;
+    }
+    return $result;
+  }
+  PrepareBMMWallet._() : super();
+  factory PrepareBMMWallet.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrepareBMMWallet.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrepareBMMWallet', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'usableCoins', $pb.PbFieldType.O3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'wantedCoins', $pb.PbFieldType.O3)
+    ..aOS(4, _omitFieldNames ? '' : 'splitTxid')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrepareBMMWallet clone() => PrepareBMMWallet()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrepareBMMWallet copyWith(void Function(PrepareBMMWallet) updates) => super.copyWith((message) => updates(message as PrepareBMMWallet)) as PrepareBMMWallet;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMWallet create() => PrepareBMMWallet._();
+  PrepareBMMWallet createEmptyInstance() => create();
+  static $pb.PbList<PrepareBMMWallet> createRepeated() => $pb.PbList<PrepareBMMWallet>();
+  @$core.pragma('dart2js:noInline')
+  static PrepareBMMWallet getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrepareBMMWallet>(create);
+  static PrepareBMMWallet? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  /// Coins the wallet holds that a sidechain can bid many rounds from.
+  @$pb.TagNumber(2)
+  $core.int get usableCoins => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set usableCoins($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasUsableCoins() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearUsableCoins() => clearField(2);
+
+  /// Coins the sidechains that spend this wallet need, one each.
+  @$pb.TagNumber(3)
+  $core.int get wantedCoins => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set wantedCoins($core.int v) { $_setSignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasWantedCoins() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearWantedCoins() => clearField(3);
+
+  /// Transaction that pays the missing coins. Empty when none was necessary.
+  @$pb.TagNumber(4)
+  $core.String get splitTxid => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set splitTxid($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSplitTxid() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSplitTxid() => clearField(4);
+}
+
 class BMMServiceApi {
   $pb.RpcClient _client;
   BMMServiceApi(this._client);
@@ -1550,8 +1958,14 @@ class BMMServiceApi {
   $async.Future<ConnectBidResponse> connectBid($pb.ClientContext? ctx, ConnectBidRequest request) =>
     _client.invoke<ConnectBidResponse>(ctx, 'BMMService', 'ConnectBid', request, ConnectBidResponse())
   ;
+  $async.Future<CancelBidResponse> cancelBid($pb.ClientContext? ctx, CancelBidRequest request) =>
+    _client.invoke<CancelBidResponse>(ctx, 'BMMService', 'CancelBid', request, CancelBidResponse())
+  ;
   $async.Future<ListBidsResponse> listBids($pb.ClientContext? ctx, ListBidsRequest request) =>
     _client.invoke<ListBidsResponse>(ctx, 'BMMService', 'ListBids', request, ListBidsResponse())
+  ;
+  $async.Future<PrepareBMMResponse> prepareBMM($pb.ClientContext? ctx, PrepareBMMRequest request) =>
+    _client.invoke<PrepareBMMResponse>(ctx, 'BMMService', 'PrepareBMM', request, PrepareBMMResponse())
   ;
 }
 

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pbjson.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pbjson.dart
@@ -234,6 +234,38 @@ final $typed_data.Uint8List createBidRequestDescriptor = $convert.base64Decode(
     'NhdF92YhgHIAEoAVIMZmVlUmF0ZVNhdFZiEiAKDG1heF9iaWRfc2F0cxgIIAEoA1IKbWF4Qmlk'
     'U2F0cw==');
 
+@$core.Deprecated('Use cancelBidRequestDescriptor instead')
+const CancelBidRequest$json = {
+  '1': 'CancelBidRequest',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'txid', '3': 2, '4': 1, '5': 9, '10': 'txid'},
+  ],
+};
+
+/// Descriptor for `CancelBidRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cancelBidRequestDescriptor = $convert.base64Decode(
+    'ChBDYW5jZWxCaWRSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSEgoEdHhpZB'
+    'gCIAEoCVIEdHhpZA==');
+
+@$core.Deprecated('Use cancelBidResponseDescriptor instead')
+const CancelBidResponse$json = {
+  '1': 'CancelBidResponse',
+  '2': [
+    {'1': 'replacement_txid', '3': 1, '4': 1, '5': 9, '10': 'replacementTxid'},
+    {'1': 'recovered_sats', '3': 2, '4': 1, '5': 3, '10': 'recoveredSats'},
+    {'1': 'fee_sats', '3': 3, '4': 1, '5': 3, '10': 'feeSats'},
+    {'1': 'cancelled_txids', '3': 4, '4': 3, '5': 9, '10': 'cancelledTxids'},
+  ],
+};
+
+/// Descriptor for `CancelBidResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cancelBidResponseDescriptor = $convert.base64Decode(
+    'ChFDYW5jZWxCaWRSZXNwb25zZRIpChByZXBsYWNlbWVudF90eGlkGAEgASgJUg9yZXBsYWNlbW'
+    'VudFR4aWQSJQoOcmVjb3ZlcmVkX3NhdHMYAiABKANSDXJlY292ZXJlZFNhdHMSGQoIZmVlX3Nh'
+    'dHMYAyABKANSB2ZlZVNhdHMSJwoPY2FuY2VsbGVkX3R4aWRzGAQgAygJUg5jYW5jZWxsZWRUeG'
+    'lkcw==');
+
 @$core.Deprecated('Use createBidResponseDescriptor instead')
 const CreateBidResponse$json = {
   '1': 'CreateBidResponse',
@@ -311,6 +343,63 @@ const ListBidsResponse$json = {
 final $typed_data.Uint8List listBidsResponseDescriptor = $convert.base64Decode(
     'ChBMaXN0Qmlkc1Jlc3BvbnNlEh8KBGJpZHMYASADKAsyCy5ibW0udjEuQmlkUgRiaWRz');
 
+@$core.Deprecated('Use prepareBMMRequestDescriptor instead')
+const PrepareBMMRequest$json = {
+  '1': 'PrepareBMMRequest',
+  '2': [
+    {'1': 'targets', '3': 1, '4': 3, '5': 11, '6': '.bmm.v1.PrepareBMMTarget', '10': 'targets'},
+  ],
+};
+
+/// Descriptor for `PrepareBMMRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prepareBMMRequestDescriptor = $convert.base64Decode(
+    'ChFQcmVwYXJlQk1NUmVxdWVzdBIyCgd0YXJnZXRzGAEgAygLMhguYm1tLnYxLlByZXBhcmVCTU'
+    '1UYXJnZXRSB3RhcmdldHM=');
+
+@$core.Deprecated('Use prepareBMMTargetDescriptor instead')
+const PrepareBMMTarget$json = {
+  '1': 'PrepareBMMTarget',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'max_bid_sats', '3': 2, '4': 1, '5': 3, '10': 'maxBidSats'},
+  ],
+};
+
+/// Descriptor for `PrepareBMMTarget`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prepareBMMTargetDescriptor = $convert.base64Decode(
+    'ChBQcmVwYXJlQk1NVGFyZ2V0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSIAoMbWF4X2'
+    'JpZF9zYXRzGAIgASgDUgptYXhCaWRTYXRz');
+
+@$core.Deprecated('Use prepareBMMResponseDescriptor instead')
+const PrepareBMMResponse$json = {
+  '1': 'PrepareBMMResponse',
+  '2': [
+    {'1': 'wallets', '3': 1, '4': 3, '5': 11, '6': '.bmm.v1.PrepareBMMWallet', '10': 'wallets'},
+  ],
+};
+
+/// Descriptor for `PrepareBMMResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prepareBMMResponseDescriptor = $convert.base64Decode(
+    'ChJQcmVwYXJlQk1NUmVzcG9uc2USMgoHd2FsbGV0cxgBIAMoCzIYLmJtbS52MS5QcmVwYXJlQk'
+    '1NV2FsbGV0Ugd3YWxsZXRz');
+
+@$core.Deprecated('Use prepareBMMWalletDescriptor instead')
+const PrepareBMMWallet$json = {
+  '1': 'PrepareBMMWallet',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'usable_coins', '3': 2, '4': 1, '5': 5, '10': 'usableCoins'},
+    {'1': 'wanted_coins', '3': 3, '4': 1, '5': 5, '10': 'wantedCoins'},
+    {'1': 'split_txid', '3': 4, '4': 1, '5': 9, '10': 'splitTxid'},
+  ],
+};
+
+/// Descriptor for `PrepareBMMWallet`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prepareBMMWalletDescriptor = $convert.base64Decode(
+    'ChBQcmVwYXJlQk1NV2FsbGV0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSIQoMdXNhYm'
+    'xlX2NvaW5zGAIgASgFUgt1c2FibGVDb2lucxIhCgx3YW50ZWRfY29pbnMYAyABKAVSC3dhbnRl'
+    'ZENvaW5zEh0KCnNwbGl0X3R4aWQYBCABKAlSCXNwbGl0VHhpZA==');
+
 const $core.Map<$core.String, $core.dynamic> BMMServiceBase$json = {
   '1': 'BMMService',
   '2': [
@@ -321,7 +410,9 @@ const $core.Map<$core.String, $core.dynamic> BMMServiceBase$json = {
     {'1': 'GetRoundBids', '2': '.bmm.v1.GetRoundBidsRequest', '3': '.bmm.v1.GetRoundBidsResponse'},
     {'1': 'CreateBid', '2': '.bmm.v1.CreateBidRequest', '3': '.bmm.v1.CreateBidResponse'},
     {'1': 'ConnectBid', '2': '.bmm.v1.ConnectBidRequest', '3': '.bmm.v1.ConnectBidResponse'},
+    {'1': 'CancelBid', '2': '.bmm.v1.CancelBidRequest', '3': '.bmm.v1.CancelBidResponse'},
     {'1': 'ListBids', '2': '.bmm.v1.ListBidsRequest', '3': '.bmm.v1.ListBidsResponse'},
+    {'1': 'PrepareBMM', '2': '.bmm.v1.PrepareBMMRequest', '3': '.bmm.v1.PrepareBMMResponse'},
   ],
 };
 
@@ -343,8 +434,14 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BMMService
   '.bmm.v1.CreateBidResponse': CreateBidResponse$json,
   '.bmm.v1.ConnectBidRequest': ConnectBidRequest$json,
   '.bmm.v1.ConnectBidResponse': ConnectBidResponse$json,
+  '.bmm.v1.CancelBidRequest': CancelBidRequest$json,
+  '.bmm.v1.CancelBidResponse': CancelBidResponse$json,
   '.bmm.v1.ListBidsRequest': ListBidsRequest$json,
   '.bmm.v1.ListBidsResponse': ListBidsResponse$json,
+  '.bmm.v1.PrepareBMMRequest': PrepareBMMRequest$json,
+  '.bmm.v1.PrepareBMMTarget': PrepareBMMTarget$json,
+  '.bmm.v1.PrepareBMMResponse': PrepareBMMResponse$json,
+  '.bmm.v1.PrepareBMMWallet': PrepareBMMWallet$json,
 };
 
 /// Descriptor for `BMMService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
@@ -357,6 +454,8 @@ final $typed_data.Uint8List bMMServiceDescriptor = $convert.base64Decode(
     'JvdW5kQmlkc1JlcXVlc3QaHC5ibW0udjEuR2V0Um91bmRCaWRzUmVzcG9uc2USQAoJQ3JlYXRl'
     'QmlkEhguYm1tLnYxLkNyZWF0ZUJpZFJlcXVlc3QaGS5ibW0udjEuQ3JlYXRlQmlkUmVzcG9uc2'
     'USQwoKQ29ubmVjdEJpZBIZLmJtbS52MS5Db25uZWN0QmlkUmVxdWVzdBoaLmJtbS52MS5Db25u'
-    'ZWN0QmlkUmVzcG9uc2USPQoITGlzdEJpZHMSFy5ibW0udjEuTGlzdEJpZHNSZXF1ZXN0GhguYm'
-    '1tLnYxLkxpc3RCaWRzUmVzcG9uc2U=');
+    'ZWN0QmlkUmVzcG9uc2USQAoJQ2FuY2VsQmlkEhguYm1tLnYxLkNhbmNlbEJpZFJlcXVlc3QaGS'
+    '5ibW0udjEuQ2FuY2VsQmlkUmVzcG9uc2USPQoITGlzdEJpZHMSFy5ibW0udjEuTGlzdEJpZHNS'
+    'ZXF1ZXN0GhguYm1tLnYxLkxpc3RCaWRzUmVzcG9uc2USQwoKUHJlcGFyZUJNTRIZLmJtbS52MS'
+    '5QcmVwYXJlQk1NUmVxdWVzdBoaLmJtbS52MS5QcmVwYXJlQk1NUmVzcG9uc2U=');
 

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pbserver.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pbserver.dart
@@ -28,7 +28,9 @@ abstract class BMMServiceBase extends $pb.GeneratedService {
   $async.Future<$4.GetRoundBidsResponse> getRoundBids($pb.ServerContext ctx, $4.GetRoundBidsRequest request);
   $async.Future<$4.CreateBidResponse> createBid($pb.ServerContext ctx, $4.CreateBidRequest request);
   $async.Future<$4.ConnectBidResponse> connectBid($pb.ServerContext ctx, $4.ConnectBidRequest request);
+  $async.Future<$4.CancelBidResponse> cancelBid($pb.ServerContext ctx, $4.CancelBidRequest request);
   $async.Future<$4.ListBidsResponse> listBids($pb.ServerContext ctx, $4.ListBidsRequest request);
+  $async.Future<$4.PrepareBMMResponse> prepareBMM($pb.ServerContext ctx, $4.PrepareBMMRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
@@ -39,7 +41,9 @@ abstract class BMMServiceBase extends $pb.GeneratedService {
       case 'GetRoundBids': return $4.GetRoundBidsRequest();
       case 'CreateBid': return $4.CreateBidRequest();
       case 'ConnectBid': return $4.ConnectBidRequest();
+      case 'CancelBid': return $4.CancelBidRequest();
       case 'ListBids': return $4.ListBidsRequest();
+      case 'PrepareBMM': return $4.PrepareBMMRequest();
       default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
@@ -53,7 +57,9 @@ abstract class BMMServiceBase extends $pb.GeneratedService {
       case 'GetRoundBids': return this.getRoundBids(ctx, request as $4.GetRoundBidsRequest);
       case 'CreateBid': return this.createBid(ctx, request as $4.CreateBidRequest);
       case 'ConnectBid': return this.connectBid(ctx, request as $4.ConnectBidRequest);
+      case 'CancelBid': return this.cancelBid(ctx, request as $4.CancelBidRequest);
       case 'ListBids': return this.listBids(ctx, request as $4.ListBidsRequest);
+      case 'PrepareBMM': return this.prepareBMM(ctx, request as $4.PrepareBMMRequest);
       default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }

--- a/sidechain_core/lib/gen/wallet/v1/wallet.pb.dart
+++ b/sidechain_core/lib/gen/wallet/v1/wallet.pb.dart
@@ -1181,6 +1181,7 @@ class WalletTransaction extends $pb.GeneratedMessage {
     $core.String? addressLabel,
     $core.String? note,
     Confirmation? confirmationTime,
+    BmmBid? bmmBid,
   }) {
     final $result = create();
     if (txid != null) {
@@ -1207,6 +1208,9 @@ class WalletTransaction extends $pb.GeneratedMessage {
     if (confirmationTime != null) {
       $result.confirmationTime = confirmationTime;
     }
+    if (bmmBid != null) {
+      $result.bmmBid = bmmBid;
+    }
     return $result;
   }
   WalletTransaction._() : super();
@@ -1222,6 +1226,7 @@ class WalletTransaction extends $pb.GeneratedMessage {
     ..aOS(6, _omitFieldNames ? '' : 'addressLabel')
     ..aOS(7, _omitFieldNames ? '' : 'note')
     ..aOM<Confirmation>(8, _omitFieldNames ? '' : 'confirmationTime', subBuilder: Confirmation.create)
+    ..aOM<BmmBid>(9, _omitFieldNames ? '' : 'bmmBid', subBuilder: BmmBid.create)
     ..hasRequiredFields = false
   ;
 
@@ -1319,6 +1324,114 @@ class WalletTransaction extends $pb.GeneratedMessage {
   void clearConfirmationTime() => clearField(8);
   @$pb.TagNumber(8)
   Confirmation ensureConfirmationTime() => $_ensure(7);
+
+  /// Set when output 0 carries a BMM request. Unset for every other transaction.
+  @$pb.TagNumber(9)
+  BmmBid get bmmBid => $_getN(8);
+  @$pb.TagNumber(9)
+  set bmmBid(BmmBid v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasBmmBid() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearBmmBid() => clearField(9);
+  @$pb.TagNumber(9)
+  BmmBid ensureBmmBid() => $_ensure(8);
+}
+
+/// BmmBid names the BMM request one wallet transaction carries.
+class BmmBid extends $pb.GeneratedMessage {
+  factory BmmBid({
+    $core.int? slot,
+    $core.String? criticalHash,
+    $core.String? prevMainHash,
+    $core.bool? lost,
+  }) {
+    final $result = create();
+    if (slot != null) {
+      $result.slot = slot;
+    }
+    if (criticalHash != null) {
+      $result.criticalHash = criticalHash;
+    }
+    if (prevMainHash != null) {
+      $result.prevMainHash = prevMainHash;
+    }
+    if (lost != null) {
+      $result.lost = lost;
+    }
+    return $result;
+  }
+  BmmBid._() : super();
+  factory BmmBid.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BmmBid.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BmmBid', package: const $pb.PackageName(_omitMessageNames ? '' : 'wallet.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'slot', $pb.PbFieldType.OU3)
+    ..aOS(2, _omitFieldNames ? '' : 'criticalHash')
+    ..aOS(3, _omitFieldNames ? '' : 'prevMainHash')
+    ..aOB(4, _omitFieldNames ? '' : 'lost')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BmmBid clone() => BmmBid()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BmmBid copyWith(void Function(BmmBid) updates) => super.copyWith((message) => updates(message as BmmBid)) as BmmBid;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BmmBid create() => BmmBid._();
+  BmmBid createEmptyInstance() => create();
+  static $pb.PbList<BmmBid> createRepeated() => $pb.PbList<BmmBid>();
+  @$core.pragma('dart2js:noInline')
+  static BmmBid getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BmmBid>(create);
+  static BmmBid? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get slot => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set slot($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSlot() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSlot() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get criticalHash => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set criticalHash($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCriticalHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCriticalHash() => clearField(2);
+
+  /// The mainchain block the sidechain block builds on. The bid reaches only
+  /// the block after it.
+  @$pb.TagNumber(3)
+  $core.String get prevMainHash => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set prevMainHash($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPrevMainHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPrevMainHash() => clearField(3);
+
+  /// True when the mainchain tip moved past prev_main_hash.
+  @$pb.TagNumber(4)
+  $core.bool get lost => $_getBF(3);
+  @$pb.TagNumber(4)
+  set lost($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasLost() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearLost() => clearField(4);
 }
 
 class ListSidechainDepositsRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/wallet/v1/wallet.pbjson.dart
+++ b/sidechain_core/lib/gen/wallet/v1/wallet.pbjson.dart
@@ -339,6 +339,7 @@ const WalletTransaction$json = {
     {'1': 'address_label', '3': 6, '4': 1, '5': 9, '10': 'addressLabel'},
     {'1': 'note', '3': 7, '4': 1, '5': 9, '10': 'note'},
     {'1': 'confirmation_time', '3': 8, '4': 1, '5': 11, '6': '.wallet.v1.Confirmation', '10': 'confirmationTime'},
+    {'1': 'bmm_bid', '3': 9, '4': 1, '5': 11, '6': '.wallet.v1.BmmBid', '10': 'bmmBid'},
   ],
 };
 
@@ -349,7 +350,25 @@ final $typed_data.Uint8List walletTransactionDescriptor = $convert.base64Decode(
     'CgxzZW50X3NhdG9zaGkYBCABKARSC3NlbnRTYXRvc2hpEhgKB2FkZHJlc3MYBSABKAlSB2FkZH'
     'Jlc3MSIwoNYWRkcmVzc19sYWJlbBgGIAEoCVIMYWRkcmVzc0xhYmVsEhIKBG5vdGUYByABKAlS'
     'BG5vdGUSRAoRY29uZmlybWF0aW9uX3RpbWUYCCABKAsyFy53YWxsZXQudjEuQ29uZmlybWF0aW'
-    '9uUhBjb25maXJtYXRpb25UaW1l');
+    '9uUhBjb25maXJtYXRpb25UaW1lEioKB2JtbV9iaWQYCSABKAsyES53YWxsZXQudjEuQm1tQmlk'
+    'UgZibW1CaWQ=');
+
+@$core.Deprecated('Use bmmBidDescriptor instead')
+const BmmBid$json = {
+  '1': 'BmmBid',
+  '2': [
+    {'1': 'slot', '3': 1, '4': 1, '5': 13, '10': 'slot'},
+    {'1': 'critical_hash', '3': 2, '4': 1, '5': 9, '10': 'criticalHash'},
+    {'1': 'prev_main_hash', '3': 3, '4': 1, '5': 9, '10': 'prevMainHash'},
+    {'1': 'lost', '3': 4, '4': 1, '5': 8, '10': 'lost'},
+  ],
+};
+
+/// Descriptor for `BmmBid`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bmmBidDescriptor = $convert.base64Decode(
+    'CgZCbW1CaWQSEgoEc2xvdBgBIAEoDVIEc2xvdBIjCg1jcml0aWNhbF9oYXNoGAIgASgJUgxjcm'
+    'l0aWNhbEhhc2gSJAoOcHJldl9tYWluX2hhc2gYAyABKAlSDHByZXZNYWluSGFzaBISCgRsb3N0'
+    'GAQgASgIUgRsb3N0');
 
 @$core.Deprecated('Use listSidechainDepositsRequestDescriptor instead')
 const ListSidechainDepositsRequest$json = {
@@ -1246,6 +1265,7 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletServ
   '.wallet.v1.ListTransactionsResponse': ListTransactionsResponse$json,
   '.wallet.v1.WalletTransaction': WalletTransaction$json,
   '.wallet.v1.Confirmation': Confirmation$json,
+  '.wallet.v1.BmmBid': BmmBid$json,
   '.wallet.v1.ListUnspentRequest': ListUnspentRequest$json,
   '.wallet.v1.ListUnspentResponse': ListUnspentResponse$json,
   '.wallet.v1.ListReceiveAddressesRequest': ListReceiveAddressesRequest$json,

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -7833,6 +7833,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
     $core.double? fee,
     $core.bool? replacedByTxid,
     $core.String? walletId,
+    BmmBid? bmmBid,
   }) {
     final $result = create();
     if (txid != null) {
@@ -7874,6 +7875,9 @@ class TransactionEntry extends $pb.GeneratedMessage {
     if (walletId != null) {
       $result.walletId = walletId;
     }
+    if (bmmBid != null) {
+      $result.bmmBid = bmmBid;
+    }
     return $result;
   }
   TransactionEntry._() : super();
@@ -7894,6 +7898,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
     ..a<$core.double>(11, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OD)
     ..aOB(12, _omitFieldNames ? '' : 'replacedByTxid')
     ..aOS(13, _omitFieldNames ? '' : 'walletId')
+    ..aOM<BmmBid>(14, _omitFieldNames ? '' : 'bmmBid', subBuilder: BmmBid.create)
     ..hasRequiredFields = false
   ;
 
@@ -8034,6 +8039,114 @@ class TransactionEntry extends $pb.GeneratedMessage {
   $core.bool hasWalletId() => $_has(12);
   @$pb.TagNumber(13)
   void clearWalletId() => clearField(13);
+
+  /// Set when output 0 carries a BMM request. Unset for every other transaction.
+  @$pb.TagNumber(14)
+  BmmBid get bmmBid => $_getN(13);
+  @$pb.TagNumber(14)
+  set bmmBid(BmmBid v) { setField(14, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasBmmBid() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearBmmBid() => clearField(14);
+  @$pb.TagNumber(14)
+  BmmBid ensureBmmBid() => $_ensure(13);
+}
+
+/// BmmBid names the BMM request one wallet transaction carries.
+class BmmBid extends $pb.GeneratedMessage {
+  factory BmmBid({
+    $core.int? slot,
+    $core.String? criticalHash,
+    $core.String? prevMainHash,
+    $core.bool? lost,
+  }) {
+    final $result = create();
+    if (slot != null) {
+      $result.slot = slot;
+    }
+    if (criticalHash != null) {
+      $result.criticalHash = criticalHash;
+    }
+    if (prevMainHash != null) {
+      $result.prevMainHash = prevMainHash;
+    }
+    if (lost != null) {
+      $result.lost = lost;
+    }
+    return $result;
+  }
+  BmmBid._() : super();
+  factory BmmBid.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BmmBid.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BmmBid', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'slot', $pb.PbFieldType.OU3)
+    ..aOS(2, _omitFieldNames ? '' : 'criticalHash')
+    ..aOS(3, _omitFieldNames ? '' : 'prevMainHash')
+    ..aOB(4, _omitFieldNames ? '' : 'lost')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BmmBid clone() => BmmBid()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BmmBid copyWith(void Function(BmmBid) updates) => super.copyWith((message) => updates(message as BmmBid)) as BmmBid;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BmmBid create() => BmmBid._();
+  BmmBid createEmptyInstance() => create();
+  static $pb.PbList<BmmBid> createRepeated() => $pb.PbList<BmmBid>();
+  @$core.pragma('dart2js:noInline')
+  static BmmBid getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BmmBid>(create);
+  static BmmBid? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get slot => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set slot($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSlot() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSlot() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get criticalHash => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set criticalHash($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCriticalHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCriticalHash() => clearField(2);
+
+  /// The mainchain block the sidechain block builds on. The bid reaches only
+  /// the block after it.
+  @$pb.TagNumber(3)
+  $core.String get prevMainHash => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set prevMainHash($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPrevMainHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPrevMainHash() => clearField(3);
+
+  /// True when the mainchain tip moved past prev_main_hash.
+  @$pb.TagNumber(4)
+  $core.bool get lost => $_getBF(3);
+  @$pb.TagNumber(4)
+  set lost($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasLost() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearLost() => clearField(4);
 }
 
 class ListTransactionsResponse extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -1814,6 +1814,7 @@ const TransactionEntry$json = {
     {'1': 'fee', '3': 11, '4': 1, '5': 1, '10': 'fee'},
     {'1': 'replaced_by_txid', '3': 12, '4': 1, '5': 8, '10': 'replacedByTxid'},
     {'1': 'wallet_id', '3': 13, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'bmm_bid', '3': 14, '4': 1, '5': 11, '6': '.walletmanager.v1.BmmBid', '10': 'bmmBid'},
   ],
 };
 
@@ -1825,7 +1826,25 @@ final $typed_data.Uint8List transactionEntryDescriptor = $convert.base64Decode(
     'F0cxIkCg1jb25maXJtYXRpb25zGAcgASgFUg1jb25maXJtYXRpb25zEh0KCmJsb2NrX3RpbWUY'
     'CCABKANSCWJsb2NrVGltZRISCgR0aW1lGAkgASgDUgR0aW1lEhQKBWxhYmVsGAogASgJUgVsYW'
     'JlbBIQCgNmZWUYCyABKAFSA2ZlZRIoChByZXBsYWNlZF9ieV90eGlkGAwgASgIUg5yZXBsYWNl'
-    'ZEJ5VHhpZBIbCgl3YWxsZXRfaWQYDSABKAlSCHdhbGxldElk');
+    'ZEJ5VHhpZBIbCgl3YWxsZXRfaWQYDSABKAlSCHdhbGxldElkEjEKB2JtbV9iaWQYDiABKAsyGC'
+    '53YWxsZXRtYW5hZ2VyLnYxLkJtbUJpZFIGYm1tQmlk');
+
+@$core.Deprecated('Use bmmBidDescriptor instead')
+const BmmBid$json = {
+  '1': 'BmmBid',
+  '2': [
+    {'1': 'slot', '3': 1, '4': 1, '5': 13, '10': 'slot'},
+    {'1': 'critical_hash', '3': 2, '4': 1, '5': 9, '10': 'criticalHash'},
+    {'1': 'prev_main_hash', '3': 3, '4': 1, '5': 9, '10': 'prevMainHash'},
+    {'1': 'lost', '3': 4, '4': 1, '5': 8, '10': 'lost'},
+  ],
+};
+
+/// Descriptor for `BmmBid`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bmmBidDescriptor = $convert.base64Decode(
+    'CgZCbW1CaWQSEgoEc2xvdBgBIAEoDVIEc2xvdBIjCg1jcml0aWNhbF9oYXNoGAIgASgJUgxjcm'
+    'l0aWNhbEhhc2gSJAoOcHJldl9tYWluX2hhc2gYAyABKAlSDHByZXZNYWluSGFzaBISCgRsb3N0'
+    'GAQgASgIUgRsb3N0');
 
 @$core.Deprecated('Use listTransactionsResponseDescriptor instead')
 const ListTransactionsResponse$json = {
@@ -2766,6 +2785,7 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.ListTransactionsRequest': ListTransactionsRequest$json,
   '.walletmanager.v1.ListTransactionsResponse': ListTransactionsResponse$json,
   '.walletmanager.v1.TransactionEntry': TransactionEntry$json,
+  '.walletmanager.v1.BmmBid': BmmBid$json,
   '.walletmanager.v1.ListUnspentRequest': ListUnspentRequest$json,
   '.walletmanager.v1.ListUnspentResponse': ListUnspentResponse$json,
   '.walletmanager.v1.ListReceiveAddressesRequest': ListReceiveAddressesRequest$json,

--- a/sidechain_core/lib/rpcs/orchestrator_bmm_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_bmm_rpc.dart
@@ -80,4 +80,15 @@ class OrchestratorBmmRPC {
       ),
     );
   }
+
+  /// Replace a stranded bid with a payment back to its own wallet, so the coins
+  /// under it come back. A bid that can still win is refused.
+  Future<bmmpb.CancelBidResponse> cancelBid({
+    required String txid,
+    String? walletId,
+  }) {
+    return _unaryClient.cancelBid(
+      bmmpb.CancelBidRequest(txid: txid, walletId: walletId ?? ''),
+    );
+  }
 }


### PR DESCRIPTION
Names a BMM bid on the wallet row, and offers Cancel bid on one the chain already built past. Cancel respends the coins under the stranded chain and pays them back to the wallet.