### PR TITLE
sidechains: show the mainchain sync phase

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -980,6 +980,13 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     if (isRunning) {
       // Running but indexing: the same SyncInfo the bottom nav reports.
       final syncInfo = _syncInfoFor(sidechain);
+      if (syncInfo != null && syncInfo.mainchainSyncing) {
+        return SizedBox(
+          key: ValueKey('mainchain_sync_slot_${sidechain.slot}_${sidechain.name}'),
+          width: 160,
+          child: MainchainSyncStatus(syncInfo: syncInfo, compact: true),
+        );
+      }
       if (syncInfo != null && !syncInfo.isSynced && syncInfo.progressGoal > 0) {
         return _ActionProgress(
           key: ValueKey('syncing_slot_${sidechain.slot}_${sidechain.name}'),

--- a/bitwindow/test/sidechains_table_test.dart
+++ b/bitwindow/test/sidechains_table_test.dart
@@ -267,4 +267,46 @@ void main() {
     expect(progressPercent(100, 100), '100%');
     expect(progressPercent(5, 0), '—');
   });
+
+  for (final (phase, label) in [
+    (MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_HEADERS, 'Fetching mainchain headers'),
+    (MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_WRITING, 'Writing mainchain headers'),
+    (MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_STATE, 'Syncing mainchain state'),
+  ]) {
+    testWidgets('a running chain in a mainchain phase shows "$label" and its percent', (tester) async {
+      setUpChain(_thunder());
+      thunderRPC.setConnected(true);
+      sync.sidechains = {
+        SidechainType.SIDECHAIN_TYPE_THUNDER: SyncInfo(
+          progressCurrent: 412000,
+          progressGoal: 997070,
+          lastBlockAt: null,
+          mainchainSyncPhase: phase,
+          mainchainTipHeight: 997070,
+        ),
+      };
+      await pumpTable(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(label), findsOneWidget);
+      expect(find.text('41.3%'), findsOneWidget);
+      expect(_button('Stop'), findsNothing);
+      expect(
+        tester.getRect(find.byType(MainchainSyncStatus)).right,
+        lessThanOrEqualTo(tester.getRect(_button('Deposit')).left),
+      );
+    });
+  }
+
+  testWidgets('a running chain without a mainchain phase keeps the block count bar', (tester) async {
+    setUpChain(_thunder());
+    thunderRPC.setConnected(true);
+    sync.sidechains = {
+      SidechainType.SIDECHAIN_TYPE_THUNDER: SyncInfo(progressCurrent: 100, progressGoal: 294, lastBlockAt: null),
+    };
+    await pumpTable(tester);
+
+    expect(find.byType(MainchainSyncStatus), findsNothing);
+    expect(find.text('34%'), findsOneWidget);
+  });
 }

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
 import 'package:sail_ui/sail_ui.dart';
 
 class DaemonConnectionCard extends StatelessWidget {
@@ -144,7 +145,9 @@ class DaemonConnectionCard extends StatelessWidget {
           // sync info or a download does not grow.
           SizedBox(
             width: progressBlockWidth(downloadProgress != null ? 1 : syncRowCount(syncInfo)),
-            height: progressBlockHeight(context, downloadProgress != null ? 1 : syncRowCount(syncInfo)),
+            height: downloadProgress == null && (syncInfo?.mainchainSyncing ?? false)
+                ? null
+                : progressBlockHeight(context, downloadProgress != null ? 1 : syncRowCount(syncInfo)),
             child: downloadProgress != null
                 ? DownloadStatusRow(
                     name: connection.binary.name,
@@ -473,6 +476,9 @@ class BlockStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (syncInfo.mainchainSyncing) {
+      return MainchainSyncStatus(syncInfo: syncInfo);
+    }
     final rows = rowsFor(syncInfo);
     if (rows.length > 1) {
       return SailColumn(
@@ -534,6 +540,136 @@ class BlockStatus extends StatelessWidget {
 String formatProgress(double progress, bool withDecimal) {
   // otherwise return with appropriate decimal places
   return progress.toStringAsFixed(withDecimal ? 1 : 0);
+}
+
+/// The label and the count unit for a mainchain sync phase. A phase this build
+/// does not name gets a plain label and no unit.
+(String, String) mainchainSyncText(MainchainSyncPhase phase) {
+  if (phase == MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_HEADERS) {
+    return ('Fetching mainchain headers', ' headers');
+  }
+  if (phase == MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_WRITING) {
+    return ('Writing mainchain headers', ' headers');
+  }
+  if (phase == MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_STATE) {
+    return ('Syncing mainchain state', ' blocks');
+  }
+  return ('Syncing mainchain', '');
+}
+
+/// A sidechain node's progress through one mainchain sync phase.
+class MainchainSyncStatus extends StatelessWidget {
+  static const double barHeight = 6;
+
+  final SyncInfo syncInfo;
+
+  /// Moves the numbers line into the tooltip, for a slot one bar high.
+  final bool compact;
+
+  const MainchainSyncStatus({super.key, required this.syncInfo, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final scaler = MediaQuery.of(context).textScaler.clamp(maxScaleFactor: 2);
+    final secondary = daemonStatusStyle(context);
+    final primary = secondary.copyWith(color: theme.colors.text);
+    final number = NumberFormat('#,##0', 'en_US');
+
+    final (label, unit) = mainchainSyncText(syncInfo.mainchainSyncPhase);
+    final done = syncInfo.progressCurrent;
+    final total = syncInfo.progressGoal;
+    final fraction = total > 0 ? (done / total).clamp(0.0, 1.0) : 0.0;
+    // A phase a few items short of its total must not read as done.
+    final percent = done < total ? math.min(fraction * 100, 99.9) : fraction * 100;
+    final counts = '${number.format(done)} / ${number.format(total)}$unit';
+    final maxHeight = 'Max height ${number.format(syncInfo.mainchainTipHeight)}';
+
+    Widget line(String text, TextStyle style) => Text(
+      text,
+      style: style,
+      textScaler: scaler,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    final percentText = line('${percent.toStringAsFixed(1)}%', primary);
+    final head = Row(
+      children: [
+        Expanded(child: line(label, primary)),
+        percentText,
+      ],
+    );
+    // Each phase starts its own bar at zero, so the bar never runs backwards.
+    final bar = _SyncBar(key: ValueKey(syncInfo.mainchainSyncPhase), fraction: fraction);
+
+    if (compact) {
+      return Tooltip(
+        message: '$label\n$counts\n$maxHeight',
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            line(label, primary),
+            const SizedBox(height: SailStyleValues.padding04),
+            Row(
+              children: [
+                Expanded(child: bar),
+                const SizedBox(width: SailStyleValues.padding08),
+                percentText,
+              ],
+            ),
+          ],
+        ),
+      );
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        head,
+        const SizedBox(height: SailStyleValues.padding04),
+        bar,
+        const SizedBox(height: SailStyleValues.padding04),
+        Row(
+          children: [
+            Expanded(child: line(counts, secondary)),
+            line(maxHeight, secondary),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _SyncBar extends StatelessWidget {
+  final double fraction;
+
+  const _SyncBar({super.key, required this.fraction});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final radius = theme.chrome.beveled ? BorderRadius.zero : BorderRadius.circular(MainchainSyncStatus.barHeight / 2);
+    return SizedBox(
+      height: MainchainSyncStatus.barHeight,
+      child: DecoratedBox(
+        decoration: BoxDecoration(color: theme.colors.backgroundSecondary, borderRadius: radius),
+        child: TweenAnimationBuilder<double>(
+          tween: Tween(begin: 0, end: fraction),
+          duration: const Duration(milliseconds: 400),
+          curve: Curves.easeOut,
+          builder: (context, value, _) => FractionallySizedBox(
+            alignment: Alignment.centerLeft,
+            widthFactor: value,
+            child: DecoratedBox(
+              decoration: BoxDecoration(color: theme.colors.primary, borderRadius: radius),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 /// Start or stop one daemon. A reader who wants to bounce a daemon stops it and

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -618,6 +618,10 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     }
 
     if (needsAdditionalSync && !(additionalSyncInfo?.isSynced ?? false)) {
+      final info = additionalSyncInfo;
+      if (info != null && info.mainchainSyncing) {
+        return '${mainchainSyncText(info.mainchainSyncPhase).$1} for ${additionalConnection.name}';
+      }
       return 'Syncing ${additionalConnection.name} blocks';
     }
 
@@ -767,6 +771,10 @@ class ChainLoader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (syncInfo.mainchainSyncing) {
+      final loader = MainchainSyncStatus(syncInfo: syncInfo, compact: true);
+      return expanded ? Expanded(child: loader) : loader;
+    }
     final currentProgress = formatProgress(syncInfo.progressCurrent, false);
     final goalProgress = formatProgress(syncInfo.progressGoal, false);
 

--- a/sail_ui/test/bottom_nav_light_mode_test.dart
+++ b/sail_ui/test/bottom_nav_light_mode_test.dart
@@ -233,6 +233,26 @@ void main() {
     expect(model.allConnected, isTrue);
     expect(model.connectionColor, SailColorScheme.orange);
   });
+
+  test('a sidechain in a mainchain phase names the phase in the status', () {
+    expect(model.connectionStatus, 'All binaries connected');
+
+    sync.sidechains[SidechainType.SIDECHAIN_TYPE_THUNDER] = SyncInfo(
+      progressCurrent: 412000,
+      progressGoal: 997070,
+      lastBlockAt: null,
+      mainchainSyncPhase: MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_WRITING,
+    );
+    expect(model.connectionStatus, 'Writing mainchain headers for Thunder');
+
+    sync.sidechains[SidechainType.SIDECHAIN_TYPE_THUNDER] = SyncInfo(
+      progressCurrent: 2,
+      progressGoal: 3,
+      lastBlockAt: null,
+    );
+    expect(model.connectionStatus, 'Syncing Thunder blocks');
+  });
+
   test('the Bitcoin light wallet ignores an unavailable enforcer', () {
     daemon.binary = BitWindow();
     enforcer.connected = false;

--- a/sail_ui/test/widgets/mainchain_sync_status_test.dart
+++ b/sail_ui/test/widgets/mainchain_sync_status_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+SyncInfo syncing(MainchainSyncPhase phase, double done, {double total = 997070, int tip = 997070}) => SyncInfo(
+  progressCurrent: done,
+  progressGoal: total,
+  lastBlockAt: null,
+  mainchainSyncPhase: phase,
+  mainchainTipHeight: tip,
+);
+
+const headers = MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_HEADERS;
+const state = MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_STATE;
+const writing = MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_WRITING;
+const other = MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_OTHER;
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: 350, child: child),
+        ),
+      ),
+    ),
+  );
+
+  double barFill(WidgetTester tester) =>
+      tester.widget<FractionallySizedBox>(find.byType(FractionallySizedBox)).widthFactor!;
+
+  testWidgets('the headers phase shows its label, percent, counts and max height', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(headers, 412000))));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Fetching mainchain headers'), findsOneWidget);
+    expect(find.text('41.3%'), findsOneWidget);
+    expect(find.text('412,000 / 997,070 headers'), findsOneWidget);
+    expect(find.text('Max height 997,070'), findsOneWidget);
+    expect(find.byType(ProgressBar), findsNothing);
+  });
+
+  testWidgets('the state phase shows its label, percent, counts and max height', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(state, 310))));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Syncing mainchain state'), findsOneWidget);
+    expect(find.text('0.0%'), findsOneWidget);
+    expect(find.text('310 / 997,070 blocks'), findsOneWidget);
+    expect(find.text('Max height 997,070'), findsOneWidget);
+  });
+
+  testWidgets('the writing phase shows its label, percent, counts and max height', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(writing, 500000))));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Writing mainchain headers'), findsOneWidget);
+    expect(find.text('50.1%'), findsOneWidget);
+    expect(find.text('500,000 / 997,070 headers'), findsOneWidget);
+    expect(find.text('Max height 997,070'), findsOneWidget);
+  });
+
+  testWidgets('a phase this build does not name shows a plain mainchain bar', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(other, 1000))));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Syncing mainchain'), findsOneWidget);
+    expect(find.text('0.1%'), findsOneWidget);
+    expect(find.text('1,000 / 997,070'), findsOneWidget);
+    expect(find.text('Max height 997,070'), findsOneWidget);
+  });
+
+  testWidgets('a phase one item short of its total does not read as done', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(headers, 997069))));
+    await tester.pumpAndSettle();
+
+    expect(find.text('99.9%'), findsOneWidget);
+  });
+
+  testWidgets('the compact loader keeps the counts and max height in its tooltip', (tester) async {
+    await tester.pumpWidget(
+      wrap(ChainLoader(name: 'Thunder', syncInfo: syncing(headers, 412000), justPercent: true, expanded: false)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Fetching mainchain headers'), findsOneWidget);
+    expect(find.text('41.3%'), findsOneWidget);
+    expect(find.byTooltip('Fetching mainchain headers\n412,000 / 997,070 headers\nMax height 997,070'), findsOneWidget);
+  });
+
+  testWidgets('a new phase starts its bar at zero, not at the last phase fill', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(headers, 997070))));
+    await tester.pumpAndSettle();
+    expect(barFill(tester), 1.0);
+
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Thunder', syncInfo: syncing(state, 310))));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(barFill(tester), lessThan(0.01));
+  });
+
+  testWidgets('a node without the phase keeps the block count bar', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        BlockStatus(
+          name: 'Thunder',
+          syncInfo: SyncInfo(progressCurrent: 0, progressGoal: 294, lastBlockAt: null),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ProgressBar), findsOneWidget);
+    expect(find.byType(MainchainSyncStatus), findsNothing);
+  });
+
+  test('a node in a phase is not synced, even at the phase total', () {
+    expect(syncing(headers, 997070).isSynced, isFalse);
+  });
+}

