### PR TITLE
orchestrator: import the bip47 key one time

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -57,6 +57,13 @@ type CoreBackend struct {
 	// wallet stays cached and later Ensure calls retry the import, gated by
 	// walletLoadingBackoff so a persistently failing rescan can't hot-loop.
 	bip47NotifRetry map[string]time.Time
+	// bip47Importing holds the wallets whose notification import waits on Core.
+	bip47Importing map[string]bool
+	// bip47Waiting holds the wallets whose import Core refused for a rescan.
+	bip47Waiting map[string]bool
+	// bip47Generation counts network resets; an import answer from an older one changes nothing.
+	bip47Generation uint64
+	bip47Imports    sync.WaitGroup
 
 	// Transient backoff: when bitcoind responds with a "still booting" error
 	// (-4 Wallet already loading, -28 Verifying blocks, …), Ensure returns
@@ -80,6 +87,8 @@ func NewCoreBackend(svc *Service, rpc *CoreRPCClient, params ParamsFunc, log zer
 		params:          params,
 		coreWallets:     make(map[string]string),
 		bip47NotifRetry: make(map[string]time.Time),
+		bip47Importing:  make(map[string]bool),
+		bip47Waiting:    make(map[string]bool),
 		staleWallets:    make(map[string]bool),
 	}
 	rpc.OnWalletError = backend.markWalletStale
@@ -115,6 +124,9 @@ func (p *CoreBackend) ResetNetworkState() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.coreWallets = make(map[string]string)
+	p.bip47Importing = make(map[string]bool)
+	p.bip47Waiting = make(map[string]bool)
+	p.bip47Generation++
 	p.loadingUntil = time.Time{}
 	p.loadingErr = nil
 }
@@ -177,11 +189,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 		return "", err
 	}
 
