### PR TITLE
bitwindow: keep user data on an eCash chain reset

### DIFF
--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -56,7 +56,7 @@ func New(
 	bitcoind *service.Service[corerpc.BitcoinServiceClient],
 	walletEngine *engines.WalletEngine,
 	config config.Config,
-	recycle func(ctx context.Context, network config.Network, networkID string) error,
+	recycle func(ctx context.Context, network config.Network, networkID string, resetFrom uint32) error,
 ) *Server {
 	s := &Server{
 		onShutdown:       onShutdown,
@@ -77,7 +77,7 @@ type Server struct {
 	bitcoind         *service.Service[corerpc.BitcoinServiceClient]
 	walletEngine     *engines.WalletEngine
 	bandwidthTracker *bandwidth.Tracker
-	recycle          func(ctx context.Context, network config.Network, networkID string) error
+	recycle          func(ctx context.Context, network config.Network, networkID string, resetFrom uint32) error
 
 	config config.Config
 
@@ -177,6 +177,19 @@ func (s *Server) UpdateNetwork(ctx context.Context, req *connect.Request[pb.Upda
 	if target == "" {
 		target = req.Msg.Network
 	}
+	// Planned before the switch runs: once it has, the plan reads as a no-op.
+	var resetFrom uint32
+	if network == config.NetworkECash && req.Msg.NetworkId != "" {
+		plan, err := confClient.PlanECashSwitch(ctx, connect.NewRequest(&orchpb.PlanECashSwitchRequest{
+			NetworkId: req.Msg.NetworkId,
+		}))
+		if err != nil {
+			return nil, connect.NewError(connect.CodeOf(err), fmt.Errorf("orchestrator.PlanECashSwitch: %w", err))
+		}
+		if plan.Msg.NeedsRollback {
+			resetFrom = plan.Msg.RewindHeight + 1
+		}
+	}
 	if _, err := confClient.SetBitcoinConfigNetwork(ctx, connect.NewRequest(&orchpb.SetBitcoinConfigNetworkRequest{
 		Network: target,
 		DataDir: req.Msg.DataDir,
@@ -184,7 +197,7 @@ func (s *Server) UpdateNetwork(ctx context.Context, req *connect.Request[pb.Upda
 		return nil, connect.NewError(connect.CodeOf(err), fmt.Errorf("orchestrator.SetBitcoinConfigNetwork: %w", err))
 	}
 
-	if err := s.recycle(ctx, network, target); err != nil {
+	if err := s.recycle(ctx, network, target, resetFrom); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("recycle runtime to %s: %w", network, err))
 	}
 

--- a/bitwindow/server/api/reset_chain_database_test.go
+++ b/bitwindow/server/api/reset_chain_database_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/stretchr/testify/require"
+)
+
+var userRows = map[string]string{
+	"address_book":       `INSERT INTO address_book (label, address, direction) VALUES ('rent', 'bc1qrent', 'send')`,
+	"transaction_notes":  `INSERT INTO transaction_notes (wallet_id, txid, note) VALUES ('w1', 'aa', 'lunch')`,
+	"cheques":            `INSERT INTO cheques (wallet_id, derivation_index, expected_amount_sats, address) VALUES ('w1', 0, 1000, 'bc1qcheque')`,
+	"denials":            `INSERT INTO denials (initial_txid, initial_vout, delay_duration, num_hops, created_at) VALUES ('bb', 0, 60, 3, CURRENT_TIMESTAMP)`,
+	"preferences":        `INSERT INTO preferences (key, value, updated_at) VALUES ('theme', 'dark', 0)`,
+	"wallet_psbt_drafts": `INSERT INTO wallet_psbt_drafts (id, wallet_id, psbt_base64, created_at, updated_at) VALUES ('d1', 'w1', 'cHNidP8=', 0, 0)`,
+	"multisig_groups":    `INSERT INTO multisig_groups (id, name, n, m, created) VALUES ('g1', 'family', 3, 2, 0)`,
+	"utxo_metadata":      `INSERT INTO utxo_metadata (outpoint, label, created_at, updated_at) VALUES ('cc:0', 'savings', 0, 0)`,
+	"cn_identity":        `INSERT INTO cn_identity (id, privkey, author_xpk) VALUES (1, x'01', x'02')`,
+	"bip47_send_state":   `INSERT INTO bip47_send_state (wallet_id, recipient_payment_code) VALUES ('w1', 'PM8T')`,
+}
+
+var chainRows = map[string]string{
+	"processed_blocks":   `INSERT INTO processed_blocks (height, block_hash, txids, block_time) VALUES (10, 'h10', '[]', CURRENT_TIMESTAMP)`,
+	"op_returns":         `INSERT INTO op_returns (txid, vout, op_return_data, fee_sats, height) VALUES ('dd', 0, '00', 1, 10)`,
+	"cn_items":           `INSERT INTO cn_items (item_id, txid, vout, block_height, tx_index, vout_index, type_tag, block_time) VALUES (x'00', 'ee', 0, 10, 1, 0, 1, CURRENT_TIMESTAMP)`,
+	"m4_messages":        `INSERT INTO m4_messages (block_height, block_hash, block_time, raw_bytes, version) VALUES (10, 'h10', CURRENT_TIMESTAMP, x'00', 1)`,
+	"withdrawal_bundles": `INSERT INTO withdrawal_bundles (sidechain_slot, bundle_hash, blocks_left, first_seen_height, last_updated_height) VALUES (0, 'b1', 10, 10, 10)`,
+}
+
+func TestAChainResetKeepsTheUserRows(t *testing.T) {
+	ctx := context.Background()
+	conf := config.Config{Datadir: t.TempDir()}
+	require.NoError(t, conf.Finalize(config.NetworkECash))
+
+	db, err := database.New(ctx, conf)
+	require.NoError(t, err)
+	for _, rows := range []map[string]string{userRows, chainRows} {
+		for table, insert := range rows {
+			_, err := db.ExecContext(ctx, insert)
+			require.NoError(t, err, table)
+		}
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO cn_topics (topic, name, retention_days, created_height, txid) VALUES (x'b1b1b1b1', 'Mined topic', 7, 10, 'ff')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	require.NoError(t, resetChainDatabase(ctx, conf, 0))
+
+	db, err = database.New(ctx, conf)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	count := func(query string) int {
+		var n int
+		require.NoError(t, db.QueryRowContext(ctx, query).Scan(&n))
+		return n
+	}
+	for table := range userRows {
+		require.Equal(t, 1, count(`SELECT COUNT(*) FROM `+table), "user table %s", table)
+	}
+	for table := range chainRows {
+		require.Zero(t, count(`SELECT COUNT(*) FROM `+table), "chain table %s", table)
+	}
+	require.Zero(t, count(`SELECT COUNT(*) FROM cn_topics WHERE txid != ''`), "mined topics")
+	require.Equal(t, 2, count(`SELECT COUNT(*) FROM cn_topics WHERE txid = ''`), "default topics")
+}

--- a/bitwindow/server/api/server.go
+++ b/bitwindow/server/api/server.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,6 +14,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	cryptorpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1/cryptov1connect"
@@ -215,8 +214,9 @@ func New(
 // network-scoped DB, builds new engines, registers new sub-handlers on a
 // new mux, atomically points the listener at the new mux, and tears down
 // the old runtime asynchronously. The HTTP server keeps running across
-// the swap on the same port; the bitwindowd process never exits.
-func (s *Server) Recycle(ctx context.Context, network config.Network, networkID string) error {
+// the swap on the same port; the bitwindowd process never exits. resetFrom is
+// the first block the new eCash network does not share with the old one.
+func (s *Server) Recycle(ctx context.Context, network config.Network, networkID string, resetFrom uint32) error {
 	s.recycleMu.Lock()
 	defer s.recycleMu.Unlock()
 
@@ -244,18 +244,16 @@ func (s *Server) Recycle(ctx context.Context, network config.Network, networkID 
 		return fmt.Errorf("finalize conf for %s: %w", network, err)
 	}
 
-	// An eCash id change keeps the network, so the old and the new runtime name
-	// the same database file. The old one has to close before the reset, or the
-	// rows survive: a rename leaves the open handle on the same inode, and on
-	// Windows it fails outright.
 	// Only an eCash id change reaches here with the network unchanged, and only
-	// then do the old and the new runtime name the same database file.
+	// then do the old and the new runtime name the same database file. The old
+	// one closes first, so its engines write no rows from the old chain after
+	// the reset.
 	sameDatabase := old != nil && old.conf.BitcoinCoreNetwork == network && network == config.NetworkECash
 	if sameDatabase {
 		old.Close()
 		old = nil
 		log.Info().Msg("old runtime closed before the database reset")
-		if err := resetChainDatabase(newConf); err != nil {
+		if err := resetChainDatabase(ctx, newConf, resetFrom); err != nil {
 			return fmt.Errorf("reset chain database for %s: %w", network, err)
 		}
 	}
@@ -484,15 +482,15 @@ func getCode(err error) (connect.Code, bool) {
 	return connect.CodeUnknown, false
 }
 
-// resetChainDatabase removes the chain-derived database for a network, so a
-// runtime that reopens it indexes the chain from scratch. Called only with the
-// database closed.
-func resetChainDatabase(conf config.Config) error {
-	path := filepath.Join(conf.Datadir, "bitwindow.db")
-	for _, p := range []string{path, path + "-wal", path + "-shm"} {
-		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove %s: %w", p, err)
-		}
+// resetChainDatabase deletes the rows a network's database derived from blocks
+// at or above height. The user's rows stay. Called only with the database closed.
+func resetChainDatabase(ctx context.Context, conf config.Config, height uint32) error {
+	db, err := database.New(ctx, conf)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
 	}
-	return nil
+	if err := engines.ResetChainData(ctx, db, height); err != nil {
+		return errors.Join(fmt.Errorf("reset chain data: %w", err), db.Close())
+	}
+	return db.Close()
 }

--- a/bitwindow/server/api/wallet/cheque_funding_height_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_height_test.go
@@ -1,0 +1,48 @@
+package api_wallet_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
+	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckChequeFunding_RecordsTheFundingBlock(t *testing.T) {
+	t.Parallel()
+	db := database.Test(t)
+
+	chequeAddr := "tb1qfundingheighttestaddr000000000000000000"
+	fundingTxid := "feed0000feed0000feed0000feed0000feed0000feed0000feed0000feed0000"
+
+	cli := walletv1connect.NewWalletServiceClient(
+		apitests.API(t, db, apitests.WithOrchestrator(&fakeOrchestrator{
+			address: chequeAddr,
+			utxos: []*orchpb.AddressUnspentOutput{
+				{Txid: fundingTxid, Vout: 0, ValueSats: 100_000_000, Confirmations: 3},
+			},
+		})),
+	)
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, chequeAddr)
+	require.NoError(t, err)
+
+	_, err = cli.CheckChequeFunding(context.Background(), connect.NewRequest(&walletv1.CheckChequeFundingRequest{
+		WalletId: testWalletID,
+		Id:       chequeID,
+	}))
+	require.NoError(t, err)
+
+	var height int64
+	require.NoError(t, db.QueryRowContext(context.Background(),
+		`SELECT block_height FROM cheque_funding_outputs WHERE cheque_id = ? AND txid = ?`,
+		chequeID, fundingTxid,
+	).Scan(&height))
+	require.EqualValues(t, 98, height, "tip 100 with 3 confirmations")
+}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1634,17 +1634,19 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 	if len(utxos) > 0 {
 		var amountSats uint64
 		var txids []string
+		var outputs []cheques.FundingOutput
 		var minConfirmations uint32 = math.MaxUint32
 		for _, utxo := range utxos {
 			amountSats += uint64(utxo.ValueSats)
 			txids = append(txids, utxo.TxID)
+			outputs = append(outputs, cheques.FundingOutput{Txid: utxo.TxID, BlockHeight: utxo.Height})
 			if confs := uint32(utxo.Confirmations); confs < minConfirmations {
 				minConfirmations = confs
 			}
 		}
 
 		// Always update — handles new fundings arriving after first one
-		if err := cheques.UpdateFunding(ctx, s.database, walletId, c.Msg.Id, txids, amountSats); err != nil {
+		if err := cheques.UpdateFunding(ctx, s.database, walletId, c.Msg.Id, outputs, amountSats); err != nil {
 			log.Error().Err(err).Msg("failed to update cheque funding")
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update funding: %w", err))
 		}

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -261,7 +261,7 @@ func TestService_DeleteChequeFundingGuard(t *testing.T) {
 		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qpartialdelete000000000000000000000000000")
 		require.NoError(t, err)
 		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
-			[]string{"partial0partial0partial0partial0partial0partial0partial0partial0"}, 50_000_000))
+			[]cheques.FundingOutput{{Txid: "partial0partial0partial0partial0partial0partial0partial0partial0"}}, 50_000_000))
 
 		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
 			WalletId: testWalletID,
@@ -283,7 +283,7 @@ func TestService_DeleteChequeFundingGuard(t *testing.T) {
 		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qfulldelete0000000000000000000000000000000")
 		require.NoError(t, err)
 		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
-			[]string{"full0000full0000full0000full0000full0000full0000full0000full0000"}, 100_000_000))
+			[]cheques.FundingOutput{{Txid: "full0000full0000full0000full0000full0000full0000full0000full0000"}}, 100_000_000))
 
 		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
 			WalletId: testWalletID,
@@ -304,7 +304,7 @@ func TestService_DeleteChequeFundingGuard(t *testing.T) {
 		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qsweptdelete000000000000000000000000000000")
 		require.NoError(t, err)
 		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
-			[]string{"swept000swept000swept000swept000swept000swept000swept000swept000"}, 100_000_000))
+			[]cheques.FundingOutput{{Txid: "swept000swept000swept000swept000swept000swept000swept000swept000"}}, 100_000_000))
 		require.NoError(t, cheques.UpdateSwept(context.Background(), db, testWalletID, chequeID,
 			"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0"))
 

--- a/bitwindow/server/database/migrations/047_cheque_funding_height.sql
+++ b/bitwindow/server/database/migrations/047_cheque_funding_height.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cheque_funding_outputs ADD COLUMN block_height INTEGER;

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -157,16 +157,26 @@ type BlockResult struct {
 	Error  error
 }
 
+// ResetChainData deletes every row derived from a block at or above height. It
+// keeps the rows the user made.
+func ResetChainData(ctx context.Context, db *sql.DB, height uint32) error {
+	_, err := purgeChainAtOrAbove(ctx, db, height)
+	return err
+}
+
 // resetProcessedChain drops every processed block and everything derived from
 // them; the derived inserts ignore conflicts, so stale rows would survive the
 // rescan.
 func (p *Parser) resetProcessedChain(ctx context.Context) error {
-	_, err := p.purgeAtOrAbove(ctx, 0)
-	return err
+	return ResetChainData(ctx, p.db, 0)
 }
 
-// purgeAtOrAbove drops every row derived from a block at height or above, so a
-// replay of that range rebuilds them against the chain Core now follows.
+func (p *Parser) purgeAtOrAbove(ctx context.Context, height uint32) (uint32, error) {
+	return purgeChainAtOrAbove(ctx, p.db, height)
+}
+
+// purgeChainAtOrAbove drops every row derived from a block at height or above,
+// so a replay of that range rebuilds them against the chain Core now follows.
 //
 // One transaction. A partial purge would delete the processed markers that make
 // the fork detectable while orphan rows survive, and the first-wins inserts on
@@ -174,8 +184,8 @@ func (p *Parser) resetProcessedChain(ctx context.Context) error {
 // It returns the height the replay has to start from, which the M4 purge can
 // take below height: a bundle whose score the orphan branch moved only rebuilds
 // by replaying the blocks that built it.
-func (p *Parser) purgeAtOrAbove(ctx context.Context, height uint32) (uint32, error) {
-	tx, err := p.db.BeginTx(ctx, nil)
+func purgeChainAtOrAbove(ctx context.Context, db *sql.DB, height uint32) (uint32, error) {
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("open the fork purge: %w", err)
 	}
@@ -184,6 +194,9 @@ func (p *Parser) purgeAtOrAbove(ctx context.Context, height uint32) (uint32, err
 	replayFrom, err := purgeM4AtOrAboveTx(ctx, tx, height)
 	if err != nil {
 		return 0, fmt.Errorf("purge m4 on fork: %w", err)
+	}
+	if err := purgeChequesAtOrAboveTx(ctx, tx, height); err != nil {
+		return 0, fmt.Errorf("purge cheques on fork: %w", err)
 	}
 	if err := blocks.DeleteProcessedBlocksAtOrAboveTx(ctx, tx, replayFrom); err != nil {
 		return 0, fmt.Errorf("delete processed blocks on fork: %w", err)
@@ -310,21 +323,15 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		return fmt.Errorf("fetch current height: %w", err)
 	}
 
-	// A node shorter than our processed tip means the chain was wiped. A healthy
-	// node — and a fresh install (processed tip 0) — is never shorter than
-	// what we've already processed, so this only fires on a real wipe, not on
-	// the pruning/reindex/restart blips that keep the tip high. Left stale,
-	// the scanner reprocesses against blocks the node no longer has and pins
-	// bitcoind, which starves getblockchaininfo and the wallet readiness probe
-	// ("Backend not ready after 60s"). Drop the stale state and re-scan the
-	// node's actual chain from scratch.
+	// The node dropped every block above its tip: a wiped datadir, or an eCash
+	// switch that rewound below the fork. The next tick checks the rest.
 	if currentHeight < lastProcessedHeight {
 		zerolog.Ctx(ctx).Warn().
 			Uint32("processed_tip", lastProcessedHeight).
 			Uint32("node_tip", currentHeight).
-			Msg("bitcoind_engine/parser: node is behind our processed tip — chain wiped, resetting processed_blocks")
-		if err := p.resetProcessedChain(ctx); err != nil {
-			return fmt.Errorf("reset processed chain on chain wipe: %w", err)
+			Msg("bitcoind_engine/parser: node is behind our processed tip, dropping the blocks above it")
+		if _, err := p.purgeAtOrAbove(ctx, currentHeight+1); err != nil {
+			return fmt.Errorf("purge above the node tip: %w", err)
 		}
 		return nil
 	}

--- a/bitwindow/server/engines/cheque_chain.go
+++ b/bitwindow/server/engines/cheque_chain.go
@@ -13,6 +13,8 @@ type ChequeUTXO struct {
 	Vout          int32
 	ValueSats     int64
 	Confirmations int32
+	// Height is the block that confirmed the output, 0 while unconfirmed.
+	Height uint32
 }
 
 // ChequeChain is the chain access a cheque needs: reads of an address the
@@ -34,7 +36,7 @@ func NewElectrumChequeChain(engine *WalletEngine) *ElectrumChequeChain {
 }
 
 func (c *ElectrumChequeChain) AddressUnspent(ctx context.Context, address string) ([]ChequeUTXO, error) {
-	utxos, _, err := c.engine.ChequeAddressUnspent(ctx, address)
+	utxos, tip, err := c.engine.ChequeAddressUnspent(ctx, address)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +46,16 @@ func (c *ElectrumChequeChain) AddressUnspent(ctx context.Context, address string
 			Vout:          u.Vout,
 			ValueSats:     u.ValueSats,
 			Confirmations: u.Confirmations,
+			Height:        confirmedHeight(tip, u.Confirmations),
 		}
 	}), nil
+}
+
+func confirmedHeight(tip, confirmations int32) uint32 {
+	if confirmations <= 0 || tip < confirmations {
+		return 0
+	}
+	return uint32(tip - confirmations + 1)
 }
 
 func (c *ElectrumChequeChain) FeeRateSatPerVByte(ctx context.Context, confTarget int32) (float64, error) {

--- a/bitwindow/server/engines/cheque_purge.go
+++ b/bitwindow/server/engines/cheque_purge.go
@@ -1,0 +1,38 @@
+package engines
+
+import (
+	"context"
+	"database/sql"
+)
+
+// purgeChequesAtOrAboveTx drops the cheque fundings and sweeps confirmed in a
+// block at or above height, so the next funding check reads them again. State
+// from a lower block, or from no known block, stays.
+func purgeChequesAtOrAboveTx(ctx context.Context, tx *sql.Tx, height uint32) error {
+	const gone = `WITH gone(txid) AS (
+		SELECT j.value FROM processed_blocks b, json_each(b.txids) j WHERE b.height >= ?1
+	) `
+	const dropped = `(COALESCE(block_height, -1) >= ?1 OR txid IN (SELECT txid FROM gone))`
+
+	const kept = `(SELECT cheque_id FROM cheque_funding_outputs WHERE NOT ` + dropped + `)`
+
+	stmts := []string{
+		// A lost output makes the total unknown until the next funding check. A
+		// cheque that loses every output also loses the external sweep read off it.
+		gone + `UPDATE cheques
+		SET actual_amount_sats = NULL,
+		    funded_at = CASE WHEN id IN ` + kept + ` THEN funded_at ELSE NULL END,
+		    swept_at = CASE WHEN swept_txid = 'swept_externally' AND id NOT IN ` + kept + ` THEN NULL ELSE swept_at END,
+		    swept_txid = CASE WHEN swept_txid = 'swept_externally' AND id NOT IN ` + kept + ` THEN NULL ELSE swept_txid END
+		WHERE id IN (SELECT cheque_id FROM cheque_funding_outputs WHERE ` + dropped + `)`,
+		gone + `DELETE FROM cheque_funding_outputs WHERE ` + dropped,
+		gone + `UPDATE cheques SET swept_txid = NULL, swept_at = NULL
+		WHERE swept_txid IN (SELECT txid FROM gone)`,
+	}
+	for _, q := range stmts {
+		if _, err := tx.ExecContext(ctx, q, height); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/bitwindow/server/engines/cheque_purge_test.go
+++ b/bitwindow/server/engines/cheque_purge_test.go
@@ -1,0 +1,71 @@
+package engines
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAForkPurgeKeepsChequeHistoryBelowTheFork(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	const wallet = "w1"
+
+	_, err := db.ExecContext(ctx, `INSERT INTO processed_blocks (height, block_hash, txids, block_time) VALUES
+		(90, 'h90', '["fundShared","sweepShared","fundKept","fundSplitShared"]', CURRENT_TIMESTAMP),
+		(110, 'h110', '["fundOld","sweepOld","fundSplitOld"]', CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	cheque := func(index uint32, funds []cheques.FundingOutput, sweep string) int64 {
+		id, err := cheques.Create(ctx, db, wallet, index, 1000, "addr"+funds[0].Txid)
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(ctx, db, wallet, id, funds, 1000))
+		if sweep != "" {
+			require.NoError(t, cheques.UpdateSwept(ctx, db, wallet, id, sweep))
+		}
+		return id
+	}
+	fundedOnOldFork := cheque(0, []cheques.FundingOutput{{Txid: "fundOld"}}, "swept_externally")
+	fundedOnOldForkLight := cheque(1, []cheques.FundingOutput{{Txid: "fundLight", BlockHeight: 105}}, "")
+	sweptBeforeFork := cheque(2, []cheques.FundingOutput{{Txid: "fundShared"}}, "sweepShared")
+	sweptOnOldFork := cheque(3, []cheques.FundingOutput{{Txid: "fundKept"}}, "sweepOld")
+	fundedAtUnknownHeight := cheque(4, []cheques.FundingOutput{{Txid: "fundUnknown"}}, "")
+	fundedOnBothSides := cheque(5, []cheques.FundingOutput{{Txid: "fundSplitShared"}, {Txid: "fundSplitOld"}}, "")
+
+	require.NoError(t, ResetChainData(ctx, db, 100))
+
+	get := func(id int64) *cheques.Cheque {
+		c, err := cheques.Get(ctx, db, wallet, id)
+		require.NoError(t, err)
+		return c
+	}
+	for _, id := range []int64{fundedOnOldFork, fundedOnOldForkLight} {
+		c := get(id)
+		require.False(t, c.IsFunded(), "cheque %d", id)
+		require.Nil(t, c.ActualAmountSats, "cheque %d", id)
+		require.Nil(t, c.FundedAt, "cheque %d", id)
+		require.Empty(t, c.FundedTxids, "cheque %d", id)
+		require.Nil(t, c.SweptTxid, "cheque %d", id)
+	}
+
+	c := get(sweptBeforeFork)
+	require.True(t, c.IsFunded())
+	require.Equal(t, []string{"fundShared"}, c.FundedTxids)
+	require.Equal(t, "sweepShared", *c.SweptTxid)
+
+	c = get(sweptOnOldFork)
+	require.True(t, c.IsFunded())
+	require.Nil(t, c.SweptTxid)
+
+	c = get(fundedAtUnknownHeight)
+	require.True(t, c.IsFunded())
+	require.Equal(t, []string{"fundUnknown"}, c.FundedTxids)
+
+	c = get(fundedOnBothSides)
+	require.Nil(t, c.ActualAmountSats, "the total counted an output the new chain lacks")
+	require.NotNil(t, c.FundedAt)
+	require.Equal(t, []string{"fundSplitShared"}, c.FundedTxids)
+}

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -221,8 +221,15 @@ func attachFundingOutputs(ctx context.Context, db *sql.DB, walletID string, cheq
 	return rows.Err()
 }
 
-// UpdateFunding updates a cheque's funding txids and amount
-func UpdateFunding(ctx context.Context, db *sql.DB, walletID string, id int64, txids []string, actualAmount uint64) error {
+// FundingOutput is one transaction paying a cheque. BlockHeight is 0 while it
+// is unconfirmed.
+type FundingOutput struct {
+	Txid        string
+	BlockHeight uint32
+}
+
+// UpdateFunding updates a cheque's funding outputs and amount
+func UpdateFunding(ctx context.Context, db *sql.DB, walletID string, id int64, outputs []FundingOutput, actualAmount uint64) error {
 	now := time.Now()
 
 	result, err := db.ExecContext(ctx, `
@@ -242,11 +249,17 @@ func UpdateFunding(ctx context.Context, db *sql.DB, walletID string, id int64, t
 		return sql.ErrNoRows
 	}
 
-	for _, txid := range txids {
+	for _, out := range outputs {
+		var height sql.NullInt64
+		if out.BlockHeight > 0 {
+			height = sql.NullInt64{Int64: int64(out.BlockHeight), Valid: true}
+		}
 		if _, err := db.ExecContext(ctx, `
-			INSERT OR IGNORE INTO cheque_funding_outputs (cheque_id, txid, vout, value_sats)
-			VALUES (?, ?, 0, 0)
-		`, id, txid); err != nil {
+			INSERT INTO cheque_funding_outputs (cheque_id, txid, vout, value_sats, block_height)
+			VALUES (?, ?, 0, 0, ?)
+			ON CONFLICT (cheque_id, txid, vout) DO UPDATE
+			SET block_height = COALESCE(excluded.block_height, block_height)
+		`, id, out.Txid, height); err != nil {
 			return fmt.Errorf("record funding output: %w", err)
 		}
 	}
@@ -331,8 +344,11 @@ func CreateOrUpdateFromRecovery(ctx context.Context, db *sql.DB, walletID string
 	}
 
 	if existing != nil {
-		// Update existing cheque
-		return UpdateFunding(ctx, db, walletID, existing.ID, txids, amount)
+		outputs := make([]FundingOutput, len(txids))
+		for i, txid := range txids {
+			outputs[i] = FundingOutput{Txid: txid}
+		}
+		return UpdateFunding(ctx, db, walletID, existing.ID, outputs, amount)
 	}
 
 	// Create new cheque as already funded


### PR DESCRIPTION
A change of eCash generation deleted bitwindow.db, and with it the address book, notes, cheques, drafts and preferences.
The reset now deletes only the rows the parser derives from the chain, with the purge the parser already uses on a fork.
A new test fills user and chain tables on disk, runs the reset, and checks that only the chain rows go.