### PR TITLE
orchestrator: keep the backend across app updates

### DIFF
--- a/bitwindow/lib/pages/welcome/node_mode_page.dart
+++ b/bitwindow/lib/pages/welcome/node_mode_page.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:bitwindow/env.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
@@ -13,13 +15,43 @@ import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wm
 class NodeModePage extends StatefulWidget {
   final VoidCallback onModePicked;
 
-  const NodeModePage({super.key, required this.onModePicked});
+  /// Names what holds the backend while it stays silent. A test passes a stub,
+  /// because the real reader opens a socket and reads the PID files.
+  final Future<String> Function() readBlocker;
+
+  const NodeModePage({super.key, required this.onModePicked, this.readBlocker = readBackendBlocker});
 
   @override
   State<NodeModePage> createState() => _NodeModePageState();
 }
 
 const String _backendDown = 'BitWindow cannot reach the local backend.';
+
+/// Reads what holds the machine while drivechaind stays silent. A user who
+/// reads a process name and a pid can act on it.
+Future<String> readBackendBlocker() async {
+  final host = Environment.orchestratorHost.value;
+  final port = Environment.orchestratorPort.value;
+
+  var listens = false;
+  try {
+    final socket = await Socket.connect(host, port, timeout: const Duration(seconds: 2));
+    socket.destroy();
+    listens = true;
+  } catch (_) {
+    listens = false;
+  }
+
+  final lines = <String>[
+    listens ? '$host:$port answers, but not as drivechaind.' : 'drivechaind does not listen on $host:$port.',
+  ];
+  final live = await GetIt.I.get<BinaryProvider>().liveDaemonNames();
+  if (live.isNotEmpty) {
+    lines.add('These still run from the last session: ${live.join(', ')}.');
+    lines.add('Stop them, then start BitWindow again.');
+  }
+  return lines.join('\n');
+}
 
 class _NodeModePageState extends State<NodeModePage> {
   NodeModeProvider get _nodeMode => GetIt.I.get<NodeModeProvider>();
@@ -30,12 +62,15 @@ class _NodeModePageState extends State<NodeModePage> {
   String? _error;
   Timer? _poll;
   bool _reloading = false;
+  bool _reading = false;
+  String? _blocker;
 
   @override
   void initState() {
     super.initState();
     _alignSelection();
     if (!_nodeMode.loaded) {
+      unawaited(_readBlocker());
       _poll = Timer.periodic(const Duration(seconds: 2), (_) => unawaited(_reload()));
     }
   }
@@ -66,7 +101,11 @@ class _NodeModePageState extends State<NodeModePage> {
     } finally {
       _reloading = false;
     }
-    if (!mounted || !_nodeMode.loaded) {
+    if (!mounted) {
+      return;
+    }
+    if (!_nodeMode.loaded) {
+      unawaited(_readBlocker());
       return;
     }
     _poll?.cancel();
@@ -76,6 +115,18 @@ class _NodeModePageState extends State<NodeModePage> {
       return;
     }
     setState(_alignSelection);
+  }
+
+  Future<void> _readBlocker() async {
+    if (_reading) {
+      return;
+    }
+    _reading = true;
+    final text = await widget.readBlocker();
+    _reading = false;
+    if (mounted && text.isNotEmpty) {
+      setState(() => _blocker = text);
+    }
   }
 
   Future<void> _confirm() async {
@@ -106,6 +157,7 @@ class _NodeModePageState extends State<NodeModePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SailText.secondary13(_backendDown, color: SailTheme.of(context).colors.error),
+            if (_blocker != null) SailText.secondary13(_blocker!),
             SailButton(
               label: 'Try again',
               onPressed: _reload,

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -401,8 +401,21 @@ func startDrivechaind(ctx context.Context, conf config.Config) (*exec.Cmd, error
 		return nil, err
 	}
 	if adopted {
-		log.Info().Str("addr", conf.OrchestratorAddr).Msg("drivechaind already running, adopting verified instance")
-		return nil, nil
+		// The running daemon still watches the frontend an app update
+		// replaced. Claim it for the new one, or it drains the whole stack a
+		// few seconds from now and leaves this install a dead port.
+		claimErr := claimOrchestratorOwner(conf.OrchestratorAddr, bitwindowDir, conf.OwnerPID)
+		if claimErr == nil {
+			log.Info().Str("addr", conf.OrchestratorAddr).Msg("drivechaind already running, adopting verified instance")
+			return nil, nil
+		}
+		// A build older than AdoptOwner cannot hand over. It drains on its own
+		// dead owner and leaves a dead port, so retire it and take the port.
+		log.Warn().Err(claimErr).Str("addr", conf.OrchestratorAddr).
+			Msg("the running drivechaind refused the handover, retiring it")
+		if err := retireOrchestrator(ctx, conf.OrchestratorAddr, bitwindowDir, log); err != nil {
+			return nil, err
+		}
 	}
 
 	// Don't touch the cookie here: drivechaind overwrites it with a fresh
@@ -654,6 +667,61 @@ func relayShutdownToDrivechaind(addr, bitwindowDir string, log zerolog.Logger) {
 		return
 	}
 	log.Info().Msg("relayed Shutdown to drivechaind on exit")
+}
+
+// claimOrchestratorOwner tells a running drivechaind which frontend owns it
+// now. Without the claim it keeps the pid of the frontend the update replaced,
+// finds it dead, and drains bitcoind, the enforcer and every sidechain.
+// An unset owner pid leaves the daemon as it is: it never drains on its own.
+func claimOrchestratorOwner(addr, bitwindowDir string, ownerPID int) error {
+	if ownerPID <= 0 {
+		return nil
+	}
+	client := orchrpc.NewOrchestratorServiceClient(http.DefaultClient, addr, connect.WithGRPC(), connect.WithInterceptors(localauth.Interceptor(bitwindowDir)))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := client.AdoptOwner(ctx, connect.NewRequest(&orchpb.AdoptOwnerRequest{
+		OwnerPid: int32(ownerPID), //nolint:gosec // a pid fits an int32 on every platform we ship
+	}))
+	if err != nil {
+		return fmt.Errorf("hand drivechaind over to pid %d: %w", ownerPID, err)
+	}
+	return nil
+}
+
+// retireDrainWait bounds the wait on a drain that stops bitcoind, the enforcer
+// and every sidechain.
+const retireDrainWait = 2 * time.Minute
+
+// retireOrchestrator drains a running drivechaind this install cannot claim,
+// and returns once it lets the port go. A fresh daemon then binds it.
+func retireOrchestrator(ctx context.Context, addr, bitwindowDir string, log *zerolog.Logger) error {
+	hostPort, err := orchestratorHostPort(addr)
+	if err != nil {
+		return err
+	}
+	client := orchrpc.NewOrchestratorServiceClient(http.DefaultClient, addr, connect.WithGRPC(), connect.WithInterceptors(localauth.Interceptor(bitwindowDir)))
+	drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if _, err := client.Shutdown(drainCtx, connect.NewRequest(&orchpb.ShutdownRequest{})); err != nil {
+		log.Warn().Err(err).Msg("ask the old drivechaind to drain (waiting for the port anyway)")
+	}
+
+	deadline := time.Now().Add(retireDrainWait)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", hostPort, 200*time.Millisecond)
+		if err != nil {
+			log.Info().Str("addr", hostPort).Msg("the retired drivechaind let the port go")
+			return nil
+		}
+		_ = conn.Close()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("drivechaind still holds %s after %s", hostPort, retireDrainWait)
 }
 
 // that view of the world. Retries for ~15s while drivechaind boots.

--- a/bitwindow/test/node_mode_page_test.dart
+++ b/bitwindow/test/node_mode_page_test.dart
@@ -17,9 +17,11 @@ void main() {
   late _FakeWallet wallet;
   late int picked;
 
-  Future<void> pumpPage(WidgetTester tester) async {
+  Future<void> pumpPage(WidgetTester tester, {String blocker = ''}) async {
     picked = 0;
-    await tester.pumpSailPage(NodeModePage(onModePicked: () => picked++));
+    await tester.pumpSailPage(
+      NodeModePage(onModePicked: () => picked++, readBlocker: () async => blocker),
+    );
   }
 
   setUp(() async {
@@ -38,6 +40,13 @@ void main() {
     expect(find.text('BitWindow cannot reach the local backend.'), findsOneWidget);
     expect(find.text('Light'), findsNothing);
     expect(find.text('Full node'), findsNothing);
+  });
+
+  testWidgets('names what holds the backend', (tester) async {
+    await pumpPage(tester, blocker: 'bitcoind (pid 1234) still runs.');
+    await tester.pump();
+
+    expect(find.text('bitcoind (pid 1234) still runs.'), findsOneWidget);
   });
 
   testWidgets('asks the question once the backend says the mode is unpicked', (tester) async {

--- a/sidechain-orchestrator/api/adopt_owner_test.go
+++ b/sidechain-orchestrator/api/adopt_owner_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/lease"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdoptOwnerRejectsLateLease(t *testing.T) {
+	for _, wait := range []bool{true, false} {
+		name := "after_exit_decision"
+		if wait {
+			name = "before_exit_request"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			fired := make(chan struct{})
+			returned := make(chan struct{})
+			clients := lease.New(0x7FFFFFF0, 0, func() {
+				close(fired)
+				if wait {
+					<-ctx.Done()
+				}
+				close(returned)
+			})
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				clients.Run(ctx)
+			}()
+			t.Cleanup(func() {
+				cancel()
+				<-done
+			})
+			select {
+			case <-fired:
+			case <-time.After(10 * time.Second):
+				t.Fatal("the lease did not expire")
+			}
+			if !wait {
+				<-returned
+			}
+			orch := &orchestrator.Orchestrator{}
+			orch.SetLease(clients)
+			response, err := NewHandler(orch).AdoptOwner(ctx, connect.NewRequest(&pb.AdoptOwnerRequest{
+				OwnerPid: int32(os.Getpid()),
+			}))
+			require.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+			require.Nil(t, response)
+		})
+	}
+}
+
+func TestAdoptOwnerAcceptsLiveLease(t *testing.T) {
+	orch := &orchestrator.Orchestrator{}
+	orch.SetLease(lease.New(os.Getpid(), time.Minute, func() {}))
+	response, err := NewHandler(orch).AdoptOwner(context.Background(), connect.NewRequest(&pb.AdoptOwnerRequest{
+		OwnerPid: int32(os.Getpid()),
+	}))
+	require.NoError(t, err)
+	require.False(t, response.Msg.CanceledExit)
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -348,6 +349,20 @@ func (h *Handler) Shutdown(_ context.Context, req *connect.Request[pb.ShutdownRe
 	}
 	h.orch.BeginShutdown()
 	return connect.NewResponse(&pb.ShutdownResponse{}), nil
+}
+
+func (h *Handler) AdoptOwner(_ context.Context, req *connect.Request[pb.AdoptOwnerRequest]) (*connect.Response[pb.AdoptOwnerResponse], error) {
+	pid := int(req.Msg.GetOwnerPid())
+	if pid <= 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("owner_pid must name a live process"))
+	}
+	canceled, err := h.orch.AdoptOwner(pid)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, err)
+	}
+	return connect.NewResponse(&pb.AdoptOwnerResponse{
+		CanceledExit: canceled,
+	}), nil
 }
 
 func (h *Handler) GetBTCPrice(ctx context.Context, req *connect.Request[pb.GetBTCPriceRequest]) (*connect.Response[pb.GetBTCPriceResponse], error) {

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -662,7 +662,7 @@ func run(cctx *cli.Context) error {
 	protocols.SetUnencryptedHTTP2(true)
 	clients := lease.New(cctx.Int("owner-pid"), lease.DefaultGrace, func() {
 		log.Info().Msg("no clients left and the owner is gone, shutting down")
-		orch.BeginShutdown()
+		orch.RequestExit()
 	})
 	orch.SetLease(clients)
 

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -898,8 +899,7 @@ func (d *DownloadManager) moveExtractedBinaries(tmpDir, destDir, binaryName stri
 		}
 
 		if err := moveFile(path, destPath); err != nil {
-			d.log.Warn().Err(err).Str("file", name).Msg("move extracted file")
-			return nil
+			return fmt.Errorf("install %s over %s: %w", name, destPath, err)
 		}
 
 		if err := chmod(destPath); err != nil {
@@ -943,6 +943,9 @@ func moveFile(src, dest string) error {
 
 	destFile, err := os.Create(dest)
 	if err != nil {
+		if errors.Is(err, syscall.ETXTBSY) {
+			return fmt.Errorf("%s runs right now; stop it before you update it", dest)
+		}
 		return err
 	}
 	defer destFile.Close() //nolint:errcheck // cleanup

--- a/sidechain-orchestrator/download_claims_test.go
+++ b/sidechain-orchestrator/download_claims_test.go
@@ -176,3 +176,19 @@ func finalProgress(ch <-chan DownloadProgress) DownloadProgress {
 	}
 	return last
 }
+
+// A part that could not land is a failed update, not a finished one. The old
+// warning let the caller record a version the disk never got.
+func TestMoveExtractedBinaries_FailsWhenAPartCannotLand(t *testing.T) {
+	dm, dataDir := newTestDownloadManager(t)
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "thunder"), []byte("new"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "thunder-cli"), []byte("new"), 0o755))
+
+	destDir := BinDir(dataDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(destDir, "thunder", "held"), 0o755))
+
+	_, err := dm.moveExtractedBinaries(tmpDir, destDir, "thunder")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "thunder")
+}

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -4901,6 +4901,96 @@ func (*ShutdownResponse) Descriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{72}
 }
 
