### PR TITLE
bitwindow: mine on the enforcer's block template

### DIFF
--- a/bitwindow/lib/dialogs/cpu_mining_dialog.dart
+++ b/bitwindow/lib/dialogs/cpu_mining_dialog.dart
@@ -10,17 +10,11 @@ class CpuMiningDialog extends StatefulWidget {
 }
 
 class _CpuMiningDialogState extends State<CpuMiningDialog> {
-  WalletReaderProvider get _walletReader => GetIt.I.get<WalletReaderProvider>();
-  OrchestratorWalletRPC get _orchestratorWallet => GetIt.I.get<OrchestratorRPC>().wallet;
   MiningProvider get _miningProvider => GetIt.I.get<MiningProvider>();
-
-  final _coinbaseAddressController = TextEditingController();
-  bool _isLoadingAddress = false;
 
   @override
   void initState() {
     super.initState();
-    _loadCoinbaseAddress();
     _miningProvider.refreshStatus();
     _miningProvider.addListener(_onMiningStateChanged);
   }
@@ -28,40 +22,12 @@ class _CpuMiningDialogState extends State<CpuMiningDialog> {
   @override
   void dispose() {
     _miningProvider.removeListener(_onMiningStateChanged);
-    _coinbaseAddressController.dispose();
     super.dispose();
   }
 
   void _onMiningStateChanged() {
     if (mounted) {
       setState(() {});
-    }
-  }
-
-  Future<void> _loadCoinbaseAddress() async {
-    setState(() {
-      _isLoadingAddress = true;
-    });
-
-    try {
-      final walletId = _walletReader.activeWalletId;
-      if (walletId != null) {
-        final address = await _orchestratorWallet.getNewAddress(walletId);
-        if (!mounted) {
-          return;
-        }
-        setState(() {
-          _coinbaseAddressController.text = address.address;
-          _isLoadingAddress = false;
-        });
-      }
-    } catch (e) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _isLoadingAddress = false;
-      });
     }
   }
 
@@ -135,17 +101,6 @@ class _CpuMiningDialogState extends State<CpuMiningDialog> {
                   ),
                 ),
           ],
-          const SizedBox(height: SailStyleValues.padding20),
-          SailTextField(
-            loading: LoadingDetails(
-              enabled: _isLoadingAddress,
-              description: 'Generating address...',
-            ),
-            label: 'Coinbase Address',
-            controller: _coinbaseAddressController,
-            hintText: 'Block rewards will be sent to this address',
-            readOnly: true,
-          ),
           const SizedBox(height: SailStyleValues.padding20),
           Row(
             children: [

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -1106,57 +1106,6 @@ walkBlocks:
 	}), nil
 }
 
