### PR TITLE
orchestrator: credit a deposit the wallet spent

### DIFF
--- a/sidechain-orchestrator/api/deposit_balance.go
+++ b/sidechain-orchestrator/api/deposit_balance.go
@@ -55,7 +55,12 @@ func (h *Handler) depositPendingSats(ctx context.Context, cfg orchestrator.Binar
 		return 0, fmt.Errorf("read the %s wallet coins: %w", cfg.DisplayName, err)
 	}
 
-	pendingSats, credited := splitCreditedDeposits(open, owned, ourCoins)
+	spentCoins, err := sidechain.SpentCoins(ctx, node, depositAddresses(open, owned))
+	if err != nil {
+		return 0, fmt.Errorf("read the %s spent wallet coins: %w", cfg.DisplayName, err)
+	}
+
+	pendingSats, credited := splitCreditedDeposits(open, owned, ourCoins, spentCoins)
 	for _, txid := range credited {
 		if err := svc.MarkSidechainDepositCredited(ctx, txid); err != nil {
 			return 0, err
@@ -68,24 +73,37 @@ func (h *Handler) depositPendingSats(ctx context.Context, cfg orchestrator.Binar
 // names the deposits it now holds a coin for.
 //
 // A sidechain names the coin a deposit made after the mainchain outpoint that
-// paid it, so one deposit answers for one coin. That coin is the deposit
-// already inside the confirmed balance, and a deposit with no coin is in no
+// paid it, so one deposit answers for one coin. A deposit whose coin the wallet
+// holds or spent is already in the balance, and a deposit with no coin is in no
 // balance at all. So one listing puts a deposit in exactly one of the two.
 func splitCreditedDeposits(
-	deposits []wallet.SidechainDeposit, owned map[string]bool, ourCoins map[string]int64,
+	deposits []wallet.SidechainDeposit, owned map[string]bool, ourCoins, spentCoins map[string]int64,
 ) (pendingSats int64, credited []string) {
 	for _, d := range deposits {
 		// A deposit to somebody else's address never becomes our money.
 		if !owned[d.Destination] {
 			continue
 		}
-		if holdsDepositCoin(ourCoins, d.Txid) {
+		if holdsDepositCoin(ourCoins, d.Txid) || holdsDepositCoin(spentCoins, d.Txid) {
 			credited = append(credited, d.Txid)
 			continue
 		}
 		pendingSats += d.AmountSats
 	}
 	return pendingSats, credited
+}
+
+// depositAddresses names each address of ours that a deposit paid, once.
+func depositAddresses(deposits []wallet.SidechainDeposit, owned map[string]bool) []string {
+	seen := make(map[string]bool)
+	addresses := make([]string, 0, len(deposits))
+	for _, d := range deposits {
+		if owned[d.Destination] && !seen[d.Destination] {
+			seen[d.Destination] = true
+			addresses = append(addresses, d.Destination)
+		}
+	}
+	return addresses
 }
 
 // holdsDepositCoin is true when the wallet lists the coin this deposit made.

--- a/sidechain-orchestrator/api/deposit_balance_test.go
+++ b/sidechain-orchestrator/api/deposit_balance_test.go
@@ -32,6 +32,7 @@ func TestSplitCreditedDeposits(t *testing.T) {
 		name         string
 		deposits     []wallet.SidechainDeposit
 		coins        map[string]int64
+		spent        map[string]int64
 		wantPending  int64
 		wantCredited []string
 	}{
@@ -45,6 +46,14 @@ func TestSplitCreditedDeposits(t *testing.T) {
 			name:         "the same deposit stops counting once the coin lands",
 			deposits:     []wallet.SidechainDeposit{{Txid: "m1", Destination: "mine", AmountSats: 1_000_000}},
 			coins:        map[string]int64{"m1:0": 1_000_000},
+			wantPending:  0,
+			wantCredited: []string{"m1"},
+		},
+		{
+			name:         "a deposit the wallet spent is credited",
+			deposits:     []wallet.SidechainDeposit{{Txid: "m1", Destination: "mine", AmountSats: 1_000_000}},
+			coins:        map[string]int64{"sidechaintx:0": 500_000, "sidechaintx:1": 499_000},
+			spent:        map[string]int64{"m1:0": 1_000_000},
 			wantPending:  0,
 			wantCredited: []string{"m1"},
 		},
@@ -84,7 +93,7 @@ func TestSplitCreditedDeposits(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			pending, credited := splitCreditedDeposits(tc.deposits, owned, tc.coins)
+			pending, credited := splitCreditedDeposits(tc.deposits, owned, tc.coins, tc.spent)
 			assert.Equal(t, tc.wantPending, pending)
 			assert.Equal(t, tc.wantCredited, credited)
 		})

--- a/sidechain-orchestrator/api/deposit_pending_balance_test.go
+++ b/sidechain-orchestrator/api/deposit_pending_balance_test.go
@@ -26,6 +26,9 @@ type depositNodeState struct {
 	balanceSats int64
 	coins       string
 	addresses   []string
+	// stxos is the get_stxos answer. Empty means the node serves no such method.
+	stxos      string
+	stxoParams json.RawMessage
 }
 
 // newDepositTestHandler starts a fake sidechain node and wires a handler with
@@ -37,6 +40,7 @@ func newDepositTestHandler(t *testing.T, state *depositNodeState) (*Handler, *wa
 		var request struct {
 			ID     json.RawMessage `json:"id"`
 			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Error(err)
@@ -55,6 +59,13 @@ func newDepositTestHandler(t *testing.T, state *depositNodeState) (*Handler, *wa
 			response["result"] = json.RawMessage(state.coins)
 		case "list_mempool":
 			response["result"] = json.RawMessage("[]")
+		case "get_stxos":
+			if state.stxos == "" {
+				response["error"] = map[string]any{"code": -32601, "message": "method not found"}
+				break
+			}
+			state.stxoParams = request.Params
+			response["result"] = json.RawMessage(state.stxos)
 		default:
 			response["error"] = map[string]any{"code": -32601, "message": "method not found"}
 		}
@@ -148,6 +159,42 @@ func TestSidechainBalanceCountsAPendingDeposit(t *testing.T) {
 	confirmed, pending = thunderBalance(t, handler)
 	assert.Zero(t, confirmed)
 	assert.Zero(t, pending, "a spent deposit never returns to the unconfirmed count")
+}
+
+// The sidechain credited the deposit and the user spent its coin before the
+// next balance read, so only the spent outputs name it.
+func TestSidechainBalanceCreditsADepositTheWalletSpent(t *testing.T) {
+	const (
+		depositTxid = "a9997ec41890321392116da102a3d260a64f1b959120197f5ced15f3823c4659"
+		destination = "31Uq54gY9MptZYuwL6XGPGY5ko9s"
+		amountSats  = 100_000_000
+	)
+	ctx := context.Background()
+	state := &depositNodeState{
+		balanceSats: 99_999_000,
+		coins: `[{"outpoint":{"Regular":{"txid":"997f3d7084f14839f66c14e8719be56bd0976582e887d4da72e11d26884d979e","vout":0}},` +
+			`"output":{"address":"` + destination + `","content":{"Value":99999000}}}]`,
+		addresses: []string{destination},
+		stxos: `[{"outpoint":{"Deposit":"` + depositTxid + `:0"},` +
+			`"output":{"output":{"address":"` + destination + `","content":{"Value":100000000}},` +
+			`"inpoint":{"Regular":{"txid":"997f3d7084f14839f66c14e8719be56bd0976582e887d4da72e11d26884d979e","vin":0}}}}]`,
+	}
+	handler, svc := newDepositTestHandler(t, state)
+
+	require.NoError(t, svc.RecordSidechainDeposit(ctx, wallet.SidechainDeposit{
+		Txid: depositTxid, WalletID: svc.ActiveWalletID(), Slot: 9,
+		Destination: destination, AmountSats: amountSats, FeeSats: 10_000,
+	}))
+
+	confirmed, pending := thunderBalance(t, handler)
+	assert.Equal(t, uint64(99_999_000), confirmed)
+	assert.Zero(t, pending, "a spent deposit coin is no pending money")
+	assert.JSONEq(t, `[["`+destination+`"]]`, string(state.stxoParams))
+
+	deposits, err := svc.SidechainDeposits(ctx, 9, "")
+	require.NoError(t, err)
+	require.Len(t, deposits, 1)
+	assert.False(t, deposits[0].CreditedAt.IsZero(), "the spent deposit is marked credited")
 }
 
 // The deposit page hands out one address, so two deposits pay the same one.

--- a/sidechain-orchestrator/rpc/client.go
+++ b/sidechain-orchestrator/rpc/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync/atomic"
@@ -50,6 +51,14 @@ type rpcError struct {
 
 func (e *rpcError) Error() string {
 	return fmt.Sprintf("rpc error %d: %s", e.Code, e.Message)
+}
+
+const methodNotFound = -32601
+
+// LacksMethod reports an error that says the node serves no such method.
+func LacksMethod(err error) bool {
+	var rpcErr *rpcError
+	return errors.As(err, &rpcErr) && rpcErr.Code == methodNotFound
 }
 
 // Call invokes a JSON-RPC method. params can be nil, a slice, a map, or a

--- a/sidechain-orchestrator/sidechain/mempool.go
+++ b/sidechain-orchestrator/sidechain/mempool.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
 )
 
 // MempoolOutput is one output of an unconfirmed transaction.
@@ -483,4 +485,59 @@ func OurCoins(ctx context.Context, node Node) (map[string]int64, error) {
 		}
 	}
 	return coins, nil
+}
+
+// SpentCoins maps each coin that addresses held and later spent to what it
+// held, keyed like OurCoins. A node that serves no get_stxos names none.
+func SpentCoins(ctx context.Context, node Node, addresses []string) (map[string]int64, error) {
+	raw, err := node.CallRaw(ctx, "get_stxos", []any{addresses})
+	if rpc.LacksMethod(err) {
+		return map[string]int64{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read the spent wallet coins: %w", err)
+	}
+	var rows []spentCoin
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil, fmt.Errorf("read the spent wallet coins: %w", err)
+	}
+	coins := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		value := OutputValueSats(row.Spent.Output.Content)
+		switch {
+		case row.Outpoint.Regular != nil:
+			coins[fmt.Sprintf("%s:%d", row.Outpoint.Regular.Txid, row.Outpoint.Regular.Vout)] = value
+		case row.Outpoint.Deposit != nil:
+			coins[*row.Outpoint.Deposit] = value
+		}
+	}
+	return coins, nil
+}
+
+// spentCoin is one get_stxos row, written as named halves or as a pair.
+type spentCoin struct {
+	Outpoint mempoolOutpoint `json:"outpoint"`
+	Spent    struct {
+		Output struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"output"`
+	} `json:"output"`
+}
+
+func (c *spentCoin) UnmarshalJSON(raw []byte) error {
+	if !bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+		type row spentCoin
+		return json.Unmarshal(raw, (*row)(c))
+	}
+	var pair []json.RawMessage
+	if err := json.Unmarshal(raw, &pair); err != nil {
+		return err
+	}
+	if len(pair) != 2 {
+		return fmt.Errorf("a spent coin holds an outpoint and an output, got %d parts", len(pair))
+	}
+	if err := json.Unmarshal(pair[0], &c.Outpoint); err != nil {
+		return err
+	}
+	return json.Unmarshal(pair[1], &c.Spent)
 }

--- a/sidechain-orchestrator/sidechain/mempool_test.go
+++ b/sidechain-orchestrator/sidechain/mempool_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +21,7 @@ type fakeNode struct {
 	template  string
 	addresses string
 	utxos     string
+	stxos     string
 	called    []string
 }
 
@@ -33,6 +38,9 @@ func (n *fakeNode) CallRaw(_ context.Context, method string, _ any) (json.RawMes
 			return json.RawMessage("[]"), nil
 		}
 		return json.RawMessage(n.utxos), nil
+	}
+	if method == "get_stxos" && n.stxos != "" {
+		return json.RawMessage(n.stxos), nil
 	}
 	return nil, fmt.Errorf("this node serves no %s", method)
 }
@@ -262,6 +270,41 @@ func TestOurCoinsKeysEachCoinByItsOutpoint(t *testing.T) {
 	require.Len(t, coins, 2, "a deposit is a coin the wallet can spend")
 	assert.Equal(t, int64(2000), coins["aa:1"])
 	assert.Equal(t, int64(500), coins["maintxid:0"])
+}
+
+func TestSpentCoinsKeysEachCoinByItsOutpoint(t *testing.T) {
+	node := &fakeNode{stxos: `[
+	  {"outpoint":{"Deposit":"maintxid:0"},
+	   "output":{"output":{"address":"mine","content":{"Value":500}},"inpoint":{"Regular":{"txid":"bb","vin":0}}}},
+	  [{"Regular":{"txid":"aa","vout":1}},
+	   {"output":{"address":"mine","content":{"Value":2000}},"inpoint":{"Regular":{"txid":"cc","vin":1}}}]
+	]`}
+
+	coins, err := SpentCoins(context.Background(), node, []string{"mine"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int64{"maintxid:0": 500, "aa:1": 2000}, coins)
+}
+
+func TestSpentCoinsIsEmptyOnANodeWithNoStxos(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	host, portText, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+
+	coins, err := SpentCoins(context.Background(), NewJSONRPCProxy(host, port), []string{"mine"})
+	require.NoError(t, err)
+	assert.Empty(t, coins)
+}
+
+func TestSpentCoinsReportsAFault(t *testing.T) {
+	_, err := SpentCoins(context.Background(), &fakeNode{}, []string{"mine"})
+	require.Error(t, err)
 }
 
 // A child spends a coin its parent made, and that coin never reached the


### PR DESCRIPTION
A sidechain deposit showed as pending after the wallet spent its coin, because the check read only the unspent coins.
The check now also reads the spent coins through get_stxos (thunder, bitnames, photon, zside).
A node that serves no get_stxos keeps the old behavior.