--- a/sidechain-orchestrator/api/mainchain_sync_phase_test.go
+++ b/sidechain-orchestrator/api/mainchain_sync_phase_test.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"testing"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainchainSyncPhaseToProto(t *testing.T) {
+	for phase, want := range map[sidechain.MainchainSyncPhase]pb.MainchainSyncPhase{
+		"":                             pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_UNSPECIFIED,
+		sidechain.MainchainSyncHeaders: pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_HEADERS,
+		sidechain.MainchainSyncWriting: pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_WRITING,
+		sidechain.MainchainSyncState:   pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_STATE,
+		"rewind":                       pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_OTHER,
+	} {
+		assert.Equal(t, want, mainchainSyncPhaseToProto(phase), "phase %q", phase)
+	}
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -536,6 +536,23 @@ func chainSyncToProto(s *orchestrator.ChainSyncResult) *pb.ChainSync {
 		RefusedBranchStart: int32(s.RefusedBranchStart),
 		VerifiedBlocks:     int32(s.VerifiedBlocks),
 		VerifiedGoal:       int32(s.VerifiedGoal),
+		MainchainSyncPhase: mainchainSyncPhaseToProto(s.MainchainSyncPhase),
+		MainchainTipHeight: int32(s.MainchainTipHeight),
+	}
+}
+
+func mainchainSyncPhaseToProto(phase sidechain.MainchainSyncPhase) pb.MainchainSyncPhase {
+	switch phase {
+	case "":
+		return pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_UNSPECIFIED
+	case sidechain.MainchainSyncHeaders:
+		return pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_HEADERS
+	case sidechain.MainchainSyncWriting:
+		return pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_WRITING
+	case sidechain.MainchainSyncState:
+		return pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_STATE
+	default:
+		return pb.MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_OTHER
 	}
 }
 

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -185,6 +185,66 @@ func (BinaryType) EnumDescriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{1}
 }
 
+type MainchainSyncPhase int32
+
+const (
+	// The node reports no mainchain sync.
+	MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_UNSPECIFIED MainchainSyncPhase = 0
+	// The node fetches the mainchain headers.
+	MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_HEADERS MainchainSyncPhase = 1
+	// The node connects the mainchain state.
+	MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_STATE MainchainSyncPhase = 2
+	// The node writes the fetched mainchain headers to disk.
+	MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_WRITING MainchainSyncPhase = 3
+	// The node reports a phase this build does not name.
+	MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_OTHER MainchainSyncPhase = 4
+)
+
+// Enum value maps for MainchainSyncPhase.
+var (
+	MainchainSyncPhase_name = map[int32]string{
+		0: "MAINCHAIN_SYNC_PHASE_UNSPECIFIED",
+		1: "MAINCHAIN_SYNC_PHASE_HEADERS",
+		2: "MAINCHAIN_SYNC_PHASE_STATE",
+		3: "MAINCHAIN_SYNC_PHASE_WRITING",
+		4: "MAINCHAIN_SYNC_PHASE_OTHER",
+	}
+	MainchainSyncPhase_value = map[string]int32{
+		"MAINCHAIN_SYNC_PHASE_UNSPECIFIED": 0,
+		"MAINCHAIN_SYNC_PHASE_HEADERS":     1,
+		"MAINCHAIN_SYNC_PHASE_STATE":       2,
+		"MAINCHAIN_SYNC_PHASE_WRITING":     3,
+		"MAINCHAIN_SYNC_PHASE_OTHER":       4,
+	}
+)
+
+func (x MainchainSyncPhase) Enum() *MainchainSyncPhase {
+	p := new(MainchainSyncPhase)
+	*p = x
+	return p
+}
+
+func (x MainchainSyncPhase) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MainchainSyncPhase) Descriptor() protoreflect.EnumDescriptor {
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[2].Descriptor()
+}
+
+func (MainchainSyncPhase) Type() protoreflect.EnumType {
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[2]
+}
+
+func (x MainchainSyncPhase) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MainchainSyncPhase.Descriptor instead.
+func (MainchainSyncPhase) EnumDescriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{2}
+}
+
 // DeletionType selects which category of a binary's files to gather/delete.
 type DeletionType int32
 
