### PR TITLE
orchestrator: connect the remote enforcer at boot

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -120,8 +120,8 @@ String lightSidechainNetworksLine(List<String> networks) {
   return 'Light mode serves sidechains on ${networks.join(', ')}.';
 }
 
-/// Stands in for the whole tab while the L1 stack is missing, and doubles as the
-/// place to start it — the same daemons the bottom nav reports on.
+/// Stands in for the whole tab while the L1 stack is missing, and in full mode
+/// doubles as the place to start it — the same daemons the bottom nav reports on.
 class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
   const _L1RequiredCard();
 
@@ -192,22 +192,18 @@ class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
               stopDaemon: NodeModeProvider.runsLocalBackends ? () => viewModel.stopDaemon(Enforcer()) : null,
               navigateToLogs: viewModel.navigateToLogs,
             ),
-            if (gate == L1Gate.stopped) ...[
+            if (gate == L1Gate.stopped && NodeModeProvider.runsLocalBackends) ...[
               const SailSpacing(SailStyleValues.padding16),
               Row(
                 children: [
                   SailButton(
-                    label: NodeModeProvider.runsLocalBackends
-                        ? 'Start Bitcoin Core + Enforcer'
-                        : 'Connect to remote enforcer',
+                    label: 'Start Bitcoin Core + Enforcer',
                     onPressed: viewModel.startL1,
                   ),
-                  if (NodeModeProvider.runsLocalBackends) ...[
-                    const SizedBox(width: SailStyleValues.padding12),
-                    Flexible(
-                      child: SailText.secondary12('The first start must download and check the chain.'),
-                    ),
-                  ],
+                  const SizedBox(width: SailStyleValues.padding12),
+                  Flexible(
+                    child: SailText.secondary12('The first start must download and check the chain.'),
+                  ),
                 ],
               ),
             ],

--- a/bitwindow/test/sidechains_availability_test.dart
+++ b/bitwindow/test/sidechains_availability_test.dart
@@ -124,17 +124,22 @@ void main() {
     expect(nodeMode.isLight, isTrue);
   });
 
