### PR TITLE
orchestrator: protect live BMM bid coins

### DIFF
--- a/sidechain-orchestrator/api/bmm_frozen.go
+++ b/sidechain-orchestrator/api/bmm_frozen.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"connectrpc.com/connect"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// FrozenCoins names the candidates a live BMM bid can take away, keyed
+// txid:vout. It answers with no frozen coin in light mode, where no bid runs.
+//
+// A replacement evicts every mempool descendant of the bid it replaces, so a
+// send over the change of a live bid dies with that bid. A send over the coin
+// the bid spends replaces the bid itself. An unconfirmed coin the mainchain
+// node cannot name yet counts as frozen, because nothing else can tell a bid's
+// change from any other change.
+func (h *BMMHandler) FrozenCoins(
+	ctx context.Context, candidates []wallet.Outpoint,
+) (map[string]bool, error) {
+	if len(candidates) == 0 || !h.BMMAvailable() {
+		return nil, nil
+	}
+
+	held, err := h.mempoolTxids(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bids := newBidCache(h)
+
+	frozen := make(map[string]bool)
+	for _, c := range candidates {
+		if !held[c.TxID] {
+			// An Electrum wallet broadcasts through Esplora and lists its own
+			// change before Core sees the transaction that paid it. A coin no
+			// block holds, and no mempool names, can still be a bid's change.
+			if !c.Confirmed {
+				frozen[c.Key()] = true
+			}
+			continue
+		}
+		onABid, err := bids.overABid(ctx, c.TxID)
+		if err != nil {
+			return nil, err
+		}
+		if onABid {
+			frozen[c.Key()] = true
+		}
+	}
+
+	spent, err := h.bidSpentCoins(ctx, candidates, bids)
+	if err != nil {
+		return nil, err
+	}
+	for key := range spent {
+		frozen[key] = true
+	}
+	return frozen, nil
+}
+
+// bidSpentCoins names the candidates a live bid already spends. A second spend
+// of one conflicts with that bid, and the node takes it only as a replacement
+// that pays more.
+func (h *BMMHandler) bidSpentCoins(
+	ctx context.Context, candidates []wallet.Outpoint, bids *bidCache,
+) (map[string]bool, error) {
+	if bids == nil {
+		bids = newBidCache(h)
+	}
+	spenders, err := h.mempoolSpenders(ctx, candidates)
+	if err != nil {
+		return nil, err
+	}
+	spent := make(map[string]bool, len(spenders))
+	for key, txid := range spenders {
+		bid, err := bids.get(ctx, txid)
+		if err != nil {
+			return nil, err
+		}
+		if bid != nil {
+			spent[key] = true
+		}
+	}
+	return spent, nil
+}
+
+func newBidCache(h *BMMHandler) *bidCache {
+	return &bidCache{
+		h:       h,
+		read:    map[string]*orchestrator.BmmRequest{},
+		lineage: map[string]*orchestrator.BmmRequest{},
+	}
+}
+
+// bidCache reads the bid a transaction carries one time.
+type bidCache struct {
+	h    *BMMHandler
+	read map[string]*orchestrator.BmmRequest
+	// lineage names the bid each transaction carries or descends from.
+	lineage map[string]*orchestrator.BmmRequest
+}
+
+// overABid says whether the transaction carries a bid, or spends the coins of
+// one through its mempool ancestors. A replacement of the bid evicts the whole
+// line below it.
+func (c *bidCache) overABid(ctx context.Context, txid string) (bool, error) {
+	bid, err := c.lineageBid(ctx, txid)
+	if err != nil {
+		return false, err
+	}
+	return bid != nil, nil
+}
+
+// lineageBid names the bid a transaction carries, or the bid its mempool
+// ancestors carry. It answers nil for a line that holds none.
+func (c *bidCache) lineageBid(ctx context.Context, txid string) (*orchestrator.BmmRequest, error) {
+	if bid, done := c.lineage[txid]; done {
+		return bid, nil
+	}
+	bid, err := c.get(ctx, txid)
+	if err != nil {
+		return nil, err
+	}
+	if bid == nil {
+		ancestors, err := c.h.mempoolAncestors(ctx, txid)
+		if err != nil {
+			return nil, err
+		}
+		for _, ancestor := range ancestors {
+			bid, err = c.get(ctx, ancestor)
+			if err != nil {
+				return nil, err
+			}
+			if bid != nil {
+				break
+			}
+		}
+	}
+	c.lineage[txid] = bid
+	return bid, nil
+}
+
+func (c *bidCache) get(ctx context.Context, txid string) (*orchestrator.BmmRequest, error) {
+	if bid, done := c.read[txid]; done {
+		return bid, nil
+	}
+	bid, err := c.h.m8Request(ctx, txid)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, err)
+	}
+	c.read[txid] = bid
+	return bid, nil
+}
+
+// mempoolAncestors names every unconfirmed ancestor of a mempool transaction.
+func (h *BMMHandler) mempoolAncestors(ctx context.Context, txid string) ([]string, error) {
+	raw, err := h.coreCall(ctx, "getmempoolancestors", fmt.Sprintf("[%q]", txid))
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf(
+			"read the ancestors of %s: %w", txid, err))
+	}
+	var ancestors []string
+	if err := json.Unmarshal(raw, &ancestors); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf(
+			"decode the ancestors of %s: %w", txid, err))
+	}
+	return ancestors, nil
+}
+
+// spenderQueryLimit is what one gettxspendingprevout call takes. Bitcoin Core
+// refuses a larger query.
+const spenderQueryLimit = 100
+
+// mempoolSpenders names the mempool transaction that spends each candidate, by
+// the txid:vout of the candidate. It skips a candidate no transaction spends.
+func (h *BMMHandler) mempoolSpenders(
+	ctx context.Context, candidates []wallet.Outpoint,
+) (map[string]string, error) {
+	out := make(map[string]string, len(candidates))
+	for batch := range slices.Chunk(candidates, spenderQueryLimit) {
+		if err := h.readSpenderBatch(ctx, batch, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (h *BMMHandler) readSpenderBatch(
+	ctx context.Context, candidates []wallet.Outpoint, out map[string]string,
+) error {
+	outputs := make([]map[string]any, 0, len(candidates))
+	for _, c := range candidates {
+		outputs = append(outputs, map[string]any{"txid": c.TxID, "vout": c.Vout})
+	}
+	params, err := json.Marshal([]any{outputs})
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("build the spender query: %w", err))
+	}
+
+	raw, err := h.coreCall(ctx, "gettxspendingprevout", string(params))
+	if err != nil {
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("read the spenders of the wallet coins: %w", err))
+	}
+	var spends []struct {
+		Txid         string `json:"txid"`
+		Vout         int    `json:"vout"`
+		SpendingTxid string `json:"spendingtxid"`
+	}
+	if err := json.Unmarshal(raw, &spends); err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("decode the spenders of the wallet coins: %w", err))
+	}
+
+	for _, s := range spends {
+		if s.SpendingTxid == "" {
+			continue
+		}
+		out[wallet.Outpoint{TxID: s.Txid, Vout: s.Vout}.Key()] = s.SpendingTxid
+	}
+	return nil
+}

