### PR TITLE
orchestrator: keep tests out of the user home

### DIFF
--- a/sidechain-orchestrator/api/bmm_mode_test.go
+++ b/sidechain-orchestrator/api/bmm_mode_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"os"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -22,9 +21,7 @@ import (
 func newBMMModeHandler(t *testing.T) (*BMMHandler, *bmmstate.Store) {
 	t.Helper()
 	home := config.HomeDir()
-	userHome, err := os.UserHomeDir()
-	require.NoError(t, err)
-	if home == userHome {
+	if home == config.UserHomeDir() {
 		home = ""
 	}
 	config.SetHomeDir(t.TempDir())

--- a/sidechain-orchestrator/config/binaries_test.go
+++ b/sidechain-orchestrator/config/binaries_test.go
@@ -1,15 +1,13 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 )
 
 func home() string {
-	h, _ := os.UserHomeDir()
-	return h
+	return UserHomeDir()
 }
 
 // Tests verify Go paths match Dart binaries.dart paths exactly.

--- a/sidechain-orchestrator/config/homedir.go
+++ b/sidechain-orchestrator/config/homedir.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"sync"
+	"testing"
 )
 
 var (
@@ -31,6 +32,26 @@ func HomeDir() string {
 	if dir != "" {
 		return dir
 	}
+	return UserHomeDir()
+}
+
+var (
+	startHome, _ = os.UserHomeDir()
+	testHome     = sync.OnceValue(func() string {
+		dir, err := os.MkdirTemp("", "orchestrator-test-home-")
+		if err != nil {
+			panic(err)
+		}
+		return dir
+	})
+)
+
+// UserHomeDir returns the user's home directory. A test binary gets a temp
+// directory in place of the home the process started with.
+func UserHomeDir() string {
 	home, _ := os.UserHomeDir()
+	if testing.Testing() && home == startHome {
+		return testHome()
+	}
 	return home
 }

--- a/sidechain-orchestrator/config/homedir_test.go
+++ b/sidechain-orchestrator/config/homedir_test.go
@@ -33,10 +33,36 @@ func TestSetHomeDirMovesEveryBinaryPath(t *testing.T) {
 }
 
 func TestHomeDirFallsBackToTheUserHome(t *testing.T) {
-	realHome, err := os.UserHomeDir()
-	require.NoError(t, err)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	SetHomeDir(t.TempDir())
 	SetHomeDir("")
-	require.Equal(t, realHome, HomeDir())
+	require.Equal(t, home, HomeDir())
+}
+
+func TestTestBinaryNeverResolvesTheStartHome(t *testing.T) {
+	require.NotEqual(t, startHome, HomeDir())
+
+	SetHomeDir(t.TempDir())
+	SetHomeDir("")
+	require.NotEqual(t, startHome, HomeDir())
+
+	t.Run("setenv", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+	})
+	require.NotEqual(t, startHome, HomeDir())
+	require.Equal(t, testHome(), HomeDir())
+
+	for _, dc := range AllDirConfigs() {
+		require.True(t, strings.HasPrefix(dc.AppDir(), testHome()),
+			"%s AppDir left the test home: %s", dc.BinaryName, dc.AppDir())
+		for _, n := range []Network{NetworkSignet, NetworkECash, NetworkMainnet} {
+			require.True(t, strings.HasPrefix(dc.DatadirNetwork(n, ""), testHome()),
+				"%s %s datadir left the test home", dc.BinaryName, n)
+		}
+	}
 }

--- a/sidechain-orchestrator/orchestrator_test.go
+++ b/sidechain-orchestrator/orchestrator_test.go
@@ -32,10 +32,7 @@ func newTestPidManager(t *testing.T) *PidFileManager {
 
 func setTestHome(t *testing.T) {
 	t.Helper()
-	previousHome := config.HomeDir()
-	userHome, err := os.UserHomeDir()
-	require.NoError(t, err)
-	if previousHome != userHome {
+	if config.HomeDir() != config.UserHomeDir() {
 		return
 	}
 	config.SetHomeDir(t.TempDir())

--- a/sidechain-orchestrator/reset_home_containment_test.go
+++ b/sidechain-orchestrator/reset_home_containment_test.go
@@ -1,7 +1,6 @@
 package orchestrator
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -58,7 +57,8 @@ func TestGatherWalletFilesStayInsideTheAppHome(t *testing.T) {
 // Without an override the real user home is still the base, so a normal
 // install keeps working.
 func TestAppHomeDefaultsToTheUserHome(t *testing.T) {
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	require.True(t, strings.HasPrefix(config.BitWindowDirs.FlutterFrontendPath(), home))
 }


### PR DESCRIPTION
Tests in sidechain-orchestrator resolved paths in the real user home, so a wipe test deleted the live bitwindow.db and sidechain chain data.
A test binary now gets a temp directory in place of the home the process started with.