### PR TITLE
bitwindow: apply the new sidechains table design

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -320,32 +320,28 @@ class SidechainsList extends ViewModelWidget<SidechainsViewModel> {
       error: viewModel._enforcerRPC.initializingBinary ? null : error,
       widgetHeaderEnd: smallVersion
           ? null
-          : SailToggle(
-              label: 'Show only filled slots',
-              value: viewModel.showOnlyFilled,
-              onChanged: (value) => viewModel.setShowOnlyFilled(value),
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SailToggle(
+                  label: 'Show only filled slots',
+                  value: viewModel.showOnlyFilled,
+                  onChanged: (value) => viewModel.setShowOnlyFilled(value),
+                ),
+                const SizedBox(width: SailStyleValues.padding12),
+                SailButton(
+                  label: 'Add / Remove',
+                  variant: ButtonVariant.outline,
+                  onPressed: viewModel.sidechainManagementUnavailable
+                      ? null
+                      : () => showSidechainActivationManagementModal(context),
+                ),
+              ],
             ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Flexible(
-            child: SailSkeletonizer(
-              description: 'Waiting for enforcer to become available..',
-              enabled: viewModel.loading,
-              child: viewModel.showOnlyFilled ? OnlyFilledTable() : FullTable(),
-            ),
-          ),
-          const SizedBox(height: SailStyleValues.padding16),
-          if (!smallVersion)
-            Center(
-              child: SailButton(
-                label: 'Add / Remove',
-                onPressed: viewModel.sidechainManagementUnavailable
-                    ? null
-                    : () => showSidechainActivationManagementModal(context),
-              ),
-            ),
-        ],
+      child: SailSkeletonizer(
+        description: 'Waiting for enforcer to become available..',
+        enabled: viewModel.loading,
+        child: viewModel.showOnlyFilled ? OnlyFilledTable() : FullTable(),
       ),
     );
   }