-  testWidgets('alphanet light mode keeps the remote connection control', (tester) async {
+  testWidgets('alphanet light mode shows the remote enforcer state with no start control', (tester) async {
     conf.network = BitcoinNetwork.BITCOIN_NETWORK_ECASH;
     nodeMode.remoteEnforcerAvailable = true;
 
     await pumpOverview(tester);
 
     expect(model.l1Gate, L1Gate.stopped);
+    expect(find.text('The enforcer connection is not ready'), findsOneWidget);
     expect(find.byType(DaemonConnectionCard), findsOneWidget);
     expect(
-      find.byWidgetPredicate((widget) => widget is SailButton && widget.label == 'Connect to remote enforcer'),
-      findsOneWidget,
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is SailButton &&
+            ((widget.label?.startsWith('Start') ?? false) || (widget.label?.startsWith('Connect') ?? false)),
+      ),
+      findsNothing,
     );
   });
 

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -700,6 +700,10 @@ func run(cctx *cli.Context) error {
 
 	go clients.Run(ctx)
 
+	if err := orch.ConnectRemoteEnforcer(ctx); err != nil {
+		return err
+	}
+
 	// Auto-boot sidechains specified via --binary flags
 	binariesToBoot := cctx.StringSlice("binary")
 	forceBackend := cctx.Bool("force-backend")

--- a/sidechain-orchestrator/node_mode.go
+++ b/sidechain-orchestrator/node_mode.go
@@ -162,6 +162,9 @@ func (o *Orchestrator) SetNodeMode(ctx context.Context, mode NodeMode) error {
 	o.syncConnMu.Lock()
 	o.enforcerSync = nil
 	o.syncConnMu.Unlock()
+	if err := o.ConnectRemoteEnforcer(context.Background()); err != nil {
+		return err
+	}
 	for name, opts := range sidechains {
 		ch, err := o.StartWithL1(context.Background(), name, opts)
 		if err != nil {

--- a/sidechain-orchestrator/remote_enforcer.go
+++ b/sidechain-orchestrator/remote_enforcer.go
@@ -134,6 +134,27 @@ func (o *Orchestrator) startRemoteEnforcer(ctx context.Context, ch chan<- Startu
 	return nil
 }
 
+// ConnectRemoteEnforcer starts the remote enforcer in light mode on a network
+// that publishes one. The enforcer monitor retries a failed connect.
+func (o *Orchestrator) ConnectRemoteEnforcer(ctx context.Context) error {
+	if _, ok := o.Configs()["enforcer"]; !ok || o.NodeMode() != NodeModeLight ||
+		config.RemoteEnforcerURLForNetwork(config.Network(o.CurrentNetwork())) == "" {
+		return nil
+	}
+	ch, err := o.StartWithL1(ctx, "enforcer", StartOpts{})
+	if err != nil {
+		return fmt.Errorf("start the remote enforcer: %w", err)
+	}
+	go func() {
+		for progress := range ch {
+			if progress.Error != nil {
+				o.log.Warn().Err(progress.Error).Msg("remote enforcer is not ready, the monitor retries")
+			}
+		}
+	}()
+	return nil
+}
+
 func (o *Orchestrator) restartRemoteOrphans(ctx context.Context, ch chan<- StartupProgress) error {
 	for name, cfg := range o.Configs() {
 		if cfg.ChainLayer != 2 || cfg.IsBitcoinCore || !o.process.IsAdopted(name) || !o.mayStopAdopted(name) {

--- a/sidechain-orchestrator/remote_enforcer_test.go
+++ b/sidechain-orchestrator/remote_enforcer_test.go
@@ -329,6 +329,33 @@ func TestNodeModeChangeClosesTheRemoteBridge(t *testing.T) {
 	require.Equal(t, NodeModeFull, o.NodeMode())
 }
 
+func TestNodeModeChangeConnectsTheRemoteEnforcer(t *testing.T) {
+	server := remoteValidatorServer(t, 42, nil)
+	o := remoteTestOrchestrator(t, server.URL)
+	require.NoError(t, WriteNodeMode(o.BitwindowDir, NodeModeFull))
+	require.NoError(t, o.SetNodeMode(context.Background(), NodeModeLight))
+	require.Eventually(t, func() bool { return o.Status("enforcer").Connected }, 5*time.Second, 20*time.Millisecond)
+	require.False(t, o.Status("enforcer").Running)
+}
+
+func TestRemoteEnforcerConnectsAtBoot(t *testing.T) {
+	server := remoteValidatorServer(t, 42, nil)
+	o := remoteTestOrchestrator(t, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, o.ConnectRemoteEnforcer(ctx))
+	require.Eventually(t, func() bool { return o.Status("enforcer").Connected }, 5*time.Second, 20*time.Millisecond)
+	require.False(t, o.Status("enforcer").Running)
+}
+
+func TestRemoteEnforcerStaysClosedInFullMode(t *testing.T) {
+	server := remoteValidatorServer(t, 42, nil)
+	o := remoteTestOrchestrator(t, server.URL)
+	require.NoError(t, WriteNodeMode(o.BitwindowDir, NodeModeFull))
+	require.NoError(t, o.ConnectRemoteEnforcer(context.Background()))
+	require.Nil(t, o.remoteEnforcer)
+}
+
 func TestNodeModeChangeStopsLocalL1BeforeTheModeWrite(t *testing.T) {
 	server := remoteValidatorServer(t, 42, nil)
 	o := remoteTestOrchestrator(t, server.URL)


### PR DESCRIPTION
In light mode the orchestrator opens the remote enforcer bridge at boot and after a change to light mode. The monitor retries a failed connect. BitWindow no longer shows a button to connect it.