@@ -228,11 +288,11 @@ func (x DeletionType) String() string {
 }
 
 func (DeletionType) Descriptor() protoreflect.EnumDescriptor {
-	return file_orchestrator_v1_orchestrator_proto_enumTypes[2].Descriptor()
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[3].Descriptor()
 }
 
 func (DeletionType) Type() protoreflect.EnumType {
-	return &file_orchestrator_v1_orchestrator_proto_enumTypes[2]
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[3]
 }
 
 func (x DeletionType) Number() protoreflect.EnumNumber {
@@ -241,7 +301,7 @@ func (x DeletionType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DeletionType.Descriptor instead.
 func (DeletionType) EnumDescriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{2}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{3}
 }
 
 // What the reject did to the chain Core follows.
@@ -284,11 +344,11 @@ func (x RejectOutcome) String() string {
 }
 
 func (RejectOutcome) Descriptor() protoreflect.EnumDescriptor {
-	return file_orchestrator_v1_orchestrator_proto_enumTypes[3].Descriptor()
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[4].Descriptor()
 }
 
 func (RejectOutcome) Type() protoreflect.EnumType {
-	return &file_orchestrator_v1_orchestrator_proto_enumTypes[3]
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[4]
 }
 
 func (x RejectOutcome) Number() protoreflect.EnumNumber {
@@ -297,7 +357,7 @@ func (x RejectOutcome) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RejectOutcome.Descriptor instead.
 func (RejectOutcome) EnumDescriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{3}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{4}
 }
 
 // Which step of a reset a progress message reports.
@@ -348,11 +408,11 @@ func (x ResetPhase) String() string {
 }
 
 func (ResetPhase) Descriptor() protoreflect.EnumDescriptor {
-	return file_orchestrator_v1_orchestrator_proto_enumTypes[4].Descriptor()
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[5].Descriptor()
 }
 
 func (ResetPhase) Type() protoreflect.EnumType {
-	return &file_orchestrator_v1_orchestrator_proto_enumTypes[4]
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[5]
 }
 
 func (x ResetPhase) Number() protoreflect.EnumNumber {
@@ -361,7 +421,7 @@ func (x ResetPhase) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ResetPhase.Descriptor instead.
 func (ResetPhase) EnumDescriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{4}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{5}
 }
 
 type BinaryStatusMsg struct {
@@ -2827,9 +2887,14 @@ type ChainSync struct {
 	VerifiedBlocks int32 `protobuf:"varint,8,opt,name=verified_blocks,json=verifiedBlocks,proto3" json:"verified_blocks,omitempty"`
 	// Height verified_blocks counts towards: the block the snapshot commits to,
 	// not the chain tip. 0 when no snapshot is loaded. Mainchain only.
-	VerifiedGoal  int32 `protobuf:"varint,9,opt,name=verified_goal,json=verifiedGoal,proto3" json:"verified_goal,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	VerifiedGoal int32 `protobuf:"varint,9,opt,name=verified_goal,json=verifiedGoal,proto3" json:"verified_goal,omitempty"`
+	// The mainchain step a sidechain node takes before it syncs its own
+	// blocks. While set, blocks and headers are that step's done and total.
+	MainchainSyncPhase MainchainSyncPhase `protobuf:"varint,10,opt,name=mainchain_sync_phase,json=mainchainSyncPhase,proto3,enum=orchestrator.v1.MainchainSyncPhase" json:"mainchain_sync_phase,omitempty"`
+	// Mainchain tip height the mainchain_sync_phase moves to, 0 when unset.
+	MainchainTipHeight int32 `protobuf:"varint,11,opt,name=mainchain_tip_height,json=mainchainTipHeight,proto3" json:"mainchain_tip_height,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ChainSync) Reset() {
@@ -2921,6 +2986,20 @@ func (x *ChainSync) GetVerifiedBlocks() int32 {
 func (x *ChainSync) GetVerifiedGoal() int32 {
 	if x != nil {
 		return x.VerifiedGoal
+	}
+	return 0
+}
+
+func (x *ChainSync) GetMainchainSyncPhase() MainchainSyncPhase {
+	if x != nil {
+		return x.MainchainSyncPhase
+	}
+	return MainchainSyncPhase_MAINCHAIN_SYNC_PHASE_UNSPECIFIED
+}
+
+func (x *ChainSync) GetMainchainTipHeight() int32 {
+	if x != nil {
+		return x.MainchainTipHeight
 	}
 	return 0
 }
@@ -5174,7 +5253,7 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\fchain_source\x18\x06 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\vchainSourceJ\x04\b\x05\x10\x06R\x0fenforcer_wallet\"u\n" +
 	"\x0fSidechainStatus\x122\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1e.orchestrator.v1.SidechainTypeR\x04type\x12.\n" +
-	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xba\x02\n" +
+	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xc3\x03\n" +
 	"\tChainSync\x12\x16\n" +
 	"\x06blocks\x18\x01 \x01(\x05R\x06blocks\x12\x18\n" +
 	"\aheaders\x18\x02 \x01(\x05R\aheaders\x12\x12\n" +
@@ -5184,7 +5263,10 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x0frejected_branch\x18\x06 \x01(\bR\x0erejectedBranch\x120\n" +
 	"\x14refused_branch_start\x18\a \x01(\x05R\x12refusedBranchStart\x12'\n" +
 	"\x0fverified_blocks\x18\b \x01(\x05R\x0everifiedBlocks\x12#\n" +
-	"\rverified_goal\x18\t \x01(\x05R\fverifiedGoal\"\x1a\n" +
+	"\rverified_goal\x18\t \x01(\x05R\fverifiedGoal\x12U\n" +
+	"\x14mainchain_sync_phase\x18\n" +
+	" \x01(\x0e2#.orchestrator.v1.MainchainSyncPhaseR\x12mainchainSyncPhase\x120\n" +
+	"\x14mainchain_tip_height\x18\v \x01(\x05R\x12mainchainTipHeight\"\x1a\n" +
 	"\x18GetDownloadStatusRequest\"Z\n" +
 	"\x19GetDownloadStatusResponse\x12=\n" +
 	"\tdownloads\x18\x01 \x03(\v2\x1f.orchestrator.v1.DownloadStatusR\tdownloads\"\x9f\x01\n" +
@@ -5364,7 +5446,13 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x12BINARY_TYPE_ZSIDED\x10\r\x12\x1d\n" +
 	"\x19BINARY_TYPE_LIQUID_SIGNET\x10\x0e\x12\x13\n" +
 	"\x0fBINARY_TYPE_BBC\x10\x0f\x12\x18\n" +
-	"\x14BINARY_TYPE_FREEBANK\x10\x10*\xaf\x01\n" +
+	"\x14BINARY_TYPE_FREEBANK\x10\x10*\xbe\x01\n" +
+	"\x12MainchainSyncPhase\x12$\n" +
+	" MAINCHAIN_SYNC_PHASE_UNSPECIFIED\x10\x00\x12 \n" +
+	"\x1cMAINCHAIN_SYNC_PHASE_HEADERS\x10\x01\x12\x1e\n" +
+	"\x1aMAINCHAIN_SYNC_PHASE_STATE\x10\x02\x12 \n" +
+	"\x1cMAINCHAIN_SYNC_PHASE_WRITING\x10\x03\x12\x1e\n" +
+	"\x1aMAINCHAIN_SYNC_PHASE_OTHER\x10\x04*\xaf\x01\n" +
 	"\fDeletionType\x12\x1d\n" +
 	"\x19DELETION_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12DELETION_TYPE_DATA\x10\x01\x12\x18\n" +
@@ -5436,189 +5524,191 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 	return file_orchestrator_v1_orchestrator_proto_rawDescData
 }
 
-var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
 var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                              // 0: orchestrator.v1.SidechainType
 	(BinaryType)(0),                                 // 1: orchestrator.v1.BinaryType
-	(DeletionType)(0),                               // 2: orchestrator.v1.DeletionType
-	(RejectOutcome)(0),                              // 3: orchestrator.v1.RejectOutcome
-	(ResetPhase)(0),                                 // 4: orchestrator.v1.ResetPhase
-	(*BinaryStatusMsg)(nil),                         // 5: orchestrator.v1.BinaryStatusMsg
-	(*StartupLogEntryMsg)(nil),                      // 6: orchestrator.v1.StartupLogEntryMsg
-	(*ListBinariesRequest)(nil),                     // 7: orchestrator.v1.ListBinariesRequest
-	(*ListBinariesResponse)(nil),                    // 8: orchestrator.v1.ListBinariesResponse
-	(*GetBinaryStatusRequest)(nil),                  // 9: orchestrator.v1.GetBinaryStatusRequest
-	(*GetBinaryStatusResponse)(nil),                 // 10: orchestrator.v1.GetBinaryStatusResponse
-	(*GetBinaryVersionRequest)(nil),                 // 11: orchestrator.v1.GetBinaryVersionRequest
-	(*GetBinaryVersionResponse)(nil),                // 12: orchestrator.v1.GetBinaryVersionResponse
-	(*DownloadBinaryRequest)(nil),                   // 13: orchestrator.v1.DownloadBinaryRequest
-	(*DownloadBinaryResponse)(nil),                  // 14: orchestrator.v1.DownloadBinaryResponse
-	(*StartBinaryRequest)(nil),                      // 15: orchestrator.v1.StartBinaryRequest
-	(*StartBinaryResponse)(nil),                     // 16: orchestrator.v1.StartBinaryResponse
-	(*StopBinaryRequest)(nil),                       // 17: orchestrator.v1.StopBinaryRequest
-	(*StopBinaryResponse)(nil),                      // 18: orchestrator.v1.StopBinaryResponse
-	(*StreamLogsRequest)(nil),                       // 19: orchestrator.v1.StreamLogsRequest
-	(*StreamLogsResponse)(nil),                      // 20: orchestrator.v1.StreamLogsResponse
-	(*StartWithL1Request)(nil),                      // 21: orchestrator.v1.StartWithL1Request
-	(*StartWithL1Response)(nil),                     // 22: orchestrator.v1.StartWithL1Response
-	(*RestartDaemonRequest)(nil),                    // 23: orchestrator.v1.RestartDaemonRequest
-	(*RestartDaemonResponse)(nil),                   // 24: orchestrator.v1.RestartDaemonResponse
-	(*RestartL1Request)(nil),                        // 25: orchestrator.v1.RestartL1Request
-	(*RestartL1Response)(nil),                       // 26: orchestrator.v1.RestartL1Response
-	(*ApplyUTXOSnapshotRequest)(nil),                // 27: orchestrator.v1.ApplyUTXOSnapshotRequest
-	(*ApplyUTXOSnapshotResponse)(nil),               // 28: orchestrator.v1.ApplyUTXOSnapshotResponse
-	(*GetSnapshotStatusRequest)(nil),                // 29: orchestrator.v1.GetSnapshotStatusRequest
-	(*GetSnapshotStatusResponse)(nil),               // 30: orchestrator.v1.GetSnapshotStatusResponse
-	(*GetPendingNetworkGenerationRequest)(nil),      // 31: orchestrator.v1.GetPendingNetworkGenerationRequest
-	(*GetPendingNetworkGenerationResponse)(nil),     // 32: orchestrator.v1.GetPendingNetworkGenerationResponse
-	(*ConfirmPendingNetworkGenerationRequest)(nil),  // 33: orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	(*ConfirmPendingNetworkGenerationResponse)(nil), // 34: orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	(*ShutdownAllRequest)(nil),                      // 35: orchestrator.v1.ShutdownAllRequest
-	(*ShutdownAllResponse)(nil),                     // 36: orchestrator.v1.ShutdownAllResponse
-	(*GetBTCPriceRequest)(nil),                      // 37: orchestrator.v1.GetBTCPriceRequest
-	(*GetBTCPriceResponse)(nil),                     // 38: orchestrator.v1.GetBTCPriceResponse
-	(*GetMainchainBlockchainInfoRequest)(nil),       // 39: orchestrator.v1.GetMainchainBlockchainInfoRequest
-	(*GetMainchainBlockchainInfoResponse)(nil),      // 40: orchestrator.v1.GetMainchainBlockchainInfoResponse
-	(*GetEnforcerBlockchainInfoRequest)(nil),        // 41: orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	(*GetEnforcerBlockchainInfoResponse)(nil),       // 42: orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	(*GetSyncStatusRequest)(nil),                    // 43: orchestrator.v1.GetSyncStatusRequest
-	(*GetSyncStatusResponse)(nil),                   // 44: orchestrator.v1.GetSyncStatusResponse
-	(*SidechainStatus)(nil),                         // 45: orchestrator.v1.SidechainStatus
-	(*ChainSync)(nil),                               // 46: orchestrator.v1.ChainSync
-	(*GetDownloadStatusRequest)(nil),                // 47: orchestrator.v1.GetDownloadStatusRequest
-	(*GetDownloadStatusResponse)(nil),               // 48: orchestrator.v1.GetDownloadStatusResponse
-	(*DownloadStatus)(nil),                          // 49: orchestrator.v1.DownloadStatus
-	(*GetMainchainBalanceRequest)(nil),              // 50: orchestrator.v1.GetMainchainBalanceRequest
-	(*GetMainchainBalanceResponse)(nil),             // 51: orchestrator.v1.GetMainchainBalanceResponse
-	(*GetSidechainBalanceRequest)(nil),              // 52: orchestrator.v1.GetSidechainBalanceRequest
-	(*GetSidechainBalanceResponse)(nil),             // 53: orchestrator.v1.GetSidechainBalanceResponse
-	(*SingleDeletion)(nil),                          // 54: orchestrator.v1.SingleDeletion
-	(*GatherFilesToDeleteRequest)(nil),              // 55: orchestrator.v1.GatherFilesToDeleteRequest
-	(*GatherFilesToDeleteResponse)(nil),             // 56: orchestrator.v1.GatherFilesToDeleteResponse
-	(*ResetFileInfo)(nil),                           // 57: orchestrator.v1.ResetFileInfo
-	(*DeleteFilesRequest)(nil),                      // 58: orchestrator.v1.DeleteFilesRequest
-	(*DeleteFilesResponse)(nil),                     // 59: orchestrator.v1.DeleteFilesResponse
-	(*RejectBlockRequest)(nil),                      // 60: orchestrator.v1.RejectBlockRequest
-	(*RejectBlockResponse)(nil),                     // 61: orchestrator.v1.RejectBlockResponse
-	(*AcceptBlockRequest)(nil),                      // 62: orchestrator.v1.AcceptBlockRequest
-	(*AcceptBlockResponse)(nil),                     // 63: orchestrator.v1.AcceptBlockResponse
-	(*ResetToBlockRequest)(nil),                     // 64: orchestrator.v1.ResetToBlockRequest
-	(*ResetToBlockResponse)(nil),                    // 65: orchestrator.v1.ResetToBlockResponse
-	(*GetCoreMempoolInfoRequest)(nil),               // 66: orchestrator.v1.GetCoreMempoolInfoRequest
-	(*GetCoreMempoolInfoResponse)(nil),              // 67: orchestrator.v1.GetCoreMempoolInfoResponse
-	(*GetBmmContextRequest)(nil),                    // 68: orchestrator.v1.GetBmmContextRequest
-	(*GetBmmContextResponse)(nil),                   // 69: orchestrator.v1.GetBmmContextResponse
-	(*CoreRawCallRequest)(nil),                      // 70: orchestrator.v1.CoreRawCallRequest
-	(*CoreRawCallResponse)(nil),                     // 71: orchestrator.v1.CoreRawCallResponse
-	(*GetForkStatusRequest)(nil),                    // 72: orchestrator.v1.GetForkStatusRequest
-	(*GetForkStatusResponse)(nil),                   // 73: orchestrator.v1.GetForkStatusResponse
-	(*ForkWalletClaim)(nil),                         // 74: orchestrator.v1.ForkWalletClaim
-	(*ForkClaimUtxo)(nil),                           // 75: orchestrator.v1.ForkClaimUtxo
-	(*ShutdownRequest)(nil),                         // 76: orchestrator.v1.ShutdownRequest
-	(*ShutdownResponse)(nil),                        // 77: orchestrator.v1.ShutdownResponse
-	(*AdoptOwnerRequest)(nil),                       // 78: orchestrator.v1.AdoptOwnerRequest
-	(*AdoptOwnerResponse)(nil),                      // 79: orchestrator.v1.AdoptOwnerResponse
-	nil,                                             // 80: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                             // 81: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(MainchainSyncPhase)(0),                         // 2: orchestrator.v1.MainchainSyncPhase
+	(DeletionType)(0),                               // 3: orchestrator.v1.DeletionType
+	(RejectOutcome)(0),                              // 4: orchestrator.v1.RejectOutcome
+	(ResetPhase)(0),                                 // 5: orchestrator.v1.ResetPhase
+	(*BinaryStatusMsg)(nil),                         // 6: orchestrator.v1.BinaryStatusMsg
+	(*StartupLogEntryMsg)(nil),                      // 7: orchestrator.v1.StartupLogEntryMsg
+	(*ListBinariesRequest)(nil),                     // 8: orchestrator.v1.ListBinariesRequest
+	(*ListBinariesResponse)(nil),                    // 9: orchestrator.v1.ListBinariesResponse
+	(*GetBinaryStatusRequest)(nil),                  // 10: orchestrator.v1.GetBinaryStatusRequest
+	(*GetBinaryStatusResponse)(nil),                 // 11: orchestrator.v1.GetBinaryStatusResponse
+	(*GetBinaryVersionRequest)(nil),                 // 12: orchestrator.v1.GetBinaryVersionRequest
+	(*GetBinaryVersionResponse)(nil),                // 13: orchestrator.v1.GetBinaryVersionResponse
+	(*DownloadBinaryRequest)(nil),                   // 14: orchestrator.v1.DownloadBinaryRequest
+	(*DownloadBinaryResponse)(nil),                  // 15: orchestrator.v1.DownloadBinaryResponse
+	(*StartBinaryRequest)(nil),                      // 16: orchestrator.v1.StartBinaryRequest
+	(*StartBinaryResponse)(nil),                     // 17: orchestrator.v1.StartBinaryResponse
+	(*StopBinaryRequest)(nil),                       // 18: orchestrator.v1.StopBinaryRequest
+	(*StopBinaryResponse)(nil),                      // 19: orchestrator.v1.StopBinaryResponse
+	(*StreamLogsRequest)(nil),                       // 20: orchestrator.v1.StreamLogsRequest
+	(*StreamLogsResponse)(nil),                      // 21: orchestrator.v1.StreamLogsResponse
+	(*StartWithL1Request)(nil),                      // 22: orchestrator.v1.StartWithL1Request
+	(*StartWithL1Response)(nil),                     // 23: orchestrator.v1.StartWithL1Response
+	(*RestartDaemonRequest)(nil),                    // 24: orchestrator.v1.RestartDaemonRequest
+	(*RestartDaemonResponse)(nil),                   // 25: orchestrator.v1.RestartDaemonResponse
+	(*RestartL1Request)(nil),                        // 26: orchestrator.v1.RestartL1Request
+	(*RestartL1Response)(nil),                       // 27: orchestrator.v1.RestartL1Response
+	(*ApplyUTXOSnapshotRequest)(nil),                // 28: orchestrator.v1.ApplyUTXOSnapshotRequest
+	(*ApplyUTXOSnapshotResponse)(nil),               // 29: orchestrator.v1.ApplyUTXOSnapshotResponse
+	(*GetSnapshotStatusRequest)(nil),                // 30: orchestrator.v1.GetSnapshotStatusRequest
+	(*GetSnapshotStatusResponse)(nil),               // 31: orchestrator.v1.GetSnapshotStatusResponse
+	(*GetPendingNetworkGenerationRequest)(nil),      // 32: orchestrator.v1.GetPendingNetworkGenerationRequest
+	(*GetPendingNetworkGenerationResponse)(nil),     // 33: orchestrator.v1.GetPendingNetworkGenerationResponse
+	(*ConfirmPendingNetworkGenerationRequest)(nil),  // 34: orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	(*ConfirmPendingNetworkGenerationResponse)(nil), // 35: orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	(*ShutdownAllRequest)(nil),                      // 36: orchestrator.v1.ShutdownAllRequest
+	(*ShutdownAllResponse)(nil),                     // 37: orchestrator.v1.ShutdownAllResponse
+	(*GetBTCPriceRequest)(nil),                      // 38: orchestrator.v1.GetBTCPriceRequest
+	(*GetBTCPriceResponse)(nil),                     // 39: orchestrator.v1.GetBTCPriceResponse
+	(*GetMainchainBlockchainInfoRequest)(nil),       // 40: orchestrator.v1.GetMainchainBlockchainInfoRequest
+	(*GetMainchainBlockchainInfoResponse)(nil),      // 41: orchestrator.v1.GetMainchainBlockchainInfoResponse
+	(*GetEnforcerBlockchainInfoRequest)(nil),        // 42: orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	(*GetEnforcerBlockchainInfoResponse)(nil),       // 43: orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	(*GetSyncStatusRequest)(nil),                    // 44: orchestrator.v1.GetSyncStatusRequest
+	(*GetSyncStatusResponse)(nil),                   // 45: orchestrator.v1.GetSyncStatusResponse
+	(*SidechainStatus)(nil),                         // 46: orchestrator.v1.SidechainStatus
+	(*ChainSync)(nil),                               // 47: orchestrator.v1.ChainSync
+	(*GetDownloadStatusRequest)(nil),                // 48: orchestrator.v1.GetDownloadStatusRequest
+	(*GetDownloadStatusResponse)(nil),               // 49: orchestrator.v1.GetDownloadStatusResponse
+	(*DownloadStatus)(nil),                          // 50: orchestrator.v1.DownloadStatus
+	(*GetMainchainBalanceRequest)(nil),              // 51: orchestrator.v1.GetMainchainBalanceRequest
+	(*GetMainchainBalanceResponse)(nil),             // 52: orchestrator.v1.GetMainchainBalanceResponse
+	(*GetSidechainBalanceRequest)(nil),              // 53: orchestrator.v1.GetSidechainBalanceRequest
+	(*GetSidechainBalanceResponse)(nil),             // 54: orchestrator.v1.GetSidechainBalanceResponse
+	(*SingleDeletion)(nil),                          // 55: orchestrator.v1.SingleDeletion
+	(*GatherFilesToDeleteRequest)(nil),              // 56: orchestrator.v1.GatherFilesToDeleteRequest
+	(*GatherFilesToDeleteResponse)(nil),             // 57: orchestrator.v1.GatherFilesToDeleteResponse
+	(*ResetFileInfo)(nil),                           // 58: orchestrator.v1.ResetFileInfo
+	(*DeleteFilesRequest)(nil),                      // 59: orchestrator.v1.DeleteFilesRequest
+	(*DeleteFilesResponse)(nil),                     // 60: orchestrator.v1.DeleteFilesResponse
+	(*RejectBlockRequest)(nil),                      // 61: orchestrator.v1.RejectBlockRequest
+	(*RejectBlockResponse)(nil),                     // 62: orchestrator.v1.RejectBlockResponse
+	(*AcceptBlockRequest)(nil),                      // 63: orchestrator.v1.AcceptBlockRequest
+	(*AcceptBlockResponse)(nil),                     // 64: orchestrator.v1.AcceptBlockResponse
+	(*ResetToBlockRequest)(nil),                     // 65: orchestrator.v1.ResetToBlockRequest
+	(*ResetToBlockResponse)(nil),                    // 66: orchestrator.v1.ResetToBlockResponse
+	(*GetCoreMempoolInfoRequest)(nil),               // 67: orchestrator.v1.GetCoreMempoolInfoRequest
+	(*GetCoreMempoolInfoResponse)(nil),              // 68: orchestrator.v1.GetCoreMempoolInfoResponse
+	(*GetBmmContextRequest)(nil),                    // 69: orchestrator.v1.GetBmmContextRequest
+	(*GetBmmContextResponse)(nil),                   // 70: orchestrator.v1.GetBmmContextResponse
+	(*CoreRawCallRequest)(nil),                      // 71: orchestrator.v1.CoreRawCallRequest
+	(*CoreRawCallResponse)(nil),                     // 72: orchestrator.v1.CoreRawCallResponse
+	(*GetForkStatusRequest)(nil),                    // 73: orchestrator.v1.GetForkStatusRequest
+	(*GetForkStatusResponse)(nil),                   // 74: orchestrator.v1.GetForkStatusResponse
+	(*ForkWalletClaim)(nil),                         // 75: orchestrator.v1.ForkWalletClaim
+	(*ForkClaimUtxo)(nil),                           // 76: orchestrator.v1.ForkClaimUtxo
+	(*ShutdownRequest)(nil),                         // 77: orchestrator.v1.ShutdownRequest
+	(*ShutdownResponse)(nil),                        // 78: orchestrator.v1.ShutdownResponse
+	(*AdoptOwnerRequest)(nil),                       // 79: orchestrator.v1.AdoptOwnerRequest
+	(*AdoptOwnerResponse)(nil),                      // 80: orchestrator.v1.AdoptOwnerResponse
+	nil,                                             // 81: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                             // 82: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
-	6,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
-	5,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
-	5,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	80, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	81, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
-	46, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
-	46, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
-	45, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
-	46, // 8: orchestrator.v1.GetSyncStatusResponse.chain_source:type_name -> orchestrator.v1.ChainSync
+	7,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
+	6,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
+	6,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
+	81, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	82, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	47, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
+	47, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
+	46, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
+	47, // 8: orchestrator.v1.GetSyncStatusResponse.chain_source:type_name -> orchestrator.v1.ChainSync
 	0,  // 9: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
-	46, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
-	49, // 11: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
-	1,  // 12: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
-	1,  // 13: orchestrator.v1.GetSidechainBalanceRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	1,  // 14: orchestrator.v1.SingleDeletion.binary:type_name -> orchestrator.v1.BinaryType
-	2,  // 15: orchestrator.v1.SingleDeletion.deletions:type_name -> orchestrator.v1.DeletionType
-	54, // 16: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	57, // 17: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
-	2,  // 18: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
-	1,  // 19: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
-	54, // 20: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	3,  // 21: orchestrator.v1.RejectBlockResponse.outcome:type_name -> orchestrator.v1.RejectOutcome
-	4,  // 22: orchestrator.v1.ResetToBlockResponse.phase:type_name -> orchestrator.v1.ResetPhase
-	74, // 23: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
-	75, // 24: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
-	7,  // 25: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	9,  // 26: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	11, // 27: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
-	13, // 28: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	15, // 29: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	17, // 30: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	19, // 31: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	21, // 32: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	23, // 33: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
-	25, // 34: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
-	27, // 35: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
-	29, // 36: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
-	31, // 37: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
-	33, // 38: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	35, // 39: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	76, // 40: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
-	78, // 41: orchestrator.v1.OrchestratorService.AdoptOwner:input_type -> orchestrator.v1.AdoptOwnerRequest
-	37, // 42: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	39, // 43: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	41, // 44: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	43, // 45: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	47, // 46: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
-	50, // 47: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	52, // 48: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
-	55, // 49: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
-	58, // 50: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
-	60, // 51: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
-	62, // 52: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
-	64, // 53: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
-	66, // 54: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	68, // 55: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
-	70, // 56: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	72, // 57: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
-	8,  // 58: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	10, // 59: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	12, // 60: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
-	14, // 61: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	16, // 62: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	18, // 63: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	20, // 64: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	22, // 65: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	24, // 66: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	26, // 67: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
-	28, // 68: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
-	30, // 69: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
-	32, // 70: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
-	34, // 71: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	36, // 72: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	77, // 73: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
-	79, // 74: orchestrator.v1.OrchestratorService.AdoptOwner:output_type -> orchestrator.v1.AdoptOwnerResponse
-	38, // 75: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	40, // 76: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	42, // 77: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	44, // 78: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	48, // 79: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
-	51, // 80: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	53, // 81: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
-	56, // 82: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
-	59, // 83: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
-	61, // 84: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
-	63, // 85: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
-	65, // 86: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
-	67, // 87: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	69, // 88: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
-	71, // 89: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	73, // 90: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
-	58, // [58:91] is the sub-list for method output_type
-	25, // [25:58] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	47, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
+	2,  // 11: orchestrator.v1.ChainSync.mainchain_sync_phase:type_name -> orchestrator.v1.MainchainSyncPhase
+	50, // 12: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
+	1,  // 13: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
+	1,  // 14: orchestrator.v1.GetSidechainBalanceRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	1,  // 15: orchestrator.v1.SingleDeletion.binary:type_name -> orchestrator.v1.BinaryType
+	3,  // 16: orchestrator.v1.SingleDeletion.deletions:type_name -> orchestrator.v1.DeletionType
+	55, // 17: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	58, // 18: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	3,  // 19: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
+	1,  // 20: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
+	55, // 21: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	4,  // 22: orchestrator.v1.RejectBlockResponse.outcome:type_name -> orchestrator.v1.RejectOutcome
+	5,  // 23: orchestrator.v1.ResetToBlockResponse.phase:type_name -> orchestrator.v1.ResetPhase
+	75, // 24: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
+	76, // 25: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
+	8,  // 26: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	10, // 27: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	12, // 28: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
+	14, // 29: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	16, // 30: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	18, // 31: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	20, // 32: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	22, // 33: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	24, // 34: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	26, // 35: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
+	28, // 36: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
+	30, // 37: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
+	32, // 38: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
+	34, // 39: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	36, // 40: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	77, // 41: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
+	79, // 42: orchestrator.v1.OrchestratorService.AdoptOwner:input_type -> orchestrator.v1.AdoptOwnerRequest
+	38, // 43: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	40, // 44: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	42, // 45: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	44, // 46: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	48, // 47: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	51, // 48: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	53, // 49: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
+	56, // 50: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
+	59, // 51: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
+	61, // 52: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
+	63, // 53: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
+	65, // 54: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
+	67, // 55: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	69, // 56: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
+	71, // 57: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	73, // 58: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
+	9,  // 59: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	11, // 60: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	13, // 61: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
+	15, // 62: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	17, // 63: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	19, // 64: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	21, // 65: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	23, // 66: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	25, // 67: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	27, // 68: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
+	29, // 69: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
+	31, // 70: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
+	33, // 71: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
+	35, // 72: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	37, // 73: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	78, // 74: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
+	80, // 75: orchestrator.v1.OrchestratorService.AdoptOwner:output_type -> orchestrator.v1.AdoptOwnerResponse
+	39, // 76: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	41, // 77: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	43, // 78: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	45, // 79: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	49, // 80: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	52, // 81: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	54, // 82: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
+	57, // 83: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
+	60, // 84: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
+	62, // 85: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
+	64, // 86: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
+	66, // 87: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
+	68, // 88: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	70, // 89: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
+	72, // 90: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	74, // 91: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
+	59, // [59:92] is the sub-list for method output_type
+	26, // [26:59] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }
@@ -5632,7 +5722,7 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
-			NumEnums:      5,
+			NumEnums:      6,
 			NumMessages:   77,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/sidechain-orchestrator/get_sync_status_test.go
+++ b/sidechain-orchestrator/get_sync_status_test.go
@@ -87,20 +87,44 @@ func sidechainCountServer(t *testing.T, status int, count int64) *httptest.Serve
 	return srv
 }
 
-// writeJSONRPCCount echoes a JSON-RPC 2.0 success envelope with `count` as
-// the result. The id is mirrored from the request body when present.
-func writeJSONRPCCount(w http.ResponseWriter, r *http.Request, count int64) {
+// readJSONRPC returns the method and id of one JSON-RPC request.
+func readJSONRPC(r *http.Request) (string, int64) {
 	var req struct {
-		ID int64 `json:"id"`
+		Method string `json:"method"`
+		ID     int64  `json:"id"`
 	}
 	body, _ := io.ReadAll(r.Body)
 	_ = json.Unmarshal(body, &req)
+	return req.Method, req.ID
+}
+
+func writeJSONRPCResult(w http.ResponseWriter, id int64, result any) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"jsonrpc": "2.0",
-		"result":  count,
-		"id":      req.ID,
+		"result":  result,
+		"id":      id,
 	})
+}
+
+func writeJSONRPCError(w http.ResponseWriter, id int64, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"error":   map[string]any{"code": code, "message": message},
+		"id":      id,
+	})
+}
+
+// writeJSONRPCCount answers getblockcount with count, and every other method
+// the way a node without that method does.
+func writeJSONRPCCount(w http.ResponseWriter, r *http.Request, count int64) {
+	method, id := readJSONRPC(r)
+	if method != "getblockcount" {
+		writeJSONRPCError(w, id, RPCMethodNotFound, "Method not found")
+		return
+	}
+	writeJSONRPCResult(w, id, count)
 }
 
 func TestGetSyncStatus_LeavesHeadersZeroWhenExplorerDown(t *testing.T) {
@@ -323,14 +347,19 @@ func TestGetSyncStatus_EveryL2SidechainHasAPort(t *testing.T) {
 	}
 }
 