+type AdoptOwnerRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Process ID of the frontend that owns the daemon now.
+	OwnerPid      int32 `protobuf:"varint,1,opt,name=owner_pid,json=ownerPid,proto3" json:"owner_pid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdoptOwnerRequest) Reset() {
+	*x = AdoptOwnerRequest{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[73]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdoptOwnerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdoptOwnerRequest) ProtoMessage() {}
+
+func (x *AdoptOwnerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[73]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdoptOwnerRequest.ProtoReflect.Descriptor instead.
+func (*AdoptOwnerRequest) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{73}
+}
+
+func (x *AdoptOwnerRequest) GetOwnerPid() int32 {
+	if x != nil {
+		return x.OwnerPid
+	}
+	return 0
+}
+
+type AdoptOwnerResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True when the daemon was on its way out and this call stopped the exit.
+	CanceledExit  bool `protobuf:"varint,1,opt,name=canceled_exit,json=canceledExit,proto3" json:"canceled_exit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdoptOwnerResponse) Reset() {
+	*x = AdoptOwnerResponse{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[74]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdoptOwnerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdoptOwnerResponse) ProtoMessage() {}
+
+func (x *AdoptOwnerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[74]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdoptOwnerResponse.ProtoReflect.Descriptor instead.
+func (*AdoptOwnerResponse) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{74}
+}
+
+func (x *AdoptOwnerResponse) GetCanceledExit() bool {
+	if x != nil {
+		return x.CanceledExit
+	}
+	return false
+}
+
 var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
 
 const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
@@ -5241,7 +5331,11 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x0fShutdownRequest\x12 \n" +
 	"\fonly_if_last\x18\x01 \x01(\bR\n" +
 	"onlyIfLast\"\x12\n" +
-	"\x10ShutdownResponse*\xf7\x01\n" +
+	"\x10ShutdownResponse\"0\n" +
+	"\x11AdoptOwnerRequest\x12\x1b\n" +
+	"\towner_pid\x18\x01 \x01(\x05R\bownerPid\"9\n" +
+	"\x12AdoptOwnerResponse\x12#\n" +
+	"\rcanceled_exit\x18\x01 \x01(\bR\fcanceledExit*\xf7\x01\n" +
 	"\rSidechainType\x12\x1e\n" +
 	"\x1aSIDECHAIN_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16SIDECHAIN_TYPE_THUNDER\x10\x01\x12\x18\n" +
@@ -5290,7 +5384,7 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x15RESET_PHASE_MOVE_BACK\x10\x02\x12\x1c\n" +
 	"\x18RESET_PHASE_SYNC_FORWARD\x10\x03\x12\x18\n" +
 	"\x14RESET_PHASE_ENFORCER\x10\x04\x12\x14\n" +
