### PR TITLE
sail_ui: uniform spacing between binaries cards

### DIFF
--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -40,18 +40,27 @@ class DaemonConnectionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final downloadProvider = GetIt.I.isRegistered<DownloadProvider>() ? GetIt.I.get<DownloadProvider>() : null;
     if (downloadProvider == null) {
-      return _buildCard(context, downloadProgress: null);
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: _buildCard(context, downloadProgress: null),
+      );
     }
     return ListenableBuilder(
       listenable: downloadProvider,
       builder: (context, _) {
         final progress = downloadProvider.statusFor(connection.binary.type);
-        return _buildCard(context, downloadProgress: progress);
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: _buildCard(context, downloadProgress: progress),
+        );
       },
     );
   }
 
-  Widget _buildCard(BuildContext context, {required DownloadProgress? downloadProgress}) {
+  Widget _buildCard(
+    BuildContext context, {
+    required DownloadProgress? downloadProgress,
+  }) {
     final theme = SailTheme.of(context);
     final providerBinary = _binaryProvider.binaries.firstWhereOrNull(
       (b) => b.name == connection.binary.name,
@@ -62,7 +71,7 @@ class DaemonConnectionCard extends StatelessWidget {
       child: SailColumn(
         children: [
           SailRow(
-            spacing: SailStyleValues.padding08,
+            spacing: SailStyleValues.padding04,
             children: [
               SailText.primary15(
                 '${connection.binary.name} daemon',
@@ -144,20 +153,22 @@ class DaemonConnectionCard extends StatelessWidget {
           // The row stays even with nothing to report, so a card that gains
           // sync info or a download does not grow.
           SizedBox(
-            width: progressBlockWidth(downloadProgress != null ? 1 : syncRowCount(syncInfo)),
+            width: progressBlockWidth(
+              downloadProgress != null ? 1 : syncRowCount(syncInfo),
+            ),
             height: downloadProgress == null && (syncInfo?.mainchainSyncing ?? false)
                 ? null
-                : progressBlockHeight(context, downloadProgress != null ? 1 : syncRowCount(syncInfo)),
+                : progressBlockHeight(
+                    context,
+                    downloadProgress != null ? 1 : syncRowCount(syncInfo),
+                  ),
             child: downloadProgress != null
                 ? DownloadStatusRow(
                     name: connection.binary.name,
                     download: downloadProgress,
                   )
                 : syncInfo != null
-                ? BlockStatus(
-                    name: connection.binary.name,
-                    syncInfo: syncInfo!,
-                  )
+                ? BlockStatus(name: connection.binary.name, syncInfo: syncInfo!)
                 : null,
           ),
           Padding(
@@ -181,7 +192,10 @@ class DaemonConnectionCard extends StatelessWidget {
     );
   }
 
-  Color _getConnectionColor(SailThemeData theme, {required bool isDownloading}) => resolveDaemonStatusColor(
+  Color _getConnectionColor(
+    SailThemeData theme, {
+    required bool isDownloading,
+  }) => resolveDaemonStatusColor(
     theme: theme,
     connectionError: connection.connectionError,
     startupError: connection.startupError,
@@ -467,9 +481,17 @@ class BlockStatus extends StatelessWidget {
   /// from genesis while it runs from a UTXO snapshot. Verification finishes at
   /// the snapshot's base block, so that row carries its own goal.
   static List<SyncRow> rowsFor(SyncInfo info) {
-    final rows = <SyncRow>[SyncRow('Blocks', info.progressCurrent, info.progressGoal)];
+    final rows = <SyncRow>[
+      SyncRow('Blocks', info.progressCurrent, info.progressGoal),
+    ];
     if (info.verifiedBlocks > 0 && info.verifiedGoal > 0) {
-      rows.add(SyncRow('Verified', info.verifiedBlocks.toDouble(), info.verifiedGoal.toDouble()));
+      rows.add(
+        SyncRow(
+          'Verified',
+          info.verifiedBlocks.toDouble(),
+          info.verifiedGoal.toDouble(),
+        ),
+      );
     }
     return rows;
   }
@@ -492,7 +514,10 @@ class BlockStatus extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                SizedBox(width: syncLabelWidth, child: SailText.secondary12(row.label)),
+                SizedBox(
+                  width: syncLabelWidth,
+                  child: SailText.secondary12(row.label),
+                ),
                 SizedBox(
                   width: progressBarWidth,
                   child: ProgressBar(current: row.current, goal: row.goal),
@@ -527,7 +552,9 @@ class BlockStatus extends StatelessWidget {
                     ),
                   )
                 else
-                  SailText.secondary12('${formatWithThousandSpacers(currentProgress)} sync height'),
+                  SailText.secondary12(
+                    '${formatWithThousandSpacers(currentProgress)} sync height',
+                  ),
               ],
             ),
           ),

--- a/sail_ui/lib/widgets/components/mining_status_card.dart
+++ b/sail_ui/lib/widgets/components/mining_status_card.dart
@@ -32,43 +32,51 @@ class MiningStatusCard extends StatelessWidget {
           hasInfoMessage: false,
         );
 
-        return SailCard(
-          child: SailColumn(
-            children: [
-              SailRow(
-                spacing: SailStyleValues.padding08,
-                children: [
-                  SailText.primary15('CPU Mining', bold: true),
-                  SailSVG.fromAsset(SailSVGAsset.iconConnectionStatus, color: statusColor),
-                  Expanded(child: Container()),
-                  Tooltip(
-                    message: 'View logs',
-                    child: SailButton(
-                      variant: ButtonVariant.ghost,
-                      onPressed: () async => onViewLogs?.call(),
-                      disabled: onViewLogs == null,
-                      label: 'View logs',
+        return Padding(
+          padding: EdgeInsets.only(bottom: 8),
+          child: SailCard(
+            child: SailColumn(
+              children: [
+                SailRow(
+                  spacing: SailStyleValues.padding08,
+                  children: [
+                    SailText.primary15('CPU Mining', bold: true),
+                    SailSVG.fromAsset(
+                      SailSVGAsset.iconConnectionStatus,
+                      color: statusColor,
+                    ),
+                    Expanded(child: Container()),
+                    Tooltip(
+                      message: 'View logs',
+                      child: SailButton(
+                        variant: ButtonVariant.ghost,
+                        onPressed: () async => onViewLogs?.call(),
+                        disabled: onViewLogs == null,
+                        label: 'View logs',
+                      ),
+                    ),
+                    SailButton(
+                      variant: ButtonVariant.icon,
+                      onPressed: () async => onOpenSettings?.call(),
+                      disabled: onOpenSettings == null,
+                      icon: SailSVGAsset.tabSettings,
+                    ),
+                    _StartStopButton(mining: mining),
+                  ],
+                ),
+                SizedBox(width: 350, child: MiningRateStatus(mining: mining)),
+                if (mining.error != null)
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      top: SailStyleValues.padding04,
+                    ),
+                    child: SailText.secondary12(
+                      prettifyLogMessage(mining.error!),
+                      monospace: true,
                     ),
                   ),
-                  SailButton(
-                    variant: ButtonVariant.icon,
-                    onPressed: () async => onOpenSettings?.call(),
-                    disabled: onOpenSettings == null,
-                    icon: SailSVGAsset.tabSettings,
-                  ),
-                  _StartStopButton(mining: mining),
-                ],
-              ),
-              SizedBox(
-                width: 350,
-                child: MiningRateStatus(mining: mining),
-              ),
-              if (mining.error != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: SailStyleValues.padding04),
-                  child: SailText.secondary12(prettifyLogMessage(mining.error!), monospace: true),
-                ),
-            ],
+              ],
+            ),
           ),
         );
       },
@@ -96,7 +104,9 @@ class MiningRateStatus extends StatelessWidget {
         spacing: SailStyleValues.padding08,
         children: [
           SailText.secondary12(mining.formattedHashRate),
-          SailText.secondary12(blocks == 1 ? '1 block found' : '$blocks blocks found'),
+          SailText.secondary12(
+            blocks == 1 ? '1 block found' : '$blocks blocks found',
+          ),
         ],
       ),
     );
@@ -138,7 +148,11 @@ class _StartStopButtonState extends State<_StartStopButton> {
     if (_busy) {
       return const Padding(
         padding: EdgeInsets.symmetric(horizontal: SailStyleValues.padding08),
-        child: SizedBox(width: 12, height: 12, child: CircularProgressIndicator(strokeWidth: 2)),
+        child: SizedBox(
+          width: 12,
+          height: 12,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
       );
     }
 

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -247,7 +247,6 @@ class BottomNav extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 SailColumn(
-                  spacing: SailStyleValues.padding12,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     if (showMainchain &&


### PR DESCRIPTION
Make spacing between binaries/mining cards uniform. 
--

screenshots:
<img width="594" height="533" alt="image" src="https://github.com/user-attachments/assets/38e90f09-68e2-4f92-847b-adf72e692e04" />

---
<img width="594" height="533" alt="image" src="https://github.com/user-attachments/assets/f7d22f4f-768f-4943-9cf8-6808e3980f0d" />

---
NB: changes appear too much due to formatting. core change consists in wrapping sailCards into a `padding.only(bottom: 8)`