-// countingSidechainServer returns an httptest.Server that records every hit
-// and replies with the JSON-RPC `getblockcount` success envelope for <count>.
+// countingSidechainServer returns an httptest.Server that records every
+// `getblockcount` and replies to it with <count>.
 func countingSidechainServer(t *testing.T, count int64) (*httptest.Server, *int32) {
 	t.Helper()
 	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, id := readJSONRPC(r)
+		if method != "getblockcount" {
+			writeJSONRPCError(w, id, RPCMethodNotFound, "Method not found")
+			return
+		}
 		atomic.AddInt32(&hits, 1)
-		writeJSONRPCCount(w, r, count)
+		writeJSONRPCResult(w, id, count)
 	}))
 	t.Cleanup(srv.Close)
 	return srv, &hits
@@ -363,9 +392,14 @@ func TestSidechainConnection_PreservesLastGoodOnError(t *testing.T) {
 
 	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, id := readJSONRPC(r)
+		if method != "getblockcount" {
+			writeJSONRPCError(w, id, RPCMethodNotFound, "Method not found")
+			return
+		}
 		n := atomic.AddInt32(&hits, 1)
 		if n == 1 {
-			writeJSONRPCCount(w, r, 1500)
+			writeJSONRPCResult(w, id, 1500)
 			return
 		}
 		w.WriteHeader(http.StatusInternalServerError)
@@ -403,9 +437,14 @@ func TestGetSyncStatus_KeepsLastGoodBlocksAcrossTransientFailures(t *testing.T) 
 
 	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, id := readJSONRPC(r)
+		if method != "getblockcount" {
+			writeJSONRPCError(w, id, RPCMethodNotFound, "Method not found")
+			return
+		}
 		n := atomic.AddInt32(&hits, 1)
 		if n == 1 {
-			writeJSONRPCCount(w, r, 1500)
+			writeJSONRPCResult(w, id, 1500)
 			return
 		}
 		w.WriteHeader(http.StatusInternalServerError)

--- a/sidechain-orchestrator/mainchain_sync_progress_test.go
+++ b/sidechain-orchestrator/mainchain_sync_progress_test.go
@@ -1,0 +1,146 @@
+package orchestrator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// thunderNode is a fake Thunder node at 294 blocks. progress answers
+// mainchain_sync_progress; a nil progress makes the node lack the method.
+func thunderNode(t *testing.T, progress func(w http.ResponseWriter, id int64)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, id := readJSONRPC(r)
+		switch {
+		case method == "getblockcount":
+			writeJSONRPCResult(w, id, 294)
+		case method == "mainchain_sync_progress" && progress != nil:
+			progress(w, id)
+		default:
+			writeJSONRPCError(w, id, RPCMethodNotFound, "Method not found")
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func answerProgress(phase string, done, total, tip uint32) func(http.ResponseWriter, int64) {
+	return func(w http.ResponseWriter, id int64) {
+		writeJSONRPCResult(w, id, map[string]any{
+			"phase":      phase,
+			"done":       done,
+			"total":      total,
+			"tip_height": tip,
+		})
+	}
+}
+
+// thunderSyncStatus returns Thunder's slot from one GetSyncStatus poll. The
+// explorer puts Thunder's tip at 500.
+func thunderSyncStatus(t *testing.T, progress func(http.ResponseWriter, int64)) *ChainSyncResult {
+	t.Helper()
+	o := newTestOrchestrator(t)
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(map[string]map[string]any{
+				"thunder": {"height": "500"},
+			}), nil
+		}),
+	}
+	srv := thunderNode(t, progress)
+	setSidechainPort(t, o, "thunder", srv.URL)
+	adoptSidechain(t, o, "thunder")
+
+	out, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+	slot := out.Sidechains["thunder"]
+	require.NotNil(t, slot)
+	return slot
+}
+
+func TestGetSyncStatus_ReportsMainchainSyncPhase(t *testing.T) {
+	for _, phase := range []sidechain.MainchainSyncPhase{
+		sidechain.MainchainSyncHeaders,
+		sidechain.MainchainSyncWriting,
+		sidechain.MainchainSyncState,
+		"rewind",
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			slot := thunderSyncStatus(t, answerProgress(string(phase), 412000, 997070, 997071))
+
+			assert.Empty(t, slot.Error)
+			assert.Equal(t, phase, slot.MainchainSyncPhase)
+			assert.Equal(t, int64(412000), slot.Blocks)
+			assert.Equal(t, int64(997070), slot.Headers, "the explorer tip must not replace the phase total")
+			assert.Equal(t, int64(997071), slot.MainchainTipHeight)
+		})
+	}
+}
+
+func TestGetSyncStatus_IdleMainchainSyncReportsBlocks(t *testing.T) {
+	slot := thunderSyncStatus(t, answerProgress("idle", 0, 0, 0))
+
+	assert.Empty(t, slot.Error)
+	assert.Empty(t, slot.MainchainSyncPhase)
+	assert.Equal(t, int64(294), slot.Blocks)
+	assert.Equal(t, int64(500), slot.Headers)
+	assert.Zero(t, slot.MainchainTipHeight)
+}
+
+func TestGetSyncStatus_NodeWithoutMainchainSyncProgressReportsBlocks(t *testing.T) {
+	slot := thunderSyncStatus(t, nil)
+
+	assert.Empty(t, slot.Error)
+	assert.Empty(t, slot.MainchainSyncPhase)
+	assert.Equal(t, int64(294), slot.Blocks)
+	assert.Equal(t, int64(500), slot.Headers)
+}
+
+func TestGetSyncStatus_MainchainSyncProgressFailureIsAnError(t *testing.T) {
+	slot := thunderSyncStatus(t, func(w http.ResponseWriter, id int64) {
+		writeJSONRPCError(w, id, -32603, "Internal error")
+	})
+
+	assert.NotEmpty(t, slot.Error)
+	assert.Zero(t, slot.Blocks)
+	assert.Empty(t, slot.MainchainSyncPhase)
+}
+
+// A phase starts at zero done. A transient failure right after must keep the
+// phase, not replace it with an error.
+func TestGetSyncStatus_KeepsZeroProgressPhaseAcrossTransientFailures(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return statusResponse(http.StatusServiceUnavailable), nil
+		}),
+	}
+	var calls int32
+	srv := thunderNode(t, func(w http.ResponseWriter, id int64) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			answerProgress("headers", 0, 997070, 997070)(w, id)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	setSidechainPort(t, o, "thunder", srv.URL)
+	adoptSidechain(t, o, "thunder")
+
+	_, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+	o.invalidateSyncConnectionCacheForTest("thunder")
+
+	out, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+	slot := out.Sidechains["thunder"]
+	assert.Empty(t, slot.Error)
+	assert.Equal(t, sidechain.MainchainSyncHeaders, slot.MainchainSyncPhase)
+	assert.Equal(t, int64(997070), slot.Headers)
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -31,6 +31,7 @@ import (
 	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	enforcerrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/lease"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/nodes"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
@@ -3369,6 +3370,19 @@ func (c *sidechainSyncConnection) Fetch(ctx context.Context) (*ChainSyncResult, 
 		return nil, fmt.Errorf("unknown sidechain: %s", c.name)
 	}
 	proxy := sidechain.NewJSONRPCProxy(cfg.RPCHost(), cfg.Port)
+	progress, err := proxy.MainchainSyncProgress(ctx)
+	switch {
+	case rpc.LacksMethod(err):
+	case err != nil:
+		return nil, err
+	case progress.Phase != sidechain.MainchainSyncIdle:
+		return &ChainSyncResult{
+			Blocks:             int64(progress.Done),
+			Headers:            int64(progress.Total),
+			MainchainSyncPhase: progress.Phase,
+			MainchainTipHeight: int64(progress.TipHeight),
+		}, nil
+	}
 	count, err := proxy.GetBlockCount(ctx)
 	if err != nil {
 		return nil, err
@@ -3477,6 +3491,11 @@ type ChainSyncResult struct {
 	// VerifiedGoal is the height VerifiedBlocks counts towards: the snapshot's
 	// base block, zero when no snapshot is loaded. Mainchain only.
 	VerifiedGoal int64
+	// MainchainSyncPhase is the mainchain step a sidechain node takes, empty
+	// when it reports none. While set, Blocks and Headers are its done and total.
+	MainchainSyncPhase sidechain.MainchainSyncPhase
+	// MainchainTipHeight is the mainchain height MainchainSyncPhase moves to.
+	MainchainTipHeight int64
 }
 
 // SyncStatus is the atomic snapshot returned by GetSyncStatus. Mainchain +
@@ -3633,7 +3652,7 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 			// back on — otherwise keep showing the last-good numbers so
 			// the UI's progress doesn't snap to zero on a transient
 			// timeout. Same behaviour for L1 (bitcoind) and L2.
-			if err != nil && (res == nil || res.Blocks == 0) {
+			if err != nil && (res == nil || (res.Blocks == 0 && res.MainchainSyncPhase == "")) {
 				j.slot.Error = err.Error()
 				return
 			}
@@ -3641,6 +3660,8 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 				j.slot.Blocks = res.Blocks
 				j.slot.Headers = res.Headers
 				j.slot.Time = res.Time
+				j.slot.MainchainSyncPhase = res.MainchainSyncPhase
+				j.slot.MainchainTipHeight = res.MainchainTipHeight
 			}
 		}()
 	}
@@ -3693,7 +3714,7 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	// sidechain as fully synced even mid-IBD — a far worse failure mode
 	// than a stuck-at-zero progress bar.
 	for name, slot := range out.Sidechains {
-		if slot.Error != "" {
+		if slot.Error != "" || slot.MainchainSyncPhase != "" {
 			continue
 		}
 		// Only an index knows the chain's tip. The node's own height would

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -564,6 +564,24 @@ message ChainSync {
   // Height verified_blocks counts towards: the block the snapshot commits to,
   // not the chain tip. 0 when no snapshot is loaded. Mainchain only.
   int32 verified_goal = 9;
+  // The mainchain step a sidechain node takes before it syncs its own
+  // blocks. While set, blocks and headers are that step's done and total.
+  MainchainSyncPhase mainchain_sync_phase = 10;
+  // Mainchain tip height the mainchain_sync_phase moves to, 0 when unset.
+  int32 mainchain_tip_height = 11;
+}
+
+enum MainchainSyncPhase {
+  // The node reports no mainchain sync.
+  MAINCHAIN_SYNC_PHASE_UNSPECIFIED = 0;
+  // The node fetches the mainchain headers.
+  MAINCHAIN_SYNC_PHASE_HEADERS = 1;
+  // The node connects the mainchain state.
+  MAINCHAIN_SYNC_PHASE_STATE = 2;
+  // The node writes the fetched mainchain headers to disk.
+  MAINCHAIN_SYNC_PHASE_WRITING = 3;
+  // The node reports a phase this build does not name.
+  MAINCHAIN_SYNC_PHASE_OTHER = 4;
 }
 
 // GetDownloadStatus

--- a/sidechain-orchestrator/rpc/lacks_method_test.go
+++ b/sidechain-orchestrator/rpc/lacks_method_test.go
@@ -1,0 +1,32 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLacksMethod(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body string
+		want bool
+	}{
+		"method not found": {`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`, true},
+		"other rpc error":  {`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error"}}`, false},
+		"malformed reply":  {`not json`, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			err := clientFor(t, srv).Call(context.Background(), "mainchain_sync_progress", nil, nil)
+			assert.Error(t, err)
+			assert.Equal(t, tc.want, LacksMethod(err))
+		})
+	}
+}

--- a/sidechain-orchestrator/sidechain/jsonrpc_proxy.go
+++ b/sidechain-orchestrator/sidechain/jsonrpc_proxy.go
@@ -47,6 +47,36 @@ func (p *JSONRPCProxy) GetBlockCount(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
+// MainchainSyncPhase is the step a sidechain node takes to catch up with the
+// mainchain.
+type MainchainSyncPhase string
+
+const (
+	MainchainSyncIdle    MainchainSyncPhase = "idle"
+	MainchainSyncHeaders MainchainSyncPhase = "headers"
+	MainchainSyncWriting MainchainSyncPhase = "writing"
+	MainchainSyncState   MainchainSyncPhase = "state"
+)
+
+// MainchainSyncProgress is how far a sidechain node is through one phase.
+// Idle holds zero in every count. A newer node can report a phase not named here.
+type MainchainSyncProgress struct {
+	Phase     MainchainSyncPhase `json:"phase"`
+	Done      uint32             `json:"done"`
+	Total     uint32             `json:"total"`
+	TipHeight uint32             `json:"tip_height"`
+}
+
+// MainchainSyncProgress returns the node's mainchain sync phase. A node
+// without the method answers with an error that rpc.LacksMethod matches.
+func (p *JSONRPCProxy) MainchainSyncProgress(ctx context.Context) (*MainchainSyncProgress, error) {
+	var progress MainchainSyncProgress
+	if err := p.Client.Call(ctx, "mainchain_sync_progress", nil, &progress); err != nil {
+		return nil, err
+	}
+	return &progress, nil
+}
+
 func (p *JSONRPCProxy) GetNewAddress(ctx context.Context) (string, error) {
 	var address string
 	if err := p.Client.Call(ctx, "get_new_address", nil, &address); err != nil {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -3044,6 +3044,8 @@ class ChainSync extends $pb.GeneratedMessage {
     $core.int? refusedBranchStart,
     $core.int? verifiedBlocks,
     $core.int? verifiedGoal,
+    MainchainSyncPhase? mainchainSyncPhase,
+    $core.int? mainchainTipHeight,
   }) {
     final $result = create();
     if (blocks != null) {
@@ -3073,6 +3075,12 @@ class ChainSync extends $pb.GeneratedMessage {
     if (verifiedGoal != null) {
       $result.verifiedGoal = verifiedGoal;
     }
+    if (mainchainSyncPhase != null) {
+      $result.mainchainSyncPhase = mainchainSyncPhase;
+    }
+    if (mainchainTipHeight != null) {
+      $result.mainchainTipHeight = mainchainTipHeight;
+    }
     return $result;
   }
   ChainSync._() : super();
@@ -3089,6 +3097,8 @@ class ChainSync extends $pb.GeneratedMessage {
     ..a<$core.int>(7, _omitFieldNames ? '' : 'refusedBranchStart', $pb.PbFieldType.O3)
     ..a<$core.int>(8, _omitFieldNames ? '' : 'verifiedBlocks', $pb.PbFieldType.O3)
     ..a<$core.int>(9, _omitFieldNames ? '' : 'verifiedGoal', $pb.PbFieldType.O3)
+    ..e<MainchainSyncPhase>(10, _omitFieldNames ? '' : 'mainchainSyncPhase', $pb.PbFieldType.OE, defaultOrMaker: MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_UNSPECIFIED, valueOf: MainchainSyncPhase.valueOf, enumValues: MainchainSyncPhase.values)
+    ..a<$core.int>(11, _omitFieldNames ? '' : 'mainchainTipHeight', $pb.PbFieldType.O3)
     ..hasRequiredFields = false
   ;
 
@@ -3210,6 +3220,27 @@ class ChainSync extends $pb.GeneratedMessage {
   $core.bool hasVerifiedGoal() => $_has(8);
   @$pb.TagNumber(9)
   void clearVerifiedGoal() => clearField(9);
+
+  /// The mainchain step a sidechain node takes before it syncs its own
+  /// blocks. While set, blocks and headers are that step's done and total.
+  @$pb.TagNumber(10)
+  MainchainSyncPhase get mainchainSyncPhase => $_getN(9);
+  @$pb.TagNumber(10)
+  set mainchainSyncPhase(MainchainSyncPhase v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasMainchainSyncPhase() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearMainchainSyncPhase() => clearField(10);
+
+  /// Mainchain tip height the mainchain_sync_phase moves to, 0 when unset.
+  @$pb.TagNumber(11)
+  $core.int get mainchainTipHeight => $_getIZ(10);
+  @$pb.TagNumber(11)
+  set mainchainTipHeight($core.int v) { $_setSignedInt32(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasMainchainTipHeight() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearMainchainTipHeight() => clearField(11);
 }
 
 class GetDownloadStatusRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
@@ -94,6 +94,27 @@ class BinaryType extends $pb.ProtobufEnum {
   const BinaryType._($core.int v, $core.String n) : super(v, n);
 }
 
+class MainchainSyncPhase extends $pb.ProtobufEnum {
+  static const MainchainSyncPhase MAINCHAIN_SYNC_PHASE_UNSPECIFIED = MainchainSyncPhase._(0, _omitEnumNames ? '' : 'MAINCHAIN_SYNC_PHASE_UNSPECIFIED');
+  static const MainchainSyncPhase MAINCHAIN_SYNC_PHASE_HEADERS = MainchainSyncPhase._(1, _omitEnumNames ? '' : 'MAINCHAIN_SYNC_PHASE_HEADERS');
+  static const MainchainSyncPhase MAINCHAIN_SYNC_PHASE_STATE = MainchainSyncPhase._(2, _omitEnumNames ? '' : 'MAINCHAIN_SYNC_PHASE_STATE');
+  static const MainchainSyncPhase MAINCHAIN_SYNC_PHASE_WRITING = MainchainSyncPhase._(3, _omitEnumNames ? '' : 'MAINCHAIN_SYNC_PHASE_WRITING');
+  static const MainchainSyncPhase MAINCHAIN_SYNC_PHASE_OTHER = MainchainSyncPhase._(4, _omitEnumNames ? '' : 'MAINCHAIN_SYNC_PHASE_OTHER');
+
+  static const $core.List<MainchainSyncPhase> values = <MainchainSyncPhase> [
+    MAINCHAIN_SYNC_PHASE_UNSPECIFIED,
+    MAINCHAIN_SYNC_PHASE_HEADERS,
+    MAINCHAIN_SYNC_PHASE_STATE,
+    MAINCHAIN_SYNC_PHASE_WRITING,
+    MAINCHAIN_SYNC_PHASE_OTHER,
+  ];
+
+  static final $core.Map<$core.int, MainchainSyncPhase> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static MainchainSyncPhase? valueOf($core.int value) => _byValue[value];
+
+  const MainchainSyncPhase._($core.int v, $core.String n) : super(v, n);
+}
+
 /// DeletionType selects which category of a binary's files to gather/delete.
 class DeletionType extends $pb.ProtobufEnum {
   static const DeletionType DELETION_TYPE_UNSPECIFIED = DeletionType._(0, _omitEnumNames ? '' : 'DELETION_TYPE_UNSPECIFIED');

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -72,6 +72,25 @@ final $typed_data.Uint8List binaryTypeDescriptor = $convert.base64Decode(
     '9UWVBFX0xJUVVJRF9TSUdORVQQDhITCg9CSU5BUllfVFlQRV9CQkMQDxIYChRCSU5BUllfVFlQ'
     'RV9GUkVFQkFOSxAQ');
 
+@$core.Deprecated('Use mainchainSyncPhaseDescriptor instead')
+const MainchainSyncPhase$json = {
+  '1': 'MainchainSyncPhase',
+  '2': [
+    {'1': 'MAINCHAIN_SYNC_PHASE_UNSPECIFIED', '2': 0},
+    {'1': 'MAINCHAIN_SYNC_PHASE_HEADERS', '2': 1},
+    {'1': 'MAINCHAIN_SYNC_PHASE_STATE', '2': 2},
+    {'1': 'MAINCHAIN_SYNC_PHASE_WRITING', '2': 3},
+    {'1': 'MAINCHAIN_SYNC_PHASE_OTHER', '2': 4},
+  ],
+};
+
+/// Descriptor for `MainchainSyncPhase`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List mainchainSyncPhaseDescriptor = $convert.base64Decode(
+    'ChJNYWluY2hhaW5TeW5jUGhhc2USJAogTUFJTkNIQUlOX1NZTkNfUEhBU0VfVU5TUEVDSUZJRU'
+    'QQABIgChxNQUlOQ0hBSU5fU1lOQ19QSEFTRV9IRUFERVJTEAESHgoaTUFJTkNIQUlOX1NZTkNf'
+    'UEhBU0VfU1RBVEUQAhIgChxNQUlOQ0hBSU5fU1lOQ19QSEFTRV9XUklUSU5HEAMSHgoaTUFJTk'
+    'NIQUlOX1NZTkNfUEhBU0VfT1RIRVIQBA==');
+
 @$core.Deprecated('Use deletionTypeDescriptor instead')
 const DeletionType$json = {
   '1': 'DeletionType',
@@ -781,6 +800,8 @@ const ChainSync$json = {
     {'1': 'refused_branch_start', '3': 7, '4': 1, '5': 5, '10': 'refusedBranchStart'},
     {'1': 'verified_blocks', '3': 8, '4': 1, '5': 5, '10': 'verifiedBlocks'},
     {'1': 'verified_goal', '3': 9, '4': 1, '5': 5, '10': 'verifiedGoal'},
+    {'1': 'mainchain_sync_phase', '3': 10, '4': 1, '5': 14, '6': '.orchestrator.v1.MainchainSyncPhase', '10': 'mainchainSyncPhase'},
+    {'1': 'mainchain_tip_height', '3': 11, '4': 1, '5': 5, '10': 'mainchainTipHeight'},
   ],
 };
 
@@ -791,7 +812,10 @@ final $typed_data.Uint8List chainSyncDescriptor = $convert.base64Decode(
     'X2Jlc3RfaGVpZ2h0GAUgASgFUg5wZWVyQmVzdEhlaWdodBInCg9yZWplY3RlZF9icmFuY2gYBi'
     'ABKAhSDnJlamVjdGVkQnJhbmNoEjAKFHJlZnVzZWRfYnJhbmNoX3N0YXJ0GAcgASgFUhJyZWZ1'
     'c2VkQnJhbmNoU3RhcnQSJwoPdmVyaWZpZWRfYmxvY2tzGAggASgFUg52ZXJpZmllZEJsb2Nrcx'
-    'IjCg12ZXJpZmllZF9nb2FsGAkgASgFUgx2ZXJpZmllZEdvYWw=');
+    'IjCg12ZXJpZmllZF9nb2FsGAkgASgFUgx2ZXJpZmllZEdvYWwSVQoUbWFpbmNoYWluX3N5bmNf'
+    'cGhhc2UYCiABKA4yIy5vcmNoZXN0cmF0b3IudjEuTWFpbmNoYWluU3luY1BoYXNlUhJtYWluY2'
+    'hhaW5TeW5jUGhhc2USMAoUbWFpbmNoYWluX3RpcF9oZWlnaHQYCyABKAVSEm1haW5jaGFpblRp'
+    'cEhlaWdodA==');
 
 @$core.Deprecated('Use getDownloadStatusRequestDescriptor instead')
 const GetDownloadStatusRequest$json = {

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -37,11 +37,20 @@ class SyncInfo {
   /// to, not the chain tip. 0 when no snapshot is loaded.
   final int verifiedGoal;
 
+  /// The mainchain step a sidechain node takes before it syncs its own blocks.
+  /// While set, progressCurrent / progressGoal are that step's done / total.
+  final orch_pb.MainchainSyncPhase mainchainSyncPhase;
+
+  /// Mainchain height [mainchainSyncPhase] moves to, 0 when unset.
+  final int mainchainTipHeight;
+
+  bool get mainchainSyncing => mainchainSyncPhase != orch_pb.MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_UNSPECIFIED;
+
   double get progress => progressGoal == 0 ? 0 : progressCurrent / progressGoal;
 
   /// A node that passed the tip its index reports holds everything anyone
   /// knows of, so an index one block behind must not read as unsynced.
-  bool get isSynced => progressGoal > 0 && progressCurrent >= progressGoal;
+  bool get isSynced => !mainchainSyncing && progressGoal > 0 && progressCurrent >= progressGoal;
 
   /// True when every height this daemon reports reached the goal. A snapshot
   /// node hits the tip in blocks hours before it verifies the rest, so a card
@@ -66,6 +75,8 @@ class SyncInfo {
     this.refusedBranchStart = 0,
     this.verifiedBlocks = 0,
     this.verifiedGoal = 0,
+    this.mainchainSyncPhase = orch_pb.MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_UNSPECIFIED,
+    this.mainchainTipHeight = 0,
   });
 
   @override
@@ -81,7 +92,9 @@ class SyncInfo {
         other.rejectedBranch == rejectedBranch &&
         other.refusedBranchStart == refusedBranchStart &&
         other.verifiedBlocks == verifiedBlocks &&
-        other.verifiedGoal == verifiedGoal;
+        other.verifiedGoal == verifiedGoal &&
+        other.mainchainSyncPhase == mainchainSyncPhase &&
+        other.mainchainTipHeight == mainchainTipHeight;
   }
 
   @override
@@ -94,6 +107,8 @@ class SyncInfo {
     refusedBranchStart,
     verifiedBlocks,
     verifiedGoal,
+    mainchainSyncPhase,
+    mainchainTipHeight,
   );
 }
 
@@ -456,6 +471,8 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
       refusedBranchStart: cs?.refusedBranchStart ?? 0,
       verifiedBlocks: cs?.verifiedBlocks ?? 0,
       verifiedGoal: cs?.verifiedGoal ?? 0,
+      mainchainSyncPhase: cs?.mainchainSyncPhase ?? orch_pb.MainchainSyncPhase.MAINCHAIN_SYNC_PHASE_UNSPECIFIED,
+      mainchainTipHeight: cs?.mainchainTipHeight ?? 0,
     );
   }
 


### PR DESCRIPTION
A sidechain node that syncs the mainchain shows the phase, the percent, done / total and the max height, not "0 / 294".
ChainSync gets a phase enum and the mainchain tip height, because no existing field holds them. Blocks and headers carry done and total.
The loader appears only with a Thunder that holds the new mainchain_sync_progress RPC. An older node keeps the block count.