@@ -356,172 +352,222 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
 
   @override
   Widget build(BuildContext context, SidechainsViewModel viewModel) {
+    return _SidechainsTable(
+      key: const ValueKey('sidechains_table_filled'),
+      slots: [
+        for (int slot = 0; slot < viewModel.sidechains.length; slot++)
+          if (viewModel.sidechains[slot] != null) slot,
+      ],
+      emptyPlaceholder: 'No active sidechains',
+    );
+  }
+}
+
+class FullTable extends StatelessWidget {
+  const FullTable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _SidechainsTable(
+      key: const ValueKey('sidechains_table_full'),
+      slots: List.generate(256, (slot) => slot),
+    );
+  }
+}
+
+/// Height of the bordered table: the header strip, the rows and the frame.
+double _tableHeight(int rows) => (rows == 0 ? 96 : rows * 48) + 40;
+
+class _SidechainsTable extends ViewModelWidget<SidechainsViewModel> {
+  final List<int> slots;
+  final String? emptyPlaceholder;
+
+  const _SidechainsTable({super.key, required this.slots, this.emptyPlaceholder});
+
+  static const _sortColumns = ['slot', 'name', 'balance'];
+
+  @override
+  Widget build(BuildContext context, SidechainsViewModel viewModel) {
     final formatter = GetIt.I<FormatterProvider>();
+    final colors = context.sailTheme.colors;
 
-    // Filter to only show filled slots
-    final filledSlots = <int>[];
-    for (int slotNumber = 0; slotNumber < viewModel.sidechains.length; slotNumber++) {
-      if (viewModel.sidechains[slotNumber] != null) {
-        filledSlots.add(slotNumber);
-      }
-    }
-
-    return ListenableBuilder(
-      listenable: formatter,
-      builder: (context, child) => SailTable(
-        key: ValueKey('sidechains_table_filled'),
-        getRowId: (index) => filledSlots[index].toString(),
-        headerBuilder: (context) => [
-          SailTableHeaderCell(name: 'Slot', onSort: () => viewModel.sortSidechains('slot')),
-          SailTableHeaderCell(name: 'Name', onSort: () => viewModel.sortSidechains('name')),
-          SailTableHeaderCell(
-            name: 'Sidechain Balance',
-            onSort: () => viewModel.sortSidechains('balance'),
-          ),
-          SailTableHeaderCell(name: 'Action', onSort: () => viewModel.sortSidechains('action')),
-          SailTableHeaderCell(name: 'Deposit', onSort: () => viewModel.sortSidechains('deposit')),
-          SailTableHeaderCell(name: 'Settings', onSort: () => viewModel.sortSidechains('update')),
-        ],
-        rowBuilder: (context, row, selected) {
-          final slot = filledSlots[row]; // Get the actual slot number from filtered list
-          final sidechain = viewModel.sidechains[slot];
-          final textColor = context.sailTheme.colors.text;
-          final buttonWidget = viewModel.sidechainWidget(context, slot);
-          final statusIcon = viewModel.sidechainStatusIcon(context, slot);
-          final updateAvailable = viewModel.updateAvailable(slot);
-          final binary = viewModel.sidechainForSlot(slot);
-
-          return [
-            SailTableCell(value: '$slot:', textColor: textColor),
-            SailTableCell(value: sidechain?.info.title ?? '', textColor: textColor),
-            SailTableCell(
-              value: formatter.formatSats(sidechain?.info.balanceSatoshi.toInt() ?? 0),
-              textColor: textColor,
-            ),
-            SailTableCell(
-              key: buttonWidget?.key,
-              value: '                    ',
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (statusIcon != null) ...[
-                    statusIcon,
-                    const SizedBox(width: SailStyleValues.padding08),
-                  ],
-                  if (buttonWidget != null) Flexible(child: buttonWidget),
-                ],
+    return LayoutBuilder(
+      builder: (context, constraints) => Container(
+        height: min(constraints.maxHeight, _tableHeight(slots.length)),
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          border: Border.all(color: colors.border),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: ListenableBuilder(
+          listenable: formatter,
+          builder: (context, child) => SailTable(
+            getRowId: (index) => slots[index].toString(),
+            cellHeight: 48,
+            headerBackgroundColor: colors.backgroundSecondary,
+            headerBuilder: (context) => [
+              SailTableHeaderCell(name: 'Slot', onSort: () => viewModel.sortSidechains('slot')),
+              SailTableHeaderCell(name: 'Name', onSort: () => viewModel.sortSidechains('name')),
+              SailTableHeaderCell(
+                name: 'Sidechain Balance',
+                alignment: Alignment.centerRight,
+                onSort: () => viewModel.sortSidechains('balance'),
               ),
-            ),
-            SailTableCell(
-              value: '        ',
-              child: sidechain != null ? _buildDepositButton(context, viewModel, slot, sidechain) : null,
-            ),
-            if (binary != null && viewModel.rpcForSlot(slot) != null)
-              SailTableCell(
-                value: '    ',
-                child: Container(
-                  constraints: BoxConstraints(maxWidth: 40, maxHeight: 40),
-                  child: Align(
-                    alignment: Alignment.center,
-                    child: SizedBox(
-                      width: 36,
-                      height: 36,
-                      child: Stack(
-                        clipBehavior: Clip.hardEdge,
-                        children: [
-                          SailButton(
-                            variant: ButtonVariant.outline,
-                            label: '',
-                            icon: SailSVGAsset.settings,
-                            insideTable: true,
-                            onPressed: () async {
-                              await showThemedDialog(
-                                context: context,
-                                builder: (context) => ChainSettingsModal(
-                                  connection: viewModel.rpcForSlot(slot)!,
-                                ),
-                              );
-                            },
-                          ),
-                          if (updateAvailable)
-                            Positioned(
-                              top: 4,
-                              right: 6,
-                              child: Container(
-                                width: 4,
-                                height: 4,
-                                decoration: BoxDecoration(
-                                  color: context.sailTheme.colors.error,
-                                  shape: BoxShape.circle,
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
+              const SailTableHeaderCell(name: 'Your balance', alignment: Alignment.centerRight, sortable: false),
+              const SailTableHeaderCell(name: '', sortable: false),
+            ],
+            rowBuilder: (context, row, selected) => _sidechainRow(context, viewModel, formatter, slots[row]),
+            rowCount: slots.length,
+            emptyPlaceholder: emptyPlaceholder,
+            sortAscending: viewModel.sortAscending,
+            sortColumnIndex: _sortColumns.indexOf(viewModel.sortColumn),
+            onSort: (columnIndex, ascending) => viewModel.sortSidechains(viewModel.sortColumn),
+            selectedRowId: viewModel.selectedIndex?.toString(),
+            // rowId is the SLOT NUMBER (e.g., "2", "4", "98") from getRowId
+            onSelectedRow: (rowId) => viewModel.toggleSelection(int.parse(rowId ?? '0')),
+            onDoubleTap: (rowId) {
+              final sidechain = viewModel.sidechains[int.parse(rowId)];
+              if (sidechain == null || sidechain.info.chaintipTxid == '') {
+                return;
+              }
+
+              showTransactionDetails(context, sidechain.info.chaintipTxid);
+            },
+            contextMenuItems: (rowId) {
+              final sidechain = viewModel.sidechains[int.parse(rowId)];
+              if (sidechain == null || sidechain.info.chaintipTxid == '') {
+                return [];
+              }
+
+              return [
+                SailMenuItem(
+                  onSelected: () => showTransactionDetails(context, sidechain.info.chaintipTxid),
+                  child: SailText.primary12('Show Chaintip Transaction'),
                 ),
-              )
-            else
-              SailTableCell(value: ''),
-          ];
-        },
-        rowCount: filledSlots.length, // Only show filled slots
-        emptyPlaceholder: 'No active sidechains',
-        sortAscending: viewModel.sortAscending,
-        sortColumnIndex: [
-          'slot',
-          'name',
-          'balance',
-          'action',
-          'deposit',
-          'update',
-        ].indexOf(viewModel.sortColumn),
-        onSort: (columnIndex, ascending) => viewModel.sortSidechains(viewModel.sortColumn),
-        selectedRowId: viewModel.selectedIndex?.toString(),
-        // rowId is the SLOT NUMBER (e.g., "2", "4", "98") from getRowId
-        onSelectedRow: (rowId) => viewModel.toggleSelection(int.parse(rowId ?? '0')),
-        onDoubleTap: (rowId) {
-          final sidechain = viewModel.sidechains[int.parse(rowId)];
-          if (sidechain == null || sidechain.info.chaintipTxid == '') {
-            return;
-          }
-
-          showTransactionDetails(context, sidechain.info.chaintipTxid);
-        },
-        contextMenuItems: (rowId) {
-          final sidechain = viewModel.sidechains[int.parse(rowId)];
-          if (sidechain == null || sidechain.info.chaintipTxid == '') {
-            return [];
-          }
-
-          return [
-            SailMenuItem(
-              onSelected: () => showTransactionDetails(context, sidechain.info.chaintipTxid),
-              child: SailText.primary12('Show Chaintip Transaction'),
-            ),
-          ];
-        },
+              ];
+            },
+          ),
+        ),
       ),
     );
   }
 
-  Widget _buildDepositButton(
+  List<Widget> _sidechainRow(
     BuildContext context,
     SidechainsViewModel viewModel,
+    FormatterProvider formatter,
     int slot,
-    SidechainOverview sidechain,
   ) {
-    final isDisabled = !viewModel.canDeposit(slot);
+    final colors = context.sailTheme.colors;
+    final sidechain = viewModel.sidechains[slot];
+    final slotCell = SailTableCell(value: '$slot', width: 56, textColor: colors.textSecondary);
+
+    if (sidechain == null) {
+      return [
+        slotCell,
+        SailTableCell(value: ''),
+        SailTableCell(value: '', width: 130),
+        SailTableCell(value: '', width: 130),
+        SailTableCell(value: '', width: 300),
+      ];
+    }
+
+    final yourBalance = viewModel.yourBalance(slot);
+
+    return [
+      slotCell,
+      SailTableCell(
+        value: sidechain.info.title,
+        child: Row(
+          children: [
+            viewModel.sidechainStatusDot(context, slot) ?? const SizedBox(width: 8),
+            const SizedBox(width: SailStyleValues.padding08),
+            Flexible(
+              child: SailText.primary13(sidechain.info.title, color: colors.text, overflow: TextOverflow.ellipsis),
+            ),
+          ],
+        ),
+      ),
+      SailTableCell(
+        value: formatter.formatSats(sidechain.info.balanceSatoshi.toInt()),
+        width: 130,
+        alignment: Alignment.centerRight,
+        textColor: colors.text,
+      ),
+      SailTableCell(
+        value: yourBalance == null ? '—' : formatter.formatBTC(yourBalance),
+        width: 130,
+        alignment: Alignment.centerRight,
+        textColor: yourBalance == null ? colors.textSecondary : colors.text,
+      ),
+      SailTableCell(
+        value: '',
+        width: 300,
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: SailStyleValues.padding12),
+        child: _SidechainActions(viewModel: viewModel, slot: slot, sidechain: sidechain),
+      ),
+    ];
+  }
+}
+
+/// The main action, Deposit and the settings button of one sidechain row.
+class _SidechainActions extends StatelessWidget {
+  final SidechainsViewModel viewModel;
+  final int slot;
+  final SidechainOverview sidechain;
+
+  const _SidechainActions({required this.viewModel, required this.slot, required this.sidechain});
+
+  @override
+  Widget build(BuildContext context) {
+    final mainAction = viewModel.sidechainWidget(context, slot);
+    final settingsConnection = viewModel.sidechainForSlot(slot) == null ? null : viewModel.rpcForSlot(slot);
+
+    // Scales down when a theme font is too wide for the fixed column.
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerRight,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (mainAction != null) ...[
+            mainAction,
+            const SizedBox(width: SailStyleValues.padding08),
+          ],
+          _depositButton(context),
+          const SizedBox(width: SailStyleValues.padding08),
+          SizedBox.square(
+            dimension: 32,
+            child: settingsConnection == null
+                ? null
+                : SailButton(
+                    variant: ButtonVariant.icon,
+                    icon: SailSVGAsset.settings,
+                    small: true,
+                    onPressed: () async {
+                      await showThemedDialog(
+                        context: context,
+                        builder: (context) => ChainSettingsModal(connection: settingsConnection),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _depositButton(BuildContext context) {
+    final canDeposit = viewModel.canDeposit(slot);
     final button = SailButton(
       label: 'Deposit',
-      variant: ButtonVariant.primary,
-      insideTable: true,
-      disabled: isDisabled,
+      variant: ButtonVariant.outline,
+      disabled: !canDeposit,
       onPressed: () => showDepositModal(context, slot, sidechain.info.title),
     );
 
-    if (!isDisabled) {
+    if (canDeposit) {
       return button;
     }
 
@@ -529,156 +575,72 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
   }
 }
 
-class FullTable extends ViewModelWidget<SidechainsViewModel> {
-  const FullTable({super.key});
+/// A slim progress bar with its percent, and an optional label in front.
+class _ActionProgress extends StatelessWidget {
+  final String? label;
+  final double width;
+  final double current;
+  final double goal;
+  final Color color;
+  final String tooltip;
+
+  const _ActionProgress({
+    super.key,
+    this.label,
+    required this.width,
+    required this.current,
+    required this.goal,
+    required this.color,
+    required this.tooltip,
+  });
 
   @override
-  Widget build(BuildContext context, SidechainsViewModel viewModel) {
-    final formatter = GetIt.I<FormatterProvider>();
+  Widget build(BuildContext context) {
+    final colors = SailTheme.of(context).colors;
+    final fraction = goal > 0 ? (current / goal).clamp(0.0, 1.0) : 0.0;
 
-    return ListenableBuilder(
-      listenable: formatter,
-      builder: (context, child) => SailTable(
-        key: ValueKey('sidechains_table_full'),
-        getRowId: (index) => index.toString(),
-        headerBuilder: (context) => [
-          SailTableHeaderCell(name: 'Slot', onSort: () => viewModel.sortSidechains('slot')),
-          SailTableHeaderCell(name: 'Name', onSort: () => viewModel.sortSidechains('name')),
-          SailTableHeaderCell(
-            name: 'Sidechain Balance',
-            onSort: () => viewModel.sortSidechains('balance'),
-          ),
-          SailTableHeaderCell(name: 'Action', onSort: () => viewModel.sortSidechains('action')),
-          SailTableHeaderCell(name: 'Deposit', onSort: () => viewModel.sortSidechains('deposit')),
-          SailTableHeaderCell(name: 'Settings', onSort: () => viewModel.sortSidechains('update')),
-        ],
-        rowBuilder: (context, row, selected) {
-          final slot = row; // This is now the slot number (0-255)
-          final sidechain = viewModel.sidechains[slot];
-          final textColor = sidechain == null ? context.sailTheme.colors.textSecondary : context.sailTheme.colors.text;
-          final buttonWidget = viewModel.sidechainWidget(context, slot);
-          final statusIcon = viewModel.sidechainStatusIcon(context, slot);
-          final updateAvailable = viewModel.updateAvailable(slot);
-          final binary = viewModel.sidechainForSlot(slot);
-
-          return [
-            SailTableCell(value: '$slot:', textColor: textColor),
-            SailTableCell(value: sidechain?.info.title ?? '', textColor: textColor),
-            SailTableCell(
-              value: formatter.formatSats(sidechain?.info.balanceSatoshi.toInt() ?? 0),
-              textColor: textColor,
-            ),
-            SailTableCell(
-              key: buttonWidget?.key,
-              value: buttonWidget?.toString() ?? '',
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (statusIcon != null) ...[
-                    statusIcon,
-                    const SizedBox(width: SailStyleValues.padding08),
-                  ],
-                  if (buttonWidget != null) Flexible(child: buttonWidget),
-                ],
+    return SailTooltip(
+      message: tooltip,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (label != null) ...[
+            SailText.secondary12(label!),
+            const SizedBox(width: SailStyleValues.padding08),
+          ],
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: Container(
+              width: width,
+              height: 6,
+              color: colors.backgroundSecondary,
+              alignment: Alignment.centerLeft,
+              child: FractionallySizedBox(
+                widthFactor: fraction,
+                heightFactor: 1,
+                child: ColoredBox(color: color),
               ),
             ),
-            SailTableCell(
-              value: '        ',
-              child: sidechain != null ? _buildFullTableDepositButton(context, viewModel, slot, sidechain) : null,
-            ),
-            if (binary != null && viewModel.rpcForSlot(slot) != null)
-              SailTableCell(
-                value: '    ', // Use spaces to represent the width needed for the settings button
-                child: Stack(
-                  children: [
-                    SailButton(
-                      variant: ButtonVariant.outline,
-                      label: '',
-                      icon: SailSVGAsset.settings,
-                      insideTable: true,
-                      onPressed: () async {
-                        await showThemedDialog(
-                          context: context,
-                          builder: (context) => ChainSettingsModal(connection: viewModel.rpcForSlot(slot)!),
-                        );
-                      },
-                    ),
-                    if (updateAvailable)
-                      Positioned(
-                        top: 4,
-                        right: 6,
-                        child: Container(
-                          width: 4,
-                          height: 4,
-                          decoration: BoxDecoration(color: context.sailTheme.colors.error, shape: BoxShape.circle),
-                        ),
-                      ),
-                  ],
-                ),
-              )
-            else
-              Container(),
-          ];
-        },
-        rowCount: 256, // Show all slots
-        sortAscending: viewModel.sortAscending,
-        sortColumnIndex: [
-          'slot',
-          'name',
-          'balance',
-          'action',
-          'deposit',
-          'update',
-        ].indexOf(viewModel.sortColumn),
-        onSort: (columnIndex, ascending) => viewModel.sortSidechains(viewModel.sortColumn),
-        selectedRowId: viewModel.selectedIndex?.toString(),
-        onSelectedRow: (rowId) => viewModel.toggleSelection(int.parse(rowId ?? '0')),
-        onDoubleTap: (rowId) {
-          final sidechain = viewModel.sidechains[int.parse(rowId)];
-          if (sidechain == null || sidechain.info.chaintipTxid == '') {
-            return;
-          }
-
-          showTransactionDetails(context, sidechain.info.chaintipTxid);
-        },
-        contextMenuItems: (rowId) {
-          final sidechain = viewModel.sidechains[int.parse(rowId)];
-          if (sidechain == null || sidechain.info.chaintipTxid == '') {
-            return [];
-          }
-
-          return [
-            SailMenuItem(
-              onSelected: () => showTransactionDetails(context, sidechain.info.chaintipTxid),
-              child: SailText.primary12('Show Chaintip Transaction'),
-            ),
-          ];
-        },
+          ),
+          const SizedBox(width: SailStyleValues.padding08),
+          SizedBox(
+            width: 32,
+            child: SailText.secondary12(progressPercent(current, goal), textAlign: TextAlign.right),
+          ),
+        ],
       ),
     );
   }
+}
 
-  Widget _buildFullTableDepositButton(
-    BuildContext context,
-    SidechainsViewModel viewModel,
-    int slot,
-    SidechainOverview sidechain,
-  ) {
-    final tooltipMessage = viewModel.canDeposit(slot) ? null : 'Start the sidechain before depositing';
-
-    final button = SailButton(
-      label: 'Deposit',
-      variant: ButtonVariant.primary,
-      insideTable: true,
-      disabled: !viewModel.canDeposit(slot),
-      onPressed: () => showDepositModal(context, slot, sidechain.info.title),
-    );
-
-    if (tooltipMessage == null) {
-      return button;
-    }
-    return SailTooltip(message: tooltipMessage, child: button);
+/// Whole percent done, never 100% before the goal; a dash when the goal is unknown.
+@visibleForTesting
+String progressPercent(double current, double goal) {
+  if (goal <= 0) {
+    return '—';
   }
+  final percent = min((current * 100 / goal).floor(), 100);
+  return current < goal ? '${min(percent, 99)}%' : '$percent%';
 }
 
 class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
@@ -739,6 +701,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     _walletReader.addListener(_onChange);
     _nodeMode?.addListener(_onChange);
+    _balanceProvider.addListener(notifyListeners);
 
     _binaryProvider.addListener(_onChange);
     _binaryProvider.addListener(notifyListeners);
@@ -924,6 +887,16 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
   bool canDeposit(int slot) => isSidechainRunning(slot);
 
+  /// The user's wallet balance in BTC on the chain in [slot], or null while the chain does not run.
+  double? yourBalance(int slot) {
+    final rpc = _sidechainRPC(slot);
+    if (rpc == null || !rpc.connected || !_balanceProvider.connections.contains(rpc)) {
+      return null;
+    }
+    final (confirmed, pending) = _balanceProvider.balanceFor(rpc);
+    return confirmed + pending;
+  }
+
   bool isSidechainRunning(int slot) => _sidechainRPC(slot)?.connected ?? false;
 
   /// The RPC connection for a slot, or null when this build has none.
@@ -971,29 +944,30 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
       return null;
     }
 
+    final colors = SailTheme.of(context).colors;
     final isRunning = _binaryProvider.isSidechainUp(sidechain);
     final isInitializing = _binaryProvider.isInitializing(sidechain);
     final stopping = _binaryProvider.isStopping(sidechain);
     final progress = _downloadProgressFor(sidechain);
     if (progress != null) {
-      final syncInfo = SyncInfo(
-        progressCurrent: progress.mbDownloaded.toDouble(),
-        progressGoal: progress.mbTotal > 0 ? progress.mbTotal.toDouble() : 0,
-        lastBlockAt: null,
-      );
+      // A download of a binary already on disk is an update.
+      final updating = sidechain.isDownloaded;
+      final verb = updating ? 'Updating' : 'Downloading';
       final tooltip = progress.mbTotal > 0
-          ? 'Downloading ${sidechain.name}\n'
+          ? '$verb ${sidechain.name}\n'
                 'Progress: ${formatDataSizeFromMB(progress.mbDownloaded.toDouble())}\n'
                 'Size: ${formatDataSizeFromMB(progress.mbTotal.toDouble())}'
-          : 'Downloading ${sidechain.name}\n'
+          : '$verb ${sidechain.name}\n'
                 '${formatDataSizeFromMB(progress.mbDownloaded.toDouble())} so far (size unknown)';
 
-      return ChainLoader(
-        name: sidechain.name,
-        syncInfo: syncInfo,
-        justPercent: true,
-        expanded: false,
-        tooltipMessage: tooltip,
+      return _ActionProgress(
+        key: ValueKey('${updating ? 'updating' : 'downloading'}_slot_${sidechain.slot}_${sidechain.name}'),
+        label: updating ? 'Updating' : null,
+        width: updating ? 64 : 96,
+        current: progress.mbDownloaded.toDouble(),
+        goal: progress.mbTotal > 0 ? progress.mbTotal.toDouble() : 0,
+        color: updating ? colors.primary : colors.orangeLight,
+        tooltip: tooltip,
       );
     }
 
@@ -1003,31 +977,34 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
         label: 'Stopping...',
         variant: ButtonVariant.outline,
         onPressed: null,
-        insideTable: true,
         loading: true,
       );
     }
 
     if (isRunning) {
-      // Running but indexing — show the same ChainLoader the daemon-status
-      // card uses so the user sees `X / Y blocks` ticking up. Reuses the
-      // SyncInfo populated by the orch's GetSyncStatus poll, so the value
-      // matches whatever the bottom-nav reports for the same chain.
+      // Running but indexing: the same SyncInfo the bottom nav reports.
       final syncInfo = _syncInfoFor(sidechain);
       if (syncInfo != null && !syncInfo.isSynced && syncInfo.progressGoal > 0) {
-        return ChainLoader(
-          name: sidechain.name,
-          syncInfo: syncInfo,
-          justPercent: true,
-          expanded: false,
+        return _ActionProgress(
+          key: ValueKey('syncing_slot_${sidechain.slot}_${sidechain.name}'),
+          width: 96,
+          current: syncInfo.progressCurrent,
+          goal: syncInfo.progressGoal,
+          color: colors.orangeLight,
+          tooltip:
+              '${sidechain.name}\n'
+              'Current height ${formatProgress(syncInfo.progressCurrent, false)}\n'
+              'Header height ${formatProgress(syncInfo.progressGoal, false)}',
         );
       }
-      return SailButton(
-        key: ValueKey('stop_slot_${sidechain.slot}_${sidechain.name}'),
-        label: 'Stop',
-        variant: ButtonVariant.outline,
-        onPressed: () async => _binaryProvider.stop(sidechain),
-        insideTable: true,
+      return _withUpdate(
+        sidechain,
+        SailButton(
+          key: ValueKey('stop_slot_${sidechain.slot}_${sidechain.name}'),
+          label: 'Stop',
+          variant: ButtonVariant.outline,
+          onPressed: () async => _binaryProvider.stop(sidechain),
+        ),
       );
     }
 
@@ -1037,7 +1014,6 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
         label: 'Launching...',
         variant: ButtonVariant.outline,
         onPressed: null,
-        insideTable: true,
         loading: true,
       );
     }
@@ -1053,32 +1029,44 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
           }
           await _binaryProvider.download(sidechain);
         },
-        insideTable: true,
       );
     }
 
-    if (sidechain.isDownloaded) {
-      return SailButton(
+    return _withUpdate(
+      sidechain,
+      SailButton(
         key: ValueKey('start_slot_${sidechain.slot}_${sidechain.name}'),
         label: 'Start',
-        variant: ButtonVariant.primary,
+        variant: sidechain.updateAvailable ? ButtonVariant.outline : ButtonVariant.primary,
         onPressed: () async => await _binaryProvider.start(sidechain),
-        insideTable: true,
-      );
-    }
-
-    return SailButton(
-      key: ValueKey('error_slot_${sidechain.slot}_${sidechain.name}'),
-      label: 'Devs did you wrong...',
-      variant: ButtonVariant.outline,
-      onPressed: () async => throw Exception('Send them this error'),
-      insideTable: true,
+      ),
     );
   }
 
-  /// Connection status icon matching the Daemon Status card style.
-  /// Shows green/orange/red icon with error tooltip on hover.
-  Widget? sidechainStatusIcon(BuildContext context, int slot) {
+  Widget _withUpdate(Sidechain sidechain, Widget action) {
+    if (!sidechain.updateAvailable) {
+      return action;
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SailButton(
+          key: ValueKey('update_slot_${sidechain.slot}_${sidechain.name}'),
+          label: 'Update',
+          icon: SailSVGAsset.circleArrowUp,
+          variant: ButtonVariant.primary,
+          onPressed: () async => _binaryProvider.update(sidechain),
+        ),
+        const SizedBox(width: SailStyleValues.padding08),
+        action,
+      ],
+    );
+  }
+
+  /// Connection status dot: green when connected, orange while it comes up,
+  /// red on a connection error. The tooltip holds the error.
+  Widget? sidechainStatusDot(BuildContext context, int slot) {
     final sidechain = sidechainForSlot(slot);
     if (sidechain == null) {
       return null;
@@ -1096,7 +1084,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     final error = _binaryProvider.connectionError(sidechain);
     final startupErr = rpc.startupError;
 
-    // Don't show icon if binary is not active at all
+    // Don't show a dot if binary is not active at all
     if (!isRunning && !isInitializing && !downloading && error == null) {
       return null;
     }
@@ -1121,23 +1109,12 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     return SailTooltip(
       message: tooltipMessage,
-      child: SailSVG.fromAsset(
-        SailSVGAsset.iconConnectionStatus,
-        color: color,
-        width: 16,
-        height: 13,
+      child: Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
       ),
     );
-  }
-
-  bool updateAvailable(int slot) {
-    final sidechain = sidechainForSlot(slot);
-
-    if (sidechain == null) {
-      return false;
-    }
-
-    return sidechain.updateAvailable;
   }
 
   List<SidechainOverview?> get sortedSidechains {
@@ -1345,6 +1322,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     _sidechainProvider.removeListener(_onChange);
     _walletReader.removeListener(_onChange);
     _nodeMode?.removeListener(_onChange);
+    _balanceProvider.removeListener(notifyListeners);
     addressController.removeListener(_onChange);
     depositAmountController.removeListener(_onChange);
     feeController.removeListener(_onChange);

--- a/bitwindow/test/sidechains_table_test.dart
+++ b/bitwindow/test/sidechains_table_test.dart
@@ -1,0 +1,270 @@
+import 'dart:io';
+
+import 'package:bitwindow/pages/sidechains_page.dart';
+import 'package:bitwindow/providers/sidechain_provider.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/mocks/mocks.dart';
+import 'package:stacked/stacked.dart';
+
+import 'test_utils.dart';
+
+class _Conf extends ChangeNotifier implements BitcoinConfProvider {
+  @override
+  BitcoinNetwork network = BitcoinNetwork.BITCOIN_NETWORK_SIGNET;
+
+  @override
+  String? get detectedDataDir => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _Sidechains extends ChangeNotifier implements SidechainProvider {
+  @override
+  List<SidechainOverview?> sidechains = List.filled(256, null);
+
+  @override
+  String? error;
+
+  @override
+  Future<void> fetch() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _Wallet extends ChangeNotifier implements WalletReaderProvider {
+  @override
+  String? get activeWalletId => null;
+
+  @override
+  String? resolveFundingWalletId(String? walletId) => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _Transactions implements TransactionProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _Binaries extends BinaryProvider {
+  final updated = <Binary>[];
+
+  // ignore: invalid_use_of_visible_for_testing_member
+  _Binaries(List<Binary> binaries) : super.test(appDir: Directory.systemTemp, binaries: binaries);
+
+  @override
+  Future<void> update(Binary binary) async {
+    updated.add(binary);
+  }
+}
+
+class _Downloads extends DownloadProvider {
+  final progress = <BinaryType, DownloadProgress>{};
+
+  _Downloads() : super(startTimer: false);
+
+  @override
+  DownloadProgress? statusFor(BinaryType binary) => progress[binary];
+}
+
+class _ThunderRPC extends MockThunderRPC {
+  (double, double) wallet = (0, 0);
+
+  @override
+  Future<(double, double)> balance() async => wallet;
+}
+
+Thunder _thunder({bool downloaded = true, bool updateAvailable = false}) {
+  final base = Thunder();
+  return base.copyWith(
+    metadata: base.metadata.copyWith(
+      remoteTimestamp: updateAvailable ? DateTime(2026, 2) : null,
+      downloadedTimestamp: downloaded ? DateTime(2026, 1) : null,
+      binaryPath: downloaded ? File('/tmp/thunder') : null,
+      updateable: true,
+    ),
+  );
+}
+
+Finder _button(String label) => find.byWidgetPredicate((widget) => widget is SailButton && widget.label == label);
+
+SailButton _buttonWidget(WidgetTester tester, String label) => tester.widget<SailButton>(_button(label));
+
+void main() {
+  late _ThunderRPC thunderRPC;
+  late _Downloads downloads;
+  late BalanceProvider balances;
+  late SyncProvider sync;
+
+  _Binaries setUpChain(Thunder thunder) {
+    final binaries = _Binaries([thunder]);
+    GetIt.I.registerSingleton<BinaryProvider>(binaries);
+    return binaries;
+  }
+
+  setUp(() async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.off));
+    sync = SyncProvider(startTimer: false);
+    thunderRPC = _ThunderRPC();
+    downloads = _Downloads();
+    final sidechains = _Sidechains();
+    sidechains.sidechains[9] = SidechainOverview(
+      ListSidechainsResponse_Sidechain(title: 'Thunder', slot: 9, balanceSatoshi: Int64(11000000)),
+      [],
+      [],
+    );
+    GetIt.I.registerSingleton<BitcoinConfProvider>(_Conf());
+    GetIt.I.registerSingleton<SyncProvider>(sync);
+    GetIt.I.registerSingleton<SidechainProvider>(sidechains);
+    GetIt.I.registerSingleton<WalletReaderProvider>(_Wallet());
+    GetIt.I.registerSingleton<TransactionProvider>(_Transactions());
+    GetIt.I.registerSingleton<LogProvider>(LogProvider());
+    GetIt.I.registerSingleton<DownloadProvider>(downloads);
+    GetIt.I.registerSingleton<ThunderRPC>(thunderRPC);
+    balances = BalanceProvider(connections: [thunderRPC]);
+    GetIt.I.registerSingleton<BalanceProvider>(balances);
+  });
+
+  tearDown(() async {
+    sync.dispose();
+    await GetIt.I.reset();
+  });
+
+  Future<void> pumpTable(WidgetTester tester) async {
+    addTearDown(() => tester.pumpWidget(const SizedBox()));
+    await tester.pumpSailPage(
+      ViewModelBuilder<SidechainsViewModel>.reactive(
+        viewModelBuilder: () => SidechainsViewModel(),
+        builder: (context, model, child) => const SidechainsList(smallVersion: false),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a downloaded chain offers a primary Start and a disabled outline Deposit', (tester) async {
+    setUpChain(_thunder());
+    await pumpTable(tester);
+
+    expect(_buttonWidget(tester, 'Start').variant, ButtonVariant.primary);
+    final deposit = _buttonWidget(tester, 'Deposit');
+    expect(deposit.variant, ButtonVariant.outline);
+    expect(deposit.disabled, isTrue);
+    expect(
+      find.ancestor(of: _button('Deposit'), matching: find.byType(SailTooltip)),
+      findsOneWidget,
+    );
+    expect(find.byType(ProgressBar), findsNothing);
+  });
+
+  testWidgets('a stopped chain shows a dash for Your balance', (tester) async {
+    setUpChain(_thunder());
+    await pumpTable(tester);
+
+    expect(find.text('Your balance'), findsOneWidget);
+    expect(find.text('—'), findsOneWidget);
+  });
+
+  testWidgets('a running chain offers an outline Stop and shows Your balance', (tester) async {
+    setUpChain(_thunder());
+    thunderRPC.wallet = (4.1, 0.0);
+    thunderRPC.setConnected(true);
+    await balances.fetch();
+    await pumpTable(tester);
+
+    expect(_buttonWidget(tester, 'Stop').variant, ButtonVariant.outline);
+    expect(_buttonWidget(tester, 'Deposit').disabled, isFalse);
+    expect(find.text(GetIt.I.get<FormatterProvider>().formatBTC(4.1)), findsOneWidget);
+    expect(find.text('—'), findsNothing);
+  });
+
+  testWidgets('a chain that is not downloaded offers a primary Download', (tester) async {
+    setUpChain(_thunder(downloaded: false));
+    await pumpTable(tester);
+
+    expect(_buttonWidget(tester, 'Download').variant, ButtonVariant.primary);
+    expect(_button('Start'), findsNothing);
+  });
+
+  testWidgets('a download in progress shows its percent in place of the button', (tester) async {
+    setUpChain(_thunder(downloaded: false));
+    downloads.progress[BinaryType.BINARY_TYPE_THUNDER] = const DownloadProgress(
+      binary: BinaryType.BINARY_TYPE_THUNDER,
+      mbDownloaded: 62,
+      mbTotal: 100,
+    );
+    await pumpTable(tester);
+
+    expect(find.text('62%'), findsOneWidget);
+    expect(find.text('Updating'), findsNothing);
+    expect(_button('Download'), findsNothing);
+  });
+
+  testWidgets('an update puts a primary Update before an outline Start', (tester) async {
+    final binaries = setUpChain(_thunder(updateAvailable: true));
+    await pumpTable(tester);
+
+    final update = _buttonWidget(tester, 'Update');
+    expect(update.variant, ButtonVariant.primary);
+    expect(update.icon, SailSVGAsset.circleArrowUp);
+    expect(_buttonWidget(tester, 'Start').variant, ButtonVariant.outline);
+    expect(tester.getTopLeft(_button('Update')).dx, lessThan(tester.getTopLeft(_button('Start')).dx));
+
+    await tester.tap(_button('Update'));
+    await tester.pump(kDoubleTapTimeout);
+    await tester.pumpAndSettle();
+    expect(binaries.updated.single.type, BinaryType.BINARY_TYPE_THUNDER);
+  });
+
+  testWidgets('an update in progress shows Updating and a percent in place of the buttons', (tester) async {
+    setUpChain(_thunder(updateAvailable: true));
+    downloads.progress[BinaryType.BINARY_TYPE_THUNDER] = const DownloadProgress(
+      binary: BinaryType.BINARY_TYPE_THUNDER,
+      mbDownloaded: 45,
+      mbTotal: 100,
+    );
+    await pumpTable(tester);
+
+    expect(find.text('Updating'), findsOneWidget);
+    expect(find.text('45%'), findsOneWidget);
+    expect(_button('Update'), findsNothing);
+    expect(_button('Start'), findsNothing);
+  });
+
+  testWidgets('the slot shows its number with no colon', (tester) async {
+    setUpChain(_thunder());
+    await pumpTable(tester);
+
+    expect(find.text('9'), findsOneWidget);
+    expect(find.text('9:'), findsNothing);
+  });
+
+  testWidgets('Add / Remove sits in the card head, next to the toggle', (tester) async {
+    setUpChain(_thunder());
+    await pumpTable(tester);
+
+    final addRemove = _buttonWidget(tester, 'Add / Remove');
+    expect(addRemove.variant, ButtonVariant.outline);
+    final head = tester.getRect(find.text('Show only filled slots'));
+    final button = tester.getRect(_button('Add / Remove'));
+    expect(button.left, greaterThan(head.right));
+    expect(button.bottom, lessThan(tester.getTopLeft(find.text('Slot')).dy));
+  });
+
+  test('progressPercent never reads 100% before the goal', () {
+    expect(progressPercent(45, 100), '45%');
+    expect(progressPercent(999, 1000), '99%');
+    expect(progressPercent(100, 100), '100%');
+    expect(progressPercent(5, 0), '—');
+  });
+}

--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -799,6 +799,11 @@ class SailTableHeaderCell extends StatelessWidget {
           children: [
             Expanded(
               child: Row(
+                mainAxisAlignment: switch (alignment.x) {
+                  > 0 => MainAxisAlignment.end,
+                  < 0 => MainAxisAlignment.start,
+                  _ => MainAxisAlignment.center,
+                },
                 children: [
                   Flexible(
                     child: SailText.primary13(

--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -199,9 +199,10 @@ class _SailTableState extends State<SailTable> {
                     name: cell.name,
                     alignment: cell.alignment,
                     padding: cell.padding,
-                    isSorted: _sortColumnIndex == i,
+                    sortable: cell.sortable,
+                    isSorted: cell.sortable && _sortColumnIndex == i,
                     isAscending: _sortAscending,
-                    onSort: () => _handleSort(i),
+                    onSort: cell.sortable ? () => _handleSort(i) : null,
                     filterWidget: cell.filterWidget,
                   ),
                 ),
@@ -770,6 +771,7 @@ class SailTableHeaderCell extends StatelessWidget {
     this.alignment = Alignment.centerLeft,
     this.padding = const EdgeInsets.symmetric(horizontal: SailStyleValues.padding12),
     this.onSort,
+    this.sortable = true,
     this.isSorted = false,
     this.isAscending = true,
     this.filterWidget,
@@ -780,6 +782,9 @@ class SailTableHeaderCell extends StatelessWidget {
   final Alignment alignment;
   final EdgeInsets padding;
   final VoidCallback? onSort;
+
+  /// False when a tap on the header must not sort the table.
+  final bool sortable;
   final bool isSorted;
   final bool isAscending;
   final Widget? filterWidget;


### PR DESCRIPTION
Changes the Sidechains card to the approved design: Add / Remove in the card head, a status dot before the name, a Your balance column, and one actions column with Update, Updating and an outline Deposit.
Your balance reads the sidechain wallet balance that BalanceProvider already gets from the orchestrator.
SailTable headers now obey their alignment, and a header can skip the sort.