-	"\x10RESET_PHASE_DONE\x10\x052\xe6\x19\n" +
+	"\x10RESET_PHASE_DONE\x10\x052\xbd\x1a\n" +
 	"\x13OrchestratorService\x12[\n" +
 	"\fListBinaries\x12$.orchestrator.v1.ListBinariesRequest\x1a%.orchestrator.v1.ListBinariesResponse\x12d\n" +
 	"\x0fGetBinaryStatus\x12'.orchestrator.v1.GetBinaryStatusRequest\x1a(.orchestrator.v1.GetBinaryStatusResponse\x12g\n" +
@@ -5309,7 +5403,9 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x1bGetPendingNetworkGeneration\x123.orchestrator.v1.GetPendingNetworkGenerationRequest\x1a4.orchestrator.v1.GetPendingNetworkGenerationResponse\x12\x94\x01\n" +
 	"\x1fConfirmPendingNetworkGeneration\x127.orchestrator.v1.ConfirmPendingNetworkGenerationRequest\x1a8.orchestrator.v1.ConfirmPendingNetworkGenerationResponse\x12Z\n" +
 	"\vShutdownAll\x12#.orchestrator.v1.ShutdownAllRequest\x1a$.orchestrator.v1.ShutdownAllResponse0\x01\x12O\n" +
-	"\bShutdown\x12 .orchestrator.v1.ShutdownRequest\x1a!.orchestrator.v1.ShutdownResponse\x12X\n" +
+	"\bShutdown\x12 .orchestrator.v1.ShutdownRequest\x1a!.orchestrator.v1.ShutdownResponse\x12U\n" +
+	"\n" +
+	"AdoptOwner\x12\".orchestrator.v1.AdoptOwnerRequest\x1a#.orchestrator.v1.AdoptOwnerResponse\x12X\n" +
 	"\vGetBTCPrice\x12#.orchestrator.v1.GetBTCPriceRequest\x1a$.orchestrator.v1.GetBTCPriceResponse\x12\x85\x01\n" +
 	"\x1aGetMainchainBlockchainInfo\x122.orchestrator.v1.GetMainchainBlockchainInfoRequest\x1a3.orchestrator.v1.GetMainchainBlockchainInfoResponse\x12\x82\x01\n" +
 	"\x19GetEnforcerBlockchainInfo\x121.orchestrator.v1.GetEnforcerBlockchainInfoRequest\x1a2.orchestrator.v1.GetEnforcerBlockchainInfoResponse\x12^\n" +
@@ -5341,7 +5437,7 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 }
 
 var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 75)
+var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                              // 0: orchestrator.v1.SidechainType
 	(BinaryType)(0),                                 // 1: orchestrator.v1.BinaryType
@@ -5421,15 +5517,17 @@ var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(*ForkClaimUtxo)(nil),                           // 75: orchestrator.v1.ForkClaimUtxo
 	(*ShutdownRequest)(nil),                         // 76: orchestrator.v1.ShutdownRequest
 	(*ShutdownResponse)(nil),                        // 77: orchestrator.v1.ShutdownResponse
-	nil,                                             // 78: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                             // 79: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(*AdoptOwnerRequest)(nil),                       // 78: orchestrator.v1.AdoptOwnerRequest
+	(*AdoptOwnerResponse)(nil),                      // 79: orchestrator.v1.AdoptOwnerResponse
+	nil,                                             // 80: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                             // 81: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	6,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
 	5,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
 	5,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	78, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	79, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	80, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	81, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
 	46, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
 	46, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
 	45, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
@@ -5466,56 +5564,58 @@ var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	33, // 38: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
 	35, // 39: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
 	76, // 40: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
-	37, // 41: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	39, // 42: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	41, // 43: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	43, // 44: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	47, // 45: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
-	50, // 46: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	52, // 47: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
-	55, // 48: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
-	58, // 49: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
-	60, // 50: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
-	62, // 51: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
-	64, // 52: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
-	66, // 53: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	68, // 54: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
-	70, // 55: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	72, // 56: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
-	8,  // 57: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	10, // 58: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	12, // 59: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
-	14, // 60: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	16, // 61: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	18, // 62: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	20, // 63: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	22, // 64: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	24, // 65: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	26, // 66: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
-	28, // 67: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
-	30, // 68: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
-	32, // 69: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
-	34, // 70: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	36, // 71: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	77, // 72: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
-	38, // 73: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	40, // 74: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	42, // 75: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	44, // 76: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	48, // 77: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
-	51, // 78: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	53, // 79: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
-	56, // 80: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
-	59, // 81: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
-	61, // 82: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
-	63, // 83: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
-	65, // 84: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
-	67, // 85: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	69, // 86: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
-	71, // 87: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	73, // 88: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
-	57, // [57:89] is the sub-list for method output_type
-	25, // [25:57] is the sub-list for method input_type
+	78, // 41: orchestrator.v1.OrchestratorService.AdoptOwner:input_type -> orchestrator.v1.AdoptOwnerRequest
+	37, // 42: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	39, // 43: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	41, // 44: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	43, // 45: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	47, // 46: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	50, // 47: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	52, // 48: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
+	55, // 49: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
+	58, // 50: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
+	60, // 51: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
+	62, // 52: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
+	64, // 53: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
+	66, // 54: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	68, // 55: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
+	70, // 56: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	72, // 57: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
+	8,  // 58: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	10, // 59: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	12, // 60: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
+	14, // 61: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	16, // 62: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	18, // 63: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	20, // 64: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	22, // 65: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	24, // 66: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	26, // 67: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
+	28, // 68: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
+	30, // 69: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
+	32, // 70: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
+	34, // 71: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	36, // 72: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	77, // 73: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
+	79, // 74: orchestrator.v1.OrchestratorService.AdoptOwner:output_type -> orchestrator.v1.AdoptOwnerResponse
+	38, // 75: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	40, // 76: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	42, // 77: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	44, // 78: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	48, // 79: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	51, // 80: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	53, // 81: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
+	56, // 82: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
+	59, // 83: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
+	61, // 84: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
+	63, // 85: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
+	65, // 86: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
+	67, // 87: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	69, // 88: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
+	71, // 89: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	73, // 90: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
+	58, // [58:91] is the sub-list for method output_type
+	25, // [25:58] is the sub-list for method input_type
 	25, // [25:25] is the sub-list for extension type_name
 	25, // [25:25] is the sub-list for extension extendee
 	0,  // [0:25] is the sub-list for field type_name
@@ -5533,7 +5633,7 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   75,
+			NumMessages:   77,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
@@ -81,6 +81,9 @@ const (
 	// OrchestratorServiceShutdownProcedure is the fully-qualified name of the OrchestratorService's
 	// Shutdown RPC.
 	OrchestratorServiceShutdownProcedure = "/orchestrator.v1.OrchestratorService/Shutdown"
+	// OrchestratorServiceAdoptOwnerProcedure is the fully-qualified name of the OrchestratorService's
+	// AdoptOwner RPC.
+	OrchestratorServiceAdoptOwnerProcedure = "/orchestrator.v1.OrchestratorService/AdoptOwner"
 	// OrchestratorServiceGetBTCPriceProcedure is the fully-qualified name of the OrchestratorService's
 	// GetBTCPrice RPC.
 	OrchestratorServiceGetBTCPriceProcedure = "/orchestrator.v1.OrchestratorService/GetBTCPrice"
@@ -200,6 +203,11 @@ type OrchestratorServiceClient interface {
 	// will-exit bit + awaits the in-flight stops) before booting a fresh
 	// stack — no separate cancel/await RPCs needed by callers.
 	Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error)
+	// Point the daemon at the frontend process that owns it now. An app update
+	// replaces the frontend with a new process, and the daemon drains itself a
+	// few seconds after the old one dies. bitwindowd calls this the moment it
+	// finds a live daemon, so the warm stack survives the swap.
+	AdoptOwner(context.Context, *connect.Request[v1.AdoptOwnerRequest]) (*connect.Response[v1.AdoptOwnerResponse], error)
 	// Get the current BTC/USD exchange rate.
 	GetBTCPrice(context.Context, *connect.Request[v1.GetBTCPriceRequest]) (*connect.Response[v1.GetBTCPriceResponse], error)
 	// Get blockchain info from Bitcoin Core (proxied via orchestrator).
@@ -361,6 +369,12 @@ func NewOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(orchestratorServiceMethods.ByName("Shutdown")),
 			connect.WithClientOptions(opts...),
 		),