--- a/sidechain-orchestrator/api/bmm_frozen_test.go
+++ b/sidechain-orchestrator/api/bmm_frozen_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+const (
+	liveBid  = "1111111111111111111111111111111111111111111111111111111111111111"
+	plainTx  = "2222222222222222222222222222222222222222222222222222222222222222"
+	oldBlock = "3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+func frozenHandler(t *testing.T, mempool *fakeSlotMempool) *BMMHandler {
+	t.Helper()
+	h, _ := newBMMModeHandler(t)
+	h.SetCoreCaller(mempool.call)
+	return h
+}
+
+// The change of a live bid dies with the replacement of that bid, because a
+// replacement evicts every mempool descendant.
+func TestFrozenCoinsHoldsTheChangeOfALiveBid(t *testing.T) {
+	h := frozenHandler(t, &fakeSlotMempool{slots: map[string]int{liveBid: 9}, plain: []string{plainTx}})
+
+	frozen, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{
+		{TxID: liveBid, Vout: 1},
+		{TxID: plainTx, Vout: 0},
+		{TxID: oldBlock, Vout: 0, Confirmed: true},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, frozen[liveBid+":1"], "the bid change belongs to the bid")
+	assert.False(t, frozen[plainTx+":0"], "an ordinary mempool coin stays free")
+	assert.False(t, frozen[oldBlock+":0"], "a confirmed coin stays free")
+}
+
+// A send over the coin a live bid spends replaces the bid itself.
+func TestFrozenCoinsHoldsACoinALiveBidSpends(t *testing.T) {
+	h := frozenHandler(t, &fakeSlotMempool{
+		slots:  map[string]int{liveBid: 9},
+		plain:  []string{plainTx},
+		spends: map[string]string{oldBlock + ":0": liveBid, oldBlock + ":1": plainTx},
+	})
+
+	frozen, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{
+		{TxID: oldBlock, Vout: 0, Confirmed: true},
+		{TxID: oldBlock, Vout: 1, Confirmed: true},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, frozen[oldBlock+":0"], "a live bid spends this coin")
+	assert.False(t, frozen[oldBlock+":1"], "an ordinary send spends this coin")
+}
+
+// The mempool drops a bid the chain confirms, and the coins it held go free.
+func TestFrozenCoinsFreesTheCoinsOfAConfirmedBid(t *testing.T) {
+	h := frozenHandler(t, &fakeSlotMempool{})
+
+	frozen, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{
+		{TxID: liveBid, Vout: 1, Confirmed: true},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, frozen)
+}
+
+// An Electrum wallet lists its own change before Core sees the transaction
+// that paid it, so an unconfirmed coin the node cannot name waits.
+func TestFrozenCoinsHoldsAnUnconfirmedCoinTheNodeCannotName(t *testing.T) {
+	h := frozenHandler(t, &fakeSlotMempool{})
+
+	frozen, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{{TxID: liveBid, Vout: 1}})
+	require.NoError(t, err)
+	assert.True(t, frozen[liveBid+":1"])
+}
+
+// Light mode runs no bid, and reads no mainchain node.
+func TestFrozenCoinsHoldsNothingInLightMode(t *testing.T) {
+	h := frozenHandler(t, &fakeSlotMempool{slots: map[string]int{liveBid: 9}})
+	require.NoError(t, orchestrator.WriteNodeMode(h.orch.BitwindowDir, orchestrator.NodeModeLight))
+
+	frozen, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{{TxID: liveBid, Vout: 1}})
+	require.NoError(t, err)
+	assert.Empty(t, frozen)
+}
+
+// A node the handler cannot read leaves the freeze unknown, and an unknown
+// freeze must fail the send rather than spend a coin a bid holds.
+func TestFrozenCoinsFailsOnAnUnreadableMempoolTx(t *testing.T) {
+	h := frozenHandler(t, &fakeSlotMempool{unreadable: []string{liveBid}})
+
+	_, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{{TxID: liveBid, Vout: 1}})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), liveBid))
+}
+
+// A deposit over the change of a live bid is no bid itself, and a replacement
+// of the bid below it evicts it just the same.
+func TestFrozenCoinsHoldsTheChangeOfABidDescendant(t *testing.T) {
+	const deposit = "5555555555555555555555555555555555555555555555555555555555555555"
+	h := frozenHandler(t, &fakeSlotMempool{
+		slots:     map[string]int{liveBid: 9},
+		plain:     []string{deposit, plainTx},
+		ancestors: map[string][]string{deposit: {liveBid}, plainTx: {}},
+	})
+
+	frozen, err := h.FrozenCoins(context.Background(), []wallet.Outpoint{
+		{TxID: deposit, Vout: 2},
+		{TxID: plainTx, Vout: 0},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, frozen[deposit+":2"], "the deposit sits over a live bid")
+	assert.False(t, frozen[plainTx+":0"], "an ordinary mempool coin stays free")
+}
+
+// Bitcoin Core takes at most 100 outpoints in one gettxspendingprevout call.
+func TestFrozenCoinsQueriesTheSpendersInBatches(t *testing.T) {
+	mempool := &fakeSlotMempool{}
+	h := frozenHandler(t, mempool)
+
+	candidates := make([]wallet.Outpoint, 0, 250)
+	for i := range 250 {
+		candidates = append(candidates, wallet.Outpoint{TxID: oldBlock, Vout: i, Confirmed: true})
+	}
+	_, err := h.FrozenCoins(context.Background(), candidates)
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{100, 100, 50}, mempool.spenderQueries)
+}

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -27,6 +27,7 @@ import (
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
 	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
 // bmmAncestorWalk bounds the walk back from the tip when looking for the block
@@ -629,12 +630,17 @@ func (h *BMMHandler) slotCoin(
 		return nil, err
 	}
 
+	// A slot-sized coin comes first, smallest of them: it covers the bid and
+	// every raise on it, and it keeps the larger coins of the wallet out of the
+	// bid lineage, where a replacement takes away whatever hangs below.
+	want := bidSats + bmmSlotCoinFeeSats
+	slotSats := slotCoinSats(req.MaxBidSats)
 	var coin *wpb.UnspentOutput
 	for _, u := range coins.own {
-		if u.AmountSats < bidSats+bmmSlotCoinFeeSats {
+		if u.AmountSats < want {
 			continue
 		}
-		if coin == nil || u.AmountSats > coin.AmountSats {
+		if coin == nil || betterSlotCoin(u, coin, slotSats) {
 			coin = u
 		}
 	}
@@ -645,6 +651,20 @@ func (h *BMMHandler) slotCoin(
 			"the wallet holds no coin of its own for slot %d", slot))
 	}
 	return coin, nil
+}
+
+// betterSlotCoin says whether a beats b as the coin one slot bids from. A coin
+// that covers a full round of raises comes first, and the smallest of those
+// wins. A wallet with none of them falls back to its largest coin.
+func betterSlotCoin(a, b *wpb.UnspentOutput, slotSats int64) bool {
+	aFits, bFits := a.AmountSats >= slotSats, b.AmountSats >= slotSats
+	if aFits != bFits {
+		return aFits
+	}
+	if aFits {
+		return a.AmountSats < b.AmountSats
+	}
+	return a.AmountSats > b.AmountSats
 }
 
 // PrepareBMM gives every bidding sidechain a coin of its own, and splits one