-	// Ensure the wallet's BIP47 notification descriptor is imported. Runs
-	// both for newly-created wallets and existing ones so the descriptor
-	// lands on first boot post-engine-deploy. Idempotent in Core, and a
-	// failure here shouldn't break wallet loading — the backend will retry
-	// next time Ensure runs.
+	// A failed notification import does not stop the load; a later call retries it.
 	if targetWallet.WalletType == WalletTypeBitcoinCore && !targetWallet.IsWatchOnly() {
 		if perr := p.ensureBip47NotificationDescriptor(ctx, walletID, walletName, targetWallet.Master.SeedHex); perr != nil {
 			// This call reaches the wallet itself, so a "not loaded" answer means
@@ -462,11 +470,11 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 	return nil
 }
 
-// EnsureNotificationWatched imports the wallet's own BIP47 notification key as a
-// pkh() descriptor so Core's listtransactions surfaces inbound notification
-// txs. Idempotent — Core ignores already-known descriptors.
-func (p *CoreBackend) EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error {
-	return p.WatchKeys(ctx, walletID, []WatchKey{notifKey})
+// EnsureNotificationWatched loads the wallet. The load imports the notification
+// key from the wallet's own seed and birthday.
+func (p *CoreBackend) EnsureNotificationWatched(ctx context.Context, walletID string, _ WatchKey) error {
+	_, err := p.walletName(ctx, walletID)
+	return err
 }
 
 // Send routes simple sends through Core's own coin selection
@@ -1127,9 +1135,9 @@ func (c coreChain) Broadcast(ctx context.Context, rawHex string) (string, error)
 // Core wallet creation (descriptor derivation + import)
 // ============================================================================
 
-// ensureBip47NotificationDescriptor imports the wallet's BIP47 notification
-// P2PKH key (m/47'/0'/0'/0) into Core. The import rescans from genesis, which
-// takes hours, so it runs one time for each network.
+// ensureBip47NotificationDescriptor starts the import of the wallet's BIP47
+// notification P2PKH key (m/47'/0'/0'/0) into Core, one time for each network.
+// The caller holds p.mu.
 //
 // Two signals gate it, and both are necessary. The wallet file names the
 // networks whose import landed, because Core keeps a descriptor whose rescan
@@ -1139,33 +1147,80 @@ func (c coreChain) Broadcast(ctx context.Context, rawHex string) (string, error)
 // the key.
 func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, walletID, walletName, seedHex string) error {
 	net := p.net()
-	if net == nil {
+	if net == nil || p.bip47Importing[walletID] {
 		return nil
 	}
 	notifPriv, notifAddr, err := bip47.DeriveOwnNotificationKey(seedHex, net)
 	if err != nil {
 		return fmt.Errorf("derive notification key: %w", err)
 	}
+	info, err := p.rpc.GetAddressInfo(ctx, walletName, notifAddr.EncodeAddress())
+	if err != nil {
+		return fmt.Errorf("read the notification address: %w", err)
+	}
 	w := p.svc.GetWalletByID(walletID)
-	if w != nil && w.Bip47NotificationImported[net.Name] {
-		info, err := p.rpc.GetAddressInfo(ctx, walletName, notifAddr.EncodeAddress())
-		if err != nil {
-			return fmt.Errorf("read the notification address: %w", err)
-		}
-		if info.IsMine {
-			return nil
-		}
+	if info.IsMine && w != nil && w.Bip47NotificationImported[net.Name] {
+		return nil
 	}
 	wif, err := btcutil.NewWIF(notifPriv, net, true)
 	if err != nil {
 		return fmt.Errorf("encode notification wif: %w", err)
 	}
-	desc := mustAddChecksum(fmt.Sprintf("pkh(%s)", wif.String()))
-	results, err := p.rpc.ImportDescriptors(ctx, walletName, []ImportDescriptor{{
-		Desc:      desc,
+	rescanFrom := Bip47RescanFrom(w)
+	if !p.bip47Waiting[walletID] {
+		p.log.Info().Str("wallet", walletName).Int64("rescan_from", rescanFrom).Msg("importing the bip47 notification key")
+	}
+	p.bip47Importing[walletID] = true
+	p.bip47Imports.Add(1)
+	go p.importBip47Notification(context.WithoutCancel(ctx), walletID, walletName, net.Name, p.bip47Generation, ImportDescriptor{
+		Desc:      mustAddChecksum(fmt.Sprintf("pkh(%s)", wif.String())),
 		Active:    false,
-		Timestamp: Bip47RescanFrom(w),
-	}})
+		Timestamp: rescanFrom,
+	})
+	return nil
+}
+
+// importBip47Notification waits for Core to import the notification key and
+// rescan, then records the outcome. A rescan runs for hours, so it holds no lock.
+func (p *CoreBackend) importBip47Notification(ctx context.Context, walletID, walletName, network string, generation uint64, key ImportDescriptor) {
+	defer p.bip47Imports.Done()
+	err := p.importBip47NotificationKey(ctx, walletName, key)
+
+	// p.mu also guards the wallet file record that ensureBip47NotificationDescriptor reads.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err == nil {
+		err = p.svc.MarkBip47NotificationImported(walletID, network)
+	}
+	// A network switch reset the state, and the new network runs its own import.
+	if generation != p.bip47Generation {
+		return
+	}
+	delete(p.bip47Importing, walletID)
+	if err == nil {
+		delete(p.bip47NotifRetry, walletID)
+		delete(p.bip47Waiting, walletID)
+		p.log.Info().Str("wallet", walletName).Msg("imported the bip47 notification key")
+		return
+	}
+	p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
+	if isWalletRescanningErr(err) {
+		if !p.bip47Waiting[walletID] {
+			p.bip47Waiting[walletID] = true
+			p.log.Info().Str("wallet", walletName).Msg("Core is rescanning, the bip47 notification import waits")
+		}
+		return
+	}
+	delete(p.bip47Waiting, walletID)
+	if isWalletNotLoadedErr(err) {
+		delete(p.coreWallets, walletID)
+		return
+	}
+	p.log.Warn().Err(err).Str("wallet", walletName).Msg("could not import the bip47 notification key")
+}
+
+func (p *CoreBackend) importBip47NotificationKey(ctx context.Context, walletName string, key ImportDescriptor) error {
+	results, err := p.rpc.ImportDescriptorsAndWait(ctx, walletName, []ImportDescriptor{key})
 	if err != nil {
 		return fmt.Errorf("import bip47 notification descriptor: %w", err)
 	}
@@ -1179,7 +1234,7 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 		}
 		return fmt.Errorf("bip47 descriptor %d import failed: %s", i, msg)
 	}
-	return p.svc.MarkBip47NotificationImported(walletID, net.Name)
+	return nil
 }
 
 // Bip47RescanFrom is the unix time a backend scans a wallet's own BIP47

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -12,10 +12,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
@@ -146,6 +148,7 @@ func newCoreBackendFixture(t *testing.T) (*CoreBackend, *fakeBitcoind, string) {
 	fake := newFakeBitcoind(t)
 	log := zerolog.New(zerolog.NewTestWriter(t))
 	backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), log)