+		adoptOwner: connect.NewClient[v1.AdoptOwnerRequest, v1.AdoptOwnerResponse](
+			httpClient,
+			baseURL+OrchestratorServiceAdoptOwnerProcedure,
+			connect.WithSchema(orchestratorServiceMethods.ByName("AdoptOwner")),
+			connect.WithClientOptions(opts...),
+		),
 		getBTCPrice: connect.NewClient[v1.GetBTCPriceRequest, v1.GetBTCPriceResponse](
 			httpClient,
 			baseURL+OrchestratorServiceGetBTCPriceProcedure,
@@ -478,6 +492,7 @@ type orchestratorServiceClient struct {
 	confirmPendingNetworkGeneration *connect.Client[v1.ConfirmPendingNetworkGenerationRequest, v1.ConfirmPendingNetworkGenerationResponse]
 	shutdownAll                     *connect.Client[v1.ShutdownAllRequest, v1.ShutdownAllResponse]
 	shutdown                        *connect.Client[v1.ShutdownRequest, v1.ShutdownResponse]
+	adoptOwner                      *connect.Client[v1.AdoptOwnerRequest, v1.AdoptOwnerResponse]
 	getBTCPrice                     *connect.Client[v1.GetBTCPriceRequest, v1.GetBTCPriceResponse]
 	getMainchainBlockchainInfo      *connect.Client[v1.GetMainchainBlockchainInfoRequest, v1.GetMainchainBlockchainInfoResponse]
 	getEnforcerBlockchainInfo       *connect.Client[v1.GetEnforcerBlockchainInfoRequest, v1.GetEnforcerBlockchainInfoResponse]
@@ -576,6 +591,11 @@ func (c *orchestratorServiceClient) ShutdownAll(ctx context.Context, req *connec
 // Shutdown calls orchestrator.v1.OrchestratorService.Shutdown.
 func (c *orchestratorServiceClient) Shutdown(ctx context.Context, req *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error) {
 	return c.shutdown.CallUnary(ctx, req)
+}
+
+// AdoptOwner calls orchestrator.v1.OrchestratorService.AdoptOwner.
+func (c *orchestratorServiceClient) AdoptOwner(ctx context.Context, req *connect.Request[v1.AdoptOwnerRequest]) (*connect.Response[v1.AdoptOwnerResponse], error) {
+	return c.adoptOwner.CallUnary(ctx, req)
 }
 
 // GetBTCPrice calls orchestrator.v1.OrchestratorService.GetBTCPrice.
@@ -728,6 +748,11 @@ type OrchestratorServiceHandler interface {
 	// will-exit bit + awaits the in-flight stops) before booting a fresh
 	// stack — no separate cancel/await RPCs needed by callers.
 	Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error)
+	// Point the daemon at the frontend process that owns it now. An app update
+	// replaces the frontend with a new process, and the daemon drains itself a
+	// few seconds after the old one dies. bitwindowd calls this the moment it
+	// finds a live daemon, so the warm stack survives the swap.
+	AdoptOwner(context.Context, *connect.Request[v1.AdoptOwnerRequest]) (*connect.Response[v1.AdoptOwnerResponse], error)
 	// Get the current BTC/USD exchange rate.
 	GetBTCPrice(context.Context, *connect.Request[v1.GetBTCPriceRequest]) (*connect.Response[v1.GetBTCPriceResponse], error)
 	// Get blockchain info from Bitcoin Core (proxied via orchestrator).
@@ -885,6 +910,12 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 		connect.WithSchema(orchestratorServiceMethods.ByName("Shutdown")),
 		connect.WithHandlerOptions(opts...),
 	)
+	orchestratorServiceAdoptOwnerHandler := connect.NewUnaryHandler(
+		OrchestratorServiceAdoptOwnerProcedure,
+		svc.AdoptOwner,
+		connect.WithSchema(orchestratorServiceMethods.ByName("AdoptOwner")),
+		connect.WithHandlerOptions(opts...),
+	)
 	orchestratorServiceGetBTCPriceHandler := connect.NewUnaryHandler(
 		OrchestratorServiceGetBTCPriceProcedure,
 		svc.GetBTCPrice,
@@ -1015,6 +1046,8 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 			orchestratorServiceShutdownAllHandler.ServeHTTP(w, r)
 		case OrchestratorServiceShutdownProcedure:
 			orchestratorServiceShutdownHandler.ServeHTTP(w, r)
+		case OrchestratorServiceAdoptOwnerProcedure:
+			orchestratorServiceAdoptOwnerHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetBTCPriceProcedure:
 			orchestratorServiceGetBTCPriceHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetMainchainBlockchainInfoProcedure:
@@ -1118,6 +1151,10 @@ func (UnimplementedOrchestratorServiceHandler) ShutdownAll(context.Context, *con
 
 func (UnimplementedOrchestratorServiceHandler) Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.Shutdown is not implemented"))
+}
+
+func (UnimplementedOrchestratorServiceHandler) AdoptOwner(context.Context, *connect.Request[v1.AdoptOwnerRequest]) (*connect.Response[v1.AdoptOwnerResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.AdoptOwner is not implemented"))
 }
 
 func (UnimplementedOrchestratorServiceHandler) GetBTCPrice(context.Context, *connect.Request[v1.GetBTCPriceRequest]) (*connect.Response[v1.GetBTCPriceResponse], error) {

--- a/sidechain-orchestrator/lease/lease.go
+++ b/sidechain-orchestrator/lease/lease.go
@@ -72,12 +72,27 @@ func (l *Lease) Goodbye() {
 	l.mu.Unlock()
 }
 
-// Run evaluates until ctx ends or the lease fires.
-func (l *Lease) Run(ctx context.Context) {
-	if l.ownerPID <= 0 {
-		return
-	}
+// SetOwner points the lease at a new owner process. An app update replaces the
+// frontend with a new process, and the dead pid alone would drain the stack
+// the replacement is about to use. Returns false once the lease fired, because
+// the drain is already under way and only the caller can cancel it.
+func (l *Lease) SetOwner(pid int) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fired := l.drained
+	l.ownerPID = pid
+	l.ownerGone = false
+	l.strikes = 0
+	l.waived = false
+	l.drained = false
+	l.idleFrom = time.Now()
+	return !fired
+}
 
+// Run evaluates until ctx ends. It keeps ticking after the lease fires,
+// because SetOwner can hand the daemon to a new frontend, and that frontend
+// needs a lease of its own.
+func (l *Lease) Run(ctx context.Context) {
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
@@ -88,10 +103,7 @@ func (l *Lease) Run(ctx context.Context) {
 		case <-ticker.C:
 		}
 		l.pollOwner()
-		if l.expired() {
-			l.fire()
-			return
-		}
+		l.fireIfExpired()
 	}
 }
 
@@ -99,21 +111,26 @@ func (l *Lease) Run(ctx context.Context) {
 // Watching only while idle would read a recycled pid as the owner come back.
 func (l *Lease) pollOwner() {
 	l.mu.Lock()
-	done := l.ownerGone || l.ownerPID <= 0
+	pid := l.ownerPID
+	done := l.ownerGone || pid <= 0
 	l.mu.Unlock()
 	if done {
 		return
 	}
 
-	if alive(l.ownerPID) {
-		l.mu.Lock()
-		l.strikes = 0
-		l.mu.Unlock()
-		return
-	}
+	live := alive(pid)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	// SetOwner can land while the lookup runs. An answer about the frontend
+	// an update replaced says nothing about the one that replaced it.
+	if l.ownerPID != pid {
+		return
+	}
+	if live {
+		l.strikes = 0
+		return
+	}
 	l.strikes++
 	l.ownerGone = l.strikes >= deadStrikes
 }
@@ -121,7 +138,10 @@ func (l *Lease) pollOwner() {
 func (l *Lease) expired() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	return l.expiredLocked()
+}
 
+func (l *Lease) expiredLocked() bool {
 	if !l.ownerGone {
 		return false
 	}
@@ -130,6 +150,20 @@ func (l *Lease) expired() bool {
 		grace = 0
 	}
 	return l.live == 0 && time.Since(l.idleFrom) >= grace
+}
+
+// fireIfExpired takes the decision and the flag under one lock. A handover
+// that lands between the two would otherwise drain the daemon it just saved.
+func (l *Lease) fireIfExpired() {
+	l.mu.Lock()
+	if l.drained || !l.expiredLocked() {
+		l.mu.Unlock()
+		return
+	}
+	l.drained = true
+	l.mu.Unlock()
+
+	l.drain()
 }
 
 func (l *Lease) fire() {

--- a/sidechain-orchestrator/lease/lease_test.go
+++ b/sidechain-orchestrator/lease/lease_test.go
@@ -3,6 +3,7 @@ package lease
 import (
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -143,5 +144,120 @@ func TestGraceHoldsUntilItElapses(t *testing.T) {
 	l.Goodbye()
 	if !l.expired() {
 		t.Fatal("goodbye did not drop the grace")
+	}
+}
+
+// An app update replaces the frontend. The new one claims the daemon before
+// the dead pid drains it.
+func TestSetOwnerHoldsTheLeaseForTheNewFrontend(t *testing.T) {
+	drained, drain := drainedFlag()
+	l := New(deadPID, 0, drain)
+
+	pollUntilOwnerGone(l)
+	if !l.expired() {
+		t.Fatal("lease did not expire after the owner died")
+	}
+
+	if !l.SetOwner(os.Getpid()) {
+		t.Fatal("SetOwner reported a drain that never ran")
+	}
+	pollUntilOwnerGone(l)
+
+	if l.expired() {
+		t.Fatal("lease expired while the new frontend is alive")
+	}
+	if *drained {
+		t.Fatal("drained a daemon a live frontend owns")
+	}
+}
+
+// A claim that lands after the drain fired says so, and the daemon serves the
+// new frontend from there on.
+func TestSetOwnerAfterTheDrainReportsTheFire(t *testing.T) {
+	_, drain := drainedFlag()
+	l := New(deadPID, 0, drain)
+
+	pollUntilOwnerGone(l)
+	l.fire()
+
+	if l.SetOwner(os.Getpid()) {
+		t.Fatal("SetOwner missed the drain that already ran")
+	}
+
+	l.ConnState(nil, http.StateNew)
+	l.ConnState(nil, http.StateClosed)
+	pollUntilOwnerGone(l)
+	if l.expired() {
+		t.Fatal("lease expired while the new frontend is alive")
+	}
+}
+
+// The daemon keeps watching after a drain, so the frontend that took it over
+// reaps it in turn.
+func TestLeaseFiresAgainForTheNewOwner(t *testing.T) {
+	fires := 0
+	l := New(deadPID, 0, func() { fires++ })
+
+	pollUntilOwnerGone(l)
+	if l.expired() {
+		l.fire()
+	}
+	l.SetOwner(deadPID)
+	pollUntilOwnerGone(l)
+	if l.expired() {
+		l.fire()
+	}
+
+	if fires != 2 {
+		t.Fatalf("drain ran %d times, want 2", fires)
+	}
+}
+
+// A handover that lands while the owner poll runs must not read the answer for
+// the frontend the update replaced onto the one that replaced it.
+func TestSetOwnerRacesThePoll(t *testing.T) {
+	_, drain := drainedFlag()
+	l := New(deadPID, 0, drain)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			l.pollOwner()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			l.SetOwner(os.Getpid())
+		}
+	}()
+	wg.Wait()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.ownerGone {
+		t.Fatal("the poll marked a live owner gone")
+	}
+}
+
+// A handover that lands between the expiry check and the drain must win. The
+// tick that read the old owner cannot drain the daemon the claim just saved.
+func TestFireIfExpiredHonoursALateHandover(t *testing.T) {
+	drained, drain := drainedFlag()
+	l := New(deadPID, 0, drain)
+
+	pollUntilOwnerGone(l)
+	if !l.expired() {
+		t.Fatal("lease did not expire after the owner died")
+	}
+
+	// The tick already read expired. The claim lands before the drain.
+	l.SetOwner(os.Getpid())
+	l.fireIfExpired()
+
+	if *drained {
+		t.Fatal("drained a daemon the new frontend had already claimed")
 	}
 }

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -86,6 +86,12 @@ service OrchestratorService {
   // stack — no separate cancel/await RPCs needed by callers.
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
 
+  // Point the daemon at the frontend process that owns it now. An app update
+  // replaces the frontend with a new process, and the daemon drains itself a
+  // few seconds after the old one dies. bitwindowd calls this the moment it
+  // finds a live daemon, so the warm stack survives the swap.
+  rpc AdoptOwner(AdoptOwnerRequest) returns (AdoptOwnerResponse);
+
   // Get the current BTC/USD exchange rate.
   rpc GetBTCPrice(GetBTCPriceRequest) returns (GetBTCPriceResponse);
 
@@ -899,3 +905,12 @@ message ShutdownRequest {
   bool only_if_last = 1;
 }
 message ShutdownResponse {}
+
+message AdoptOwnerRequest {
+  // Process ID of the frontend that owns the daemon now.
+  int32 owner_pid = 1;
+}
+message AdoptOwnerResponse {
+  // True when the daemon was on its way out and this call stopped the exit.
+  bool canceled_exit = 1;
+}

--- a/sidechain-orchestrator/shutdown.go
+++ b/sidechain-orchestrator/shutdown.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"os"
 	"time"
 
@@ -38,6 +39,21 @@ func (o *Orchestrator) ClientLeaving() {
 	}
 }
 
+// AdoptOwner changes the frontend owner and returns whether it canceled an exit.
+func (o *Orchestrator) AdoptOwner(pid int) (bool, error) {
+	inTime := true
+	if o.clients != nil {
+		inTime = o.clients.SetOwner(pid)
+	}
+	canceled := o.CancelShutdownExit()
+	if !inTime && !canceled {
+		return false, errors.New("the daemon exit already started")
+	}
+	o.log.Info().Int("owner_pid", pid).Bool("in_time", inTime).
+		Bool("canceled_exit", canceled).Msg("a new frontend took over the daemon")
+	return canceled, nil
+}
+
 // BeginShutdown kicks off the drivechaind shutdown sequence. Idempotent:
 // subsequent calls while a drain is in flight are no-ops. Returns true iff
 // this call initiated a fresh drain.
@@ -47,14 +63,40 @@ func (o *Orchestrator) BeginShutdown() bool {
 		o.shutdownMu.Unlock()
 		return false
 	}
-	o.shutdownState = shutdownStateDrainingExit
-	o.shutdownIdle = make(chan struct{})
-	idleCh := o.shutdownIdle
-	o.shutdownGen.Add(1)
+	idleCh := o.startDrainLocked()
 	o.shutdownMu.Unlock()
 
 	go o.runShutdown(idleCh)
 	return true
+}
+
+// startDrainLocked marks a fresh drain. The caller holds shutdownMu, the state
+// is RUNNING, and the caller starts runShutdown on the channel it returns.
+func (o *Orchestrator) startDrainLocked() chan struct{} {
+	o.shutdownState = shutdownStateDrainingExit
+	o.shutdownIdle = make(chan struct{})
+	o.shutdownGen.Add(1)
+	return o.shutdownIdle
+}
+
+// RequestExit drains every child and exits. A drain that already runs is set
+// back to exit, so a KEEP the daemon took for a frontend that then left cannot
+// strand it.
+func (o *Orchestrator) RequestExit() {
+	o.shutdownMu.Lock()
+	if o.shutdownState == shutdownStateDrainingKeep {
+		o.shutdownState = shutdownStateDrainingExit
+		o.shutdownMu.Unlock()
+		return
+	}
+	if o.shutdownState != shutdownStateRunning {
+		o.shutdownMu.Unlock()
+		return
+	}
+	idleCh := o.startDrainLocked()
+	o.shutdownMu.Unlock()
+
+	go o.runShutdown(idleCh)
 }
 
 // runShutdown drains all managed children, then either os.Exit(0)s or stays

--- a/sidechain-orchestrator/shutdown_status_test.go
+++ b/sidechain-orchestrator/shutdown_status_test.go
@@ -2,14 +2,60 @@ package orchestrator
 
 import (
 	"context"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/lease"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAdoptOwnerCancelsExit(t *testing.T) {
+	o := &Orchestrator{shutdownState: shutdownStateDrainingExit}
+	o.SetLease(lease.New(os.Getpid(), time.Minute, func() {}))
+
+	canceled, err := o.AdoptOwner(os.Getpid())
+
+	require.NoError(t, err)
+	require.True(t, canceled)
+	drain, exit := o.ShutdownDraining()
+	require.True(t, drain)
+	require.False(t, exit)
+}
+
+func TestAdoptOwnerCancelsExpiredLease(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fired := make(chan struct{})
+	clients := lease.New(0x7FFFFFF0, 0, func() { close(fired) })
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		clients.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	select {
+	case <-fired:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the lease did not expire")
+	}
+	o := &Orchestrator{shutdownState: shutdownStateDrainingExit}
+	o.SetLease(clients)
+
+	canceled, err := o.AdoptOwner(os.Getpid())
+
+	require.NoError(t, err)
+	require.True(t, canceled)
+	drain, exit := o.ShutdownDraining()
+	require.True(t, drain)
+	require.False(t, exit)
+}
 
 // TestStop_EmitsStoppingThenStopped guards the frontend-visible shutdown
 // sequence: the daemon-status card relies on stoppingBinary flipping to
@@ -115,4 +161,38 @@ func TestMarkStopped_SuppressesRestartTimer(t *testing.T) {
 	time.Sleep(1100 * time.Millisecond)
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(&restarts), "MarkStopped must short-circuit the restart timer; otherwise stopped-by-user binaries come back from the dead")
+}
+
+// A frontend that took over a drain and then left must not strand the daemon.
+// The lease fires again, and the drain in flight goes back to exit.
+func TestRequestExit_RearmsAKeptDrain(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	o.shutdownMu.Lock()
+	o.shutdownState = shutdownStateDrainingKeep
+	o.shutdownIdle = make(chan struct{})
+	o.shutdownMu.Unlock()
+
+	o.RequestExit()
+
+	o.shutdownMu.Lock()
+	defer o.shutdownMu.Unlock()
+	assert.Equal(t, shutdownStateDrainingExit, o.shutdownState)
+}
+
+// A drain already set to exit stays that way, and RequestExit starts no second
+// drain over the top of it.
+func TestRequestExit_LeavesAnExitDrainAlone(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	o.shutdownMu.Lock()
+	o.shutdownState = shutdownStateDrainingExit
+	o.shutdownIdle = make(chan struct{})
+	o.shutdownMu.Unlock()
+
+	o.RequestExit()
+
+	o.shutdownMu.Lock()
+	defer o.shutdownMu.Unlock()
+	assert.Equal(t, shutdownStateDrainingExit, o.shutdownState)
 }

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
@@ -331,6 +331,27 @@ extension type OrchestratorServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// Point the daemon at the frontend process that owns it now. An app update
+  /// replaces the frontend with a new process, and the daemon drains itself a
+  /// few seconds after the old one dies. bitwindowd calls this the moment it
+  /// finds a live daemon, so the warm stack survives the swap.
+  Future<orchestratorv1orchestrator.AdoptOwnerResponse> adoptOwner(
+    orchestratorv1orchestrator.AdoptOwnerRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.OrchestratorService.adoptOwner,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// Get the current BTC/USD exchange rate.
   Future<orchestratorv1orchestrator.GetBTCPriceResponse> getBTCPrice(
     orchestratorv1orchestrator.GetBTCPriceRequest input, {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
@@ -173,6 +173,17 @@ abstract final class OrchestratorService {
     orchestratorv1orchestrator.ShutdownResponse.new,
   );
 
+  /// Point the daemon at the frontend process that owns it now. An app update
+  /// replaces the frontend with a new process, and the daemon drains itself a
+  /// few seconds after the old one dies. bitwindowd calls this the moment it
+  /// finds a live daemon, so the warm stack survives the swap.
+  static const adoptOwner = connect.Spec(
+    '/$name/AdoptOwner',
+    connect.StreamType.unary,
+    orchestratorv1orchestrator.AdoptOwnerRequest.new,
+    orchestratorv1orchestrator.AdoptOwnerResponse.new,
+  );
+
   /// Get the current BTC/USD exchange rate.
   static const getBTCPrice = connect.Spec(
     '/$name/GetBTCPrice',

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -5686,6 +5686,108 @@ class ShutdownResponse extends $pb.GeneratedMessage {
   static ShutdownResponse? _defaultInstance;
 }
 
+class AdoptOwnerRequest extends $pb.GeneratedMessage {
+  factory AdoptOwnerRequest({
+    $core.int? ownerPid,
+  }) {
+    final $result = create();
+    if (ownerPid != null) {
+      $result.ownerPid = ownerPid;
+    }
+    return $result;
+  }
+  AdoptOwnerRequest._() : super();
+  factory AdoptOwnerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AdoptOwnerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AdoptOwnerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'ownerPid', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  AdoptOwnerRequest clone() => AdoptOwnerRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AdoptOwnerRequest copyWith(void Function(AdoptOwnerRequest) updates) => super.copyWith((message) => updates(message as AdoptOwnerRequest)) as AdoptOwnerRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static AdoptOwnerRequest create() => AdoptOwnerRequest._();
+  AdoptOwnerRequest createEmptyInstance() => create();
+  static $pb.PbList<AdoptOwnerRequest> createRepeated() => $pb.PbList<AdoptOwnerRequest>();
+  @$core.pragma('dart2js:noInline')
+  static AdoptOwnerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AdoptOwnerRequest>(create);
+  static AdoptOwnerRequest? _defaultInstance;
+
+  /// Process ID of the frontend that owns the daemon now.
+  @$pb.TagNumber(1)
+  $core.int get ownerPid => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set ownerPid($core.int v) { $_setSignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOwnerPid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOwnerPid() => clearField(1);
+}
+
+class AdoptOwnerResponse extends $pb.GeneratedMessage {
+  factory AdoptOwnerResponse({
+    $core.bool? canceledExit,
+  }) {
+    final $result = create();
+    if (canceledExit != null) {
+      $result.canceledExit = canceledExit;
+    }
+    return $result;
+  }
+  AdoptOwnerResponse._() : super();
+  factory AdoptOwnerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AdoptOwnerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AdoptOwnerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'canceledExit')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  AdoptOwnerResponse clone() => AdoptOwnerResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AdoptOwnerResponse copyWith(void Function(AdoptOwnerResponse) updates) => super.copyWith((message) => updates(message as AdoptOwnerResponse)) as AdoptOwnerResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static AdoptOwnerResponse create() => AdoptOwnerResponse._();
+  AdoptOwnerResponse createEmptyInstance() => create();
+  static $pb.PbList<AdoptOwnerResponse> createRepeated() => $pb.PbList<AdoptOwnerResponse>();
+  @$core.pragma('dart2js:noInline')
+  static AdoptOwnerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AdoptOwnerResponse>(create);
+  static AdoptOwnerResponse? _defaultInstance;
+
+  /// True when the daemon was on its way out and this call stopped the exit.
+  @$pb.TagNumber(1)
+  $core.bool get canceledExit => $_getBF(0);
+  @$pb.TagNumber(1)
+  set canceledExit($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCanceledExit() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCanceledExit() => clearField(1);
+}
+
 class OrchestratorServiceApi {
   $pb.RpcClient _client;
   OrchestratorServiceApi(this._client);
@@ -5737,6 +5839,9 @@ class OrchestratorServiceApi {
   ;
   $async.Future<ShutdownResponse> shutdown($pb.ClientContext? ctx, ShutdownRequest request) =>
     _client.invoke<ShutdownResponse>(ctx, 'OrchestratorService', 'Shutdown', request, ShutdownResponse())
+  ;
+  $async.Future<AdoptOwnerResponse> adoptOwner($pb.ClientContext? ctx, AdoptOwnerRequest request) =>
+    _client.invoke<AdoptOwnerResponse>(ctx, 'OrchestratorService', 'AdoptOwner', request, AdoptOwnerResponse())
   ;
   $async.Future<GetBTCPriceResponse> getBTCPrice($pb.ClientContext? ctx, GetBTCPriceRequest request) =>
     _client.invoke<GetBTCPriceResponse>(ctx, 'OrchestratorService', 'GetBTCPrice', request, GetBTCPriceResponse())

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -1285,6 +1285,31 @@ const ShutdownResponse$json = {
 final $typed_data.Uint8List shutdownResponseDescriptor = $convert.base64Decode(
     'ChBTaHV0ZG93blJlc3BvbnNl');
 
+@$core.Deprecated('Use adoptOwnerRequestDescriptor instead')
+const AdoptOwnerRequest$json = {
+  '1': 'AdoptOwnerRequest',
+  '2': [
+    {'1': 'owner_pid', '3': 1, '4': 1, '5': 5, '10': 'ownerPid'},
+  ],
+};
+
+/// Descriptor for `AdoptOwnerRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List adoptOwnerRequestDescriptor = $convert.base64Decode(
+    'ChFBZG9wdE93bmVyUmVxdWVzdBIbCglvd25lcl9waWQYASABKAVSCG93bmVyUGlk');
+
+@$core.Deprecated('Use adoptOwnerResponseDescriptor instead')
+const AdoptOwnerResponse$json = {
+  '1': 'AdoptOwnerResponse',
+  '2': [
+    {'1': 'canceled_exit', '3': 1, '4': 1, '5': 8, '10': 'canceledExit'},
+  ],
+};
+
+/// Descriptor for `AdoptOwnerResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List adoptOwnerResponseDescriptor = $convert.base64Decode(
+    'ChJBZG9wdE93bmVyUmVzcG9uc2USIwoNY2FuY2VsZWRfZXhpdBgBIAEoCFIMY2FuY2VsZWRFeG'
+    'l0');
+
 const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
   '1': 'OrchestratorService',
   '2': [
@@ -1304,6 +1329,7 @@ const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
     {'1': 'ConfirmPendingNetworkGeneration', '2': '.orchestrator.v1.ConfirmPendingNetworkGenerationRequest', '3': '.orchestrator.v1.ConfirmPendingNetworkGenerationResponse'},
     {'1': 'ShutdownAll', '2': '.orchestrator.v1.ShutdownAllRequest', '3': '.orchestrator.v1.ShutdownAllResponse', '6': true},
     {'1': 'Shutdown', '2': '.orchestrator.v1.ShutdownRequest', '3': '.orchestrator.v1.ShutdownResponse'},
+    {'1': 'AdoptOwner', '2': '.orchestrator.v1.AdoptOwnerRequest', '3': '.orchestrator.v1.AdoptOwnerResponse'},
     {'1': 'GetBTCPrice', '2': '.orchestrator.v1.GetBTCPriceRequest', '3': '.orchestrator.v1.GetBTCPriceResponse'},
     {'1': 'GetMainchainBlockchainInfo', '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest', '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'},
     {'1': 'GetEnforcerBlockchainInfo', '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest', '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'},
@@ -1361,6 +1387,8 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
   '.orchestrator.v1.ShutdownAllResponse': ShutdownAllResponse$json,
   '.orchestrator.v1.ShutdownRequest': ShutdownRequest$json,
   '.orchestrator.v1.ShutdownResponse': ShutdownResponse$json,
+  '.orchestrator.v1.AdoptOwnerRequest': AdoptOwnerRequest$json,
+  '.orchestrator.v1.AdoptOwnerResponse': AdoptOwnerResponse$json,
   '.orchestrator.v1.GetBTCPriceRequest': GetBTCPriceRequest$json,
   '.orchestrator.v1.GetBTCPriceResponse': GetBTCPriceResponse$json,
   '.orchestrator.v1.GetMainchainBlockchainInfoRequest': GetMainchainBlockchainInfoRequest$json,
@@ -1433,35 +1461,37 @@ final $typed_data.Uint8List orchestratorServiceDescriptor = $convert.base64Decod
     'b3JrR2VuZXJhdGlvblJlc3BvbnNlEloKC1NodXRkb3duQWxsEiMub3JjaGVzdHJhdG9yLnYxLl'
     'NodXRkb3duQWxsUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TaHV0ZG93bkFsbFJlc3BvbnNl'
     'MAESTwoIU2h1dGRvd24SIC5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25SZXF1ZXN0GiEub3JjaG'
-    'VzdHJhdG9yLnYxLlNodXRkb3duUmVzcG9uc2USWAoLR2V0QlRDUHJpY2USIy5vcmNoZXN0cmF0'
-    'b3IudjEuR2V0QlRDUHJpY2VSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkdldEJUQ1ByaWNlUm'
-    'VzcG9uc2UShQEKGkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvEjIub3JjaGVzdHJhdG9yLnYx'
-    'LkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVxdWVzdBozLm9yY2hlc3RyYXRvci52MS5HZX'
-    'RNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEoIBChlHZXRFbmZvcmNlckJsb2NrY2hh'
-    'aW5JbmZvEjEub3JjaGVzdHJhdG9yLnYxLkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXF1ZX'
-    'N0GjIub3JjaGVzdHJhdG9yLnYxLkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXNwb25zZRJe'
-    'Cg1HZXRTeW5jU3RhdHVzEiUub3JjaGVzdHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXF1ZXN0Gi'
-    'Yub3JjaGVzdHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXNwb25zZRJqChFHZXREb3dubG9hZFN0'
-    'YXR1cxIpLm9yY2hlc3RyYXRvci52MS5HZXREb3dubG9hZFN0YXR1c1JlcXVlc3QaKi5vcmNoZX'
-    'N0cmF0b3IudjEuR2V0RG93bmxvYWRTdGF0dXNSZXNwb25zZRJwChNHZXRNYWluY2hhaW5CYWxh'
-    'bmNlEisub3JjaGVzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3JjaG'
-    'VzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJhbGFuY2VSZXNwb25zZRJwChNHZXRTaWRlY2hhaW5C'
-    'YWxhbmNlEisub3JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3'
-    'JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaGFpbkJhbGFuY2VSZXNwb25zZRJwChNHYXRoZXJGaWxl'
-    'c1RvRGVsZXRlEisub3JjaGVzdHJhdG9yLnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXF1ZXN0Gi'
-    'wub3JjaGVzdHJhdG9yLnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXNwb25zZRJaCgtEZWxldGVG'
-    'aWxlcxIjLm9yY2hlc3RyYXRvci52MS5EZWxldGVGaWxlc1JlcXVlc3QaJC5vcmNoZXN0cmF0b3'
-    'IudjEuRGVsZXRlRmlsZXNSZXNwb25zZTABElgKC1JlamVjdEJsb2NrEiMub3JjaGVzdHJhdG9y'
-    'LnYxLlJlamVjdEJsb2NrUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5SZWplY3RCbG9ja1Jlc3'
-    'BvbnNlElgKC0FjY2VwdEJsb2NrEiMub3JjaGVzdHJhdG9yLnYxLkFjY2VwdEJsb2NrUmVxdWVz'
-    'dBokLm9yY2hlc3RyYXRvci52MS5BY2NlcHRCbG9ja1Jlc3BvbnNlEl0KDFJlc2V0VG9CbG9jax'
-    'IkLm9yY2hlc3RyYXRvci52MS5SZXNldFRvQmxvY2tSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYx'
-    'LlJlc2V0VG9CbG9ja1Jlc3BvbnNlMAESbQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3JjaGVzdH'
-    'JhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuR2V0'
-    'Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2USXgoNR2V0Qm1tQ29udGV4dBIlLm9yY2hlc3RyYXRvci'
-    '52MS5HZXRCbW1Db250ZXh0UmVxdWVzdBomLm9yY2hlc3RyYXRvci52MS5HZXRCbW1Db250ZXh0'
-    'UmVzcG9uc2USWAoLQ29yZVJhd0NhbGwSIy5vcmNoZXN0cmF0b3IudjEuQ29yZVJhd0NhbGxSZX'
-    'F1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUmVzcG9uc2USXgoNR2V0Rm9ya1N0'
-    'YXR1cxIlLm9yY2hlc3RyYXRvci52MS5HZXRGb3JrU3RhdHVzUmVxdWVzdBomLm9yY2hlc3RyYX'
-    'Rvci52MS5HZXRGb3JrU3RhdHVzUmVzcG9uc2U=');
+    'VzdHJhdG9yLnYxLlNodXRkb3duUmVzcG9uc2USVQoKQWRvcHRPd25lchIiLm9yY2hlc3RyYXRv'
+    'ci52MS5BZG9wdE93bmVyUmVxdWVzdBojLm9yY2hlc3RyYXRvci52MS5BZG9wdE93bmVyUmVzcG'
+    '9uc2USWAoLR2V0QlRDUHJpY2USIy5vcmNoZXN0cmF0b3IudjEuR2V0QlRDUHJpY2VSZXF1ZXN0'
+    'GiQub3JjaGVzdHJhdG9yLnYxLkdldEJUQ1ByaWNlUmVzcG9uc2UShQEKGkdldE1haW5jaGFpbk'
+    'Jsb2NrY2hhaW5JbmZvEjIub3JjaGVzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJsb2NrY2hhaW5J'
+    'bmZvUmVxdWVzdBozLm9yY2hlc3RyYXRvci52MS5HZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1'
+    'Jlc3BvbnNlEoIBChlHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvEjEub3JjaGVzdHJhdG9yLnYx'
+    'LkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjIub3JjaGVzdHJhdG9yLnYxLkdldE'
+    'VuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXNwb25zZRJeCg1HZXRTeW5jU3RhdHVzEiUub3JjaGVz'
+    'dHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXF1ZXN0GiYub3JjaGVzdHJhdG9yLnYxLkdldFN5bm'
+    'NTdGF0dXNSZXNwb25zZRJqChFHZXREb3dubG9hZFN0YXR1cxIpLm9yY2hlc3RyYXRvci52MS5H'
+    'ZXREb3dubG9hZFN0YXR1c1JlcXVlc3QaKi5vcmNoZXN0cmF0b3IudjEuR2V0RG93bmxvYWRTdG'
+    'F0dXNSZXNwb25zZRJwChNHZXRNYWluY2hhaW5CYWxhbmNlEisub3JjaGVzdHJhdG9yLnYxLkdl'
+    'dE1haW5jaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3JjaGVzdHJhdG9yLnYxLkdldE1haW5jaGFpbk'
+    'JhbGFuY2VSZXNwb25zZRJwChNHZXRTaWRlY2hhaW5CYWxhbmNlEisub3JjaGVzdHJhdG9yLnYx'
+    'LkdldFNpZGVjaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaG'
+    'FpbkJhbGFuY2VSZXNwb25zZRJwChNHYXRoZXJGaWxlc1RvRGVsZXRlEisub3JjaGVzdHJhdG9y'
+    'LnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXF1ZXN0Giwub3JjaGVzdHJhdG9yLnYxLkdhdGhlck'
+    'ZpbGVzVG9EZWxldGVSZXNwb25zZRJaCgtEZWxldGVGaWxlcxIjLm9yY2hlc3RyYXRvci52MS5E'
+    'ZWxldGVGaWxlc1JlcXVlc3QaJC5vcmNoZXN0cmF0b3IudjEuRGVsZXRlRmlsZXNSZXNwb25zZT'
+    'ABElgKC1JlamVjdEJsb2NrEiMub3JjaGVzdHJhdG9yLnYxLlJlamVjdEJsb2NrUmVxdWVzdBok'
+    'Lm9yY2hlc3RyYXRvci52MS5SZWplY3RCbG9ja1Jlc3BvbnNlElgKC0FjY2VwdEJsb2NrEiMub3'
+    'JjaGVzdHJhdG9yLnYxLkFjY2VwdEJsb2NrUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5BY2Nl'
+    'cHRCbG9ja1Jlc3BvbnNlEl0KDFJlc2V0VG9CbG9jaxIkLm9yY2hlc3RyYXRvci52MS5SZXNldF'
+    'RvQmxvY2tSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLlJlc2V0VG9CbG9ja1Jlc3BvbnNlMAES'
+    'bQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3JjaGVzdHJhdG9yLnYxLkdldENvcmVNZW1wb29sSW'
+    '5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuR2V0Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2US'
+    'XgoNR2V0Qm1tQ29udGV4dBIlLm9yY2hlc3RyYXRvci52MS5HZXRCbW1Db250ZXh0UmVxdWVzdB'
+    'omLm9yY2hlc3RyYXRvci52MS5HZXRCbW1Db250ZXh0UmVzcG9uc2USWAoLQ29yZVJhd0NhbGwS'
+    'Iy5vcmNoZXN0cmF0b3IudjEuQ29yZVJhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLk'
+    'NvcmVSYXdDYWxsUmVzcG9uc2USXgoNR2V0Rm9ya1N0YXR1cxIlLm9yY2hlc3RyYXRvci52MS5H'
+    'ZXRGb3JrU3RhdHVzUmVxdWVzdBomLm9yY2hlc3RyYXRvci52MS5HZXRGb3JrU3RhdHVzUmVzcG'
+    '9uc2U=');
 

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
@@ -37,6 +37,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
   $async.Future<$3.ConfirmPendingNetworkGenerationResponse> confirmPendingNetworkGeneration($pb.ServerContext ctx, $3.ConfirmPendingNetworkGenerationRequest request);
   $async.Future<$3.ShutdownAllResponse> shutdownAll($pb.ServerContext ctx, $3.ShutdownAllRequest request);
   $async.Future<$3.ShutdownResponse> shutdown($pb.ServerContext ctx, $3.ShutdownRequest request);
+  $async.Future<$3.AdoptOwnerResponse> adoptOwner($pb.ServerContext ctx, $3.AdoptOwnerRequest request);
   $async.Future<$3.GetBTCPriceResponse> getBTCPrice($pb.ServerContext ctx, $3.GetBTCPriceRequest request);
   $async.Future<$3.GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo($pb.ServerContext ctx, $3.GetMainchainBlockchainInfoRequest request);
   $async.Future<$3.GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo($pb.ServerContext ctx, $3.GetEnforcerBlockchainInfoRequest request);
@@ -72,6 +73,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
       case 'ConfirmPendingNetworkGeneration': return $3.ConfirmPendingNetworkGenerationRequest();
       case 'ShutdownAll': return $3.ShutdownAllRequest();
       case 'Shutdown': return $3.ShutdownRequest();
+      case 'AdoptOwner': return $3.AdoptOwnerRequest();
       case 'GetBTCPrice': return $3.GetBTCPriceRequest();
       case 'GetMainchainBlockchainInfo': return $3.GetMainchainBlockchainInfoRequest();
       case 'GetEnforcerBlockchainInfo': return $3.GetEnforcerBlockchainInfoRequest();
@@ -110,6 +112,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
       case 'ConfirmPendingNetworkGeneration': return this.confirmPendingNetworkGeneration(ctx, request as $3.ConfirmPendingNetworkGenerationRequest);
       case 'ShutdownAll': return this.shutdownAll(ctx, request as $3.ShutdownAllRequest);
       case 'Shutdown': return this.shutdown(ctx, request as $3.ShutdownRequest);
+      case 'AdoptOwner': return this.adoptOwner(ctx, request as $3.AdoptOwnerRequest);
       case 'GetBTCPrice': return this.getBTCPrice(ctx, request as $3.GetBTCPriceRequest);
       case 'GetMainchainBlockchainInfo': return this.getMainchainBlockchainInfo(ctx, request as $3.GetMainchainBlockchainInfoRequest);
       case 'GetEnforcerBlockchainInfo': return this.getEnforcerBlockchainInfo(ctx, request as $3.GetEnforcerBlockchainInfoRequest);

--- a/sidechain_core/lib/providers/binaries/binary_provider.dart
+++ b/sidechain_core/lib/providers/binaries/binary_provider.dart
@@ -398,6 +398,19 @@ class BinaryProvider extends ChangeNotifier {
     );
   }
 
+  /// Names every daemon a PID file still points at, as "bitcoind (pid 1234)".
+  /// A page with no backend to ask uses this to name what holds the machine.
+  Future<List<String>> liveDaemonNames() async {
+    final found = <String>[];
+    for (final binary in binaries) {
+      final pid = await _processManager.pidFileManager.readPidFile(binary);
+      if (pid != null && await _processManager.pidFileManager.validatePid(pid, binary)) {
+        found.add('${binary.binaryName} (pid $pid)');
+      }
+    }
+    return found;
+  }
+
   /// Daemon binaries are spawned directly by Flutter rather than via the
   /// orchestrator RPC (it can't start itself, and bitwindowd is the host
   /// process for the embedded orchestrator).


### PR DESCRIPTION
An app update keeps the backend alive when the new frontend takes control before exit. Late transfers return an error.
