### PR TITLE
orchestrator: place an opening BMM bid in light mode

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -111,6 +111,15 @@ L1Gate resolveL1Gate({
   return synced ? L1Gate.ready : L1Gate.syncing;
 }
 
+/// Names the networks that serve sidechains in light mode.
+@visibleForTesting
+String lightSidechainNetworksLine(List<String> networks) {
+  if (networks.isEmpty) {
+    return 'No network hosts an enforcer yet, so light mode serves sidechains nowhere.';
+  }
+  return 'Light mode serves sidechains on ${networks.join(', ')}.';
+}
+
 /// Stands in for the whole tab while the L1 stack is missing, and doubles as the
 /// place to start it — the same daemons the bottom nav reports on.
 class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
@@ -130,8 +139,9 @@ class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               SailText.secondary13(
-                'This network has no remote enforcer. Select full mode in Settings to use sidechains.',
+                'This network hosts no enforcer. Select full mode in Settings to use sidechains here.',
               ),
+              SailText.secondary13(lightSidechainNetworksLine(viewModel.remoteEnforcerNetworks)),
               SailText.secondary13('Your Bitcoin wallet still uses Electrum.'),
             ],
           ),
@@ -747,6 +757,9 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
   }
 
   bool get loading => _enforcerRPC.initializingBinary;
+
+  /// Networks that serve sidechains in light mode.
+  List<String> get remoteEnforcerNetworks => _nodeMode?.remoteEnforcerNetworks ?? const [];
 
   /// The connection state before the tab can read BIP300 data.
   L1Gate get l1Gate => resolveL1Gate(

--- a/bitwindow/test/sidechains_l1_gate_test.dart
+++ b/bitwindow/test/sidechains_l1_gate_test.dart
@@ -163,4 +163,26 @@ void main() {
       );
     });
   });
+
+  // A user who reads the unavailable card must learn where light mode does
+  // serve sidechains, not only that this network does not.
+  group('lightSidechainNetworksLine', () {
+    test('names the networks that host an enforcer', () {
+      expect(
+        lightSidechainNetworksLine(['Alphanet']),
+        'Light mode serves sidechains on Alphanet.',
+      );
+      expect(
+        lightSidechainNetworksLine(['Alphanet', 'signet']),
+        'Light mode serves sidechains on Alphanet, signet.',
+      );
+    });
+
+    test('says so when no network hosts one', () {
+      expect(
+        lightSidechainNetworksLine([]),
+        'No network hosts an enforcer yet, so light mode serves sidechains nowhere.',
+      );
+    });
+  });
 }

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -9,6 +9,10 @@ import 'package:sidechain_core/utils/explorer_url.dart';
 import 'package:stacked/stacked.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+/// What light mode cannot do, which the bid controls say out loud.
+const String raiseUnavailableInLightMode =
+    'Light mode places an opening bid. It reads no rival bid, so it never raises.';
+
 /// Reason bidding is unavailable, or null when it is allowed.
 ///
 /// A bid commits to the tip the enforcer has validated, so one built while it
@@ -16,23 +20,41 @@ import 'package:url_launcher/url_launcher.dart';
 /// never be included. The orchestrator rejects those bids too — this only keeps
 /// the controls from offering an action that cannot succeed.
 String? bidBlockedReasonFor(SyncProvider sync, {bool lightMode = false}) {
-  if (lightMode) {
-    return 'BMM is unavailable in light mode';
-  }
   // Without Core the enforcer's goal falls back to its own height, which reads
-  // as synced however far behind it is.
-  if (sync.mainchainSyncInfo == null || (sync.mainchainError?.isNotEmpty ?? false)) {
+  // as synced however far behind it is. A light install runs no Core at all,
+  // and the remote validator it reads stands at the tip.
+  if (!lightMode && (sync.mainchainSyncInfo == null || (sync.mainchainError?.isNotEmpty ?? false))) {
     return 'Waiting for Bitcoin Core';
   }
   final enforcer = sync.enforcerSyncInfo;
   if (enforcer == null || (sync.enforcerError?.isNotEmpty ?? false)) {
     return 'Waiting for the enforcer to start';
   }
+  if (lightMode) {
+    return lightEnforcerBlockedReason(sync, enforcer);
+  }
   if (enforcer.isSynced) {
     return null;
   }
   return 'Enforcer is syncing — '
       '${enforcer.progressCurrent.toInt()} of ${enforcer.progressGoal.toInt()} blocks';
+}
+
+/// Reason the remote enforcer blocks a light-mode bid, null when it allows one.
+///
+/// Without Core the enforcer reports its own height as the goal, so it reads as
+/// synced however far it trails. The wallet chain source carries the only other
+/// mainchain tip a light install reads.
+String? lightEnforcerBlockedReason(SyncProvider sync, SyncInfo enforcer) {
+  final source = sync.chainSourceSyncInfo;
+  if (source == null || (sync.chainSourceError?.isNotEmpty ?? false) || source.progressCurrent <= 0) {
+    return 'Waiting for the wallet chain source';
+  }
+  if (enforcer.progressCurrent >= source.progressCurrent) {
+    return null;
+  }
+  return 'Enforcer is syncing — '
+      '${enforcer.progressCurrent.toInt()} of ${source.progressCurrent.toInt()} blocks';
 }
 
 final NumberFormat _thousands = NumberFormat('#,##0', 'en_US');
@@ -232,7 +254,7 @@ class _Controls extends StatelessWidget {
             ),
           ],
         ),
