### PR TITLE
orchestrator: install sidechain parts all or none

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.333
+version: 1.0.334
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.333
+version: 1.0.334
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.204
+version: 0.2.205
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.8
+version: 1.0.9
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.206
+version: 1.0.207
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -62,6 +62,7 @@ type DownloadManager struct {
 	httpClient     *http.Client
 	log            zerolog.Logger
 	inFlight       sync.Map
+	claimMu        sync.Mutex
 	// state holds the latest DownloadState for each in-flight binary, keyed
 	// by the binary's logical name (e.g. "bitcoind", "thunder"). Updated on
 	// every progress event from downloadFile, deleted on Done/Error so a
@@ -161,13 +162,7 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 
 	// A second caller waits for the running download instead of failing.
 	// SwapNetwork drops the core binary and restarts L1, so two paths ask at once.
-	claims := lo.Map(targets, func(target DownloadTarget, _ int) inFlightClaim {
-		done := make(chan struct{})
-		if existing, loaded := d.inFlight.LoadOrStore(target.InFlightKey, done); loaded {
-			return inFlightClaim{target: target, done: existing.(chan struct{})}
-		}
-		return inFlightClaim{target: target, done: done, owned: true}
-	})
+	owned, busy := d.claim(targets)
 
 	ch := make(chan DownloadProgress, 100)
 
@@ -180,18 +175,6 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 	d.state.Store(stateKey, DownloadState{Running: true})
 
 	go func() {
-		release := func(i int) {
-			close(claims[i].done)
-			d.inFlight.Delete(claims[i].target.InFlightKey)
-			claims[i].owned = false
-		}
-		defer func() {
-			for i := range claims {
-				if claims[i].owned {
-					release(i)
-				}
-			}
-		}()
 		defer d.state.Delete(stateKey)
 		defer close(ch)
 
@@ -234,25 +217,37 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 			}
 		}
 
