### PR TITLE
integration: cache test binaries outside the home

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Cache managed binaries
         uses: actions/cache@v5
         with:
-          path: ~/.local/share/bitwindow/assets/bin
+          path: ~/.cache/drivechain-test-binaries
           key: managed-binaries-v2-${{ runner.os }}-${{ hashFiles('sidechain-orchestrator/chains_config.json', 'sidechain-orchestrator/config/chains_config.json') }}
 
       - name: Run bitwindow backend smoke test
@@ -70,11 +70,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            cache-path: ~/.local/share/bitwindow/assets/bin
+            cache-path: ~/.cache/drivechain-test-binaries
           - os: windows-latest
-            cache-path: ~/AppData/Roaming/10520LayertwoLabs/BitWindow/assets/bin
+            cache-path: ~/AppData/Local/drivechain-test-binaries
           - os: macos-latest
-            cache-path: ~/Library/Application Support/bitwindow/assets/bin
+            cache-path: ~/Library/Caches/drivechain-test-binaries
 
     steps:
       - uses: actions/checkout@v5

--- a/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
+++ b/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
@@ -30,6 +30,7 @@ import (
 	walletpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	walletrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/localauth"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/testharness"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -152,6 +153,7 @@ func startBitwindowd(t *testing.T, binPath string, node *orchestratorOnlyNode, a
 		"--enforcer.host", fmt.Sprintf("127.0.0.1:%d", node.EnforcerGRPCPort),
 		"--orchestrator.addr", fmt.Sprintf("http://127.0.0.1:%d", node.OrchdGRPCPort),
 	)
+	cmd.Env = append(os.Environ(), "HOME="+filepath.Dir(node.BitwindowDir))
 	cmd.Stdout = stdoutFile
 	cmd.Stderr = stderrFile
 
@@ -190,9 +192,12 @@ func newOrchestratorOnlyNode(t *testing.T) *orchestratorOnlyNode {
 	rpcPort := basePort
 	p2pPort := basePort + 100
 	grpcPort := basePort + 200
-	prepareEnforcerConfigForSmokeTest(t, basePort+210, basePort+211, basePort+212)
 
 	nodeDir := filepath.Join(rootDir, "node0")
+	orchconfig.SetHomeDir(nodeDir)
+	t.Cleanup(func() { orchconfig.SetHomeDir("") })
+	prepareEnforcerConfigForSmokeTest(t, basePort+210, basePort+211, basePort+212)
+
 	bitwindowDir := filepath.Join(nodeDir, "bitwindow")
 	bitcoinDataDir := filepath.Join(nodeDir, "bitcoin")
 	require.NoError(t, os.MkdirAll(bitwindowDir, 0o700))
@@ -240,6 +245,8 @@ port=%d
 		"--loglevel", "info",
 		"--binary=enforcer",
 	)
+	// Confines drivechaind and the daemons it spawns to nodeDir.
+	orchCmd.Env = append(os.Environ(), "HOME="+nodeDir, "XDG_DATA_HOME="+filepath.Join(nodeDir, ".local", "share"))
 	orchStdout, err := orchCmd.StdoutPipe()
 	require.NoError(t, err)
 	orchStderr, err := orchCmd.StderrPipe()
@@ -335,7 +342,7 @@ func (n *orchestratorOnlyNode) Close(t *testing.T) {
 func findEnforcer(t *testing.T) string {
 	t.Helper()
 	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
-	dataDir := orchestrator.DefaultDataDir()
+	dataDir := testharness.BinaryCacheDir(t)
 	orchPath := orchestrator.BinaryPath(dataDir, "bip300301-enforcer")
 
 	if _, err := os.Stat(orchPath); err == nil {
@@ -343,7 +350,7 @@ func findEnforcer(t *testing.T) string {
 		return orchPath
 	}
 
-	configPath := orchestrator.ConfigFilePath(orchestrator.DefaultBitwindowDir())
+	configPath := orchestrator.ConfigFilePath(dataDir)
 	configs := orchestrator.LoadConfigFile(configPath, log)
 	var enforcerConfig *orchestrator.BinaryConfig
 	for i := range configs {
@@ -370,20 +377,9 @@ func findEnforcer(t *testing.T) string {
 func findBitcoind(t *testing.T) string {
 	t.Helper()
 	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
-	dataDir := orchestrator.DefaultDataDir()
-	bitwindowDir := orchestrator.DefaultBitwindowDir()
-	configPath := orchestrator.ConfigFilePath(bitwindowDir)
+	dataDir := testharness.BinaryCacheDir(t)
+	configPath := orchestrator.ConfigFilePath(dataDir)
 	configs := orchestrator.LoadConfigFile(configPath, log)
-	orchPath := orchestrator.ActiveCoreBinaryPath(dataDir, bitwindowDir, configs, "bitcoind", "regtest", "")
-
-	if _, err := os.Stat(orchPath); err == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := exec.CommandContext(ctx, orchPath, "--version").Run(); err == nil {
-			log.Info().Str("path", orchPath).Msg("found working bitcoind via orchestrator")
-			return orchPath
-		}
-	}
 
 	var bitcoindConfig *orchestrator.BinaryConfig
 	for i := range configs {
@@ -394,10 +390,21 @@ func findBitcoind(t *testing.T) string {
 	}
 	require.NotNil(t, bitcoindConfig)
 
-	dm := orchestrator.NewDownloadManager(dataDir, configPath, log)
 	// bitcoind downloads are now variant-keyed; pick a regtest-compatible
 	// variant explicitly since we don't have a full Orchestrator here.
 	variant := bitcoindConfig.Variants["core"]
+	orchPath := orchestrator.CoreBinaryPath(dataDir, variant, "bitcoind")
+
+	if _, err := os.Stat(orchPath); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := exec.CommandContext(ctx, orchPath, "--version").Run(); err == nil {
+			log.Info().Str("path", orchPath).Msg("found working bitcoind via orchestrator")
+			return orchPath
+		}
+	}
+
+	dm := orchestrator.NewDownloadManager(dataDir, configPath, log)
 	dm.CoreVariant = func() (orchestrator.CoreVariantSpec, bool) { return variant, true }
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/sidechain-orchestrator/testharness/bitcoind.go
+++ b/sidechain-orchestrator/testharness/bitcoind.go
@@ -4,12 +4,23 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
 	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
 	"github.com/rs/zerolog"
 )
+
+// BinaryCacheDir returns the directory integration tests download managed binaries into.
+func BinaryCacheDir(t *testing.T) string {
+	t.Helper()
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("testharness: user cache dir: %v", err)
+	}
+	return filepath.Join(cache, "drivechain-test-binaries")
+}
 
 // bitcoindBinaryPath returns the on-disk path for a specific Core variant
 // from a configs slice. Falls back to the legacy flat layout when the variant
@@ -40,7 +51,7 @@ func findBitcoind(t *testing.T, log zerolog.Logger) string {
 		return bin
 	}
 
-	dataDir := orchestrator.DefaultDataDir()
+	dataDir := BinaryCacheDir(t)
 	// Testharness uses the default ("patched") variant unconditionally — it
 	// always wants the drivechain build, regardless of whatever the user has
 	// pinned in orchestrator_settings.json.
@@ -61,7 +72,7 @@ func findBitcoind(t *testing.T, log zerolog.Logger) string {
 	// Download using orchestrator's download logic.
 	log.Info().Msg("downloading bitcoind via orchestrator...")
 
-	configPath := orchestrator.ConfigFilePath(orchestrator.DefaultBitwindowDir())
+	configPath := orchestrator.ConfigFilePath(dataDir)
 	configs = orchestrator.LoadConfigFile(configPath, log)
 
 	var bitcoindConfig *orchestrator.BinaryConfig


### PR DESCRIPTION
The HomeDir test guard moved the managed binary cache into a new temp home, so the smoke test downloaded bitcoind on each run and timed out.
Integration tests now cache binaries in the user cache dir, and CI caches that path. The smoke test runs drivechaind and bitwindowd with a temp HOME, so the enforcer stays out of the real app data.