### PR TITLE
orchestrator: update a sidechain app and backend

### DIFF
--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/samber/lo"
 )
 
 type DownloadProgress struct {
@@ -134,12 +135,17 @@ func (d *DownloadManager) Download(ctx context.Context, config BinaryConfig, net
 }
 
 // DownloadWithOptions is Download with per-call overrides (see DownloadOptions).
+// It downloads every target of the config, so a test sidechain gets its backend too.
 func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config BinaryConfig, network string, force bool, opts DownloadOptions) (<-chan DownloadProgress, error) {
-	target := d.ResolveTarget(config, network, opts)
-	binPath := target.BinPath
+	targets := d.Targets(config, network, opts)
+	binPath := targets[0].BinPath
 
 	if !force {
-		if _, err := os.Stat(binPath); err == nil {
+		targets = lo.Filter(targets, func(target DownloadTarget, _ int) bool {
+			_, err := os.Stat(target.BinPath)
+			return err != nil
+		})
+		if len(targets) == 0 {
 			ch := make(chan DownloadProgress, 1)
 			ch <- DownloadProgress{Message: binPath, Done: true}
 			close(ch)
@@ -147,19 +153,21 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		}
 	}
 
-	fileName := target.FileName
-	baseURL := target.BaseURL
-	if fileName == "" || baseURL == "" {
-		return nil, fmt.Errorf("no download available for %s on %s", config.Name, currentPlatform())
+	for _, target := range targets {
+		if target.FileName == "" || target.BaseURL == "" {
+			return nil, fmt.Errorf("no download available for %s on %s", config.Name, currentPlatform())
+		}
 	}
 
-	inFlightKey := target.InFlightKey
-	// A second caller attaches to the running download instead of failing.
+	// A second caller waits for the running download instead of failing.
 	// SwapNetwork drops the core binary and restarts L1, so two paths ask at once.
-	done := make(chan struct{})
-	if existing, loaded := d.inFlight.LoadOrStore(inFlightKey, done); loaded {
-		return d.attachToInFlight(ctx, existing.(chan struct{}), config.Name, binPath), nil
-	}
+	claims := lo.Map(targets, func(target DownloadTarget, _ int) inFlightClaim {
+		done := make(chan struct{})
+		if existing, loaded := d.inFlight.LoadOrStore(target.InFlightKey, done); loaded {
+			return inFlightClaim{target: target, done: existing.(chan struct{})}
+		}
+		return inFlightClaim{target: target, done: done, owned: true}
+	})
 
 	ch := make(chan DownloadProgress, 100)
 
@@ -172,8 +180,18 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 	d.state.Store(stateKey, DownloadState{Running: true})
 
 	go func() {
-		defer d.inFlight.Delete(inFlightKey)
-		defer close(done)
+		release := func(i int) {
+			close(claims[i].done)
+			d.inFlight.Delete(claims[i].target.InFlightKey)
+			claims[i].owned = false
+		}
+		defer func() {
+			for i := range claims {
+				if claims[i].owned {
+					release(i)
+				}
+			}
+		}()
 		defer d.state.Delete(stateKey)
 		defer close(ch)
 
@@ -216,73 +234,94 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 			}
 		}
 
-		// Test sidechain alt URLs are always served directly from
-		// releases.drivechain.info; the prod-side DownloadSourceGitHub flag
-		// (used by zside/thunder-orchard for the production builds) doesn't
-		// apply to them. Falling through to resolveGitHubURL would try to
-		// JSON-parse an HTML 404 and abort the download with a confusing
-		// "decode response: invalid character '<'" error.
-		var downloadURL string
-		switch target.Source {
-		case DownloadSourceGitHub:
-			url, err := d.resolveGitHubURL(ctx, baseURL, fileName)
-			if err != nil {
-				send(DownloadProgress{Error: fmt.Errorf("resolve GitHub URL: %w", err)})
+		for i, claim := range claims {
+			if claim.owned {
+				if err := d.fetch(ctx, config, network, claim.target, send); err != nil {
+					send(DownloadProgress{Error: err})
+					return
+				}
+				release(i)
+				continue
+			}
+			select {
+			case <-claim.done:
+			case <-ctx.Done():
+				send(DownloadProgress{Error: ctx.Err()})
 				return
 			}
-			downloadURL = url
-		case DownloadSourceDirect:
-			downloadURL = baseURL + fileName
-		}
-
-		d.log.Info().Str("url", downloadURL).Str("binary", config.Name).Msg("downloading")
-
-		tmpDir, err := os.MkdirTemp("", "orchestrator-download-*")
-		if err != nil {
-			send(DownloadProgress{Error: fmt.Errorf("create temp dir: %w", err)})
-			return
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup
-
-		savePath := filepath.Join(tmpDir, filepath.Base(downloadURL))
-
-		if err := d.downloadFile(ctx, downloadURL, savePath, send); err != nil {
-			send(DownloadProgress{Error: err})
-			return
-		}
-
-		// Compute SHA256 hash and write back to config
-		if !send(DownloadProgress{Message: "verifying hash..."}) {
-			return
-		}
-		archiveHash, archiveSize, err := hashFile(savePath)
-		if err != nil {
-			d.log.Warn().Err(err).Msg("failed to hash archive")
-		} else {
-			d.log.Info().Str("hash", archiveHash).Int64("size", archiveSize).Str("binary", config.Name).Msg("archive hash")
-			if d.configFilePath != "" {
-				if err := writeHashToConfig(d.configFilePath, config.Name, currentPlatform(), archiveHash, archiveSize); err != nil {
-					d.log.Warn().Err(err).Msg("failed to write hash to config")
-				}
+			if _, err := os.Stat(claim.target.BinPath); err != nil {
+				send(DownloadProgress{Error: fmt.Errorf("%s download finished without a binary", config.Name)})
+				return
 			}
 		}
 
-		if !send(DownloadProgress{Message: "extracting..."}) {
-			return
-		}
-
-		hasCLI, err := d.extractBinary(savePath, config, target, d.dataDir, network)
-		if err != nil {
-			d.log.Error().Err(err).Str("binary", config.Name).Msg("extract failed")
-			send(DownloadProgress{Error: fmt.Errorf("extract: %w", err)})
-			return
-		}
-		d.log.Info().Bool("has_cli", hasCLI).Str("binary", target.ExtractName).Msg("extraction complete")
-
-		send(DownloadProgress{Message: target.BinPath, Done: true})
+		send(DownloadProgress{Message: binPath, Done: true})
 	}()
 
 	return ch, nil
+}
+
+// fetch downloads one target's archive, records its hash and extracts it.
+func (d *DownloadManager) fetch(ctx context.Context, config BinaryConfig, network string, target DownloadTarget, send func(DownloadProgress) bool) error {
+	// Test sidechain alt URLs are always served directly from
+	// releases.drivechain.info; the prod-side DownloadSourceGitHub flag
+	// (used by zside/thunder-orchard for the production builds) doesn't
+	// apply to them. Falling through to resolveGitHubURL would try to
+	// JSON-parse an HTML 404 and abort the download with a confusing
+	// "decode response: invalid character '<'" error.
+	var downloadURL string
+	switch target.Source {
+	case DownloadSourceGitHub:
+		url, err := d.resolveGitHubURL(ctx, target.BaseURL, target.FileName)
+		if err != nil {
+			return fmt.Errorf("resolve GitHub URL: %w", err)
+		}
+		downloadURL = url
+	case DownloadSourceDirect:
+		downloadURL = target.BaseURL + target.FileName
+	}
+
+	d.log.Info().Str("url", downloadURL).Str("binary", config.Name).Msg("downloading")
+
+	tmpDir, err := os.MkdirTemp("", "orchestrator-download-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup
+
+	savePath := filepath.Join(tmpDir, filepath.Base(downloadURL))
+
+	if err := d.downloadFile(ctx, downloadURL, savePath, send); err != nil {
+		return err
+	}
+
+	// Compute SHA256 hash and write back to config
+	if !send(DownloadProgress{Message: "verifying hash..."}) {
+		return ctx.Err()
+	}
+	archiveHash, archiveSize, err := hashFile(savePath)
+	if err != nil {
+		d.log.Warn().Err(err).Msg("failed to hash archive")
+	} else {
+		d.log.Info().Str("hash", archiveHash).Int64("size", archiveSize).Str("binary", config.Name).Msg("archive hash")
+		if d.configFilePath != "" {
+			if err := writeHashToConfig(d.configFilePath, config.Name, currentPlatform(), archiveHash, archiveSize); err != nil {
+				d.log.Warn().Err(err).Msg("failed to write hash to config")
+			}
+		}
+	}
+
+	if !send(DownloadProgress{Message: "extracting..."}) {
+		return ctx.Err()
+	}
+
+	hasCLI, err := d.extractBinary(savePath, config, target, d.dataDir, network)
+	if err != nil {
+		d.log.Error().Err(err).Str("binary", config.Name).Msg("extract failed")
+		return fmt.Errorf("extract: %w", err)
+	}
+	d.log.Info().Bool("has_cli", hasCLI).Str("binary", target.ExtractName).Msg("extraction complete")
+	return nil
 }
 
 // activeVariant resolves the Core variant for the given config, if applicable.
@@ -1021,22 +1060,23 @@ func StripPlatformSuffix(name string) string {
 
 // attachToInFlight waits for an already-running download of the same binary and
 // reports success iff it left a binary on disk.
-func (d *DownloadManager) attachToInFlight(ctx context.Context, done chan struct{}, name, binPath string) chan DownloadProgress {
-	ch := make(chan DownloadProgress, 1)
-	go func() {
-		defer close(ch)
-		select {
-		case <-done:
-			if _, err := os.Stat(binPath); err != nil {
-				ch <- DownloadProgress{Error: fmt.Errorf("%s download finished without a binary", name)}
-				return
-			}
-			ch <- DownloadProgress{Message: binPath, Done: true}
-		case <-ctx.Done():
-			ch <- DownloadProgress{Error: ctx.Err()}
-		}
-	}()
-	return ch
+// inFlightClaim is one target's slot in the in-flight map. owned is true while
+// this caller holds the claim.
+type inFlightClaim struct {
+	target DownloadTarget
+	done   chan struct{}
+	owned  bool
+}
+
+// Targets lists every download that writes a binary for this config. A layer-2
+// binary with the test build enabled has two: the test build and its backend.
+func (d *DownloadManager) Targets(config BinaryConfig, network string, opts DownloadOptions) []DownloadTarget {
+	target := d.ResolveTarget(config, network, opts)
+	backend := d.ResolveTarget(config, network, DownloadOptions{ForceBackend: true})
+	if backend.InFlightKey == target.InFlightKey || backend.FileName == "" || backend.BaseURL == "" {
+		return []DownloadTarget{target}
+	}
+	return []DownloadTarget{target, backend}
 }
 
 // DownloadTarget is where a binary lives on disk and where its archive comes

--- a/sidechain-orchestrator/download_claims_test.go
+++ b/sidechain-orchestrator/download_claims_test.go
@@ -1,0 +1,63 @@
+package orchestrator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two callers can each own one part of a sidechain download. Each part must
+// clear its claim when it lands, or the callers wait on each other forever.
+func TestDownload_ReleasesEachTargetBeforeTheNext(t *testing.T) {
+	binName := "thunder"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	archive := makeZipBytes(t, map[string][]byte{binName: []byte("test-bin")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dm, _ := newTestDownloadManager(t)
+	dm.httpClient = srv.Client()
+	cfg := makeSidechainConfig(srv.URL + "/")
+	dm.SidechainVariant = func(c BinaryConfig) (sidechainVariantSpec, bool) {
+		return sidechainVariantSpec{
+			BinaryName: c.AltBinaryName,
+			BaseURL:    c.AltBaseURL("default"),
+			FileName:   fileForPlatform(c.AltFiles),
+		}, true
+	}
+
+	targets := dm.Targets(cfg, "default", DownloadOptions{})
+	require.Len(t, targets, 2)
+	app, backend := targets[0], targets[1]
+
+	backendDone := make(chan struct{})
+	dm.inFlight.Store(backend.InFlightKey, backendDone)
+
+	ch, err := dm.Download(context.Background(), cfg, "default", true)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, busy := dm.inFlight.Load(app.InFlightKey)
+		return !busy
+	}, 5*time.Second, 10*time.Millisecond, "the app claim must clear while the backend is in flight")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(backend.BinPath), 0o755))
+	require.NoError(t, os.WriteFile(backend.BinPath, []byte("prod-bin"), 0o755))
+	dm.inFlight.Delete(backend.InFlightKey)
+	close(backendDone)
+
+	last := drainProgress(t, ch)
+	assert.True(t, last.Done)
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -735,7 +735,7 @@ func (o *Orchestrator) StatusWithOptions(name string, opts DownloadOptions) Bina
 	}
 
 	if o.releases != nil {
-		if check, ok := o.releases.Check(config, o.CurrentNetwork(), requestedPath); ok {
+		if check, ok := o.releases.CheckDownloads(config, o.CurrentNetwork(), opts); ok {
 			status.UpdateAvailable = check.UpdateAvailable()
 			status.RemoteTimestamp = check.Remote
 			status.LocalTimestamp = check.Local

--- a/sidechain-orchestrator/release_check.go
+++ b/sidechain-orchestrator/release_check.go
@@ -94,6 +94,18 @@ func (r *ReleaseChecker) Check(config BinaryConfig, network, binPath string) (Re
 	return ReleaseCheck{Remote: remote, Local: localModTime(binPath)}, true
 }
 
+// CheckDownloads compares every download that an update with opts replaces. It
+// returns the first one with an update waiting, else the first download.
+func (r *ReleaseChecker) CheckDownloads(config BinaryConfig, network string, opts DownloadOptions) (ReleaseCheck, bool) {
+	targets := r.downloads.Targets(config, network, opts)
+	for _, target := range targets {
+		if check, ok := r.Check(config, network, target.BinPath); ok && check.UpdateAvailable() {
+			return check, true
+		}
+	}
+	return r.Check(config, network, targets[0].BinPath)
+}
+
 // Run probes every binary at once, then again on each tick, until ctx ends.
 // It reads configs and network on every tick, so a swap takes effect at once.
 func (r *ReleaseChecker) Run(ctx context.Context, configs func() []BinaryConfig, network func() string) {

--- a/sidechain-orchestrator/release_check.go
+++ b/sidechain-orchestrator/release_check.go
@@ -78,7 +78,7 @@ func (o *Orchestrator) StartReleaseChecks(ctx context.Context) {
 // backend are two downloads of one binary, and the other one's timestamp says
 // nothing about this file.
 func (r *ReleaseChecker) Check(config BinaryConfig, network, binPath string) (ReleaseCheck, bool) {
-	target, ok := lo.Find(r.targets(config, network), func(t DownloadTarget) bool {
+	target, ok := lo.Find(r.downloads.Targets(config, network, DownloadOptions{}), func(t DownloadTarget) bool {
 		return t.BinPath == binPath
 	})
 	if !ok {
@@ -92,18 +92,6 @@ func (r *ReleaseChecker) Check(config BinaryConfig, network, binPath string) (Re
 		return ReleaseCheck{}, false
 	}
 	return ReleaseCheck{Remote: remote, Local: localModTime(binPath)}, true
-}
-
-// targets lists every download that writes a binary for this config. A layer-2
-// binary with the test build enabled has two: the test build the launcher picks
-// and the prod backend a sidechain app runs.
-func (r *ReleaseChecker) targets(config BinaryConfig, network string) []DownloadTarget {
-	targets := []DownloadTarget{r.downloads.ResolveTarget(config, network, DownloadOptions{})}
-	backend := r.downloads.ResolveTarget(config, network, DownloadOptions{ForceBackend: true})
-	if backend.InFlightKey != targets[0].InFlightKey {
-		targets = append(targets, backend)
-	}
-	return targets
 }
 
 // Run probes every binary at once, then again on each tick, until ctx ends.
@@ -139,7 +127,7 @@ func (r *ReleaseChecker) Run(ctx context.Context, configs func() []BinaryConfig,
 
 // Refresh probes every download of one binary and stores the published times.
 func (r *ReleaseChecker) Refresh(ctx context.Context, config BinaryConfig, network string) {
-	for _, target := range r.targets(config, network) {
+	for _, target := range r.downloads.Targets(config, network, DownloadOptions{}) {
 		remote, err := r.remoteTime(ctx, target)
 		if err != nil {
 			// A probe that fails leaves the binary with no remote time, which

--- a/sidechain-orchestrator/release_check_test.go
+++ b/sidechain-orchestrator/release_check_test.go
@@ -383,3 +383,42 @@ func TestStatusChecksTheRequestedDownloadNotTheRunningOne(t *testing.T) {
 	backend := o.StatusWithOptions(cfg.Name, DownloadOptions{ForceBackend: true})
 	assert.False(t, backend.UpdateAvailable, "force_backend must read the production build")
 }
+
+// A sidechain update replaces the test build and the backend, so a newer
+// backend release offers it, and the timestamps name the stale backend.
+func TestStatusOffersAnUpdateForTheBackend(t *testing.T) {
+	setTestHome(t)
+	testBuilt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	prodBuilt := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		built := prodBuilt
+		if strings.Contains(r.URL.Path, "test") {
+			built = testBuilt
+		}
+		w.Header().Set("Last-Modified", built.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir, bwDir := t.TempDir(), t.TempDir()
+	cfg := makeSidechainConfig(server.URL + "/")
+	o := New(dataDir, "signet", bwDir, []BinaryConfig{cfg}, testLogger(t))
+
+	testPath := TestSidechainBinaryPath(dataDir, cfg.AltBinaryName)
+	prodPath := BinaryPath(dataDir, cfg.BinaryName)
+	for path, built := range map[string]time.Time{
+		testPath: testBuilt.Add(time.Hour),
+		prodPath: prodBuilt.Add(-time.Hour),
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("bin"), 0o755))
+		require.NoError(t, os.Chtimes(path, built, built))
+	}
+
+	o.releases.Refresh(context.Background(), cfg, "signet")
+
+	status := o.Status(cfg.Name)
+	assert.True(t, status.UpdateAvailable)
+	assert.Equal(t, prodBuilt, status.RemoteTimestamp.UTC())
+	assert.Equal(t, prodBuilt.Add(-time.Hour), status.LocalTimestamp.UTC())
+}

--- a/sidechain-orchestrator/sidechain_variant_boot_test.go
+++ b/sidechain-orchestrator/sidechain_variant_boot_test.go
@@ -97,14 +97,7 @@ func TestSidechainVariant_DownloadAndBoot(t *testing.T) {
 	require.NotZero(t, info.Size(), "%s is empty", binPath)
 	require.NoError(t, os.Chmod(binPath, 0o755), "chmod +x test variant")
 
-	// And the prod path stays empty — flipping the toggle must not double-write.
-	prodPath := filepath.Join(BinDir(dataDir), "thunder")
-	if runtime.GOOS == "windows" {
-		prodPath += ".exe"
-	}
-	if _, err := os.Stat(prodPath); err == nil {
-		t.Fatalf("prod binary unexpectedly present at %s when only test variant was downloaded", prodPath)
-	}
+	require.FileExists(t, BinaryPath(dataDir, "thunder"), "the backend lands next to the test build")
 
 	// Step 4: ProcessManager.Start with the same SidechainVariant resolver
 	// boots the test variant. We share the dataDir with the download

--- a/sidechain-orchestrator/sidechain_variant_test.go
+++ b/sidechain-orchestrator/sidechain_variant_test.go
@@ -34,7 +34,7 @@ func makeSidechainConfig(baseURL string) BinaryConfig {
 	}
 }
 
-func TestDownload_SidechainVariant_HitsAltURL(t *testing.T) {
+func TestDownload_SidechainVariant_FetchesAppAndBackend(t *testing.T) {
 	binName := "thunder"
 	if runtime.GOOS == "windows" {
 		binName += ".exe"
@@ -42,9 +42,9 @@ func TestDownload_SidechainVariant_HitsAltURL(t *testing.T) {
 	prodArchive := makeZipBytes(t, map[string][]byte{binName: []byte("prod-bin")})
 	testArchive := makeZipBytes(t, map[string][]byte{binName: []byte("test-bin")})
 
-	var requested string
+	var requested []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requested = r.URL.Path
+		requested = append(requested, r.URL.Path)
 		switch r.URL.Path {
 		case "/thunder-test.zip":
 			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(testArchive)))
@@ -74,19 +74,17 @@ func TestDownload_SidechainVariant_HitsAltURL(t *testing.T) {
 	require.NoError(t, err)
 	last := drainProgress(t, ch)
 	assert.True(t, last.Done)
-	assert.Equal(t, "/thunder-test.zip", requested)
+	assert.Equal(t, TestSidechainBinaryPath(dir, "thunder"), last.Message)
+	assert.Contains(t, requested, "/thunder-test.zip")
+	assert.Contains(t, requested, "/thunder-prod.zip")
 
-	// Test build lands under bin/test/<binary>/<binary> — Flutter app
-	// archives need a per-binary namespace for their lib/data trees, so
-	// every test sidechain extracts into its own subdirectory and the
-	// resolver finds the binary inside.
-	expected := TestSidechainBinaryPath(dir, "thunder")
-	got, err := os.ReadFile(expected)
+	app, err := os.ReadFile(TestSidechainBinaryPath(dir, "thunder"))
 	require.NoError(t, err)
-	assert.Equal(t, "test-bin", string(got))
+	assert.Equal(t, "test-bin", string(app))
 
-	_, err = os.Stat(filepath.Join(BinDir(dir), binName))
-	assert.True(t, os.IsNotExist(err), "must not write thunder to BinDir root when test variant is active")
+	backend, err := os.ReadFile(filepath.Join(BinDir(dir), binName))
+	require.NoError(t, err)
+	assert.Equal(t, "prod-bin", string(backend))
 }
 
 func TestDownload_SidechainVariant_FallsBackToProd(t *testing.T) {
@@ -225,7 +223,10 @@ func TestIntegration_TestSidechains_FreshSwitchHitsAltURL(t *testing.T) {
 	assert.True(t, last.Done)
 
 	assert.Contains(t, requested, "/test/thunder.zip", "must hit alt URL when toggle is on")
-	assert.NotContains(t, requested, "/prod/thunder.zip")
+	assert.Contains(t, requested, "/prod/thunder.zip", "must fetch the backend too")
+	prodGot, err := os.ReadFile(BinaryPath(dataDir, "thunder"))
+	require.NoError(t, err)
+	assert.Equal(t, "prod-bin", string(prodGot))
 
 	// Test build lives under bin/test/<binary>/<binary>.
 	got, err := os.ReadFile(TestSidechainBinaryPath(dataDir, "thunder"))
@@ -246,7 +247,7 @@ func TestIntegration_TestSidechains_FreshSwitchHitsAltURL(t *testing.T) {
 	drainProgress(t, progress)
 
 	assert.Contains(t, requested, "/prod/thunder.zip", "must hit prod URL when toggle is off")
-	prodGot, err := os.ReadFile(BinaryPath(dataDir, "thunder"))
+	prodGot, err = os.ReadFile(BinaryPath(dataDir, "thunder"))
 	require.NoError(t, err)
 	assert.Equal(t, "prod-bin", string(prodGot))
 }


### PR DESCRIPTION
With test sidechains on, a sidechain update now downloads the test app and its backend daemon.
Before, the update got only the app, so the settings modal could not find the daemon for its version.
A newer release of either part now shows the update button.