-		for i, claim := range claims {
-			if claim.owned {
-				if err := d.fetch(ctx, config, network, claim.target, send); err != nil {
-					send(DownloadProgress{Error: err})
+		for len(busy) > 0 {
+			for _, claim := range busy {
+				select {
+				case <-claim.done:
+				case <-ctx.Done():
+					send(DownloadProgress{Error: ctx.Err()})
 					return
 				}
-				release(i)
-				continue
+				if claim.err != nil {
+					send(DownloadProgress{Error: claim.err})
+					return
+				}
 			}
-			select {
-			case <-claim.done:
-			case <-ctx.Done():
-				send(DownloadProgress{Error: ctx.Err()})
-				return
+			waitedOn := func(target DownloadTarget, _ int) bool {
+				return lo.ContainsBy(busy, func(claim *inFlightClaim) bool {
+					return claim.target.InFlightKey == target.InFlightKey
+				})
 			}
-			if _, err := os.Stat(claim.target.BinPath); err != nil {
-				send(DownloadProgress{Error: fmt.Errorf("%s download finished without a binary", config.Name)})
-				return
+			for _, target := range lo.Filter(targets, waitedOn) {
+				if _, err := os.Stat(target.BinPath); err != nil {
+					send(DownloadProgress{Error: fmt.Errorf("%s download finished without a binary", config.Name)})
+					return
+				}
 			}
+			targets = lo.Reject(targets, waitedOn)
+			owned, busy = d.claim(targets)
+		}
+
+		if err := d.install(ctx, config, network, owned, send); err != nil {
+			send(DownloadProgress{Error: err})
+			return
 		}
 
 		send(DownloadProgress{Message: binPath, Done: true})
@@ -261,8 +256,50 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 	return ch, nil
 }
 
-// fetch downloads one target's archive, records its hash and extracts it.
-func (d *DownloadManager) fetch(ctx context.Context, config BinaryConfig, network string, target DownloadTarget, send func(DownloadProgress) bool) error {
+// install downloads every claimed archive before it extracts any, so a failed
+// download leaves every installed part in place.
+func (d *DownloadManager) install(ctx context.Context, config BinaryConfig, network string, claims []*inFlightClaim, send func(DownloadProgress) bool) (err error) {
+	if len(claims) == 0 {
+		return nil
+	}
+	defer func() {
+		for _, claim := range claims {
+			claim.err = err
+			d.inFlight.Delete(claim.target.InFlightKey)
+			close(claim.done)
+		}
+	}()
+
+	tmpDir, err := os.MkdirTemp("", "orchestrator-download-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup
+
+	archives := make([]string, len(claims))
+	for i, claim := range claims {
+		if archives[i], err = d.fetchArchive(ctx, config, claim.target, tmpDir, send); err != nil {
+			return err
+		}
+	}
+
+	if !send(DownloadProgress{Message: "extracting..."}) {
+		return ctx.Err()
+	}
+	for i, claim := range claims {
+		hasCLI, extractErr := d.extractBinary(archives[i], config, claim.target, d.dataDir, network)
+		if extractErr != nil {
+			d.log.Error().Err(extractErr).Str("binary", config.Name).Msg("extract failed")
+			return fmt.Errorf("extract: %w", extractErr)
+		}
+		d.log.Info().Bool("has_cli", hasCLI).Str("binary", claim.target.ExtractName).Msg("extraction complete")
+	}
+	return nil
+}
+
+// fetchArchive downloads one target's archive into its own directory under
+// tmpDir and records its hash.
+func (d *DownloadManager) fetchArchive(ctx context.Context, config BinaryConfig, target DownloadTarget, tmpDir string, send func(DownloadProgress) bool) (string, error) {
 	// Test sidechain alt URLs are always served directly from
 	// releases.drivechain.info; the prod-side DownloadSourceGitHub flag
 	// (used by zside/thunder-orchard for the production builds) doesn't
@@ -274,7 +311,7 @@ func (d *DownloadManager) fetch(ctx context.Context, config BinaryConfig, networ
 	case DownloadSourceGitHub:
 		url, err := d.resolveGitHubURL(ctx, target.BaseURL, target.FileName)
 		if err != nil {
-			return fmt.Errorf("resolve GitHub URL: %w", err)
+			return "", fmt.Errorf("resolve GitHub URL: %w", err)
 		}
 		downloadURL = url
 	case DownloadSourceDirect:
@@ -283,21 +320,19 @@ func (d *DownloadManager) fetch(ctx context.Context, config BinaryConfig, networ
 
 	d.log.Info().Str("url", downloadURL).Str("binary", config.Name).Msg("downloading")
 
-	tmpDir, err := os.MkdirTemp("", "orchestrator-download-*")
+	dir, err := os.MkdirTemp(tmpDir, "archive-*")
 	if err != nil {
-		return fmt.Errorf("create temp dir: %w", err)
+		return "", fmt.Errorf("create temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup
-
-	savePath := filepath.Join(tmpDir, filepath.Base(downloadURL))
+	savePath := filepath.Join(dir, filepath.Base(downloadURL))
 
 	if err := d.downloadFile(ctx, downloadURL, savePath, send); err != nil {
-		return err
+		return "", err
 	}
 
 	// Compute SHA256 hash and write back to config
 	if !send(DownloadProgress{Message: "verifying hash..."}) {
-		return ctx.Err()
+		return "", ctx.Err()
 	}
 	archiveHash, archiveSize, err := hashFile(savePath)
 	if err != nil {
@@ -310,18 +345,7 @@ func (d *DownloadManager) fetch(ctx context.Context, config BinaryConfig, networ
 			}
 		}
 	}
-
-	if !send(DownloadProgress{Message: "extracting..."}) {
-		return ctx.Err()
-	}
-
-	hasCLI, err := d.extractBinary(savePath, config, target, d.dataDir, network)
-	if err != nil {
-		d.log.Error().Err(err).Str("binary", config.Name).Msg("extract failed")
-		return fmt.Errorf("extract: %w", err)
-	}
-	d.log.Info().Bool("has_cli", hasCLI).Str("binary", target.ExtractName).Msg("extraction complete")
-	return nil
+	return savePath, nil
 }
 
 // activeVariant resolves the Core variant for the given config, if applicable.
@@ -1060,12 +1084,33 @@ func StripPlatformSuffix(name string) string {
 
 // attachToInFlight waits for an already-running download of the same binary and
 // reports success iff it left a binary on disk.
-// inFlightClaim is one target's slot in the in-flight map. owned is true while
-// this caller holds the claim.
+// inFlightClaim is one target's slot in the in-flight map. err holds the
+// owner's result once done closes.
 type inFlightClaim struct {
 	target DownloadTarget
 	done   chan struct{}
-	owned  bool
+	err    error
+}
+
+// claim takes every target, or none while another caller downloads one of
+// them. A holder never waits on another claim, so callers cannot deadlock.
+func (d *DownloadManager) claim(targets []DownloadTarget) (owned, busy []*inFlightClaim) {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	for _, target := range targets {
+		if existing, ok := d.inFlight.Load(target.InFlightKey); ok {
+			busy = append(busy, existing.(*inFlightClaim))
+		}
+	}
+	if len(busy) > 0 {
+		return nil, busy
+	}
+	for _, target := range targets {
+		claim := &inFlightClaim{target: target, done: make(chan struct{})}
+		d.inFlight.Store(target.InFlightKey, claim)
+		owned = append(owned, claim)
+	}
+	return owned, nil
 }
 
 // Targets lists every download that writes a binary for this config. A layer-2

--- a/sidechain-orchestrator/download_claims_test.go
+++ b/sidechain-orchestrator/download_claims_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Two callers can each own one part of a sidechain download. Each part must
-// clear its claim when it lands, or the callers wait on each other forever.
-func TestDownload_ReleasesEachTargetBeforeTheNext(t *testing.T) {
+// A caller waits for a backend another caller downloads, then fetches the
+// app. It holds no claim while it waits, so two callers cannot deadlock.
+func TestDownload_WaitsForABusyBackend(t *testing.T) {
 	binName := "thunder"
 	if runtime.GOOS == "windows" {
 		binName += ".exe"
@@ -30,34 +30,149 @@ func TestDownload_ReleasesEachTargetBeforeTheNext(t *testing.T) {
 	dm, _ := newTestDownloadManager(t)
 	dm.httpClient = srv.Client()
 	cfg := makeSidechainConfig(srv.URL + "/")
-	dm.SidechainVariant = func(c BinaryConfig) (sidechainVariantSpec, bool) {
-		return sidechainVariantSpec{
-			BinaryName: c.AltBinaryName,
-			BaseURL:    c.AltBaseURL("default"),
-			FileName:   fileForPlatform(c.AltFiles),
-		}, true
-	}
+	dm.SidechainVariant = testSidechainResolver
 
 	targets := dm.Targets(cfg, "default", DownloadOptions{})
 	require.Len(t, targets, 2)
 	app, backend := targets[0], targets[1]
 
-	backendDone := make(chan struct{})
-	dm.inFlight.Store(backend.InFlightKey, backendDone)
+	backendClaim := &inFlightClaim{target: backend, done: make(chan struct{})}
+	dm.inFlight.Store(backend.InFlightKey, backendClaim)
 
 	ch, err := dm.Download(context.Background(), cfg, "default", true)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
-		_, busy := dm.inFlight.Load(app.InFlightKey)
-		return !busy
-	}, 5*time.Second, 10*time.Millisecond, "the app claim must clear while the backend is in flight")
+	require.Never(t, func() bool {
+		_, held := dm.inFlight.Load(app.InFlightKey)
+		return held
+	}, 200*time.Millisecond, 10*time.Millisecond, "a caller holds no claim while it waits")
 
-	require.NoError(t, os.MkdirAll(filepath.Dir(backend.BinPath), 0o755))
-	require.NoError(t, os.WriteFile(backend.BinPath, []byte("prod-bin"), 0o755))
+	writeBinary(t, backend.BinPath, "prod-bin")
 	dm.inFlight.Delete(backend.InFlightKey)
-	close(backendDone)
+	close(backendClaim.done)
 
 	last := drainProgress(t, ch)
 	assert.True(t, last.Done)
+}
+
+// A sidechain update installs the app and the backend together. When one
+// download fails, both installed parts stay as they were.
+func TestDownload_KeepsBothPartsWhenOneDownloadFails(t *testing.T) {
+	binName := "thunder"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	archive := makeZipBytes(t, map[string][]byte{binName: []byte("new-bin")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/thunder-prod.zip" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dm, dir := newTestDownloadManager(t)
+	dm.httpClient = srv.Client()
+	cfg := makeSidechainConfig(srv.URL + "/")
+	dm.SidechainVariant = testSidechainResolver
+
+	appPath := TestSidechainBinaryPath(dir, "thunder")
+	backendPath := BinaryPath(dir, "thunder")
+	writeBinary(t, appPath, "old-app")
+	writeBinary(t, backendPath, "old-backend")
+
+	ch, err := dm.Download(context.Background(), cfg, "default", true)
+	require.NoError(t, err)
+	require.Error(t, finalProgress(ch).Error)
+
+	assertBinary(t, appPath, "old-app")
+	assertBinary(t, backendPath, "old-backend")
+}
+
+// A caller that waits on a part the owner never downloaded gets the owner's
+// failure, not the old binary on disk.
+func TestDownload_WaiterGetsTheOwnersFailure(t *testing.T) {
+	binName := "thunder"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	archive := makeZipBytes(t, map[string][]byte{binName: []byte("new-bin")})
+	gate := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/thunder-test.zip" {
+			<-gate
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dm, dir := newTestDownloadManager(t)
+	dm.httpClient = srv.Client()
+	cfg := makeSidechainConfig(srv.URL + "/")
+	dm.SidechainVariant = testSidechainResolver
+	writeBinary(t, BinaryPath(dir, "thunder"), "old-backend")
+
+	owner, err := dm.Download(context.Background(), cfg, "default", true)
+	require.NoError(t, err)
+	waiter, err := dm.DownloadWithOptions(context.Background(), cfg, "default", true, DownloadOptions{ForceBackend: true})
+	require.NoError(t, err)
+	close(gate)
+
+	require.Error(t, finalProgress(owner).Error)
+	require.Error(t, finalProgress(waiter).Error, "the old backend is not a finished download")
+}
+
+// A waiter checks its own binary path, not the path of the owner it waited on.
+func TestDownload_WaiterChecksItsOwnPath(t *testing.T) {
+	dm, dir := newTestDownloadManager(t)
+	cfg := BinaryConfig{
+		Name:           "waittest",
+		BinaryName:     "waittest",
+		DownloadSource: DownloadSourceDirect,
+		Files:          map[string]string{currentPlatform(): "waittest.zip"},
+		DownloadURLs:   map[string]string{"default": "http://example.invalid/"},
+	}
+
+	ownerPath := filepath.Join(dir, "owner-binary")
+	writeBinary(t, ownerPath, "owner")
+	owner := &inFlightClaim{target: DownloadTarget{InFlightKey: cfg.Name, BinPath: ownerPath}, done: make(chan struct{})}
+	close(owner.done)
+	dm.inFlight.Store(cfg.Name, owner)
+
+	ch, err := dm.Download(context.Background(), cfg, "default", true)
+	require.NoError(t, err)
+	require.Error(t, finalProgress(ch).Error, "the waiter's own binary is missing")
+}
+
+func testSidechainResolver(c BinaryConfig) (sidechainVariantSpec, bool) {
+	return sidechainVariantSpec{
+		BinaryName: c.AltBinaryName,
+		BaseURL:    c.AltBaseURL("default"),
+		FileName:   fileForPlatform(c.AltFiles),
+	}, true
+}
+
+func writeBinary(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+}
+
+func assertBinary(t *testing.T, path, content string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+}
+
+// finalProgress reads the channel to its end and returns the last event.
+func finalProgress(ch <-chan DownloadProgress) DownloadProgress {
+	var last DownloadProgress
+	for p := range ch {
+		last = p
+	}
+	return last
 }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.335
+version: 1.0.336
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.206
+version: 1.0.207
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.332
+version: 1.0.333
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
A sidechain update now downloads the app and the backend first and installs them only when both downloads succeed.
A caller that waits on a part now gets the owner's failure, not the old binary on disk.
This follows #2243.