### PR TITLE
orchestrator: open a bmm bid over the next block rate

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.335
+version: 1.0.336
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.335
+version: 1.0.336
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.207
+version: 0.2.208
 
 environment:
   sdk: 3.12.2

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.10
+version: 1.0.11
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -98,6 +98,11 @@ type MainchainTip interface {
 // reports neither an estimate nor a relay floor.
 const relayMinimumRate = 1.0
 
+// openingMarginSatVb is what an opening bid adds over the next block rate, in
+// sats per vByte. One whole sat clears every transaction that pays the rate
+// exactly, and it also covers the fee a bid loses to its own size estimate.
+const openingMarginSatVb = 1.0
+
 type bmmTarget struct {
 	maxBidSats int64
 	// walletID funds every bid. Empty spends from the active wallet.
@@ -663,7 +668,7 @@ func (e *BmmEngine) openRound(
 	e.current[sidechain] = round
 	e.mu.Unlock()
 
-	if err := e.placeBid(ctx, sidechain, round, walletID, 0, e.NextBlockRate(ctx),
+	if err := e.placeBid(ctx, sidechain, round, walletID, 0, e.openingRate(ctx),
 		target.maxBidSats, replaceTxid, target.capToBlockWorth); err != nil {
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
 			e.log.Info().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid refused, retrying next tick")
@@ -908,12 +913,18 @@ func (e *BmmEngine) placeBid(
 	return nil
 }
 
+// openingRate is the fee rate an opening bid pays, in sats per vByte. It
+// clears the next block rate by a margin, because a bid that only matches that
+// rate sits with the transactions a miner cuts, and the engine raises a bid
+// only against a competitor. A chain nobody competes for then loses every
+// block that closes at the rate.
+func (e *BmmEngine) openingRate(ctx context.Context) float64 {
+	return e.NextBlockRate(ctx) + openingMarginSatVb
+}
+
 // NextBlockRate is the fee rate a bid pays to enter the next mainchain block,
 // in sats per vByte. Core reports it, and the relay minimum stands in when
 // Core answers nothing.
-//
-// A miner leaves a cheaper bid in the mempool, and the engine raises only
-// against a competitor, so an opening bid under this rate never gets mined.
 func (e *BmmEngine) NextBlockRate(ctx context.Context) float64 {
 	if e.fee == nil {
 		return relayMinimumRate

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -73,6 +73,9 @@ func (f *fakeBackend) CreateBid(
 	if req.Msg.CapToBlockWorth && f.feesSats > 0 && bid > f.feesSats {
 		bid = f.feesSats
 	}
+	if req.Msg.MaxBidSats > 0 && bid > req.Msg.MaxBidSats {
+		bid = req.Msg.MaxBidSats
+	}
 	f.lastBidSats = bid
 	f.lastExpectTip = req.Msg.ExpectPrevMainHash
 	f.lastWalletID = req.Msg.WalletId
@@ -533,7 +536,24 @@ func TestBmmEngineOpensByRateNotByAmount(t *testing.T) {
 
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	assert.InDelta(t, 42, backend.lastFeeRate, 0.001)
+	assert.InDelta(t, 42+openingMarginSatVb, backend.lastFeeRate, 0.001)
+}
+
+// A block closes on a fee rate, and the transactions that pay it exactly are
+// the ones a miner cuts. Nobody competes for most sidechains, so the engine
+// never raises, and a bid that matches the rate loses every such block.
+func TestBmmEngineOpensOverTheNextBlockRate(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	engine.fee.(*fakeFee).set(2)
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 10_000, false))
+	tip.set("main-1")
+
+	engine.tick(context.Background())
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Greater(t, backend.lastFeeRate, 2.0, "an opening bid must beat the rate, not match it")
+	assert.InDelta(t, 3, backend.lastFeeRate, 0.001)
 }
 
 // The sidechain never saw the block it just won, so it cannot look up which

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.337
+version: 1.0.338
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.334
+version: 1.0.335
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
A sidechain that nobody competes for went hours without a block. Its bid matched the fee rate exactly, which puts it with the transactions a miner cuts, and the engine raises a bid only against a rival. The opening bid now beats the rate instead of matching it.