-// getCoinbaseAddress gets a new address from the active wallet for mining rewards
-func (s *Server) getCoinbaseAddress(ctx context.Context) (string, error) {
-	// Get the active wallet from wallet engine
-	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get active wallet: %w", err)
-	}
-
-	// Get wallet type
-	walletType, err := s.walletEngine.GetWalletBackendType(ctx, activeWallet.ID)
-	if err != nil {
-		return "", fmt.Errorf("get wallet type: %w", err)
-	}
-
-	// get bitcoind-client here because we need it for both watch-only wallets and core wallets
-	bitcoind, err := s.bitcoind.Get(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	switch walletType {
-	case engines.WalletTypeBitcoinCore:
-		// Watch-only Core wallets import a descriptor; full wallets use the
-		// seed-derived wallet. Both serve addresses from Bitcoin Core.
-		var walletName string
-		var err error
-		if activeWallet.IsWatchOnly() {
-			walletName, err = s.walletEngine.EnsureWatchOnlyWallet(ctx, activeWallet.ID)
-		} else {
-			walletName, err = s.walletEngine.GetBitcoinCoreWalletName(ctx, activeWallet.ID)
-		}
-		if err != nil {
-			return "", fmt.Errorf("ensure core wallet: %w", err)
-		}
-		addr, err := bitcoind.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
-			Wallet: walletName,
-		}))
-		if err != nil {
-			return "", err
-		}
-		return addr.Msg.Address, nil
-
-	case engines.WalletTypeElectrum:
-		// Electrum derives the address in the orchestrator (Esplora-backed).
-		return s.walletEngine.GetElectrumReceiveAddress(ctx, activeWallet.ID)
-
-	default:
-		return "", fmt.Errorf("unsupported wallet type: %s", walletType)
-	}
-}
-
 // StartMining spins up the backend CPU miner on eCash, idempotently. The miner
 // runs on a detached context and keeps going after this call returns.
 func (s *Server) StartMining(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
@@ -1176,47 +1125,11 @@ func (s *Server) StartMining(ctx context.Context, req *connect.Request[emptypb.E
 		return connect.NewResponse(&emptypb.Empty{}), nil
 	}
 
-	bitcoind, err := s.bitcoind.Get(ctx)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("bitcoin core unreachable: %w", err))
-	}
-	if _, err := bitcoind.GetBlockchainInfo(ctx, connect.NewRequest(&corepb.GetBlockchainInfoRequest{})); err != nil {
-		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("bitcoin core unreachable: %w", err))
-	}
-
-	// Get a payout address from the active wallet for mining rewards.
-	address, err := s.getCoinbaseAddress(ctx)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("get mining address: %w", err))
-	}
-
-	// cpuminer talks raw bitcoind JSON-RPC; pull the live creds from
-	// drivechaind so we always match whatever bitcoind is running with.
-	confClient := orchrpc.NewBitcoinConfServiceClient(
-		http.DefaultClient,
-		s.config.OrchestratorAddr,
-		connect.WithGRPC(),
-		connect.WithInterceptors(localauth.Interceptor(s.config.BitwindowDir())),
-	)
-	confResp, err := confClient.GetBitcoinConfig(ctx, connect.NewRequest(&orchpb.GetBitcoinConfigRequest{}))
-	if err != nil {
-		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("read bitcoin config from orchestrator: %w", err))
-	}
+	// Core gives templates only to the enforcer. The enforcer adds the
+	// BIP300/301 outputs and the payout to the coinbase.
 	miner, err := cpuminer.New(cpuminer.Config{
-		RpcURL: fmt.Sprintf("http://localhost:%d", confResp.Msg.RpcPort),
-		// Re-resolve creds per request: Core rotates its cookie on restart, so a
-		// pair snapshotted here would 401 the moment bitcoind restarts.
-		Credentials: func() (string, string, error) {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			resp, err := confClient.GetBitcoinConfig(ctx, connect.NewRequest(&orchpb.GetBitcoinConfigRequest{}))
-			if err != nil {
-				return "", "", fmt.Errorf("read bitcoin config from orchestrator: %w", err)
-			}
-			return resp.Msg.RpcUser, resp.Msg.RpcPassword, nil
-		},
-		Routines:        1,
-		CoinbaseAddress: address,
+		RpcURL:   "http://" + s.config.EnforcerJSONRPCAddr,
+		Routines: 1,
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create miner: %w", err))

--- a/bitwindow/server/api/bitwindowd/bitwindowd_test.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd_test.go
@@ -3,7 +3,12 @@ package api_bitwindowd_test
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1894,6 +1899,56 @@ this line is not valid json
 		assert.Contains(t, exported.Msg.Jsonl, "Savings")
 		assert.Contains(t, exported.Msg.Jsonl, "Coinjoin change")
 	})
+}
+
+// A nil Core client makes the test panic if the miner goes to Core.
+func TestService_StartMiningAsksTheEnforcer(t *testing.T) {
+	t.Parallel()
+
+	type call struct {
+		method string
+		auth   bool
+	}
+	var (
+		mu    sync.Mutex
+		calls []call
+	)
+	enforcer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		_, _, auth := r.BasicAuth()
+		mu.Lock()
+		calls = append(calls, call{method: req.Method, auth: auth})
+		mu.Unlock()
+		//nolint:errcheck
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": -1, "message": "enforcer template"},
+		})
+	}))
+	defer enforcer.Close()
+
+	server := api_bitwindowd.New(nil, nil, nil, nil, config.Config{
+		BitcoinCoreNetwork:  config.NetworkECash,
+		EnforcerJSONRPCAddr: strings.TrimPrefix(enforcer.URL, "http://"),
+		Datadir:             t.TempDir(),
+	}, nil)
+
+	_, err := server.StartMining(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		status, err := server.GetMiningStatus(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		return err == nil && strings.Contains(status.Msg.Error, "enforcer template")
+	}, 10*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []call{{method: "getblocktemplate"}}, calls)
 }
 
 // expectWatchWalletNoop satisfies the background ensureWatchWallet path


### PR DESCRIPTION
The patched Core gives getblocktemplate only to the enforcer, so the CPU miner stopped with an error.
The miner now gets the template from the enforcer, and sends the block back through the enforcer.
The enforcer pays the starter wallet, so the miner dialog no longer shows an address from the active wallet.