-        if (viewModel.isLight) SailText.secondary12(viewModel.bidBlockedReason!),
+        if (viewModel.isLight) SailText.secondary12(raiseUnavailableInLightMode),
         if (viewModel.fundingWarning)
           SailText.secondary12(
             viewModel.fundingWarningLabel,
@@ -734,9 +756,6 @@ class BMMViewModel extends BaseViewModel {
   }
 
   String get slotStatus {
-    if (isLight) {
-      return 'Paused';
-    }
     if (!running) {
       return 'Not bidding';
     }
@@ -861,8 +880,11 @@ class BMMViewModel extends BaseViewModel {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SailText.secondary13(
-                  'A losing bid never confirms and leaves the mempool, so this is every bid we saw '
-                  'while the block was pending — not proof that it was all of them.',
+                  isLight
+                      ? 'Light mode reads no mainchain mempool, so this lists our own bids alone. '
+                            'A rival bid can exist and never appear here.'
+                      : 'A losing bid never confirms and leaves the mempool, so this is every bid we saw '
+                            'while the block was pending — not proof that it was all of them.',
                 ),
                 _TableFrame(
                   height: tableFrameHeight(bids.length),

--- a/sail_ui/test/bmm_light_mode_test.dart
+++ b/sail_ui/test/bmm_light_mode_test.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/pages/sidechains/bmm_tab.dart';
 import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/bmm/v1/bmm.pb.dart' as bmmpb;
 import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 
 class _Bmm extends ChangeNotifier implements BMMProvider {
@@ -15,6 +16,9 @@ class _Bmm extends ChangeNotifier implements BMMProvider {
 
   @override
   bool running = false;
+
+  @override
+  bmmpb.Bid? get liveBid => null;
 
   int stops = 0;
 
@@ -52,7 +56,8 @@ void main() {
     bmm = _Bmm();
     sync = SyncProvider(startTimer: false)
       ..mainchainSyncInfo = SyncInfo(progressCurrent: 42, progressGoal: 42, lastBlockAt: null)
-      ..enforcerSyncInfo = SyncInfo(progressCurrent: 42, progressGoal: 42, lastBlockAt: null);
+      ..enforcerSyncInfo = SyncInfo(progressCurrent: 42, progressGoal: 42, lastBlockAt: null)
+      ..chainSourceSyncInfo = SyncInfo(progressCurrent: 42, progressGoal: 42, lastBlockAt: null);
     GetIt.I.registerSingleton<NodeModeProvider>(mode);
     GetIt.I.registerSingleton<BMMProvider>(bmm);
     GetIt.I.registerSingleton<BitcoinConfProvider>(_Conf());
@@ -69,7 +74,7 @@ void main() {
     await GetIt.I.reset();
   });
 
-  test('a mode change blocks bids even when Core and the enforcer are ready', () {
+  test('light mode bids, and a Core outage never blocks it', () {
     var changes = 0;
     model.addListener(() => changes++);
     expect(model.canBid, isTrue);
@@ -77,29 +82,57 @@ void main() {
     mode.setMode(wmpb.NodeMode.NODE_MODE_LIGHT);
 
     expect(changes, 1);
-    expect(model.canBid, isFalse);
-    expect(model.bidBlockedReason, 'BMM is unavailable in light mode');
+    expect(model.canBid, isTrue, reason: 'light mode places an opening bid');
+    expect(model.bidBlockedReason, isNull);
 
-    mode.setMode(wmpb.NodeMode.NODE_MODE_FULL);
+    sync.mainchainError = 'Core is unavailable';
 
-    expect(changes, 2);
-    expect(model.canBid, isTrue);
+    expect(model.canBid, isTrue, reason: 'a light install runs no Core to wait for');
   });
 
-  test('light mode states the BMM limit before a Core connection error', () {
+  test('full mode still waits for Core', () {
     sync.mainchainError = 'Core is unavailable';
+
+    expect(model.canBid, isFalse);
+    expect(model.bidBlockedReason, 'Waiting for Bitcoin Core');
+  });
+
+  test('light mode waits for an enforcer behind the chain source', () {
+    mode.setMode(wmpb.NodeMode.NODE_MODE_LIGHT);
+    sync.enforcerSyncInfo = SyncInfo(progressCurrent: 40, progressGoal: 40, lastBlockAt: null);
+
+    expect(model.canBid, isFalse, reason: 'a bid on a stale tip pays for a round it cannot win');
+    expect(model.bidBlockedReason, 'Enforcer is syncing — 40 of 42 blocks');
+  });
+
+  test('light mode bids with an enforcer ahead of the chain source', () {
+    mode.setMode(wmpb.NodeMode.NODE_MODE_LIGHT);
+    sync.enforcerSyncInfo = SyncInfo(progressCurrent: 43, progressGoal: 43, lastBlockAt: null);
+
+    expect(model.bidBlockedReason, isNull, reason: 'an electrum server that trails must not stop a bid');
+  });
+
+  test('light mode waits without a chain source tip', () {
+    mode.setMode(wmpb.NodeMode.NODE_MODE_LIGHT);
+    sync.chainSourceError = 'electrum is not reachable';
+
+    expect(model.bidBlockedReason, 'Waiting for the wallet chain source');
+  });
+
+  test('light mode says it cannot raise', () {
     mode.setMode(wmpb.NodeMode.NODE_MODE_LIGHT);
 
-    expect(model.bidBlockedReason, 'BMM is unavailable in light mode');
+    expect(model.isLight, isTrue);
+    expect(raiseUnavailableInLightMode, contains('never raises'));
+    expect(raiseUnavailableInLightMode, contains('reads no rival bid'));
   });
 
-  test('light mode pauses a saved target and permits Stop', () async {
+  test('light mode reports the bid state, not a pause', () async {
     bmm.running = true;
     mode.setMode(wmpb.NodeMode.NODE_MODE_LIGHT);
 
     expect(model.running, isTrue);
-    expect(model.canBid, isFalse);
-    expect(model.slotStatus, 'Paused');
+    expect(model.slotStatus, 'Assembling');
     await model.stopBidding();
     expect(bmm.stops, 1);
   });

--- a/sidechain-orchestrator/api/bmm_cancel.go
+++ b/sidechain-orchestrator/api/bmm_cancel.go
@@ -25,7 +25,7 @@ const cancelDustSats = 546
 func (h *BMMHandler) CancelBid(
 	ctx context.Context, req *connect.Request[bmmpb.CancelBidRequest],
 ) (*connect.Response[bmmpb.CancelBidResponse], error) {
-	if err := h.requireBMMAvailable(); err != nil {
+	if err := h.requireMempoolRead("a cancel"); err != nil {
 		return nil, err
 	}
 	if h.wallet == nil {

--- a/sidechain-orchestrator/api/bmm_frozen.go
+++ b/sidechain-orchestrator/api/bmm_frozen.go
@@ -12,18 +12,11 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
-// FrozenCoins names the candidates a live BMM bid can take away, keyed
-// txid:vout. It answers with no frozen coin in light mode, where no bid runs.
-//
-// A replacement evicts every mempool descendant of the bid it replaces, so a
-// send over the change of a live bid dies with that bid. A send over the coin
-// the bid spends replaces the bid itself. An unconfirmed coin the mainchain
-// node cannot name yet counts as frozen, because nothing else can tell a bid's
-// change from any other change.
+// FrozenCoins returns the candidate outpoints a live BMM bid can remove, keyed by txid:vout.
 func (h *BMMHandler) FrozenCoins(
 	ctx context.Context, candidates []wallet.Outpoint,
 ) (map[string]bool, error) {
-	if len(candidates) == 0 || !h.BMMAvailable() {
+	if len(candidates) == 0 || !h.ReadsMempool() {
 		return nil, nil
 	}
 
@@ -69,6 +62,9 @@ func (h *BMMHandler) FrozenCoins(
 func (h *BMMHandler) bidSpentCoins(
 	ctx context.Context, candidates []wallet.Outpoint, bids *bidCache,
 ) (map[string]bool, error) {
+	if !h.ReadsMempool() {
+		return nil, nil
+	}
 	if bids == nil {
 		bids = newBidCache(h)
 	}

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -97,16 +97,22 @@ func (h *BMMHandler) SetEngine(engine *engines.BmmEngine) {
 	h.engine = engine
 }
 
-// BMMAvailable reports whether the selected node mode supports BMM.
-func (h *BMMHandler) BMMAvailable() bool {
+func (h *BMMHandler) runsLocalCore() bool {
 	return h.orch.NodeMode() != orchestrator.NodeModeLight
 }
 
-func (h *BMMHandler) requireBMMAvailable() error {
-	if !h.BMMAvailable() {
-		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("BMM is unavailable in light mode"))
+// ReadsMempool reports whether this install reads the mainchain mempool. Only a
+// local Bitcoin Core serves that read; the remote enforcer publishes no mempool method.
+func (h *BMMHandler) ReadsMempool() bool {
+	return h.runsLocalCore()
+}
+
+func (h *BMMHandler) requireMempoolRead(action string) error {
+	if h.ReadsMempool() {
+		return nil
 	}
-	return nil
+	return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+		"%s reads the mainchain mempool, and light mode runs no Bitcoin Core", action))
 }
 
 // requireEnforcerSynced rejects bidding until the enforcer has validated every
@@ -118,31 +124,51 @@ func (h *BMMHandler) requireBMMAvailable() error {
 // controls unlock: GetSyncStatus fills the enforcer's Headers from the
 // mainchain tip, leaving Blocks == Headers as "level with Core".
 func (h *BMMHandler) requireEnforcerSynced(ctx context.Context) error {
-	if err := h.requireBMMAvailable(); err != nil {
-		return err
-	}
 	status, err := h.orch.GetSyncStatus(ctx)
 	if err != nil {
 		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("read sync status: %w", err))
 	}
-	return enforcerBiddingBlocked(status)
+	return enforcerBiddingBlocked(status, h.runsLocalCore())
 }
 
 // enforcerBiddingBlocked returns the reason bidding is unavailable for status,
-// or nil when it is allowed.
-func enforcerBiddingBlocked(status *orchestrator.SyncStatus) error {
-	if status == nil || status.Mainchain == nil || status.Enforcer == nil {
+// or nil when it is allowed. readsCore is false for an install with no local
+// Bitcoin Core, which reports a mainchain error at all times.
+func enforcerBiddingBlocked(status *orchestrator.SyncStatus, readsCore bool) error {
+	if status == nil || status.Enforcer == nil || (readsCore && status.Mainchain == nil) {
 		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("sync status unavailable"))
 	}
-	if msg := status.Mainchain.Error; msg != "" {
-		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("bitcoin core is not available: %s", msg))
+	if readsCore && status.Mainchain.Error != "" {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"bitcoin core is not available: %s", status.Mainchain.Error))
 	}
 	if msg := status.Enforcer.Error; msg != "" {
 		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("enforcer is not available: %s", msg))
 	}
+	if !readsCore {
+		return enforcerLevelWithChainSource(status)
+	}
 	if status.Enforcer.Headers <= 0 || status.Enforcer.Blocks != status.Enforcer.Headers {
 		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
 			"enforcer is still syncing: %d of %d blocks", status.Enforcer.Blocks, status.Enforcer.Headers,
+		))
+	}
+	return nil
+}
+
+// enforcerLevelWithChainSource measures the remote enforcer against the wallet
+// chain source. Without Core, GetSyncStatus fills the enforcer's Headers from
+// its own Blocks, so that pair reports a stale enforcer as synced. The wallet
+// chain source is the only other mainchain tip a light install reads.
+func enforcerLevelWithChainSource(status *orchestrator.SyncStatus) error {
+	source := status.ChainSource
+	if source == nil || source.Error != "" || source.Blocks <= 0 {
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
+			"the wallet chain source reports no tip to measure the enforcer against"))
+	}
+	if status.Enforcer.Blocks < source.Blocks {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"enforcer is still syncing: %d of %d blocks", status.Enforcer.Blocks, source.Blocks,
 		))
 	}
 	return nil
@@ -330,6 +356,12 @@ func (h *BMMHandler) CreateBid(
 	if err := checkBidInput(req.Msg.BidSats, req.Msg.FeeRateSatVb); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	// A raise is refused for good, so it names its own reason before a gate that refuses for a moment.
+	if req.Msg.ReplaceTxid != "" {
+		if err := h.requireMempoolRead("a raise"); err != nil {
+			return nil, err
+		}
+	}
 	if err := h.requireEnforcerSynced(ctx); err != nil {
 		return nil, err
 	}
@@ -440,12 +472,12 @@ func (h *BMMHandler) CreateBid(
 	// The fee is spent by now, so a lookup that misses — an electrum broadcast
 	// the local node has not seen, or a block that already took it — reports
 	// the asking price rather than losing the bid.
-	if paid, err := h.bidFeeSats(ctx, send.Msg.Txid); err == nil {
+	if !h.ReadsMempool() {
+		bidSats = askingBidSats(bidSats, byRate, req.Msg.FeeRateSatVb)
+	} else if paid, err := h.bidFeeSats(ctx, send.Msg.Txid); err == nil {
 		bidSats = paid
 	} else {
-		if byRate {
-			bidSats = int64(math.Ceil(req.Msg.FeeRateSatVb * nominalBidVsize))
-		}
+		bidSats = askingBidSats(bidSats, byRate, req.Msg.FeeRateSatVb)
 		zerolog.Ctx(ctx).Warn().Err(err).Str("txid", send.Msg.Txid).
 			Msg("could not read what the bid paid, reporting what it asked for")
 	}
@@ -532,7 +564,7 @@ func connectTarget(want string, inclusions []string) string {
 func (h *BMMHandler) ListBids(
 	ctx context.Context, req *connect.Request[bmmpb.ListBidsRequest],
 ) (*connect.Response[bmmpb.ListBidsResponse], error) {
-	if err := h.requireBMMAvailable(); err != nil {
+	if err := h.requireMempoolRead("the competing bids"); err != nil {
 		return nil, err
 	}
 	cfg, err := h.sidechainConfig(req.Msg.Sidechain)
@@ -573,8 +605,12 @@ func (h *BMMHandler) ListBids(
 	return connect.NewResponse(&bmmpb.ListBidsResponse{Bids: bids}), nil
 }
 
-// mempoolTxids names every transaction the mainchain mempool holds.
+// mempoolTxids names every transaction the mainchain mempool holds. It names
+// none for an install that reads no mempool.
 func (h *BMMHandler) mempoolTxids(ctx context.Context) (map[string]bool, error) {
+	if !h.ReadsMempool() {
+		return nil, nil
+	}
 	raw, err := h.coreCall(ctx, "getrawmempool", "[false]")
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("get raw mempool: %w", err))
@@ -672,9 +708,6 @@ func betterSlotCoin(a, b *wpb.UnspentOutput, slotSats int64) bool {
 func (h *BMMHandler) PrepareBMM(
 	ctx context.Context, req *connect.Request[bmmpb.PrepareBMMRequest],
 ) (*connect.Response[bmmpb.PrepareBMMResponse], error) {
-	if err := h.requireBMMAvailable(); err != nil {
-		return nil, err
-	}
 	if len(req.Msg.Targets) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("targets must name a sidechain"))
 	}
@@ -846,8 +879,9 @@ func (h *BMMHandler) readWalletCoins(
 			out.free = append(out.free, u)
 			continue
 		}
-		// A deposit over a bid carries no bid of its own, and a replacement of
-		// the bid below it takes the deposit and its change away as well.
+		if !h.ReadsMempool() {
+			continue
+		}
 		request, err := bids.get(ctx, u.Txid)
 		if err != nil {
 			zerolog.Ctx(ctx).Debug().Err(err).Str("txid", u.Txid).Msg("read the parent of a wallet coin")
@@ -933,6 +967,15 @@ func largestCoin(coins []*wpb.UnspentOutput) *wpb.UnspentOutput {
 		}
 	}
 	return largest
+}
+
+// askingBidSats is the price a bid asked for. It stands in when no mempool entry
+// reports what the bid paid.
+func askingBidSats(bidSats int64, byRate bool, rateSatVb float64) int64 {
+	if !byRate {
+		return bidSats
+	}
+	return int64(math.Ceil(rateSatVb * nominalBidVsize))
 }
 
 // pinSats is what the pinned coin has to cover. A bid sized at a rate carries

--- a/sidechain-orchestrator/api/bmm_mode_test.go
+++ b/sidechain-orchestrator/api/bmm_mode_test.go
@@ -3,11 +3,13 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
@@ -16,6 +18,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/engines/bmmstate"
 	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 )
 
 func newBMMModeHandler(t *testing.T) (*BMMHandler, *bmmstate.Store) {
@@ -37,35 +40,136 @@ func newBMMModeHandler(t *testing.T) (*BMMHandler, *bmmstate.Store) {
 	return h, store
 }
 
-func TestBMMLightModeRejectsCoreWork(t *testing.T) {
-	for _, operation := range []string{"start", "create", "list"} {
-		t.Run(operation, func(t *testing.T) {
-			h, _ := newBMMModeHandler(t)
-			require.NoError(t, orchestrator.WriteNodeMode(h.orch.BitwindowDir, orchestrator.NodeModeLight))
-			require.Equal(t, orchestrator.NodeModeLight, h.orch.NodeMode())
-			var coreCalls int
-			h.SetCoreCaller(func(context.Context, string, string, string) (json.RawMessage, error) {
-				coreCalls++
-				return json.RawMessage(`{}`), nil
-			})
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			var err error
-			switch operation {
-			case "start":
-				_, err = h.Start(ctx, connect.NewRequest(&bmmpb.StartRequest{Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER, MaxBidSats: 10000}))
-			case "create":
-				_, err = h.CreateBid(ctx, connect.NewRequest(&bmmpb.CreateBidRequest{Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER, BidSats: 1000}))
-			case "list":
-				_, err = h.ListBids(ctx, connect.NewRequest(&bmmpb.ListBidsRequest{Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER}))
-			}
-			require.ErrorContains(t, err, "BMM is unavailable in light mode")
-			require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
-			require.Zero(t, coreCalls)
-			running, _, _ := h.engine.Running(pb.BinaryType_BINARY_TYPE_THUNDER)
-			require.False(t, running)
+// lightHandler answers in light mode, and fails the test on a Core call.
+func lightHandler(t *testing.T) *BMMHandler {
+	t.Helper()
+	h, _ := newBMMModeHandler(t)
+	require.NoError(t, orchestrator.WriteNodeMode(h.orch.BitwindowDir, orchestrator.NodeModeLight))
+	require.Equal(t, orchestrator.NodeModeLight, h.orch.NodeMode())
+	h.SetCoreCaller(func(_ context.Context, method, _, _ string) (json.RawMessage, error) {
+		t.Errorf("light mode called core: %s", method)
+		return nil, fmt.Errorf("no core")
+	})
+	return h
+}
+
+// Every mempool read names the mempool as the reason, so a user reads what is
+// missing rather than which mode they picked.
+func TestBMMLightModeRefusesTheMempoolReads(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		call   func(*BMMHandler) error
+	}{
+		{
+			name:   "list the competing bids",
+			reason: "the competing bids reads the mainchain mempool",
+			call: func(h *BMMHandler) error {
+				_, err := h.ListBids(context.Background(),
+					connect.NewRequest(&bmmpb.ListBidsRequest{Sidechain: pb.BinaryType_BINARY_TYPE_THUNDER}))
+				return err
+			},
+		},
+		{
+			name:   "raise a live bid",
+			reason: "a raise reads the mainchain mempool",
+			call: func(h *BMMHandler) error {
+				_, err := h.CreateBid(context.Background(), connect.NewRequest(&bmmpb.CreateBidRequest{
+					Sidechain:   pb.BinaryType_BINARY_TYPE_THUNDER,
+					BidSats:     2_000,
+					MaxBidSats:  30_000,
+					ReplaceTxid: "live",
+				}))
+				return err
+			},
+		},
+		{
+			name:   "cancel a stranded bid",
+			reason: "a cancel reads the mainchain mempool",
+			call: func(h *BMMHandler) error {
+				_, err := h.CancelBid(context.Background(),
+					connect.NewRequest(&bmmpb.CancelBidRequest{Txid: "stranded"}))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call(lightHandler(t))
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+			assert.Contains(t, err.Error(), tc.reason)
+			assert.Contains(t, err.Error(), "light mode runs no Bitcoin Core")
 		})
 	}
+}
+
+// The opening bid picks its coin without a mempool read. Only a confirmed coin
+// qualifies: the parent of an unconfirmed one names the slot that owns it, and
+// that parent is out of reach.
+func TestBMMLightModePicksAConfirmedCoin(t *testing.T) {
+	const unconfirmed = "1111111111111111111111111111111111111111111111111111111111111111"
+	const confirmed = "2222222222222222222222222222222222222222222222222222222222222222"
+
+	h := lightHandler(t)
+	h.wallet = &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: unconfirmed, Vout: 0, AmountSats: 3_000_000, Spendable: true},
+		{Txid: confirmed, Vout: 0, AmountSats: 500_000, Spendable: true, Confirmations: 6},
+	}}
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 9, 10_000)
+	require.NoError(t, err)
+	assert.Equal(t, confirmed, coin.Txid)
+}
+
+// The coin split spends through the wallet alone, so light mode prepares its
+// coins like any other install.
+func TestBMMLightModePreparesCoins(t *testing.T) {
+	const coin = "3333333333333333333333333333333333333333333333333333333333333333"
+
+	h := lightHandler(t)
+	wallet := &fakeBidWallet{utxos: []*wpb.UnspentOutput{
+		{Txid: coin, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+	}}
+	h.wallet = wallet
+
+	resp, err := h.PrepareBMM(context.Background(), connect.NewRequest(&bmmpb.PrepareBMMRequest{
+		Targets: []*bmmpb.PrepareBMMTarget{{WalletId: "bidder", MaxBidSats: 30_000}},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Wallets, 1)
+	assert.EqualValues(t, 1, resp.Msg.Wallets[0].UsableCoins)
+	assert.Empty(t, wallet.sends, "one coin funds one sidechain")
+}
+
+// A bid that stays unconfirmed leaves change no light-mode bid can spend, so
+// the wallet splits another coin rather than counts that change as prepared.
+func TestBMMLightModeSplitsPastAnUnconfirmedCoin(t *testing.T) {
+	const unconfirmed = "4444444444444444444444444444444444444444444444444444444444444444"
+	const confirmed = "5555555555555555555555555555555555555555555555555555555555555555"
+
+	h := lightHandler(t)
+	wallet := &fakeBidWallet{
+		sendTxid: "6666666666666666666666666666666666666666666666666666666666666666",
+		utxos: []*wpb.UnspentOutput{
+			{Txid: unconfirmed, Vout: 0, AmountSats: 3_000_000, Spendable: true},
+			{Txid: confirmed, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+		},
+	}
+	h.wallet = wallet
+
+	resp, err := h.PrepareBMM(context.Background(), connect.NewRequest(&bmmpb.PrepareBMMRequest{
+		Targets: []*bmmpb.PrepareBMMTarget{
+			{WalletId: "bidder", MaxBidSats: 30_000},
+			{WalletId: "bidder", MaxBidSats: 30_000},
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Wallets, 1)
+	assert.EqualValues(t, 1, resp.Msg.Wallets[0].UsableCoins, "the unconfirmed coin counts for nothing")
+	require.Len(t, wallet.sends, 1, "the wallet splits the confirmed coin")
+	assert.Equal(t, confirmed, wallet.sends[0].RequiredInputs[0].Txid)
 }
 
 func TestBMMFullModeReadsCore(t *testing.T) {
@@ -101,5 +205,6 @@ func TestBMMLightModeKeepsStopAndPaidHistory(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, state.Running)
 	require.Len(t, state.History, 1)
-	require.Zero(t, state.NextBlockFeeRateSatVb)
+	// Light mode still opens a bid, so it still reports the rate one opens at.
+	require.Positive(t, state.NextBlockFeeRateSatVb)
 }

--- a/sidechain-orchestrator/api/bmm_sync_gate_test.go
+++ b/sidechain-orchestrator/api/bmm_sync_gate_test.go
@@ -14,46 +14,94 @@ func syncStatus(mainchain, enforcer *orchestrator.ChainSyncResult) *orchestrator
 	return &orchestrator.SyncStatus{Mainchain: mainchain, Enforcer: enforcer}
 }
 
+func withChainSource(status *orchestrator.SyncStatus, source *orchestrator.ChainSyncResult) *orchestrator.SyncStatus {
+	status.ChainSource = source
+	return status
+}
+
 func TestEnforcerBiddingBlocked(t *testing.T) {
+	synced := func() *orchestrator.ChainSyncResult {
+		return &orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}
+	}
+	coreDown := func() *orchestrator.ChainSyncResult {
+		return &orchestrator.ChainSyncResult{Error: "not running"}
+	}
+
 	tests := []struct {
-		name   string
-		status *orchestrator.SyncStatus
-		code   connect.Code
-		reason string
+		name      string
+		status    *orchestrator.SyncStatus
+		readsCore bool
+		code      connect.Code
+		reason    string
 	}{
 		{
-			name:   "level with core",
-			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}),
+			name:      "level with core",
+			status:    syncStatus(synced(), synced()),
+			readsCore: true,
 		},
 		{
-			name:   "enforcer trails core",
-			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Blocks: 4000, Headers: 8725}),
+			name:      "enforcer trails core",
+			status:    syncStatus(synced(), &orchestrator.ChainSyncResult{Blocks: 4000, Headers: 8725}),
+			readsCore: true,
+			code:      connect.CodeFailedPrecondition,
+			reason:    "still syncing",
+		},
+		{
+			name:      "enforcer ahead of core",
+			status:    syncStatus(synced(), &orchestrator.ChainSyncResult{Blocks: 8726, Headers: 8725}),
+			readsCore: true,
+			code:      connect.CodeFailedPrecondition,
+			reason:    "still syncing",
+		},
+		{
+			name:      "nothing synced yet",
+			status:    syncStatus(&orchestrator.ChainSyncResult{}, &orchestrator.ChainSyncResult{}),
+			readsCore: true,
+			code:      connect.CodeFailedPrecondition,
+			reason:    "still syncing",
+		},
+		{
+			name:      "enforcer not running",
+			status:    syncStatus(synced(), &orchestrator.ChainSyncResult{Error: "not running"}),
+			readsCore: true,
+			code:      connect.CodeFailedPrecondition,
+			reason:    "enforcer is not available",
+		},
+		{
+			name:      "core not running",
+			status:    syncStatus(&orchestrator.ChainSyncResult{Error: "not running"}, synced()),
+			readsCore: true,
+			code:      connect.CodeFailedPrecondition,
+			reason:    "bitcoin core is not available",
+		},
+		{
+			// An install with no local Core reports a mainchain error at all
+			// times, so the wallet chain source measures the remote enforcer.
+			name:   "no core, enforcer level with the chain source",
+			status: withChainSource(syncStatus(coreDown(), synced()), synced()),
+		},
+		{
+			name:   "no core, enforcer trails the chain source",
+			status: withChainSource(syncStatus(coreDown(), &orchestrator.ChainSyncResult{Blocks: 8700, Headers: 8700}), synced()),
 			code:   connect.CodeFailedPrecondition,
 			reason: "still syncing",
 		},
 		{
-			name:   "enforcer ahead of core",
-			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Blocks: 8726, Headers: 8725}),
-			code:   connect.CodeFailedPrecondition,
-			reason: "still syncing",
+			// An electrum server that trails the enforcer must not stop a bid.
+			name:   "no core, enforcer ahead of the chain source",
+			status: withChainSource(syncStatus(coreDown(), &orchestrator.ChainSyncResult{Blocks: 8726, Headers: 8726}), synced()),
 		},
 		{
-			name:   "nothing synced yet",
-			status: syncStatus(&orchestrator.ChainSyncResult{}, &orchestrator.ChainSyncResult{}),
-			code:   connect.CodeFailedPrecondition,
-			reason: "still syncing",
+			name:   "no core, no chain source tip",
+			status: withChainSource(syncStatus(coreDown(), synced()), &orchestrator.ChainSyncResult{Error: "electrum is not reachable"}),
+			code:   connect.CodeUnavailable,
+			reason: "no tip to measure the enforcer against",
 		},
 		{
-			name:   "enforcer not running",
-			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Error: "not running"}),
+			name:   "no core, remote enforcer down",
+			status: withChainSource(syncStatus(coreDown(), &orchestrator.ChainSyncResult{Error: "remote validator is not ready"}), synced()),
 			code:   connect.CodeFailedPrecondition,
 			reason: "enforcer is not available",
-		},
-		{
-			name:   "core not running",
-			status: syncStatus(&orchestrator.ChainSyncResult{Error: "not running"}, &orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}),
-			code:   connect.CodeFailedPrecondition,
-			reason: "bitcoin core is not available",
 		},
 		{
 			name:   "no status",
@@ -65,7 +113,7 @@ func TestEnforcerBiddingBlocked(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := enforcerBiddingBlocked(tc.status)
+			err := enforcerBiddingBlocked(tc.status, tc.readsCore)
 			if tc.reason == "" {
 				assert.NoError(t, err)
 				return

--- a/sidechain-orchestrator/api/node_mode.go
+++ b/sidechain-orchestrator/api/node_mode.go
@@ -55,6 +55,7 @@ func (h *WalletHandler) GetNodeMode(
 		Mode:                    nodeModeToProto(mode),
 		LightModeAvailable:      config.SupportsLightMode(network),
 		RemoteEnforcerAvailable: config.RemoteEnforcerURLForNetwork(network) != "",
+		RemoteEnforcerNetworks:  config.RemoteEnforcerNetworks(),
 	}), nil
 }
 

--- a/sidechain-orchestrator/config/remote_enforcer.go
+++ b/sidechain-orchestrator/config/remote_enforcer.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+import (
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+	"github.com/samber/lo"
+)
 
 // RemoteEnforcerURLForNetwork returns the published validator URL, or an empty string.
 func RemoteEnforcerURLForNetwork(network Network) string {
@@ -13,4 +16,22 @@ func RemoteEnforcerURLForNetwork(network Network) string {
 		return ""
 	}
 	return embedded.Services.Enforcer.URL
+}
+
+// RemoteEnforcerNetworks names every network that publishes a validator URL, by
+// the name the user reads. Light mode serves sidechains on these networks only.
+func RemoteEnforcerNetworks() []string {
+	withEnforcer := lo.Filter(AllNetworks(), func(n Network, _ int) bool {
+		return RemoteEnforcerURLForNetwork(n) != ""
+	})
+	return lo.Map(withEnforcer, func(n Network, _ int) string { return NetworkDisplayName(n) })
+}
+
+// NetworkDisplayName is the name the user reads for a network. The catalog
+// names the live eCash network, and the rest carry the name of the network.
+func NetworkDisplayName(n Network) string {
+	if name := PublishedDisplayName(n); name != "" {
+		return name
+	}
+	return string(n)
 }

--- a/sidechain-orchestrator/config/remote_enforcer_networks_test.go
+++ b/sidechain-orchestrator/config/remote_enforcer_networks_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A network that supports light mode still serves no sidechains without a
+// hosted validator. The list is what the UI names in its place.
+func TestRemoteEnforcerNetworksNamesOnlyThePublishedOnes(t *testing.T) {
+	names := RemoteEnforcerNetworks()
+	require.NotEmpty(t, names, "at least one network publishes a validator")
+
+	for _, n := range AllNetworks() {
+		hosted := RemoteEnforcerURLForNetwork(n) != ""
+		listed := slices.Contains(names, NetworkDisplayName(n))
+		assert.Equal(t, hosted, listed, "%s: the list and the URL must agree", n)
+	}
+}
+
+func TestNetworkDisplayNameFallsBackToTheNetwork(t *testing.T) {
+	assert.Equal(t, string(NetworkRegtest), NetworkDisplayName(NetworkRegtest))
+}

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -73,7 +73,9 @@ const (
 // BmmBackend assembles, broadcasts and connects bids, and reads what a
 // mainchain block committed to. Implemented by the BMM handler.
 type BmmBackend interface {
-	BMMAvailable() bool
+	// ReadsMempool reports whether the install reads the mainchain mempool.
+	// The competing bids and the price of a raise both come from it.
+	ReadsMempool() bool
 	CreateBid(context.Context, *connect.Request[bmmpb.CreateBidRequest]) (*connect.Response[bmmpb.CreateBidResponse], error)
 	ConnectBid(context.Context, *connect.Request[bmmpb.ConnectBidRequest]) (*connect.Response[bmmpb.ConnectBidResponse], error)
 	ListBids(context.Context, *connect.Request[bmmpb.ListBidsRequest]) (*connect.Response[bmmpb.ListBidsResponse], error)
@@ -531,9 +533,6 @@ func (e *BmmEngine) resumeUnconnected() {
 }
 
 func (e *BmmEngine) tick(ctx context.Context) {
-	if !e.backend.BMMAvailable() {
-		return
-	}
 	e.mu.Lock()
 	targets := make(map[pb.BinaryType]bmmTarget, len(e.targets))
 	for k, v := range e.targets {
@@ -585,7 +584,9 @@ func (e *BmmEngine) tick(ctx context.Context) {
 
 		// Same tip means the same round; the only move left is to out-bid.
 		if target.lastTip == tip {
-			e.maybeRaise(ctx, sidechain, target)
+			if e.backend.ReadsMempool() {
+				e.maybeRaise(ctx, sidechain, target)
+			}
 			continue
 		}
 		if !e.markTip(sidechain, tip) {
@@ -693,6 +694,9 @@ func (e *BmmEngine) openRound(
 func (e *BmmEngine) strandedBid(
 	ctx context.Context, sidechain pb.BinaryType, tip string,
 ) (bmmstate.Bid, bool) {
+	if !e.backend.ReadsMempool() {
+		return bmmstate.Bid{}, false
+	}
 	resp, err := e.backend.ListBids(ctx, connect.NewRequest(&bmmpb.ListBidsRequest{Sidechain: sidechain}))
 	if err != nil {
 		e.log.Debug().Err(err).Stringer("sidechain", sidechain).Msg("read mempool bids")
@@ -791,8 +795,12 @@ func (e *BmmEngine) retryTip(sidechain pb.BinaryType, tip string) {
 }
 
 // snapshotOthers records the competing bids. Once the round is decided these
-// are unrecoverable, so this is the only chance to see them.
+// are unrecoverable, so this is the only chance to see them. An install that
+// reads no mempool records none, rather than an empty list of rivals.
 func (e *BmmEngine) snapshotOthers(ctx context.Context, sidechain pb.BinaryType, tip string) []bmmstate.Bid {
+	if !e.backend.ReadsMempool() {
+		return nil
+	}
 	resp, err := e.backend.ListBids(ctx, connect.NewRequest(&bmmpb.ListBidsRequest{Sidechain: sidechain}))
 	if err != nil {
 		e.log.Debug().Err(err).Stringer("sidechain", sidechain).Msg("read competing bids")
@@ -903,9 +911,6 @@ func (e *BmmEngine) placeBid(
 // A miner leaves a cheaper bid in the mempool, and the engine raises only
 // against a competitor, so an opening bid under this rate never gets mined.
 func (e *BmmEngine) NextBlockRate(ctx context.Context) float64 {
-	if !e.backend.BMMAvailable() {
-		return 0
-	}
 	if e.fee == nil {
 		return relayMinimumRate
 	}

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -25,7 +25,7 @@ const testSidechain = pb.BinaryType_BINARY_TYPE_THUNDER
 type fakeBackend struct {
 	mu sync.Mutex
 
-	disabled          bool
+	noMempool         bool
 	bids              int
 	connects          int
 	connected         bool
@@ -51,10 +51,10 @@ type fakeBackend struct {
 	lastFeeRate       float64
 }
 
-func (f *fakeBackend) BMMAvailable() bool {
+func (f *fakeBackend) ReadsMempool() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return !f.disabled
+	return !f.noMempool
 }
 
 func (f *fakeBackend) CreateBid(

--- a/sidechain-orchestrator/engines/bmm_mode_test.go
+++ b/sidechain-orchestrator/engines/bmm_mode_test.go
@@ -4,62 +4,77 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
 )
 
-func TestBmmEnginePausesWhenBackendIsUnavailable(t *testing.T) {
-	for _, resume := range []bool{false, true} {
-		name := "active"
-		if resume {
-			name = "resumed"
-		}
-		t.Run(name, func(t *testing.T) {
-			engine, backend, tip, store := newEngine(t)
-			fee := newFakeFee()
-			engine.fee = fee
-			ctx := context.Background()
-			require.NoError(t, engine.Start(ctx, testSidechain, "wallet", 20000, false))
-			engine.tick(ctx)
-			backend.commitment = "critical"
-			backend.noInclusion = true
-			tip.set("block-2")
-			engine.tick(ctx)
-			history := mustHistory(t, engine)
-			require.Equal(t, ResultWon, history[len(history)-1].Result)
-			current := engine.Current(testSidechain)
-			targets, err := store.Targets()
-			require.NoError(t, err)
-			bids, connects, tipCalls, feeCalls := backend.bids, backend.connects, tip.calls, fee.calls
-			backend.disabled = true
-			if resume {
-				engine = NewBmmEngine(engine.log, backend, tip, fee, store)
-				engine.resumeTargets()
-				engine.resumeUnconnected()
-			}
-			tip.set("block-3")
-			for range 2 {
-				engine.tick(ctx)
-			}
-			require.Equal(t, bids, backend.bids)
-			require.Equal(t, connects, backend.connects)
-			require.Equal(t, tipCalls, tip.calls)
-			require.Zero(t, engine.NextBlockRate(ctx))
-			require.Equal(t, feeCalls, fee.calls)
-			require.Equal(t, history, mustHistory(t, engine))
-			require.Equal(t, current, engine.Current(testSidechain))
-			savedTargets, err := store.Targets()
-			require.NoError(t, err)
-			require.Equal(t, targets, savedTargets)
-			running, _, _ := engine.Running(testSidechain)
-			require.True(t, running)
+// A backend with no mempool read still opens a bid and connects the block it
+// wins. Only the raise and the rival list depend on the mempool.
+func TestBmmEngineBidsWithNoMempoolRead(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	backend.noMempool = true
+	backend.feesSats = 50_000
+	backend.connected = true
+	ctx := context.Background()
+	require.NoError(t, engine.Start(ctx, testSidechain, "wallet", 30_000, false))
 
-			backend.disabled = false
-			backend.noInclusion = false
-			backend.connected = true
-			engine.tick(ctx)
-			require.Greater(t, backend.bids, bids)
-			require.Greater(t, backend.connects, connects)
-			require.Equal(t, BidConnected, roundOn(t, engine, "block-1").OurBids[0].State)
-		})
-	}
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids, "the opening bid goes out")
+
+	backend.commitment = "critical"
+	tip.set("block-2")
+	engine.tick(ctx)
+
+	require.Equal(t, 1, backend.connects, "the won block connects")
+	assert.Equal(t, BidConnected, roundOn(t, engine, "block-1").OurBids[0].State)
+}
+
+// A rival never reaches a backend with no mempool read, so it never raises.
+func TestBmmEngineNeverRaisesWithNoMempoolRead(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.noMempool = true
+	backend.feesSats = 50_000
+	ctx := context.Background()
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 30_000, false))
+
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids)
+
+	backend.others = []*bmmpb.Bid{{Txid: "rival", CriticalHash: "rival-h", BidSats: 12_000}}
+	engine.tick(ctx)
+
+	assert.Equal(t, 1, backend.bids, "the bid stands at its opening price")
+	round := engine.Current(testSidechain)
+	require.Len(t, round.OurBids, 1)
+	assert.Equal(t, BidLive, round.OurBids[0].State)
+	assert.Empty(t, round.OtherBids, "an unread mempool names no rival")
+}
+
+// The same backend with a mempool read raises against that rival.
+func TestBmmEngineRaisesWithAMempoolRead(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.feesSats = 50_000
+	ctx := context.Background()
+	require.NoError(t, engine.Start(ctx, testSidechain, "", 30_000, false))
+
+	engine.tick(ctx)
+	backend.others = []*bmmpb.Bid{{Txid: "rival", CriticalHash: "rival-h", BidSats: 12_000}}
+	engine.tick(ctx)
+
+	require.Equal(t, 2, backend.bids, "outbid, so we raise")
+	assert.Equal(t, int64(13_000), backend.lastBidSats)
+	assert.Equal(t, "txid-1", backend.lastReplace)
+}
+
+// The opening rate comes from the fee source, not from the mempool.
+func TestBmmEngineRatesWithNoMempoolRead(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.noMempool = true
+	fee := newFakeFee()
+	engine.fee = fee
+
+	assert.Positive(t, engine.NextBlockRate(context.Background()))
+	assert.Equal(t, 1, fee.calls)
 }

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -744,8 +744,10 @@ type GetNodeModeResponse struct {
 	LightModeAvailable bool `protobuf:"varint,2,opt,name=light_mode_available,json=lightModeAvailable,proto3" json:"light_mode_available,omitempty"`
 	// True when the current network has a remote validator endpoint.
 	RemoteEnforcerAvailable bool `protobuf:"varint,3,opt,name=remote_enforcer_available,json=remoteEnforcerAvailable,proto3" json:"remote_enforcer_available,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Display names of every network with a remote validator endpoint.
+	RemoteEnforcerNetworks []string `protobuf:"bytes,4,rep,name=remote_enforcer_networks,json=remoteEnforcerNetworks,proto3" json:"remote_enforcer_networks,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *GetNodeModeResponse) Reset() {
@@ -797,6 +799,13 @@ func (x *GetNodeModeResponse) GetRemoteEnforcerAvailable() bool {
 		return x.RemoteEnforcerAvailable
 	}
 	return false
+}
+
+func (x *GetNodeModeResponse) GetRemoteEnforcerNetworks() []string {
+	if x != nil {
+		return x.RemoteEnforcerNetworks
+	}
+	return nil
 }
 
 type SetNodeModeRequest struct {
@@ -10091,11 +10100,12 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"total_sats\x18\x01 \x01(\x03R\ttotalSats\x12\x1f\n" +
 	"\vrecent_sats\x18\x02 \x01(\x03R\n" +
 	"recentSats\"\x14\n" +
-	"\x12GetNodeModeRequest\"\xb3\x01\n" +
+	"\x12GetNodeModeRequest\"\xed\x01\n" +
 	"\x13GetNodeModeResponse\x12.\n" +
 	"\x04mode\x18\x01 \x01(\x0e2\x1a.walletmanager.v1.NodeModeR\x04mode\x120\n" +
 	"\x14light_mode_available\x18\x02 \x01(\bR\x12lightModeAvailable\x12:\n" +
-	"\x19remote_enforcer_available\x18\x03 \x01(\bR\x17remoteEnforcerAvailable\"D\n" +
+	"\x19remote_enforcer_available\x18\x03 \x01(\bR\x17remoteEnforcerAvailable\x128\n" +
+	"\x18remote_enforcer_networks\x18\x04 \x03(\tR\x16remoteEnforcerNetworks\"D\n" +
 	"\x12SetNodeModeRequest\x12.\n" +
 	"\x04mode\x18\x01 \x01(\x0e2\x1a.walletmanager.v1.NodeModeR\x04mode\"\x15\n" +
 	"\x13SetNodeModeResponse\"\xd8\x01\n" +

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -206,6 +206,8 @@ message GetNodeModeResponse {
   bool light_mode_available = 2;
   // True when the current network has a remote validator endpoint.
   bool remote_enforcer_available = 3;
+  // Display names of every network with a remote validator endpoint.
+  repeated string remote_enforcer_networks = 4;
 }
 
 message SetNodeModeRequest {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -585,6 +585,7 @@ class GetNodeModeResponse extends $pb.GeneratedMessage {
     NodeMode? mode,
     $core.bool? lightModeAvailable,
     $core.bool? remoteEnforcerAvailable,
+    $core.Iterable<$core.String>? remoteEnforcerNetworks,
   }) {
     final $result = create();
     if (mode != null) {
@@ -596,6 +597,9 @@ class GetNodeModeResponse extends $pb.GeneratedMessage {
     if (remoteEnforcerAvailable != null) {
       $result.remoteEnforcerAvailable = remoteEnforcerAvailable;
     }
+    if (remoteEnforcerNetworks != null) {
+      $result.remoteEnforcerNetworks.addAll(remoteEnforcerNetworks);
+    }
     return $result;
   }
   GetNodeModeResponse._() : super();
@@ -606,6 +610,7 @@ class GetNodeModeResponse extends $pb.GeneratedMessage {
     ..e<NodeMode>(1, _omitFieldNames ? '' : 'mode', $pb.PbFieldType.OE, defaultOrMaker: NodeMode.NODE_MODE_UNSPECIFIED, valueOf: NodeMode.valueOf, enumValues: NodeMode.values)
     ..aOB(2, _omitFieldNames ? '' : 'lightModeAvailable')
     ..aOB(3, _omitFieldNames ? '' : 'remoteEnforcerAvailable')
+    ..pPS(4, _omitFieldNames ? '' : 'remoteEnforcerNetworks')
     ..hasRequiredFields = false
   ;
 
@@ -658,6 +663,10 @@ class GetNodeModeResponse extends $pb.GeneratedMessage {
   $core.bool hasRemoteEnforcerAvailable() => $_has(2);
   @$pb.TagNumber(3)
   void clearRemoteEnforcerAvailable() => clearField(3);
+
+  /// Display names of every network with a remote validator endpoint.
+  @$pb.TagNumber(4)
+  $core.List<$core.String> get remoteEnforcerNetworks => $_getList(3);
 }
 
 class SetNodeModeRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -220,6 +220,7 @@ const GetNodeModeResponse$json = {
     {'1': 'mode', '3': 1, '4': 1, '5': 14, '6': '.walletmanager.v1.NodeMode', '10': 'mode'},
     {'1': 'light_mode_available', '3': 2, '4': 1, '5': 8, '10': 'lightModeAvailable'},
     {'1': 'remote_enforcer_available', '3': 3, '4': 1, '5': 8, '10': 'remoteEnforcerAvailable'},
+    {'1': 'remote_enforcer_networks', '3': 4, '4': 3, '5': 9, '10': 'remoteEnforcerNetworks'},
   ],
 };
 
@@ -228,7 +229,8 @@ final $typed_data.Uint8List getNodeModeResponseDescriptor = $convert.base64Decod
     'ChNHZXROb2RlTW9kZVJlc3BvbnNlEi4KBG1vZGUYASABKA4yGi53YWxsZXRtYW5hZ2VyLnYxLk'
     '5vZGVNb2RlUgRtb2RlEjAKFGxpZ2h0X21vZGVfYXZhaWxhYmxlGAIgASgIUhJsaWdodE1vZGVB'
     'dmFpbGFibGUSOgoZcmVtb3RlX2VuZm9yY2VyX2F2YWlsYWJsZRgDIAEoCFIXcmVtb3RlRW5mb3'
-    'JjZXJBdmFpbGFibGU=');
+    'JjZXJBdmFpbGFibGUSOAoYcmVtb3RlX2VuZm9yY2VyX25ldHdvcmtzGAQgAygJUhZyZW1vdGVF'
+    'bmZvcmNlck5ldHdvcmtz');
 
 @$core.Deprecated('Use setNodeModeRequestDescriptor instead')
 const SetNodeModeRequest$json = {

--- a/sidechain_core/lib/providers/node_mode_provider.dart
+++ b/sidechain_core/lib/providers/node_mode_provider.dart
@@ -16,6 +16,9 @@ class NodeModeProvider extends ChangeNotifier implements NetworkScoped {
 
   bool remoteEnforcerAvailable = false;
 
+  /// Display names of the networks with a remote validator endpoint.
+  List<String> remoteEnforcerNetworks = const [];
+
   /// True once a read reaches the backend. A failed read is not an unpicked
   /// mode, so the first-run question waits for this.
   bool loaded = false;
@@ -52,6 +55,7 @@ class NodeModeProvider extends ChangeNotifier implements NetworkScoped {
       mode = resp.mode;
       lightModeAvailable = resp.lightModeAvailable;
       remoteEnforcerAvailable = resp.remoteEnforcerAvailable;
+      remoteEnforcerNetworks = List.unmodifiable(resp.remoteEnforcerNetworks);
       loaded = true;
       notifyListeners();
     } catch (e) {


### PR DESCRIPTION
Light mode users could not bid on a sidechain block at all. They can now.
Raising a bid still needs full mode.
