### PR TITLE
orchestrator: skip a deleted bidding wallet

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.335
+version: 1.0.336
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.335
+version: 1.0.336
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.207
+version: 0.2.208
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.10
+version: 1.0.11
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/api/bid_source.go
+++ b/sidechain-orchestrator/api/bid_source.go
@@ -34,7 +34,7 @@ type BidSource interface {
 	// Replacement prices a replacement of one of our own bids.
 	Replacement(ctx context.Context, walletID, txid string) (Replacement, error)
 	// PendingTxids names our own transactions no block carries yet, over every
-	// wallet in walletIDs.
+	// wallet in walletIDs. The first id names the current funding wallet.
 	PendingTxids(ctx context.Context, walletIDs []string) (map[string]bool, error)
 	// PaidSats reports what one of our own bids paid. It reports false when
 	// no source names the transaction.

--- a/sidechain-orchestrator/api/bid_source_wallet.go
+++ b/sidechain-orchestrator/api/bid_source_wallet.go
@@ -87,18 +87,24 @@ func (w walletBids) evicted(_ context.Context, _, chain []string) []string {
 const pendingListCount = 100_000
 
 // PendingTxids names our own transactions no block carries yet, over every
-// wallet in walletIDs.
+// wallet in walletIDs. The first id names the current funding wallet.
 func (w walletBids) PendingTxids(ctx context.Context, walletIDs []string) (map[string]bool, error) {
 	if w.h.wallet == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no wallet is wired"))
 	}
 	held := make(map[string]bool)
-	for _, walletID := range lo.Uniq(walletIDs) {
+	for i, walletID := range lo.Uniq(walletIDs) {
 		resp, err := w.h.wallet.ListTransactions(ctx, connect.NewRequest(&wpb.ListTransactionsRequest{
 			WalletId: walletID,
 			Count:    pendingListCount,
 		}))
 		if err != nil {
+			// A stored round names its funding wallet forever, so the tail of
+			// this list can name a wallet the user deleted since. The current
+			// wallet reads the same backend, so a backend that is down fails.
+			if i > 0 {
+				continue
+			}
 			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("list the wallet transactions: %w", err))
 		}
 		for _, tx := range resp.Msg.Transactions {

--- a/sidechain-orchestrator/api/bid_source_wallet.go
+++ b/sidechain-orchestrator/api/bid_source_wallet.go
@@ -87,11 +87,12 @@ func (w walletBids) evicted(_ context.Context, _, chain []string) []string {
 // whole confirmed history.
 const pendingListCount = 100_000
 
-// walletGone reports whether the wallet no longer exists. The router answers
+// walletGone reports whether walletID no longer exists. The router answers
 // "wallet <id> not found" for one a user deleted, and the handler carries that
-// text through as an internal error.
-func walletGone(err error) bool {
-	return strings.Contains(err.Error(), "not found")
+// text through. A looser match would swallow "method not found" from a live
+// wallet whose backend is at fault.
+func walletGone(err error, walletID string) bool {
+	return strings.Contains(err.Error(), "wallet "+walletID+" not found")
 }
 
 // PendingTxids names our own transactions no block carries yet, over every
@@ -111,7 +112,7 @@ func (w walletBids) PendingTxids(ctx context.Context, walletIDs []string) (map[s
 			// this list can name a wallet the user deleted since. Only that
 			// answer is safe to skip; every other one hides a backend fault
 			// and would report a stranded bid as absent.
-			if i > 0 && walletGone(err) {
+			if i > 0 && walletGone(err, walletID) {
 				continue
 			}
 			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("list the wallet transactions: %w", err))

--- a/sidechain-orchestrator/api/bid_source_wallet.go
+++ b/sidechain-orchestrator/api/bid_source_wallet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/samber/lo"
@@ -86,6 +87,13 @@ func (w walletBids) evicted(_ context.Context, _, chain []string) []string {
 // whole confirmed history.
 const pendingListCount = 100_000
 
+// walletGone reports whether the wallet no longer exists. The router answers
+// "wallet <id> not found" for one a user deleted, and the handler carries that
+// text through as an internal error.
+func walletGone(err error) bool {
+	return strings.Contains(err.Error(), "not found")
+}
+
 // PendingTxids names our own transactions no block carries yet, over every
 // wallet in walletIDs. The first id names the current funding wallet.
 func (w walletBids) PendingTxids(ctx context.Context, walletIDs []string) (map[string]bool, error) {
@@ -100,9 +108,10 @@ func (w walletBids) PendingTxids(ctx context.Context, walletIDs []string) (map[s
 		}))
 		if err != nil {
 			// A stored round names its funding wallet forever, so the tail of
-			// this list can name a wallet the user deleted since. The current
-			// wallet reads the same backend, so a backend that is down fails.
-			if i > 0 {
+			// this list can name a wallet the user deleted since. Only that
+			// answer is safe to skip; every other one hides a backend fault
+			// and would report a stranded bid as absent.
+			if i > 0 && walletGone(err) {
 				continue
 			}
 			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("list the wallet transactions: %w", err))

--- a/sidechain-orchestrator/api/bmm_light_pending_test.go
+++ b/sidechain-orchestrator/api/bmm_light_pending_test.go
@@ -45,6 +45,21 @@ func TestLightPendingSkipsADeletedWallet(t *testing.T) {
 	require.Len(t, wallet.listed, 2)
 }
 
+// A wallet a stored round names can answer with a transient fault rather than
+// a deletion. Reading that as "no pending bids" leaves a stranded bid in place
+// and opens a second bid beside it, so the read fails instead.
+func TestLightPendingFailsOnATransientPriorWallet(t *testing.T) {
+	h := lightHandler(t)
+	h.wallet = &fakeBidWallet{
+		txs:     []*wpb.TransactionEntry{{Txid: "bid", Confirmations: 0}},
+		listErr: map[string]error{"older": fmt.Errorf("context deadline exceeded")},
+	}
+
+	_, err := h.MempoolTxids(context.Background(), []string{"bidder", "older"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
 // The current funding wallet is the first id. A backend that cannot list it
 // reports nothing about our bids, so the read fails rather than reports none.
 func TestLightPendingFailsOnTheCurrentWallet(t *testing.T) {

--- a/sidechain-orchestrator/api/bmm_light_pending_test.go
+++ b/sidechain-orchestrator/api/bmm_light_pending_test.go
@@ -60,6 +60,20 @@ func TestLightPendingFailsOnATransientPriorWallet(t *testing.T) {
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 }
 
+// A live wallet can answer "method not found" when its backend is at fault.
+// Reading that as a deletion hides the fault and drops a pending bid.
+func TestLightPendingFailsOnAMethodNotFound(t *testing.T) {
+	h := lightHandler(t)
+	h.wallet = &fakeBidWallet{
+		txs:     []*wpb.TransactionEntry{{Txid: "bid", Confirmations: 0}},
+		listErr: map[string]error{"older": fmt.Errorf("electrum error: method not found")},
+	}
+
+	_, err := h.MempoolTxids(context.Background(), []string{"bidder", "older"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "method not found")
+}
+
 // The current funding wallet is the first id. A backend that cannot list it
 // reports nothing about our bids, so the read fails rather than reports none.
 func TestLightPendingFailsOnTheCurrentWallet(t *testing.T) {

--- a/sidechain-orchestrator/api/bmm_light_pending_test.go
+++ b/sidechain-orchestrator/api/bmm_light_pending_test.go
@@ -27,6 +27,35 @@ func TestLightPendingReadsTheFundingWallet(t *testing.T) {
 	assert.Equal(t, "bidder", wallet.listed[0].WalletId)
 }
 
+// A stored round names its funding wallet forever, so the list outlives a
+// wallet the user deletes. That wallet must not hide the bids of the current
+// one, or no later round ever replaces a stranded bid.
+func TestLightPendingSkipsADeletedWallet(t *testing.T) {
+	h := lightHandler(t)
+	wallet := &fakeBidWallet{
+		txs:     []*wpb.TransactionEntry{{Txid: "bid", Confirmations: 0}},
+		listErr: map[string]error{"gone": fmt.Errorf("wallet gone not found")},
+	}
+	h.wallet = wallet
+
+	held, err := h.MempoolTxids(context.Background(), []string{"bidder", "gone"})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]bool{"bid": true}, held)
+	require.Len(t, wallet.listed, 2)
+}
+
+// The current funding wallet is the first id. A backend that cannot list it
+// reports nothing about our bids, so the read fails rather than reports none.
+func TestLightPendingFailsOnTheCurrentWallet(t *testing.T) {
+	h := lightHandler(t)
+	h.wallet = &fakeBidWallet{listErr: map[string]error{"bidder": fmt.Errorf("esplora is down")}}
+
+	_, err := h.MempoolTxids(context.Background(), []string{"bidder", "gone"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "esplora is down")
+}
+
 // An Electrum wallet carries no block time on an unconfirmed row, so it sorts
 // one after the whole confirmed history. The read asks past that history.
 func TestLightPendingReadsPastTheConfirmedHistory(t *testing.T) {

--- a/sidechain-orchestrator/api/bmm_slot_coin_test.go
+++ b/sidechain-orchestrator/api/bmm_slot_coin_test.go
@@ -125,6 +125,9 @@ type fakeBidWallet struct {
 	// details answers GetTransactionDetails, and txs answers ListTransactions.
 	details map[string]*wpb.GetTransactionDetailsResponse
 	txs     []*wpb.TransactionEntry
+	// listErr fails ListTransactions per wallet, for a test that names a
+	// wallet the manager no longer holds.
+	listErr map[string]error
 	// listed records every ListTransactions request the wallet took.
 	listed []*wpb.ListTransactionsRequest
 }
@@ -143,6 +146,9 @@ func (w *fakeBidWallet) ListTransactions(
 	_ context.Context, req *connect.Request[wpb.ListTransactionsRequest],
 ) (*connect.Response[wpb.ListTransactionsResponse], error) {
 	w.listed = append(w.listed, req.Msg)
+	if err, ok := w.listErr[req.Msg.WalletId]; ok {
+		return nil, err
+	}
 	// The handler defaults an unset count to 100, and the electrum backend cuts
 	// the list at it after sorting an unconfirmed row last.
 	count := int(req.Msg.Count)

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.337
+version: 1.0.338
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.334
+version: 1.0.335
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
A user who deletes a wallet stopped their light mode bidder for good. It
keeps bidding now.