@@ -801,10 +821,23 @@ func (h *BMMHandler) readWalletCoins(
 	if err != nil {
 		return nil, err
 	}
+	// An electrum scan lists a coin a live bid already spends until the scan
+	// catches up. An opening bid over one of those conflicts with that bid, and
+	// the node refuses it at the same fee.
+	bids := newBidCache(h)
+	spent, err := h.bidSpentCoins(ctx, lo.Map(unspent.Msg.Utxos, func(u *wpb.UnspentOutput, _ int) wallet.Outpoint {
+		return wallet.Outpoint{TxID: u.Txid, Vout: int(u.Vout), Confirmed: u.Confirmations > 0}
+	}), bids)
+	if err != nil {
+		return nil, err
+	}
 
 	out := &walletCoins{held: held}
 	for _, u := range unspent.Msg.Utxos {
 		if !u.Spendable {
+			continue
+		}
+		if spent[(wallet.Outpoint{TxID: u.Txid, Vout: int(u.Vout)}).Key()] {
 			continue
 		}
 		if u.Confirmations > 0 {
@@ -813,10 +846,21 @@ func (h *BMMHandler) readWalletCoins(
 			out.free = append(out.free, u)
 			continue
 		}
-		request, err := h.m8Request(ctx, u.Txid)
+		// A deposit over a bid carries no bid of its own, and a replacement of
+		// the bid below it takes the deposit and its change away as well.
+		request, err := bids.get(ctx, u.Txid)
 		if err != nil {
 			zerolog.Ctx(ctx).Debug().Err(err).Str("txid", u.Txid).Msg("read the parent of a wallet coin")
 			continue
+		}
+		if request == nil {
+			ancestor, err := bids.lineageBid(ctx, u.Txid)
+			if err != nil {
+				return nil, err
+			}
+			if ancestor != nil {
+				continue
+			}
 		}
 		out.all = append(out.all, u)
 		if request == nil {

--- a/sidechain-orchestrator/api/bmm_slot_coin_test.go
+++ b/sidechain-orchestrator/api/bmm_slot_coin_test.go
@@ -27,6 +27,14 @@ type fakeSlotMempool struct {
 	plain []string
 	// unreadable names the mempool transactions the node refuses to read.
 	unreadable []string
+	// spends names the mempool transaction that spends each outpoint, by
+	// txid:vout.
+	spends map[string]string
+	// ancestors names the unconfirmed ancestors of each mempool transaction.
+	ancestors map[string][]string
+	// spenderQueries counts the gettxspendingprevout calls, and the outpoints
+	// each one carried.
+	spenderQueries []int
 }
 
 func (m *fakeSlotMempool) call(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
@@ -46,6 +54,32 @@ func (m *fakeSlotMempool) call(_ context.Context, method, paramsJSON, _ string) 
 			entries[txid] = map[string]any{"fees": map[string]any{"base": 0.0001}}
 		}
 		return json.Marshal(entries)
+
+	case "getmempoolancestors":
+		var params []string
+		if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+			return nil, err
+		}
+		return json.Marshal(m.ancestors[params[0]])
+
+	case "gettxspendingprevout":
+		var params [][]struct {
+			Txid string `json:"txid"`
+			Vout int    `json:"vout"`
+		}
+		if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+			return nil, err
+		}
+		m.spenderQueries = append(m.spenderQueries, len(params[0]))
+		out := []map[string]any{}
+		for _, o := range params[0] {
+			entry := map[string]any{"txid": o.Txid, "vout": o.Vout}
+			if spender, ok := m.spends[fmt.Sprintf("%s:%d", o.Txid, o.Vout)]; ok {
+				entry["spendingtxid"] = spender
+			}
+			out = append(out, entry)
+		}
+		return json.Marshal(out)
 
 	case "getrawtransaction":
 		var params []any
@@ -208,19 +242,19 @@ func TestSlotCoinGivesTwoSlotsTwoCoins(t *testing.T) {
 	ctx := context.Background()
 	coinOne, err := h.slotCoin(ctx, bidRequest(), 1, 10_000)
 	require.NoError(t, err)
-	require.Equal(t, first, coinOne.Txid)
+	require.Equal(t, second, coinOne.Txid, "the smaller slot-sized coin comes first")
 
 	// Slot 1 spends its coin, so the wallet now holds that bid's change.
 	mempool.slots = map[string]int{bidOfFirstSlot: 1}
 	wallet.utxos = []*wpb.UnspentOutput{
-		{Txid: bidOfFirstSlot, Vout: 1, AmountSats: 2_990_000, Spendable: true},
-		{Txid: second, Vout: 0, AmountSats: 2_000_000, Spendable: true, Confirmations: 6},
+		{Txid: bidOfFirstSlot, Vout: 1, AmountSats: 1_990_000, Spendable: true},
+		{Txid: first, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
 	}
 
 	coinTwo, err := h.slotCoin(ctx, bidRequest(), 2, 10_000)
 	require.NoError(t, err)
 
-	assert.Equal(t, second, coinTwo.Txid)
+	assert.Equal(t, first, coinTwo.Txid)
 	assert.NotEqual(t, coinOne.Txid, coinTwo.Txid, "the two slots spend separate coins")
 	assert.Empty(t, wallet.sends, "two free coins need no split")
 }
@@ -601,4 +635,103 @@ func TestPrepareBMMDropsTheHoldOnceTheSplitPaid(t *testing.T) {
 
 	assert.Equal(t, "split-txid", prepared(t, resp).SplitTxid, "the wallet pays the coins it still needs")
 	assert.Len(t, wallet.sends, 2)
+}
+
+// An electrum scan lists a coin a live bid already spends until it catches up.
+// An opening bid over that coin conflicts with the bid, and the node refuses it
+// at the same fee.
+func TestSlotCoinSkipsACoinALiveBidSpends(t *testing.T) {
+	const taken = "6666666666666666666666666666666666666666666666666666666666666666"
+	const free = "7777777777777777777777777777777777777777777777777777777777777777"
+	const bid = "8888888888888888888888888888888888888888888888888888888888888888"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: taken, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+		{Txid: free, Vout: 0, AmountSats: 1_000_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{
+		slots:  map[string]int{bid: 9},
+		spends: map[string]string{taken + ":0": bid},
+	}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 99, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, free, coin.Txid, "the larger coin already funds a live bid")
+}
+
+// The largest coin of the wallet pays every other send. A bid takes a
+// slot-sized coin instead, so a replacement can never take that balance away.
+func TestSlotCoinTakesTheSmallestSlotSizedCoin(t *testing.T) {
+	const slotSized = "9999999999999999999999999999999999999999999999999999999999999999"
+	const bulk = "aaaa999999999999999999999999999999999999999999999999999999999999"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: slotSized, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+		{Txid: bulk, Vout: 0, AmountSats: 480_000_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 9, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, slotSized, coin.Txid)
+}
+
+// A deposit over a live bid carries no bid of its own. A replacement of the
+// bid below it takes the deposit and its change away as well, so no other slot
+// may bid from that change.
+func TestSlotCoinSkipsTheChangeOfABidDescendant(t *testing.T) {
+	const bid = "bbbb111111111111111111111111111111111111111111111111111111111111"
+	const deposit = "cccc222222222222222222222222222222222222222222222222222222222222"
+	const free = "dddd333333333333333333333333333333333333333333333333333333333333"
+
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: deposit, Vout: 2, AmountSats: 400_000_000, Spendable: true},
+		{Txid: free, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{
+		slots:     map[string]int{bid: 9},
+		plain:     []string{deposit},
+		ancestors: map[string][]string{deposit: {bid}},
+	}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 2, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, free, coin.Txid, "the deposit change belongs to slot 9")
+}
+
+func TestSlotCoinSkipsItsOwnBidDescendant(t *testing.T) {
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: plainTx, Vout: 0, AmountSats: 4_000_000, Spendable: true},
+		{Txid: oldBlock, Vout: 0, AmountSats: 5_000_000, Spendable: true, Confirmations: 6},
+	}}
+	h := slotCoinHandler(t, &fakeSlotMempool{
+		slots:     map[string]int{liveBid: 9},
+		plain:     []string{plainTx},
+		ancestors: map[string][]string{plainTx: {liveBid}},
+	}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 9, 10_000)
+	require.NoError(t, err)
+	assert.Equal(t, oldBlock, coin.Txid)
+}
+
+func TestPrepareBMMSkipsABidDescendant(t *testing.T) {
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: plainTx, Vout: 0, AmountSats: 4_000_000, Spendable: true},
+		{Txid: oldBlock, Vout: 0, AmountSats: 10_000_000, Spendable: true, Confirmations: 6},
+	}, sendTxid: "split"}
+	h := slotCoinHandler(t, &fakeSlotMempool{
+		slots:     map[string]int{liveBid: 9},
+		plain:     []string{plainTx},
+		ancestors: map[string][]string{plainTx: {liveBid}},
+	}, wallet)
+
+	_, err := h.PrepareBMM(context.Background(), prepareRequest(2))
+	require.NoError(t, err)
+	require.Len(t, wallet.sends, 1)
+	require.Len(t, wallet.sends[0].RequiredInputs, 1)
+	assert.Equal(t, oldBlock, wallet.sends[0].RequiredInputs[0].Txid)
 }

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -512,6 +512,7 @@ func run(cctx *cli.Context) error {
 	bmmStore := bmmstate.NewStore(walletSvc.NetworkDir(), 0)
 	bmmEngine := engines.NewBmmEngine(log, bmmHandler, orch, orch, bmmStore)
 	bmmHandler.SetEngine(bmmEngine)
+	walletSvc.SetFrozenCoins(bmmHandler.FrozenCoins)
 	walletEngine.OnNetworkReset(func(dir string) { bmmStore.Rebind(dir) })
 	go func() {
 		if err := bmmEngine.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -57,7 +57,7 @@ const (
 )
 
 const (
-	reasonRefused  = "the sidechain refused the block"
+	reasonRefused  = "the sidechain did not connect the block"
 	reasonNoAnswer = "the sidechain never accepted the block"
 )
 
@@ -1232,15 +1232,16 @@ func (e *BmmEngine) retire(sidechain pb.BinaryType, round *bmmstate.Round, reaso
 	}
 	e.log.Warn().Stringer("sidechain", sidechain).Str("round", round.PrevMainHash).
 		Str("main_block", round.IncludedInBlock).Str("reason", reason).
-		Msg("retiring a won block the sidechain will not take")
+		Msg("retiring a won block the sidechain did not connect")
 	e.save(round)
 }
 
 // connectWon hands the won block to the sidechain, naming the mainchain block
 // that carries the commitment — the sidechain cannot name a block it never saw.
 //
-// An empty answer means the sidechain has not seen the inclusion yet; an answer
-// that names the block means the sidechain judged it and said no.
+// An empty answer means the sidechain has not seen the inclusion yet. An answer
+// that names the block means the sidechain did not take ours, which a node that
+// already holds the block from a peer answers as well.
 func (e *BmmEngine) connectWon(
 	ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round,
 ) roundStep {
@@ -1265,8 +1266,10 @@ func (e *BmmEngine) connectWon(
 				Msg("the sidechain has not seen the bid included yet")
 			return stepRetry
 		}
+		// A node that already holds the block from a peer answers false as
+		// well, so a false answer alone names no lost block.
 		e.log.Warn().Stringer("sidechain", sidechain).Str("critical_hash", live.CriticalHash).
-			Str("main_block", resp.Msg.MainBlockHash).Msg("sidechain refused the won block")
+			Str("main_block", resp.Msg.MainBlockHash).Msg("the sidechain did not connect the won block")
 		return stepRetire
 	}
 	live.State = BidConnected

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -480,6 +480,12 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 	}
 	protect := ReplayProtect(p.svc.Network(), req.AllowReplay)
 
