### PR TITLE
orchestrator: price a BMM cancel from its guard

### DIFF
--- a/sidechain-orchestrator/api/bmm_cancel.go
+++ b/sidechain-orchestrator/api/bmm_cancel.go
@@ -56,7 +56,7 @@ func (h *BMMHandler) CancelBid(
 		return nil, err
 	}
 
-	evictedSats, err := h.evictedFeeSats(ctx, roots)
+	evictedSats, err := h.evictedFeeSats(ctx, evicted)
 	if err != nil {
 		return nil, err
 	}
@@ -181,23 +181,6 @@ func incrementalRelayFeeSatPerKvB(ctx context.Context, call coreReader) (int64, 
 		return 0, fmt.Errorf("the node reports no incremental relay fee")
 	}
 	return int64(math.Round(*info.IncrementalFee * 1e8)), nil
-}
-
-// evictedByReplacement names every transaction the replacement removes: each
-// root of the chain and everything the mempool holds over it.
-func (h *BMMHandler) evictedByReplacement(ctx context.Context, roots []string) []string {
-	seen := make(map[string]bool)
-	var all []string
-	for _, root := range roots {
-		for _, txid := range append([]string{root}, h.mempoolDescendants(ctx, root)...) {
-			if seen[txid] {
-				continue
-			}
-			seen[txid] = true
-			all = append(all, txid)
-		}
-	}
-	return all
 }
 
 // requireNoLiveBid refuses a cancel that would take this round's bid with it.

--- a/sidechain-orchestrator/api/bmm_cancel_test.go
+++ b/sidechain-orchestrator/api/bmm_cancel_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -48,6 +49,9 @@ type cancelNode struct {
 	tip string
 	// incrementalFee is the incremental relay fee, in BTC/kvB.
 	incrementalFee float64
+	// late names bids the mempool gets over a transaction after its first
+	// descendant read.
+	late map[string][]string
 }
 
 func (n *cancelNode) call(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
@@ -66,7 +70,14 @@ func (n *cancelNode) call(_ context.Context, method, paramsJSON, _ string) (json
 	case "getbestblockhash":
 		return json.Marshal(n.tip)
 	case "getmempooldescendants":
-		return json.Marshal(n.txs[txid].descendants)
+		tx := n.txs[txid]
+		out := tx.descendants
+		if late := n.late[txid]; len(late) > 0 {
+			tx.descendants = append(slices.Clone(out), late...)
+			n.txs[txid] = tx
+			delete(n.late, txid)
+		}
+		return json.Marshal(out)
 	case "getnetworkinfo":
 		return json.Marshal(map[string]any{"incrementalfee": n.incrementalFee})
 	case "getmempoolentry":
@@ -330,4 +341,25 @@ func TestCancelBidPaysTheIncrementalRelayFeeOnItsSize(t *testing.T) {
 	require.Len(t, w.sends[0].RequiredInputs, coins)
 	require.Equal(t, int64(10_000+2*(2_100+coins)), got.FeeSats,
 		"the evicted fee plus 2 sat/vB on the largest the cancel can be")
+}
+
+// The bidder can put a live bid over the chain after the guard reads it. The
+// cancel pays only for the bids the guard saw, so the node refuses to evict it.
+func TestCancelBidPaysOnlyForTheBidsItChecked(t *testing.T) {
+	node := strandedNode()
+	node.txs["live"] = cancelTx{
+		vin:      []string{"lost:1"},
+		values:   []int64{0, 99_970_000},
+		slot:     4,
+		prevMain: cancelTip,
+		feeSats:  20_000,
+	}
+	node.late = map[string][]string{"lost": {"live"}}
+	w := &fakeBidWallet{sendTxid: "replacement"}
+
+	got, err := cancel(t, node, w, "lost")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"lost"}, got.CancelledTxids)
+	require.Equal(t, int64(10_189), got.FeeSats, "under the live bid's fee, so the node refuses the cancel")
 }

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -1075,33 +1075,42 @@ func (h *BMMHandler) sidechainConfig(binary pb.BinaryType) (orchestrator.BinaryC
 //
 // A transaction the mempool no longer holds needs no floor at all.
 func (h *BMMHandler) replacementFloorSats(ctx context.Context, roots []string) (int64, error) {
-	total, err := h.evictedFeeSats(ctx, roots)
+	total, err := h.evictedFeeSats(ctx, h.evictedByReplacement(ctx, roots))
 	if err != nil || total == 0 {
 		return 0, err
 	}
 	return total + replacementBumpSats, nil
 }
 
-// evictedFeeSats totals the modified fees of every mempool transaction a
-// replacement of roots evicts.
-func (h *BMMHandler) evictedFeeSats(ctx context.Context, roots []string) (int64, error) {
+// evictedByReplacement names every transaction the replacement removes: each
+// root of the chain and everything the mempool holds over it.
+func (h *BMMHandler) evictedByReplacement(ctx context.Context, roots []string) []string {
 	// One chain can carry two roots, and a bid over both of them belongs to
 	// each root's descendants. So each transaction counts one time, by txid.
-	counted := make(map[string]bool)
-	var total int64
+	seen := make(map[string]bool)
+	var all []string
 	for _, root := range roots {
 		for _, txid := range append([]string{root}, h.mempoolDescendants(ctx, root)...) {
-			if counted[txid] {
+			if seen[txid] {
 				continue
 			}
-			counted[txid] = true
-			fee, ok, err := h.modifiedFeeSats(ctx, txid)
-			if err != nil {
-				return 0, err
-			}
-			if ok {
-				total += fee
-			}
+			seen[txid] = true
+			all = append(all, txid)
+		}
+	}
+	return all
+}
+
+// evictedFeeSats totals the modified fees of the evicted transactions.
+func (h *BMMHandler) evictedFeeSats(ctx context.Context, evicted []string) (int64, error) {
+	var total int64
+	for _, txid := range evicted {
+		fee, ok, err := h.modifiedFeeSats(ctx, txid)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			total += fee
 		}
 	}
 	// A node that deprioritised the chain reports a fee far below zero, and a


### PR DESCRIPTION
A BMM cancel read the mempool two times: one time for the live-bid guard, and one time for the fee.
A live bid that arrived between the two reads got paid for, so the cancel evicted it.
The guard and the fee now read one list, so the node refuses that cancel. Follow-up to #2242.