### PR TITLE
sail_ui: increase timestamp width & split timestamp from log msg

### DIFF
--- a/sail_ui/lib/pages/log_page.dart
+++ b/sail_ui/lib/pages/log_page.dart
@@ -557,8 +557,9 @@ class _ProcessLogsTabState extends State<_ProcessLogsTab> {
                     color: SailColorScheme.greyLight,
                   ),
                 ),
-                SailText.secondary12('|',
-                    color: SailColorScheme.greyLight,
+                SailText.secondary12(
+                  '|',
+                  color: SailColorScheme.greyLight,
                 ),
                 const SizedBox(width: 8),
                 if (log.isStderr) ...[

--- a/sail_ui/lib/pages/log_page.dart
+++ b/sail_ui/lib/pages/log_page.dart
@@ -119,10 +119,9 @@ class _FileLogsTabState extends State<_FileLogsTab> {
                   if (index == _logLines.length) {
                     return const SizedBox(height: 100);
                   }
-                  final timestamp = _logLines[index].length > 20
-                      ? DateTime.tryParse(_logLines[index].substring(0, 20))
-                      : DateTime.now();
-                  final logMsg = timestamp != null ? _logLines[index].substring(20) : _logLines[index];
+                  final line = _logLines[index];
+                  final timestamp = line.length > 20 ? DateTime.tryParse(line.substring(0, 20)) : null;
+                  final logMsg = timestamp != null ? line.substring(20) : line;
                   return Padding(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 16.0,
@@ -132,10 +131,10 @@ class _FileLogsTabState extends State<_FileLogsTab> {
                       scrollDirection: Axis.horizontal,
                       child: Row(
                         children: [
-                          SailText.secondary12(
-                            formatDate(timestamp ?? DateTime.now(), long: false),
-                          ),
-                          SailText.secondary12(' | '),
+                          if (timestamp != null) ...[
+                            SailText.secondary12(formatDate(timestamp, long: false)),
+                            SailText.secondary12(' | '),
+                          ],
                           Text.rich(
                             _parseAnsiCodes(logMsg),
                             softWrap: false,

--- a/sail_ui/lib/pages/log_page.dart
+++ b/sail_ui/lib/pages/log_page.dart
@@ -119,6 +119,10 @@ class _FileLogsTabState extends State<_FileLogsTab> {
                   if (index == _logLines.length) {
                     return const SizedBox(height: 100);
                   }
+                  final timestamp = _logLines[index].length > 20
+                      ? DateTime.tryParse(_logLines[index].substring(0, 20))
+                      : DateTime.now();
+                  final logMsg = timestamp != null ? _logLines[index].substring(20) : _logLines[index];
                   return Padding(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 16.0,
@@ -126,14 +130,22 @@ class _FileLogsTabState extends State<_FileLogsTab> {
                     ),
                     child: SingleChildScrollView(
                       scrollDirection: Axis.horizontal,
-                      child: Text.rich(
-                        _parseAnsiCodes(_logLines[index]),
-                        softWrap: false,
-                        style: const TextStyle(
-                          fontFamily: 'IBMPlexMono',
-                          fontSize: 10,
-                          color: SailColorScheme.whiteDark,
-                        ),
+                      child: Row(
+                        children: [
+                          SailText.secondary12(
+                            formatDate(timestamp ?? DateTime.now(), long: false),
+                          ),
+                          SailText.secondary12(' | '),
+                          Text.rich(
+                            _parseAnsiCodes(logMsg),
+                            softWrap: false,
+                            style: const TextStyle(
+                              fontFamily: 'IBMPlexMono',
+                              fontSize: 10,
+                              color: SailColorScheme.whiteDark,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   );
@@ -557,10 +569,7 @@ class _ProcessLogsTabState extends State<_ProcessLogsTab> {
                     color: SailColorScheme.greyLight,
                   ),
                 ),
-                SailText.secondary12(
-                  '|',
-                  color: SailColorScheme.greyLight,
-                ),
+                SailText.secondary12('|', color: SailColorScheme.greyLight),
                 const SizedBox(width: 8),
                 if (log.isStderr) ...[
                   Container(
@@ -580,7 +589,10 @@ class _ProcessLogsTabState extends State<_ProcessLogsTab> {
                   const SizedBox(width: 8),
                 ],
                 Expanded(
-                  child: SailText.primary12(log.message.substring(20), color: textColor),
+                  child: SailText.primary12(
+                    log.message.substring(20),
+                    color: textColor,
+                  ),
                 ),
               ],
             ),

--- a/sail_ui/lib/pages/log_page.dart
+++ b/sail_ui/lib/pages/log_page.dart
@@ -551,11 +551,14 @@ class _ProcessLogsTabState extends State<_ProcessLogsTab> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SizedBox(
-                  width: 90,
+                  width: 130,
                   child: SailText.secondary12(
                     formatDate(log.timestamp, long: false),
                     color: SailColorScheme.greyLight,
                   ),
+                ),
+                SailText.secondary12('|',
+                    color: SailColorScheme.greyLight,
                 ),
                 const SizedBox(width: 8),
                 if (log.isStderr) ...[
@@ -576,7 +579,7 @@ class _ProcessLogsTabState extends State<_ProcessLogsTab> {
                   const SizedBox(width: 8),
                 ],
                 Expanded(
-                  child: SailText.primary12(log.message, color: textColor),
+                  child: SailText.primary12(log.message.substring(20), color: textColor),
                 ),
               ],
             ),


### PR DESCRIPTION
Also adds a pipe between timestamp and log message, see below:
<img width="840" height="446" alt="image" src="https://github.com/user-attachments/assets/0021c2ff-745c-4257-b7b3-b1987de991c3" />