+	unlock, err := p.lockFrozenCoins(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+
 	needsRawPath := req.OpReturnHex != "" ||
 		req.FeeRateSatPerVB > 0 ||
 		req.FixedFeeSats > 0 ||
@@ -730,7 +736,6 @@ func (p *CoreBackend) selectInputsForFixedFee(ctx context.Context, walletID stri
 	if err != nil {
 		return nil, 0, fmt.Errorf("list unspent: %w", err)
 	}
-
 	sort.Slice(utxos, func(i, j int) bool {
 		return utxos[i].Amount > utxos[j].Amount
 	})
@@ -921,6 +926,13 @@ func (p *CoreBackend) BumpFee(ctx context.Context, walletID string, req BumpFeeR
 	if err != nil {
 		return nil, err
 	}
+	// A bump can reach for a wallet coin when the change cannot pay the raise.
+	unlock, err := p.lockFrozenCoins(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
 	preview, tx, err := p.previewBumpFee(ctx, name, req)
 	if err != nil {
 		return nil, err
@@ -1043,6 +1055,10 @@ func (p *CoreBackend) CreateCpfp(ctx context.Context, walletID string, req CpfpR
 	if parent.Confirmations > 0 {
 		return "", connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("outpoint %s:%d is already confirmed; CPFP only applies to unconfirmed parents", req.ParentTxID, req.ParentVout))
+	}
+
+	if err := p.svc.checkCpfpParent(ctx, req); err != nil {
+		return "", err
 	}
 
 	entry, err := p.rpc.GetMempoolEntry(ctx, req.ParentTxID)

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -384,6 +384,13 @@ func (c *CoreRPCClient) ListUnspentMinConf(ctx context.Context, walletName strin
 	return utxos, nil
 }
 
+// LockUnspent locks or unlocks outputs, so Core's own coin selection leaves
+// them alone. Core holds the locks in memory, and a restart drops them.
+func (c *CoreRPCClient) LockUnspent(ctx context.Context, walletName string, unlock bool, outputs []RawInput) error {
+	_, err := c.call(ctx, walletName, "lockunspent", unlock, outputs)
+	return err
+}
+
 // CreateRawTransaction builds an unsigned transaction node-side. Outputs
 // keep their given order; each entry is {address: btc} or {"data": hex}. A
 // non-zero locktime is set on the tx, and Core lowers the given inputs'

--- a/sidechain-orchestrator/wallet/cpfp.go
+++ b/sidechain-orchestrator/wallet/cpfp.go
@@ -1,8 +1,11 @@
 package wallet
 
 import (
+	"context"
 	"fmt"
 	"math"
+
+	"connectrpc.com/connect"
 )
 
 // CpfpRequest selects an unconfirmed wallet UTXO (the parent's output that this
@@ -41,4 +44,16 @@ func cpfpChildPlan(targetRate, parentVsize, parentFee, childVsize, parentValue i
 		return 0, 0, fmt.Errorf("child fee %d sats exceeds parent output value %d sats", childFee, parentValue)
 	}
 	return childFee, parentValue - childFee, nil
+}
+
+func (s *Service) checkCpfpParent(ctx context.Context, req CpfpRequest) error {
+	parent := Outpoint{TxID: req.ParentTxID, Vout: req.ParentVout}
+	frozen, err := s.FrozenCoins(ctx, []Outpoint{parent})
+	if err != nil {
+		return err
+	}
+	if frozen[parent.Key()] {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("outpoint %s is held by a live bmm bid", parent.Key()))
+	}
+	return nil
 }

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -961,6 +961,12 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 	remaining := lo.Filter(pool, func(u electrumUTXO, _ int) bool {
 		return !required[fmt.Sprintf("%s:%d", u.txid, u.vout)]
 	})
+	// A coin a live BMM bid holds is the largest coin the wallet lists, so
+	// largest-first selection takes it first and the send dies with the bid.
+	remaining, frozenErr := p.dropFrozenCoins(ctx, remaining)
+	if frozenErr != nil {
+		return nil, nil, nil, frozenErr
+	}
 	sort.Slice(remaining, func(i, j int) bool { return remaining[i].amountSats > remaining[j].amountSats })
 
 	feeRate := float64(req.FeeRateSatPerVB)
@@ -1646,6 +1652,10 @@ func (p *ElectrumBackend) CreateCpfp(ctx context.Context, walletID string, req C
 	if parentUTXO.confirmed {
 		return "", connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("outpoint %s:%d is already confirmed; CPFP only applies to unconfirmed parents", req.ParentTxID, req.ParentVout))
+	}
+
+	if err := p.svc.checkCpfpParent(ctx, req); err != nil {
+		return "", err
 	}
 
 	parentTx, err := p.client.Tx(ctx, req.ParentTxID)

--- a/sidechain-orchestrator/wallet/frozen_coins.go
+++ b/sidechain-orchestrator/wallet/frozen_coins.go
@@ -1,0 +1,107 @@
+package wallet
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+// Outpoint names one transaction output, and says whether a block holds it.
+type Outpoint struct {
+	TxID      string
+	Vout      int
+	Confirmed bool
+}
+
+// Key names the outpoint as txid:vout.
+func (o Outpoint) Key() string { return fmt.Sprintf("%s:%d", o.TxID, o.Vout) }
+
+// FrozenCoinsFunc names the candidates a live BMM bid can take away, keyed
+// txid:vout. A coin the bid created dies with a replacement of that bid, and a
+// coin the bid spends conflicts with a second spend of it.
+type FrozenCoinsFunc func(ctx context.Context, candidates []Outpoint) (map[string]bool, error)
+
+// SetFrozenCoins wires the source that names the coins a live BMM bid holds.
+// Coin selection leaves those coins alone. A pinned input still spends one,
+// because a bid raise has to spend the inputs of the bid it replaces.
+func (s *Service) SetFrozenCoins(fn FrozenCoinsFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.frozenCoins = fn
+}
+
+// FreezesCoins says whether a source of frozen coins is wired.
+func (s *Service) FreezesCoins() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.frozenCoins != nil
+}
+
+// FrozenCoins names the candidates a live BMM bid holds. It names none while no
+// source is wired.
+func (s *Service) FrozenCoins(ctx context.Context, candidates []Outpoint) (map[string]bool, error) {
+	s.mu.RLock()
+	fn := s.frozenCoins
+	s.mu.RUnlock()
+	if fn == nil || len(candidates) == 0 {
+		return nil, nil
+	}
+	frozen, err := fn(ctx, candidates)
+	if err != nil {
+		return nil, fmt.Errorf("read the coins a bmm bid holds: %w", err)
+	}
+	return frozen, nil
+}
+
+func (p *ElectrumBackend) dropFrozenCoins(ctx context.Context, pool []electrumUTXO) ([]electrumUTXO, error) {
+	frozen, err := p.svc.FrozenCoins(ctx, lo.Map(pool, func(u electrumUTXO, _ int) Outpoint {
+		return Outpoint{TxID: u.txid, Vout: u.vout, Confirmed: u.confirmed}
+	}))
+	if err != nil || len(frozen) == 0 {
+		return pool, err
+	}
+	return lo.Filter(pool, func(u electrumUTXO, _ int) bool {
+		return !frozen[Outpoint{TxID: u.txid, Vout: u.vout}.Key()]
+	}), nil
+}
+
+// lockFrozenCoins locks the coins a live BMM bid holds for the length of one
+// send, because Core picks the coins itself on most of its send paths. The
+// caller unlocks them with the function it gets back.
+func (p *CoreBackend) lockFrozenCoins(ctx context.Context, walletName string) (func(), error) {
+	if !p.svc.FreezesCoins() {
+		return func() {}, nil
+	}
+	// The coin a live bid holds is its own change, and Core hides an
+	// unconfirmed coin from listunspent unless the call asks for it.
+	utxos, err := p.rpc.ListUnspentMinConf(ctx, walletName, 0)
+	if err != nil {
+		return nil, fmt.Errorf("list unspent: %w", err)
+	}
+	frozen, err := p.svc.FrozenCoins(ctx, lo.Map(utxos, func(u UTXO, _ int) Outpoint {
+		return Outpoint{TxID: u.TxID, Vout: u.Vout, Confirmed: u.Confirmations > 0}
+	}))
+	if err != nil {
+		return nil, err
+	}
+	held := lo.FilterMap(utxos, func(u UTXO, _ int) (RawInput, bool) {
+		return RawInput{TxID: u.TxID, Vout: u.Vout}, frozen[Outpoint{TxID: u.TxID, Vout: u.Vout}.Key()]
+	})
+	if len(held) == 0 {
+		return func() {}, nil
+	}
+	if err := p.rpc.LockUnspent(ctx, walletName, false, held); err != nil {
+		return nil, err
+	}
+	return func() {
+		// A canceled send must still give the coins back, or they stay locked
+		// until the next restart.
+		free, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := p.rpc.LockUnspent(free, walletName, true, held); err != nil {
+			p.log.Warn().Err(err).Msg("unlock the coins a bmm bid holds")
+		}
+	}, nil
+}

--- a/sidechain-orchestrator/wallet/frozen_coins_test.go
+++ b/sidechain-orchestrator/wallet/frozen_coins_test.go
@@ -1,0 +1,320 @@
+package wallet
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	frozenCoinTxid = "1111111111111111111111111111111111111111111111111111111111111111"
+	freeCoinTxid   = "2222222222222222222222222222222222222222222222222222222222222222"
+)
+
+// twoCoinWallet gives the wallet a large coin a live bid holds, and a smaller
+// free coin that covers the send on its own.
+func twoCoinWallet(t *testing.T) (*ElectrumBackend, *fakeEsplora, *WalletData, string) {
+	t.Helper()
+	p, fake, w, addr := newElectrumFixture(t)
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 2, FundedTxoSum: 5_000_000, TxCount: 2},
+	}
+	fake.utxos[addr] = []EsploraUTXO{
+		{TxID: frozenCoinTxid, Vout: 1, Value: 4_000_000, Status: EsploraStatus{Confirmed: false}},
+		{TxID: freeCoinTxid, Vout: 0, Value: 1_000_000, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}},
+	}
+	p.svc.SetFrozenCoins(func(_ context.Context, candidates []Outpoint) (map[string]bool, error) {
+		frozen := map[string]bool{}
+		for _, c := range candidates {
+			if c.TxID == frozenCoinTxid {
+				frozen[c.Key()] = true
+			}
+		}
+		return frozen, nil
+	})
+	return p, fake, w, addr
+}
+
+func broadcastTx(t *testing.T, fake *fakeEsplora) *wire.MsgTx {
+	t.Helper()
+	require.Len(t, fake.broadcast, 1)
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	return &tx
+}
+
+func inputTxids(tx *wire.MsgTx) []string {
+	txids := make([]string, 0, len(tx.TxIn))
+	for _, in := range tx.TxIn {
+		txids = append(txids, in.PreviousOutPoint.Hash.String())
+	}
+	return txids
+}
+
+// Coin selection takes the largest coin first, and the change of a live bid is
+// the largest coin the wallet lists.
+func TestElectrumSendSkipsACoinABidHolds(t *testing.T) {
+	p, fake, w, _ := twoCoinWallet(t)
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{freeCoinTxid}, inputTxids(broadcastTx(t, fake)))
+}
+
+// A deposit spends the sidechain treasury plus a wallet coin. The wallet coin
+// must outlive the next round, or the deposit dies with the bid below it.
+func TestElectrumDepositSkipsACoinABidHolds(t *testing.T) {
+	p, fake, w, _ := twoCoinWallet(t)
+	ctx := context.Background()
+
+	treasuryScript := []byte{txscript.OP_NOP5, txscript.OP_DATA_1, 9, txscript.OP_TRUE}
+	treasuryPrev := wire.NewMsgTx(2)
+	treasuryPrev.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	treasuryPrev.AddTxOut(wire.NewTxOut(250_000, treasuryScript))
+	var buf bytes.Buffer
+	require.NoError(t, treasuryPrev.Serialize(&buf))
+	ctipTxid := treasuryPrev.TxHash().String()
+	fake.hexByID[ctipTxid] = hex.EncodeToString(buf.Bytes())
+
+	_, err := p.Send(ctx, w.ID, SendRequest{
+		FixedFeeSats: 50_000,
+		RawOutputs: []TxOutSpec{
+			{RawScriptHex: hex.EncodeToString(treasuryScript), AmountSats: 1_150_000},
+		},
+		OpReturnHex:    hex.EncodeToString([]byte("sidechainaddress")),
+		ExternalInputs: []ExternalInput{{TxID: ctipTxid, Vout: 0, AmountSats: 250_000}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{ctipTxid, freeCoinTxid}, inputTxids(broadcastTx(t, fake)))
+}
+
+// A raise replaces its own bid, so it has to spend the inputs of that bid. The
+// freeze holds every other send off those coins, and lets the raise through.
+func TestElectrumSendPinsACoinTheFreezeHolds(t *testing.T) {
+	p, fake, w, _ := twoCoinWallet(t)
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+		RequiredInputs:   []RequiredInput{{TxID: frozenCoinTxid, Vout: 1}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{frozenCoinTxid}, inputTxids(broadcastTx(t, fake)))
+}
+
+// A freeze the backend cannot read leaves it blind to the bids, and a blind
+// send can spend a coin the next replacement takes away.
+func TestElectrumSendFailsWhenTheFreezeCannotBeRead(t *testing.T) {
+	p, fake, w, _ := twoCoinWallet(t)
+	p.svc.SetFrozenCoins(func(context.Context, []Outpoint) (map[string]bool, error) {
+		return nil, errors.New("the node is down")
+	})
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.ErrorContains(t, err, "the node is down")
+	assert.Empty(t, fake.broadcast)
+}
+
+// A Core-backed wallet can bid too, and its fixed-fee path picks the largest
+// coin first, which is the change of a live bid.
+func TestCoreBackendSendSkipsACoinABidHolds(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0x88), net)
+	change := p2wpkhAddr(t, fixedKey(0x99), net)
+
+	// Core hides a locked output from listunspent, which is how a lock keeps
+	// every one of its selection paths off the coin.
+	locked := map[string]bool{}
+	var minConf []json.RawMessage
+	fake.handle("listunspent", func(c bitcoindCall) (any, string) {
+		if len(c.Params) > 0 {
+			minConf = append(minConf, c.Params[0])
+		}
+		coins := []map[string]any{}
+		for _, c := range []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "amount": 0.04, "spendable": true},
+			{"txid": freeCoinTxid, "vout": 0, "amount": 0.01, "spendable": true},
+		} {
+			if !locked[fmt.Sprintf("%s:%d", c["txid"], c["vout"])] {
+				coins = append(coins, c)
+			}
+		}
+		return coins, ""
+	})
+	fake.handle("getrawchangeaddress", func(bitcoindCall) (any, string) { return change, "" })
+	var selected []RawInput
+	fake.handle("createrawtransaction", func(c bitcoindCall) (any, string) {
+		require.NoError(t, json.Unmarshal(c.Params[0], &selected))
+		return "deadbeef00112233", ""
+	})
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		return map[string]any{"hex": mustString(t, c.Params[0]), "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "txid-fixed", "" })
+
+	backend.svc.SetFrozenCoins(func(_ context.Context, candidates []Outpoint) (map[string]bool, error) {
+		frozen := map[string]bool{}
+		for _, c := range candidates {
+			if c.TxID == frozenCoinTxid {
+				frozen[c.Key()] = true
+			}
+		}
+		return frozen, nil
+	})
+
+	var locks []bitcoindCall
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		locks = append(locks, c)
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		var outputs []RawInput
+		require.NoError(t, json.Unmarshal(c.Params[1], &outputs))
+		for _, o := range outputs {
+			locked[fmt.Sprintf("%s:%d", o.TxID, o.Vout)] = !unlock
+		}
+		return true, ""
+	})
+
+	_, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, selected, 1)
+	assert.Equal(t, freeCoinTxid, selected[0].TxID)
+
+	// Core picks the coins itself on its other send paths, so the send holds a
+	// lock on the frozen coin for as long as it runs.
+	require.Len(t, locks, 2)
+	var unlock bool
+	require.NoError(t, json.Unmarshal(locks[0].Params[0], &unlock))
+	assert.False(t, unlock, "the send locks first")
+	var held []RawInput
+	require.NoError(t, json.Unmarshal(locks[0].Params[1], &held))
+	require.Len(t, held, 1)
+	assert.Equal(t, frozenCoinTxid, held[0].TxID)
+	require.NoError(t, json.Unmarshal(locks[1].Params[0], &unlock))
+	assert.True(t, unlock, "the send unlocks when it ends")
+	// The coin a live bid holds is unconfirmed change, which Core hides at the
+	// default minconf.
+	require.NotEmpty(t, minConf)
+	assert.Equal(t, "0", string(minConf[0]))
+}
+
+// A canceled send must still give the coins back, or they stay locked until
+// the next restart and the wallet cannot spend them at all.
+func TestCoreBackendUnlocksAfterACanceledSend(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		return []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "amount": 0.04, "spendable": true},
+		}, ""
+	})
+	var locks []bool
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		locks = append(locks, unlock)
+		return true, ""
+	})
+	fake.handle("sendtoaddress", func(bitcoindCall) (any, string) { return "", "the node is busy" })
+
+	backend.svc.SetFrozenCoins(func(_ context.Context, candidates []Outpoint) (map[string]bool, error) {
+		frozen := map[string]bool{}
+		for _, c := range candidates {
+			frozen[c.Key()] = true
+		}
+		return frozen, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err := backend.Send(ctx, coreID, SendRequest{
+		DestinationsSats: map[string]int64{"bcrt1qdest": 25_000},
+	})
+	cancel()
+	require.Error(t, err)
+
+	require.Equal(t, []bool{false, true}, locks, "the send locks, then unlocks")
+}
+
+func TestElectrumCpfpRejectsACoinABidHolds(t *testing.T) {
+	p, fake, w, _ := twoCoinWallet(t)
+	fake.txByID[frozenCoinTxid] = EsploraTx{
+		TxID:   frozenCoinTxid,
+		Weight: 600,
+		Fee:    150,
+		Status: EsploraStatus{Confirmed: false},
+	}
+
+	_, err := p.CreateCpfp(context.Background(), w.ID, CpfpRequest{
+		ParentTxID: frozenCoinTxid, ParentVout: 1, TargetRate: 20,
+	})
+	assert.ErrorContains(t, err, "held by a live bmm bid")
+	assert.Empty(t, fake.broadcast)
+}
+
+func TestCoreCpfpRejectsACoinABidHolds(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	backend.svc.SetFrozenCoins(func(_ context.Context, candidates []Outpoint) (map[string]bool, error) {
+		frozen := map[string]bool{}
+		for _, c := range candidates {
+			if c.TxID == frozenCoinTxid {
+				frozen[c.Key()] = true
+			}
+		}
+		return frozen, nil
+	})
+	childAddr := p2wpkhAddr(t, fixedKey(0x77), &chaincfg.RegressionNetParams)
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		return []map[string]any{{"txid": frozenCoinTxid, "vout": 1, "amount": 0.002, "spendable": true}}, ""
+	})
+	fake.handle("getmempoolentry", func(bitcoindCall) (any, string) {
+		return map[string]any{"vsize": 150, "fees": map[string]any{"base": 0.0000015}}, ""
+	})
+	fake.handle("listreceivedbyaddress", func(bitcoindCall) (any, string) {
+		return []map[string]any{{"address": childAddr, "amount": 0.0, "txids": []string{}}}, ""
+	})
+	fake.handle("createrawtransaction", func(bitcoindCall) (any, string) { return "child", "" })
+	fake.handle("signrawtransactionwithwallet", func(bitcoindCall) (any, string) {
+		return map[string]any{"hex": "child", "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "child-txid", "" })
+
+	_, err := backend.CreateCpfp(context.Background(), coreID, CpfpRequest{
+		ParentTxID: frozenCoinTxid, ParentVout: 1, TargetRate: 20,
+	})
+	assert.ErrorContains(t, err, "held by a live bmm bid")
+	assert.Empty(t, fake.callsFor("sendrawtransaction"))
+}

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -54,6 +54,10 @@ type Service struct {
 	lastWalletDigest      walletfile.Digest
 	lastWalletDigestKnown bool
 
+	// frozenCoins names the coins a live BMM bid holds, so coin selection
+	// leaves them alone.
+	frozenCoins FrozenCoinsFunc
+
 	// Callbacks
 	// Dart: deleteAllWallets stops all binaries before wiping (L560-575)
 	OnStopAllBinaries func() error


### PR DESCRIPTION
Wallet sends, fee bumps, and new bids leave live bid coins alone. Each sidechain can replace its own bid.
