### PR TITLE
bitwindow: remove sorting from the sidechains table

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -259,6 +259,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
         GetIt.I.get<ZSideRPC>(),
         GetIt.I.get<PhotonRPC>(),
         GetIt.I.get<TruthcoinRPC>(),
+        GetIt.I.get<CoinShiftRPC>(),
       ],
     ),
   );

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -380,8 +380,6 @@ class _SidechainsTable extends ViewModelWidget<SidechainsViewModel> {
 
   const _SidechainsTable({super.key, required this.slots, this.emptyPlaceholder});
 
-  static const _sortColumns = ['slot', 'name', 'balance'];
-
   @override
   Widget build(BuildContext context, SidechainsViewModel viewModel) {
     final formatter = GetIt.I<FormatterProvider>();
@@ -402,22 +400,15 @@ class _SidechainsTable extends ViewModelWidget<SidechainsViewModel> {
             cellHeight: 48,
             headerBackgroundColor: colors.backgroundSecondary,
             headerBuilder: (context) => [
-              SailTableHeaderCell(name: 'Slot', onSort: () => viewModel.sortSidechains('slot')),
-              SailTableHeaderCell(name: 'Name', onSort: () => viewModel.sortSidechains('name')),
-              SailTableHeaderCell(
-                name: 'Sidechain Balance',
-                alignment: Alignment.centerRight,
-                onSort: () => viewModel.sortSidechains('balance'),
-              ),
+              const SailTableHeaderCell(name: 'Slot', sortable: false),
+              const SailTableHeaderCell(name: 'Name', sortable: false),
+              const SailTableHeaderCell(name: 'Sidechain Balance', alignment: Alignment.centerRight, sortable: false),
               const SailTableHeaderCell(name: 'Your balance', alignment: Alignment.centerRight, sortable: false),
               const SailTableHeaderCell(name: '', sortable: false),
             ],
             rowBuilder: (context, row, selected) => _sidechainRow(context, viewModel, formatter, slots[row]),
             rowCount: slots.length,
             emptyPlaceholder: emptyPlaceholder,
-            sortAscending: viewModel.sortAscending,
-            sortColumnIndex: _sortColumns.indexOf(viewModel.sortColumn),
-            onSort: (columnIndex, ascending) => viewModel.sortSidechains(viewModel.sortColumn),
             selectedRowId: viewModel.selectedIndex?.toString(),
             // rowId is the SLOT NUMBER (e.g., "2", "4", "98") from getRowId
             onSelectedRow: (rowId) => viewModel.toggleSelection(int.parse(rowId ?? '0')),
@@ -823,10 +814,6 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
   }
 
   List<SidechainOverview?> get sidechains => _sidechainProvider.sidechains;
-  List<SidechainOverview?> _sortedSidechains = [];
-
-  String sortColumn = 'slot';
-  bool sortAscending = true;
 
   bool showOnlyFilled = true;
   void setShowOnlyFilled(bool value) {
@@ -1113,61 +1100,6 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     );
   }
 
-  List<SidechainOverview?> get sortedSidechains {
-    if (!listEquals(_sortedSidechains, sidechains)) {
-      _sortedSidechains = List<SidechainOverview?>.from(sidechains);
-      _sortEntries();
-    }
-    return _sortedSidechains;
-  }
-
-  void sortSidechains(String column) {
-    if (sortColumn == column) {
-      sortAscending = !sortAscending;
-    } else {
-      sortColumn = column;
-      sortAscending = true;
-    }
-    _sortEntries();
-    notifyListeners();
-  }
-
-  void _sortEntries() {
-    _sortedSidechains.sort((a, b) {
-      if (a == null && b == null) {
-        return 0;
-      }
-      if (a == null) {
-        return sortAscending ? 1 : -1;
-      }
-      if (b == null) {
-        return sortAscending ? -1 : 1;
-      }
-
-      dynamic aValue;
-      dynamic bValue;
-
-      switch (sortColumn) {
-        case 'index':
-          aValue = sidechains.indexOf(a);
-          bValue = sidechains.indexOf(b);
-          break;
-        case 'balance':
-          aValue = a.info.balanceSatoshi;
-          bValue = b.info.balanceSatoshi;
-          break;
-        case 'title':
-          aValue = a.info.title;
-          bValue = b.info.title;
-          break;
-        default:
-          return 0;
-      }
-
-      return sortAscending ? aValue.compareTo(bValue) : bValue.compareTo(aValue);
-    });
-  }
-
   int? _selectedIndex;
 
   int? get selectedIndex => _selectedIndex;
@@ -1352,8 +1284,6 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     track('depositWalletId', depositWalletId);
 
     // Sorting state
-    track('sortColumn', sortColumn);
-    track('sortAscending', sortAscending);
     track('depositSortColumn', depositSortColumn);
     track('depositSortAscending', depositSortAscending);
 

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.206
+version: 0.2.207
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/test/sidechains_table_test.dart
+++ b/bitwindow/test/sidechains_table_test.dart
@@ -84,6 +84,13 @@ class _ThunderRPC extends MockThunderRPC {
   Future<(double, double)> balance() async => wallet;
 }
 
+class _CoinShiftRPC extends MockCoinShiftRPC {
+  (double, double) wallet = (0, 0);
+
+  @override
+  Future<(double, double)> balance() async => wallet;
+}
+
 Thunder _thunder({bool downloaded = true, bool updateAvailable = false}) {
   final base = Thunder();
   return base.copyWith(
@@ -102,6 +109,7 @@ SailButton _buttonWidget(WidgetTester tester, String label) => tester.widget<Sai
 
 void main() {
   late _ThunderRPC thunderRPC;
+  late _CoinShiftRPC coinShiftRPC;
   late _Downloads downloads;
   late BalanceProvider balances;
   late SyncProvider sync;
@@ -132,7 +140,9 @@ void main() {
     GetIt.I.registerSingleton<LogProvider>(LogProvider());
     GetIt.I.registerSingleton<DownloadProvider>(downloads);
     GetIt.I.registerSingleton<ThunderRPC>(thunderRPC);
-    balances = BalanceProvider(connections: [thunderRPC]);
+    coinShiftRPC = _CoinShiftRPC();
+    GetIt.I.registerSingleton<CoinShiftRPC>(coinShiftRPC);
+    balances = BalanceProvider(connections: [thunderRPC, coinShiftRPC]);
     GetIt.I.registerSingleton<BalanceProvider>(balances);
   });
 
@@ -186,6 +196,35 @@ void main() {
     expect(_buttonWidget(tester, 'Deposit').disabled, isFalse);
     expect(find.text(GetIt.I.get<FormatterProvider>().formatBTC(4.1)), findsOneWidget);
     expect(find.text('—'), findsNothing);
+  });
+
+  testWidgets('a running CoinShift shows its balance, not a dash', (tester) async {
+    final coinShift = CoinShift();
+    GetIt.I.registerSingleton<BinaryProvider>(
+      _Binaries([
+        _thunder(),
+        coinShift.copyWith(
+          metadata: coinShift.metadata.copyWith(
+            remoteTimestamp: null,
+            downloadedTimestamp: DateTime(2026, 1),
+            binaryPath: File('/tmp/coinshift'),
+            updateable: true,
+          ),
+        ),
+      ]),
+    );
+    GetIt.I.get<SidechainProvider>().sidechains[255] = SidechainOverview(
+      ListSidechainsResponse_Sidechain(title: 'CoinShift', slot: 255, balanceSatoshi: Int64(5000000)),
+      [],
+      [],
+    );
+    coinShiftRPC.wallet = (0.25, 0.0);
+    coinShiftRPC.setConnected(true);
+    await balances.fetch();
+    await pumpTable(tester);
+
+    expect(find.text(GetIt.I.get<FormatterProvider>().formatBTC(0.25)), findsOneWidget);
+    expect(find.text('—'), findsOneWidget);
   });
 
   testWidgets('a chain that is not downloaded offers a primary Download', (tester) async {

--- a/bitwindow/test/sidechains_table_test.dart
+++ b/bitwindow/test/sidechains_table_test.dart
@@ -241,6 +241,27 @@ void main() {
     expect(_button('Start'), findsNothing);
   });
 
+  testWidgets('a header tap changes neither the row order nor the headers', (tester) async {
+    setUpChain(_thunder());
+    GetIt.I.get<SidechainProvider>().sidechains[2] = SidechainOverview(
+      ListSidechainsResponse_Sidechain(title: 'BitNames', slot: 2, balanceSatoshi: Int64(99000000)),
+      [],
+      [],
+    );
+    await pumpTable(tester);
+
+    for (final header in ['Slot', 'Name', 'Sidechain Balance', 'Your balance']) {
+      await tester.tap(find.text(header));
+      await tester.pumpAndSettle();
+
+      expect(tester.getTopLeft(find.text('2')).dy, lessThan(tester.getTopLeft(find.text('9')).dy));
+      expect(
+        tester.widgetList<SailTableHeaderCell>(find.byType(SailTableHeaderCell)).any((cell) => cell.isSorted),
+        isFalse,
+      );
+    }
+  });
+
   testWidgets('the slot shows its number with no colon', (tester) async {
     setUpChain(_thunder());
     await pumpTable(tester);


### PR DESCRIPTION
Removes sorting from the Sidechains table, so no header sorts and the rows stay in slot order.
Adds CoinShift to the BalanceProvider list, so a running CoinShift shows its balance in the Your balance column.