+	t.Cleanup(backend.bip47Imports.Wait)
 	return backend, fake, core.ID
 }
 
@@ -155,6 +158,7 @@ func TestCoreBackendEnsureCreatesDescriptorWallet(t *testing.T) {
 
 	name, err := backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Equal(t, "wallet_"+coreID[:8], name)
 
 	creates := fake.callsFor("createwallet")
@@ -215,6 +219,7 @@ func TestCoreBackendEnsureNilNetworkFailsClosed(t *testing.T) {
 	fake.stubEnsureFlow()
 	log := zerolog.New(zerolog.NewTestWriter(t))
 	backend := NewCoreBackend(svc, fake.client(t), nil, log)
+	t.Cleanup(backend.bip47Imports.Wait)
 
 	_, err = backend.Ensure(context.Background(), core.ID)
 	require.ErrorContains(t, err, "no chain params")
@@ -263,6 +268,7 @@ func TestCoreBackendImportsBip47NotificationKeyOnce(t *testing.T) {
 
 	_, err := backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	require.Equal(t, 1, notificationImports(t, fake))
 	require.True(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 
@@ -270,6 +276,7 @@ func TestCoreBackendImportsBip47NotificationKeyOnce(t *testing.T) {
 	require.NoError(t, err)
 	_, err = backend.walletName(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Equal(t, 1, notificationImports(t, fake))
 }
 
@@ -291,9 +298,11 @@ func TestCoreBackendImportedSeedBip47NotificationScansGenesis(t *testing.T) {
 		StaticParams(&chaincfg.RegressionNetParams),
 		zerolog.New(zerolog.NewTestWriter(t)),
 	)
+	t.Cleanup(backend.bip47Imports.Wait)
 
 	_, err = backend.Ensure(context.Background(), core.ID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 
 	imports := fake.callsFor("importdescriptors")
 	require.Len(t, imports, 2, "BIP84 pair + BIP47 notification descriptor")
@@ -321,10 +330,12 @@ func TestCoreBackendImportsBip47NotificationKeyPerNetwork(t *testing.T) {
 		ParamsFunc(func() *chaincfg.Params { return params }),
 		zerolog.New(zerolog.NewTestWriter(t)),
 	)
+	t.Cleanup(backend.bip47Imports.Wait)
 	ctx := context.Background()
 
 	_, err = backend.Ensure(ctx, core.ID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	require.Equal(t, 1, notificationImports(t, fake))
 	require.True(t, svc.GetWalletByID(core.ID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 
@@ -332,6 +343,7 @@ func TestCoreBackendImportsBip47NotificationKeyPerNetwork(t *testing.T) {
 	backend.ResetNetworkState()
 	_, err = backend.Ensure(ctx, core.ID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Equal(t, 2, notificationImports(t, fake))
 	assert.True(t, svc.GetWalletByID(core.ID).Bip47NotificationImported[chaincfg.SigNetParams.Name])
 }
@@ -345,6 +357,7 @@ func TestCoreBackendImportsBip47NotificationKeyCoreLacksIt(t *testing.T) {
 
 	_, err := backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	require.Equal(t, 1, notificationImports(t, fake))
 
 	// A fresh Core datadir: the wallet exists, and owns none of its addresses.
@@ -356,6 +369,7 @@ func TestCoreBackendImportsBip47NotificationKeyCoreLacksIt(t *testing.T) {
 	backend.ResetNetworkState()
 	_, err = backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Equal(t, 2, notificationImports(t, fake))
 }
 
@@ -387,6 +401,7 @@ func TestCoreBackendRetriesBip47ImportCoreAlreadyOwns(t *testing.T) {
 
 	_, err := backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	require.Equal(t, 1, notificationImports(t, fake))
 	require.False(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 
@@ -399,6 +414,7 @@ func TestCoreBackendRetriesBip47ImportCoreAlreadyOwns(t *testing.T) {
 
 	_, err = backend.walletName(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Equal(t, 2, notificationImports(t, fake))
 	assert.True(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
 }
@@ -428,11 +444,13 @@ func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
 
 	_, err := backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	require.Len(t, fake.callsFor("importdescriptors"), 2)
 
 	// Within the backoff window the failed import isn't hammered.
 	_, err = backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Len(t, fake.callsFor("importdescriptors"), 2)
 
 	mu.Lock()
@@ -445,6 +463,7 @@ func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
 	// Once the backoff elapses the notification descriptor is imported again.
 	_, err = backend.walletName(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	imports := fake.callsFor("importdescriptors")
 	require.Len(t, imports, 3)
 	var notif []ImportDescriptor
@@ -455,6 +474,7 @@ func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
 	// Now that it succeeded, no further imports.
 	_, err = backend.Ensure(ctx, coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	assert.Len(t, fake.callsFor("importdescriptors"), 3)
 	assert.Empty(t, backend.bip47NotifRetry)
 }
@@ -841,6 +861,7 @@ func TestCoreBackendCreateCpfpTaproot(t *testing.T) {
 	fake := newFakeBitcoind(t)
 	log := zerolog.New(zerolog.NewTestWriter(t))
 	backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), log)
+	t.Cleanup(backend.bip47Imports.Wait)
 	coreID := core.ID
 
 	// The wallet resolves to taproot.
@@ -939,6 +960,7 @@ func TestCoreBackendCpfpBase58Kinds(t *testing.T) {
 
 			fake := newFakeBitcoind(t)
 			backend := NewCoreBackend(svc, fake.client(t), StaticParams(net), zerolog.New(zerolog.NewTestWriter(t)))
+			t.Cleanup(backend.bip47Imports.Wait)
 			coreID := core.ID
 			require.Equal(t, tc.kind, backend.walletScriptKind(coreID))
 
@@ -1037,8 +1059,11 @@ func TestCpfpChildPlanRejectsFeeExceedingParent(t *testing.T) {
 func TestCoreBackendWatchKeys(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()
+	_, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 
-	err := backend.WatchKeys(context.Background(), coreID, []WatchKey{
+	err = backend.WatchKeys(context.Background(), coreID, []WatchKey{
 		{WIF: "cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN8rFTv2sfUK", RescanFrom: 1_700_000_000},
 	})
 	require.NoError(t, err)
@@ -1195,6 +1220,7 @@ func TestCoreBackendNextChangeAddressKind(t *testing.T) {
 
 		fake := newFakeBitcoind(t)
 		backend := NewCoreBackend(svc, fake.client(t), func() *chaincfg.Params { return net }, zerolog.New(zerolog.NewTestWriter(t)))
+		t.Cleanup(backend.bip47Imports.Wait)
 		coreID := core.ID
 		require.Equal(t, ScriptTaproot, backend.walletScriptKind(coreID))
 
@@ -1412,6 +1438,7 @@ func TestCoreBackendImportsTheWalletScriptTypeWithoutAPath(t *testing.T) {
 
 	fake := newFakeBitcoind(t)
 	backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	t.Cleanup(backend.bip47Imports.Wait)
 	fake.stubEnsureFlow()
 
 	_, err = backend.Ensure(context.Background(), core.ID)
@@ -1443,6 +1470,7 @@ func TestCoreBackendImportsEveryKindTheWalletAdvertises(t *testing.T) {
 
 	fake := newFakeBitcoind(t)
 	backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	t.Cleanup(backend.bip47Imports.Wait)
 	fake.stubEnsureFlow()
 
 	_, err = backend.Ensure(context.Background(), core.ID)
@@ -1826,6 +1854,7 @@ func TestEnsureReloadsAfterTheCachedWalletGoesAway(t *testing.T) {
 
 	name, err := backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 
 	// Core drops the wallet, and the pending BIP47 retry comes due.
 	fake.stubEnsureFlowBip47Unloaded()
@@ -1848,6 +1877,7 @@ func TestBalanceReloadsRatherThanReadAStaleWallet(t *testing.T) {
 
 	_, err := backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 
 	// Core drops the wallet, and the pending BIP47 retry comes due.
 	fake.stubEnsureFlowBip47Unloaded()
@@ -1883,6 +1913,7 @@ func TestARescanningWalletKeepsServing(t *testing.T) {
 
 	name, err := backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err, "a rescan must not take the wallet away")
+	backend.bip47Imports.Wait()
 	assert.Equal(t, "wallet_"+coreID[:8], name)
 
 	cached, ok := backend.coreWallets[coreID]
@@ -1890,6 +1921,270 @@ func TestARescanningWalletKeepsServing(t *testing.T) {
 	assert.Equal(t, name, cached)
 	_, pending := backend.bip47NotifRetry[coreID]
 	assert.True(t, pending, "the notification import retries once the rescan ends")
+}
+
+// switchFixture serves a Core whose first notification import rescans until
+// endRescan, then answers lateErr, or success when lateErr is empty.
+type switchFixture struct {
+	backend   *CoreBackend
+	fake      *fakeBitcoind
+	coreID    string
+	params    atomic.Pointer[chaincfg.Params]
+	endRescan func()
+}
+
+func newSwitchFixture(t *testing.T, lateErr string) *switchFixture {
+	t.Helper()
+	svc := newTestService(t)
+	_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+	require.NoError(t, err)
+	core, err := svc.GenerateWallet("Core", "", "", testSlots)
+	require.NoError(t, err)
+
+	f := &switchFixture{fake: newFakeBitcoind(t), coreID: core.ID}
+	f.fake.stubEnsureFlow()
+	rescan := make(chan struct{})
+	var once sync.Once
+	f.endRescan = func() { once.Do(func() { close(rescan) }) }
+	var mu sync.Mutex
+	first := true
+	f.fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		if len(descs) == 1 {
+			mu.Lock()
+			late := first
+			first = false
+			mu.Unlock()
+			if late {
+				<-rescan
+				if lateErr != "" {
+					return nil, lateErr
+				}
+			}
+		}
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+	f.params.Store(&chaincfg.RegressionNetParams)
+	f.backend = NewCoreBackend(svc, f.fake.client(t), ParamsFunc(f.params.Load), zerolog.New(zerolog.NewTestWriter(t)))
+	t.Cleanup(f.backend.bip47Imports.Wait)
+	t.Cleanup(f.endRescan)
+
+	_, err = f.backend.Ensure(context.Background(), core.ID)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return len(f.fake.callsFor("importdescriptors")) == 2 }, 5*time.Second, 10*time.Millisecond)
+	return f
+}
+
+func (f *switchFixture) switchTo(net *chaincfg.Params) {
+	f.params.Store(net)
+	f.backend.ResetNetworkState()
+}
+
+func (f *switchFixture) imported(net string) bool {
+	f.backend.mu.Lock()
+	defer f.backend.mu.Unlock()
+	return f.backend.svc.GetWalletByID(f.coreID).Bip47NotificationImported[net]
+}
+
+// A network switch can land while an import still rescans. The new network's
+// wallet imports its own key, and the old import's outcome leaves it alone.
+func TestANetworkSwitchDuringAnImportImportsForTheNewNetwork(t *testing.T) {
+	f := newSwitchFixture(t, "")
+
+	f.switchTo(&chaincfg.SigNetParams)
+	_, err := f.backend.Ensure(context.Background(), f.coreID)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return f.imported(chaincfg.SigNetParams.Name) }, 5*time.Second, 10*time.Millisecond,
+		"the new network imports its key while the old import still rescans")
+
+	f.endRescan()
+	f.backend.bip47Imports.Wait()
+	assert.True(t, f.imported(chaincfg.RegressionNetParams.Name))
+	assert.Equal(t, 2, notificationImports(t, f.fake))
+}
+
+// A switch away and back can land while the first import still rescans. Its
+// late answer belongs to an older generation and leaves the new state alone.
+func TestALateImportAnswerLeavesTheSameNetworkAlone(t *testing.T) {
+	f := newSwitchFixture(t, "Requested wallet does not exist or is not loaded")
+
+	f.switchTo(&chaincfg.SigNetParams)
+	f.switchTo(&chaincfg.RegressionNetParams)
+	_, err := f.backend.Ensure(context.Background(), f.coreID)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return f.imported(chaincfg.RegressionNetParams.Name) }, 5*time.Second, 10*time.Millisecond)
+
+	f.endRescan()
+	f.backend.bip47Imports.Wait()
+	_, cached := f.backend.coreWallets[f.coreID]
+	assert.True(t, cached, "a late answer must not evict the wallet")
+	assert.Empty(t, f.backend.bip47NotifRetry, "a late answer must not schedule a retry")
+}
+
+// ownNotificationKey is the key the BIP47 engine gives EnsureNotificationWatched.
+func ownNotificationKey(t *testing.T, w *WalletData) WatchKey {
+	t.Helper()
+	net := &chaincfg.RegressionNetParams
+	priv, _, err := bip47.DeriveOwnNotificationKey(w.Master.SeedHex, net)
+	require.NoError(t, err)
+	wif, err := btcutil.NewWIF(priv, net, true)
+	require.NoError(t, err)
+	return WatchKey{WIF: wif.String(), RescanFrom: Bip47RescanFrom(w)}
+}
+
+type lockedLog struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *lockedLog) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *lockedLog) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+// Core rescans from the key's timestamp on every import, so a key it holds gets
+// no second import from the engine tick or from the next start.
+func TestEnsureNotificationWatchedLeavesAnImportedKeyAlone(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	backend.bip47Imports.Wait()
+	require.Equal(t, 1, notificationImports(t, fake))
+
+	restarted := NewCoreBackend(backend.svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	t.Cleanup(restarted.bip47Imports.Wait)
+	key := ownNotificationKey(t, backend.svc.GetWalletByID(coreID))
+	for _, b := range []*CoreBackend{backend, restarted} {
+		for range 3 {
+			require.NoError(t, b.EnsureNotificationWatched(ctx, coreID, key))
+		}
+		b.bip47Imports.Wait()
+	}
+	assert.Equal(t, 1, notificationImports(t, fake))
+}
+
+// Core refuses an import while a rescan holds the wallet. That is a wait: the
+// ticks send no import of their own, and the backend logs no warning.
+func TestARescanningWalletGetsNoImportPerTick(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	var logs lockedLog
+	backend.log = zerolog.New(&logs)
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		if len(descs) == 1 {
+			return nil, "Wallet is currently rescanning. Abort existing rescan or wait."
+		}
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+	key := ownNotificationKey(t, backend.svc.GetWalletByID(coreID))
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	backend.bip47Imports.Wait()
+	for range 10 {
+		require.NoError(t, backend.EnsureNotificationWatched(ctx, coreID, key))
+	}
+	backend.bip47Imports.Wait()
+	assert.Equal(t, 1, notificationImports(t, fake), "the ticks inside one backoff send no import")
+
+	for range 5 {
+		backend.mu.Lock()
+		backend.bip47NotifRetry[coreID] = time.Time{}
+		backend.mu.Unlock()
+		require.NoError(t, backend.EnsureNotificationWatched(ctx, coreID, key))
+		backend.bip47Imports.Wait()
+	}
+	assert.Equal(t, 6, notificationImports(t, fake), "one refused import for each backoff")
+	assert.NotContains(t, logs.String(), `"level":"warn"`)
+	assert.Equal(t, 1, strings.Count(logs.String(), "bip47 notification import waits"))
+	assert.False(t, backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name])
+}
+
+// A fresh wallet imports its notification key one time, from its birthday. The
+// rescan outlasts any client timeout, so the backend waits for Core's answer and
+// sends no second import while the rescan runs.
+func TestAFreshWalletImportsItsNotificationKeyOnce(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	var mu sync.Mutex
+	landed := false
+	rescan := make(chan struct{})
+	var once sync.Once
+	endRescan := func() { once.Do(func() { close(rescan) }) }
+	t.Cleanup(endRescan)
+	fake.handle("getaddressinfo", func(c bitcoindCall) (any, string) {
+		var address string
+		_ = json.Unmarshal(c.Params[0], &address)
+		mu.Lock()
+		defer mu.Unlock()
+		return map[string]any{"address": address, "ismine": landed}, ""
+	})
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		if len(descs) == 1 {
+			<-rescan
+			mu.Lock()
+			landed = true
+			mu.Unlock()
+		}
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+	imported := func() bool {
+		return backend.svc.GetWalletByID(coreID).Bip47NotificationImported[chaincfg.RegressionNetParams.Name]
+	}
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err, "the load does not wait for the rescan")
+	require.Eventually(t, func() bool { return len(fake.callsFor("importdescriptors")) == 2 }, 5*time.Second, 10*time.Millisecond)
+
+	key := ownNotificationKey(t, backend.svc.GetWalletByID(coreID))
+	for range 5 {
+		require.NoError(t, backend.EnsureNotificationWatched(ctx, coreID, key))
+	}
+	assert.Equal(t, 1, notificationImports(t, fake), "no second import while the rescan runs")
+	assert.False(t, imported())
+
+	endRescan()
+	backend.bip47Imports.Wait()
+	require.True(t, imported())
+	for range 5 {
+		require.NoError(t, backend.EnsureNotificationWatched(ctx, coreID, key))
+	}
+	backend.bip47Imports.Wait()
+	require.Equal(t, 1, notificationImports(t, fake))
+
+	var notif []ImportDescriptor
+	require.NoError(t, json.Unmarshal(fake.callsFor("importdescriptors")[1].Params[0], &notif))
+	require.Len(t, notif, 1)
+	assert.Equal(t, float64(backend.svc.GetWalletByID(coreID).CreatedAt.Unix()), asFloat(t, notif[0].Timestamp))
 }
 
 // Core lists a wallet it no longer holds, so this path skips the load and every
@@ -2016,6 +2311,7 @@ func TestAnyWalletCallDropsAWalletCoreUnloaded(t *testing.T) {
 
 	_, err := backend.Ensure(context.Background(), coreID)
 	require.NoError(t, err)
+	backend.bip47Imports.Wait()
 	require.Empty(t, backend.bip47NotifRetry, "the happy path leaves no retry to hang the eviction on")
 
 	// Core unloads the wallet, so the next balance read meets -18.

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -38,6 +38,8 @@ func StaticCoreEndpoint(host string, port int, user, password string) CoreEndpoi
 type CoreRPCClient struct {
 	resolve CoreEndpointFunc
 	client  *http.Client
+	// rescanClient has no timeout: Core answers an import only when its rescan ends.
+	rescanClient *http.Client
 
 	// OnWalletError sees every failed call that names a wallet. The backend
 	// reads it to drop a wallet Core stopped holding, which reaches all of its
@@ -54,8 +56,9 @@ func NewCoreRPCClient(resolve CoreEndpointFunc) *CoreRPCClient {
 	}
 
 	return &CoreRPCClient{
-		resolve: resolve,
-		client:  &http.Client{Timeout: timeout},
+		resolve:      resolve,
+		client:       &http.Client{Timeout: timeout},
+		rescanClient: &http.Client{},
 	}
 }
 
@@ -79,14 +82,18 @@ type rpcError struct {
 // call makes a JSON-RPC call to Bitcoin Core.
 // If walletName is non-empty, routes to /wallet/<name>.
 func (c *CoreRPCClient) call(ctx context.Context, walletName, method string, params ...interface{}) (json.RawMessage, error) {
-	raw, err := c.callWallet(ctx, walletName, method, params...)
+	return c.callWith(ctx, c.client, walletName, method, params...)
+}
+
+func (c *CoreRPCClient) callWith(ctx context.Context, client *http.Client, walletName, method string, params ...interface{}) (json.RawMessage, error) {
+	raw, err := c.callWallet(ctx, client, walletName, method, params...)
 	if err != nil && walletName != "" && c.OnWalletError != nil {
 		c.OnWalletError(walletName, err)
 	}
 	return raw, err
 }
 
-func (c *CoreRPCClient) callWallet(ctx context.Context, walletName, method string, params ...interface{}) (json.RawMessage, error) {
+func (c *CoreRPCClient) callWallet(ctx context.Context, client *http.Client, walletName, method string, params ...interface{}) (json.RawMessage, error) {
 	if params == nil {
 		params = []interface{}{}
 	}
@@ -116,7 +123,7 @@ func (c *CoreRPCClient) callWallet(ctx context.Context, walletName, method strin
 		req.SetBasicAuth(endpoint.User, endpoint.Password)
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s call: %w", method, err)
 	}
@@ -203,7 +210,17 @@ type ImportDescriptorResult struct {
 
 // ImportDescriptors imports descriptors into a Bitcoin Core wallet.
 func (c *CoreRPCClient) ImportDescriptors(ctx context.Context, walletName string, descriptors []ImportDescriptor) ([]ImportDescriptorResult, error) {
-	result, err := c.call(ctx, walletName, "importdescriptors", descriptors)
+	return c.importDescriptors(ctx, c.client, walletName, descriptors)
+}
+
+// ImportDescriptorsAndWait imports descriptors and waits for the rescan to end,
+// however long it runs. Only ctx stops the wait.
+func (c *CoreRPCClient) ImportDescriptorsAndWait(ctx context.Context, walletName string, descriptors []ImportDescriptor) ([]ImportDescriptorResult, error) {
+	return c.importDescriptors(ctx, c.rescanClient, walletName, descriptors)
+}
+
+func (c *CoreRPCClient) importDescriptors(ctx context.Context, client *http.Client, walletName string, descriptors []ImportDescriptor) ([]ImportDescriptorResult, error) {
+	result, err := c.callWith(ctx, client, walletName, "importdescriptors", descriptors)
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/wallet/startup_errors.go
+++ b/sidechain-orchestrator/wallet/startup_errors.go
@@ -73,6 +73,12 @@ func isWalletNotLoadedErr(err error) bool {
 	return false
 }
 
+// isWalletRescanningErr reports whether Core refused a call because a rescan
+// holds the wallet.
+func isWalletRescanningErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "currently rescanning")
+}
+
 // isWalletAlreadyLoadedErr reports whether Core refused a load because it
 // already holds the wallet. That is the same outcome as a load that worked.
 func isWalletAlreadyLoadedErr(err error) bool {


### PR DESCRIPTION
The BIP47 notification key import timed out after 30 seconds, so the orchestrator did not see it finish and started a new genesis rescan every hour.
The load now waits for the import to end and imports the key one time. The engine tick sends no import of its own, and a Core rescan in progress is a quiet wait.