### PR TITLE
orchestrator: count a won block the chain holds

### DIFF
--- a/sidechain-orchestrator/api/bid_source.go
+++ b/sidechain-orchestrator/api/bid_source.go
@@ -36,6 +36,8 @@ type BidSource interface {
 	// PendingTxids names our own transactions no block carries yet, over every
 	// wallet in walletIDs. The first id names the current funding wallet.
 	PendingTxids(ctx context.Context, walletIDs []string) (map[string]bool, error)
+	// Mined reports whether a block carries txid, one that PendingTxids named.
+	Mined(ctx context.Context, txid string) (bool, error)
 	// PaidSats reports what one of our own bids paid. It reports false when
 	// no source names the transaction.
 	PaidSats(ctx context.Context, walletID, txid string) (int64, bool, error)
@@ -60,6 +62,8 @@ type ownBids interface {
 	// PendingTxids names our own transactions no block carries yet, over every
 	// wallet in walletIDs.
 	PendingTxids(ctx context.Context, walletIDs []string) (map[string]bool, error)
+	// mined reports whether a block carries txid, one that PendingTxids named.
+	mined(ctx context.Context, txid string) (bool, error)
 	// frozenCoins names the candidates a live bid of ours holds.
 	frozenCoins(ctx context.Context, walletID string, candidates []wallet.Outpoint) (map[string]bool, error)
 }
@@ -87,6 +91,10 @@ func (s bidSource) Rivals(ctx context.Context, slot int, prevMainHash string) ([
 
 func (s bidSource) PendingTxids(ctx context.Context, walletIDs []string) (map[string]bool, error) {
 	return s.own.PendingTxids(ctx, walletIDs)
+}
+
+func (s bidSource) Mined(ctx context.Context, txid string) (bool, error) {
+	return s.own.mined(ctx, txid)
 }
 
 func (s bidSource) PaidSats(ctx context.Context, walletID, txid string) (int64, bool, error) {

--- a/sidechain-orchestrator/api/bid_source_core.go
+++ b/sidechain-orchestrator/api/bid_source_core.go
@@ -166,3 +166,9 @@ func (c coreBids) PendingTxids(ctx context.Context, _ []string) (map[string]bool
 	}
 	return held, nil
 }
+
+// mined reports false: Core drops a transaction from its mempool in the same
+// step as the block that carries it, so a txid PendingTxids named is unmined.
+func (coreBids) mined(context.Context, string) (bool, error) {
+	return false, nil
+}

--- a/sidechain-orchestrator/api/bid_source_wallet.go
+++ b/sidechain-orchestrator/api/bid_source_wallet.go
@@ -126,6 +126,18 @@ func (w walletBids) PendingTxids(ctx context.Context, walletIDs []string) (map[s
 	return held, nil
 }
 
+// mined reads the chain source, because the wallet cache lags a new block.
+func (w walletBids) mined(ctx context.Context, txid string) (bool, error) {
+	if w.h.wallet == nil {
+		return false, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no wallet is wired"))
+	}
+	status, err := w.h.wallet.TxStatus(ctx, txid)
+	if err != nil {
+		return false, connect.NewError(connect.CodeUnavailable, fmt.Errorf("read the chain status of %s: %w", txid, err))
+	}
+	return status.Confirmed, nil
+}
+
 // m8Script says whether the transaction carries a BMM request in its first
 // output, which is where an M8 sits.
 func m8Script(details *wpb.GetTransactionDetailsResponse) bool {

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -70,6 +70,8 @@ type bidWallet interface {
 	ListTransactions(
 		context.Context, *connect.Request[wpb.ListTransactionsRequest],
 	) (*connect.Response[wpb.ListTransactionsResponse], error)
+	// TxStatus reads the chain status of one transaction from the chain source.
+	TxStatus(ctx context.Context, txid string) (wallet.EsploraStatus, error)
 }
 
 // BMMHandler serves BMMService. It owns bid assembly; the engine drives it on
@@ -631,6 +633,11 @@ func (h *BMMHandler) enforcerBids(ctx context.Context, slot int, prevMainHash st
 // names the wallets that funded them, and an empty id names the active wallet.
 func (h *BMMHandler) MempoolTxids(ctx context.Context, walletIDs []string) (map[string]bool, error) {
 	return h.bids().PendingTxids(ctx, walletIDs)
+}
+
+// Mined reports whether a block carries txid, one that MempoolTxids named.
+func (h *BMMHandler) Mined(ctx context.Context, txid string) (bool, error) {
+	return h.bids().Mined(ctx, txid)
 }
 
 // m8Request reads the bid a transaction carries, nil when it carries none.

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -516,6 +516,7 @@ func (h *BMMHandler) ConnectBid(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("connect block: %w", err))
 	}
+	var held bool
 	if !connected {
 		// A sidechain learns of an inclusion by polling, and refuses every block
 		// until it does. The empty answer names no block, which is how the caller
@@ -527,12 +528,20 @@ func (h *BMMHandler) ConnectBid(
 		if connectTarget(mainBlockHash, inclusions) == "" {
 			return connect.NewResponse(&bmmpb.ConnectBidResponse{}), nil
 		}
+		held, err = proxy.ChainHolds(ctx, req.Msg.CriticalHash, heldBlockDepth)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("read the sidechain chain: %w", err))
+		}
 	}
 	return connect.NewResponse(&bmmpb.ConnectBidResponse{
 		Connected:     connected,
 		MainBlockHash: mainBlockHash,
+		Held:          held,
 	}), nil
 }
+
+// heldBlockDepth covers every won block the engine still offers: one sidechain block per mainchain block.
+const heldBlockDepth = 11
 
 func bmmInclusions(ctx context.Context, proxy sidechain.BMMNode, criticalHash string) ([]string, error) {
 	inclusions, err := proxy.GetBmmInclusions(ctx, criticalHash)

--- a/sidechain-orchestrator/api/bmm_light_pending_test.go
+++ b/sidechain-orchestrator/api/bmm_light_pending_test.go
@@ -9,7 +9,37 @@ import (
 	"github.com/stretchr/testify/require"
 
 	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
+
+// The wallet cache lists a bid as pending for a time after a block took it.
+// The chain source answers for the block.
+func TestLightMinedReadsTheChainSource(t *testing.T) {
+	h := lightHandler(t)
+	h.wallet = &fakeBidWallet{
+		txs:    []*wpb.TransactionEntry{{Txid: "bid"}},
+		status: map[string]wallet.EsploraStatus{"bid": {Confirmed: true, BlockHeight: 997083}},
+	}
+
+	held, err := h.MempoolTxids(context.Background(), []string{"bidder"})
+	require.NoError(t, err)
+	require.True(t, held["bid"], "the cache still lists the bid")
+
+	mined, err := h.Mined(context.Background(), "bid")
+	require.NoError(t, err)
+	assert.True(t, mined)
+}
+
+// A chain source that cannot answer says nothing about the bid, so the read
+// fails rather than reports it pending.
+func TestLightMinedFailsWhenTheChainSourceFails(t *testing.T) {
+	h := lightHandler(t)
+	h.wallet = &fakeBidWallet{statusErr: fmt.Errorf("esplora is down")}
+
+	_, err := h.Mined(context.Background(), "bid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "esplora is down")
+}
 
 // The BMM controls let a user fund the bids from a wallet they never made
 // active. The pending read has to name that wallet, or it reports none of its

--- a/sidechain-orchestrator/api/bmm_slot_coin_test.go
+++ b/sidechain-orchestrator/api/bmm_slot_coin_test.go
@@ -17,6 +17,7 @@ import (
 	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
 	bmmpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bmm/v1"
 	wpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
 // fakeSlotMempool answers the two Core reads the coin choice makes.
@@ -130,6 +131,13 @@ type fakeBidWallet struct {
 	listErr map[string]error
 	// listed records every ListTransactions request the wallet took.
 	listed []*wpb.ListTransactionsRequest
+	// status answers TxStatus, and statusErr fails it.
+	status    map[string]wallet.EsploraStatus
+	statusErr error
+}
+
+func (w *fakeBidWallet) TxStatus(_ context.Context, txid string) (wallet.EsploraStatus, error) {
+	return w.status[txid], w.statusErr
 }
 
 func (w *fakeBidWallet) GetTransactionDetails(

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -685,6 +685,14 @@ func (h *WalletHandler) ResolveWalletID(walletID string) (string, error) {
 	return h.engine.ResolveWalletID(walletID)
 }
 
+// TxStatus reads the chain status of one transaction from the chain source.
+func (h *WalletHandler) TxStatus(ctx context.Context, txid string) (wallet.EsploraStatus, error) {
+	if err := h.requireEngine(); err != nil {
+		return wallet.EsploraStatus{}, err
+	}
+	return h.engine.TxStatus(ctx, txid)
+}
+
 func (h *WalletHandler) requireEngine() error {
 	if h.engine == nil {
 		return fmt.Errorf("bitcoin Core RPC not configured")

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -1280,14 +1280,12 @@ func (e *BmmEngine) connectWon(
 			Str("critical_hash", live.CriticalHash).Msg("connect won block")
 		return stepRetry
 	}
-	if !resp.Msg.Connected {
+	if !resp.Msg.Connected && !resp.Msg.Held {
 		if resp.Msg.MainBlockHash == "" {
 			e.log.Debug().Stringer("sidechain", sidechain).Str("critical_hash", live.CriticalHash).
 				Msg("the sidechain has not seen the bid included yet")
 			return stepRetry
 		}
-		// A node that already holds the block from a peer answers false as
-		// well, so a false answer alone names no lost block.
 		e.log.Warn().Stringer("sidechain", sidechain).Str("critical_hash", live.CriticalHash).
 			Str("main_block", resp.Msg.MainBlockHash).Msg("the sidechain did not connect the won block")
 		return stepRetire

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -77,6 +77,9 @@ type BmmBackend interface {
 	// install that reads no mempool names the pending transactions of the
 	// named wallets instead.
 	MempoolTxids(ctx context.Context, walletIDs []string) (map[string]bool, error)
+	// Mined reports whether a block carries txid, one that MempoolTxids named.
+	// It reads a live source.
+	Mined(ctx context.Context, txid string) (bool, error)
 	CreateBid(context.Context, *connect.Request[bmmpb.CreateBidRequest]) (*connect.Response[bmmpb.CreateBidResponse], error)
 	ConnectBid(context.Context, *connect.Request[bmmpb.ConnectBidRequest]) (*connect.Response[bmmpb.ConnectBidResponse], error)
 	ListBids(context.Context, *connect.Request[bmmpb.ListBidsRequest]) (*connect.Response[bmmpb.ListBidsResponse], error)
@@ -724,6 +727,16 @@ func (e *BmmEngine) strandedBid(
 		}
 		for _, bid := range round.OurBids {
 			if bid.Txid == "" || !inMempool[bid.Txid] {
+				continue
+			}
+			// A pending list can lag the block that took the bid.
+			mined, err := e.backend.Mined(ctx, bid.Txid)
+			if err != nil {
+				e.log.Warn().Err(err).Stringer("sidechain", sidechain).Str("txid", bid.Txid).
+					Msg("read whether a block holds a bmm bid")
+				return bmmstate.Bid{}, false
+			}
+			if mined {
 				continue
 			}
 			if !found || round.PrevMainHeight < height {

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -29,6 +29,8 @@ type fakeBackend struct {
 	bids              int
 	connects          int
 	connected         bool
+	held              bool
+	connectErr        error
 	noInclusion       bool
 	lastMainBlockHash string
 	bidErr            error
@@ -97,6 +99,9 @@ func (f *fakeBackend) ConnectBid(
 	defer f.mu.Unlock()
 	f.connects++
 	f.lastMainBlockHash = req.Msg.MainBlockHash
+	if f.connectErr != nil {
+		return nil, f.connectErr
+	}
 	// The handler names no block while the sidechain reports no inclusion for
 	// the critical hash.
 	if f.noInclusion {
@@ -111,6 +116,7 @@ func (f *fakeBackend) ConnectBid(
 	return connect.NewResponse(&bmmpb.ConnectBidResponse{
 		Connected:     f.connected,
 		MainBlockHash: main,
+		Held:          f.held,
 	}), nil
 }
 
@@ -1233,6 +1239,48 @@ func TestBmmEngineRetiresARefusedBlock(t *testing.T) {
 	restarted := NewBmmEngine(zerolog.New(zerolog.NewTestWriter(t)), backend, &fakeTip{}, newFakeFee(), store)
 	restarted.resumeUnconnected()
 	assert.Zero(t, pendingCount(restarted), "a restart leaves the retired round alone")
+}
+
+// A node that already holds the block from a peer refuses ours. The block is on
+// its chain, so the round is a win.
+func TestBmmEngineCountsAWonBlockTheSidechainHolds(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.connected = false
+	backend.held = true
+
+	round := unconnectedRound("held-round", 996770)
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	engine.retryConnects(context.Background(), testSidechain, "tip", 996773)
+
+	assert.Zero(t, pendingCount(engine), "the round leaves the retry list")
+	assert.Equal(t, ResultWon, round.Result)
+	require.Len(t, round.OurBids, 1)
+	assert.Equal(t, BidConnected, round.OurBids[0].State)
+	assert.Empty(t, round.OurBids[0].Error)
+	assert.Equal(t, "critical", round.WinnerCriticalHash)
+	assert.Equal(t, "won-txid", round.WinnerTxid)
+	assert.Equal(t, "main-block", round.IncludedInBlock)
+}
+
+// A failed read of the sidechain chain names no refusal, so the round waits.
+func TestBmmEngineRetriesWhenTheHeldCheckFails(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.connectErr = errors.New("read the sidechain chain: connection refused")
+
+	round := unconnectedRound("check-failed-round", 996770)
+	engine.mu.Lock()
+	engine.unconnected[testSidechain] = []*bmmstate.Round{round}
+	engine.mu.Unlock()
+
+	engine.retryConnects(context.Background(), testSidechain, "tip", 996773)
+
+	assert.Equal(t, 1, backend.connects)
+	assert.Equal(t, 1, pendingCount(engine), "the round stays on the retry list")
+	assert.Equal(t, BidLive, round.OurBids[0].State)
+	assert.Empty(t, round.OurBids[0].Error)
 }
 
 // A sidechain that has not seen the bid included names no block. The mainchain

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -53,6 +53,10 @@ type fakeBackend struct {
 	lastFeeRate       float64
 	// lastMempoolWallets names the wallets the last mempool read asked about.
 	lastMempoolWallets []string
+	// mined answers the live read, and minedReads records every txid it took.
+	mined      map[string]bool
+	minedErr   error
+	minedReads []string
 }
 
 func (f *fakeBackend) CreateBid(
@@ -149,6 +153,13 @@ func (f *fakeBackend) MempoolTxids(_ context.Context, walletIDs []string) (map[s
 		held[bid.Txid] = true
 	}
 	return held, nil
+}
+
+func (f *fakeBackend) Mined(_ context.Context, txid string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.minedReads = append(f.minedReads, txid)
+	return f.mined[txid], f.minedErr
 }
 
 func (f *fakeBackend) PrepareBMM(
@@ -1155,6 +1166,87 @@ func TestBmmEngineReplacesAStrandedBidAfterRestart(t *testing.T) {
 	assert.Equal(t, "txid-1", backend.lastReplace,
 		"the oldest stranded bid is the root of the chain, so replacing it evicts them all")
 	assert.Equal(t, "core-wallet", backend.lastWalletID)
+}
+
+// A wallet can list a bid as pending for a time after a block took it. The
+// live read wins, so the opening bid respends no input the block spent.
+func TestBmmEngineKeepsAPendingBidABlockHolds(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	require.Equal(t, 1, backend.bids)
+
+	// The block takes the bid, and the wallet still lists it as pending.
+	backend.mu.Lock()
+	backend.commitment = "critical"
+	backend.connected = true
+	backend.others = []*bmmpb.Bid{{Txid: "txid-1", PrevMainHash: "block-1"}}
+	backend.mined = map[string]bool{"txid-1": true}
+	backend.mu.Unlock()
+
+	tip.set("block-2")
+	engine.tick(ctx)
+
+	assert.Equal(t, 2, backend.bids)
+	assert.Empty(t, backend.lastReplace, "a block holds the bid, so its inputs are spent")
+}
+
+// A bid the live read also shows as pending is stranded, and the opening bid
+// replaces it as before.
+func TestBmmEngineReplacesABidTheLiveReadShowsPending(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+
+	backend.mu.Lock()
+	backend.others = []*bmmpb.Bid{{Txid: "txid-1", PrevMainHash: "block-1"}}
+	backend.mined = map[string]bool{"txid-1": false}
+	backend.mu.Unlock()
+
+	tip.set("block-2")
+	engine.tick(ctx)
+
+	assert.Equal(t, "txid-1", backend.lastReplace)
+	assert.Contains(t, backend.minedReads, "txid-1", "the engine reads a live source before it replaces")
+}
+
+// A live read that fails decides nothing. The pass replaces nothing, the round
+// opens with a fresh bid, and the next pass reads again.
+func TestBmmEngineReplacesNothingWhenTheLiveReadFails(t *testing.T) {
+	engine, backend, tip, _ := newEngine(t)
+	require.NoError(t, engine.Start(context.Background(), testSidechain, "", 20_000, false))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+
+	backend.mu.Lock()
+	backend.others = []*bmmpb.Bid{{Txid: "txid-1", PrevMainHash: "block-1"}}
+	backend.minedErr = errors.New("esplora is down")
+	backend.mu.Unlock()
+
+	tip.set("block-2")
+	engine.tick(ctx)
+
+	assert.Equal(t, 2, backend.bids)
+	assert.Empty(t, backend.lastReplace)
+	round := engine.Current(testSidechain)
+	require.NotNil(t, round)
+	assert.Equal(t, ResultOpen, round.Result)
+	require.NotEmpty(t, round.OurBids)
+	assert.Equal(t, BidLive, round.OurBids[len(round.OurBids)-1].State)
+
+	backend.mu.Lock()
+	backend.minedErr = nil
+	backend.mu.Unlock()
+
+	tip.set("block-3")
+	engine.tick(ctx)
+
+	assert.Equal(t, "txid-1", backend.lastReplace, "the next pass reads again and replaces the stranded bid")
 }
 
 // A won block the chain left far behind can never connect, because its header

--- a/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
+++ b/sidechain-orchestrator/gen/bmm/v1/bmm.pb.go
@@ -1191,6 +1191,8 @@ type ConnectBidResponse struct {
 	Connected bool `protobuf:"varint,1,opt,name=connected,proto3" json:"connected,omitempty"`
 	// Mainchain block that included the bid, when connected.
 	MainBlockHash string `protobuf:"bytes,2,opt,name=main_block_hash,json=mainBlockHash,proto3" json:"main_block_hash,omitempty"`
+	// The sidechain's chain already holds the block, from a peer or an earlier call.
+	Held          bool `protobuf:"varint,3,opt,name=held,proto3" json:"held,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1237,6 +1239,13 @@ func (x *ConnectBidResponse) GetMainBlockHash() string {
 		return x.MainBlockHash
 	}
 	return ""
+}
+
+func (x *ConnectBidResponse) GetHeld() bool {
+	if x != nil {
+		return x.Held
+	}
+	return false
 }
 
 type ListBidsRequest struct {
@@ -1646,10 +1655,11 @@ const file_bmm_v1_bmm_proto_rawDesc = "" +
 	"\rcritical_hash\x18\x02 \x01(\tR\fcriticalHash\x12\x1d\n" +
 	"\n" +
 	"block_json\x18\x03 \x01(\tR\tblockJson\x12&\n" +
-	"\x0fmain_block_hash\x18\x04 \x01(\tR\rmainBlockHash\"Z\n" +
+	"\x0fmain_block_hash\x18\x04 \x01(\tR\rmainBlockHash\"n\n" +
 	"\x12ConnectBidResponse\x12\x1c\n" +
 	"\tconnected\x18\x01 \x01(\bR\tconnected\x12&\n" +
-	"\x0fmain_block_hash\x18\x02 \x01(\tR\rmainBlockHash\"r\n" +
+	"\x0fmain_block_hash\x18\x02 \x01(\tR\rmainBlockHash\x12\x12\n" +
+	"\x04held\x18\x03 \x01(\bR\x04held\"r\n" +
 	"\x0fListBidsRequest\x129\n" +
 	"\tsidechain\x18\x01 \x01(\x0e2\x1b.orchestrator.v1.BinaryTypeR\tsidechain\x12$\n" +
 	"\x0eprev_main_hash\x18\x02 \x01(\tR\fprevMainHash\"3\n" +

--- a/sidechain-orchestrator/proto/bmm/v1/bmm.proto
+++ b/sidechain-orchestrator/proto/bmm/v1/bmm.proto
@@ -222,6 +222,8 @@ message ConnectBidResponse {
   bool connected = 1;
   // Mainchain block that included the bid, when connected.
   string main_block_hash = 2;
+  // The sidechain's chain already holds the block, from a peer or an earlier call.
+  bool held = 3;
 }
 
 message ListBidsRequest {

--- a/sidechain-orchestrator/sidechain/bbc/client.go
+++ b/sidechain-orchestrator/sidechain/bbc/client.go
@@ -5,8 +5,10 @@ package bbc
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/corenode"
@@ -73,6 +75,39 @@ func (c *Client) ConnectBlock(ctx context.Context, block json.RawMessage, mainBl
 // GetBmmInclusions returns the mainchain blocks that carry a critical hash.
 func (c *Client) GetBmmInclusions(ctx context.Context, criticalHash string) ([]string, error) {
 	return corenode.Decode[[]string](ctx, c.Client, "get_bmm_inclusions", []any{criticalHash})
+}
+
+// ChainHolds reports whether a critical hash names one of the depth blocks
+// nearest the tip.
+func (c *Client) ChainHolds(ctx context.Context, criticalHash string, depth int) (bool, error) {
+	raw, err := hex.DecodeString(criticalHash)
+	if err != nil {
+		return false, fmt.Errorf("decode critical hash: %w", err)
+	}
+	// critical_hash is in internal byte order, and Core names a block in display order.
+	slices.Reverse(raw)
+	want := hex.EncodeToString(raw)
+
+	next, err := corenode.Decode[string](ctx, c.Client, "getbestblockhash", nil)
+	if err != nil {
+		return false, err
+	}
+	for range depth {
+		if next == want {
+			return true, nil
+		}
+		header, err := corenode.Decode[struct {
+			PreviousBlockHash string `json:"previousblockhash"`
+		}](ctx, c.Client, "getblockheader", []any{next})
+		if err != nil {
+			return false, err
+		}
+		if header.PreviousBlockHash == "" {
+			return false, nil
+		}
+		next = header.PreviousBlockHash
+	}
+	return false, nil
 }
 
 // GetBmmCommitment returns the sidechain block hash committed to by a mainchain

--- a/sidechain-orchestrator/sidechain/bbc/client_test.go
+++ b/sidechain-orchestrator/sidechain/bbc/client_test.go
@@ -85,6 +85,35 @@ func TestBlockTemplateCarriesTheCriticalHash(t *testing.T) {
 	assert.Equal(t, int64(4200), template.FeesSats)
 }
 
+const (
+	internalHash = "01" + "0000000000000000000000000000000000000000000000000000000000" + "ff"
+	displayHash  = "ff" + "0000000000000000000000000000000000000000000000000000000000" + "01"
+)
+
+// critical_hash is in internal byte order, and Core names its tip in display order.
+func TestChainHoldsReversesTheCriticalHash(t *testing.T) {
+	srv := fakeNode(t, map[string]json.RawMessage{
+		"getbestblockhash": json.RawMessage(`"` + displayHash + `"`),
+	})
+	defer srv.Close()
+
+	held, err := clientFor(t, srv).ChainHolds(context.Background(), internalHash, 11)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+func TestChainHoldsMissesABlockOffTheChain(t *testing.T) {
+	srv := fakeNode(t, map[string]json.RawMessage{
+		"getbestblockhash": json.RawMessage(`"` + internalHash + `"`),
+		"getblockheader":   json.RawMessage(`{"previousblockhash":""}`),
+	})
+	defer srv.Close()
+
+	held, err := clientFor(t, srv).ChainHolds(context.Background(), internalHash, 11)
+	require.NoError(t, err)
+	assert.False(t, held, "an unreversed hash names no block")
+}
+
 // The BMM engine drives Bbc blocks, but Bbc settles withdrawals elsewhere. The
 // explorer reads that from the type rather than from a stub error.
 func TestBbcDrivesBmmButProposesNoBundle(t *testing.T) {

--- a/sidechain-orchestrator/sidechain/bitassets/testdata/openapi_schema.json
+++ b/sidechain-orchestrator/sidechain/bitassets/testdata/openapi_schema.json
@@ -1189,6 +1189,53 @@
         }
       }
     },
+    "get_stxos": {
+      "post": {
+        "description": "Get stxos for addresses",
+        "operationId": "get_stxos",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "description": "A spent output, and the outpoint that created it",
+                    "required": [
+                      "outpoint",
+                      "output"
+                    ],
+                    "properties": {
+                      "outpoint": {
+                        "$ref": "#/components/schemas/OutPoint"
+                      },
+                      "output": {
+                        "$ref": "#/components/schemas/SpentOutput"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "get_transaction": {
       "post": {
         "description": "Get transaction by txid",
@@ -1400,6 +1447,186 @@
         }
       }
     },
+    "get_utxos": {
+      "post": {
+        "description": "Get utxos for addresses",
+        "operationId": "get_utxos",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "outpoint",
+                      "output"
+                    ],
+                    "properties": {
+                      "outpoint": {
+                        "$ref": "#/components/schemas/OutPoint"
+                      },
+                      "output": {
+                        "type": "object",
+                        "required": [
+                          "address",
+                          "content",
+                          "memo"
+                        ],
+                        "properties": {
+                          "address": {
+                            "$ref": "#/components/schemas/Address"
+                          },
+                          "content": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "AmmLpToken"
+                                ],
+                                "properties": {
+                                  "AmmLpToken": {
+                                    "type": "object",
+                                    "required": [
+                                      "asset0",
+                                      "asset1",
+                                      "amount"
+                                    ],
+                                    "properties": {
+                                      "amount": {
+                                        "type": "integer",
+                                        "format": "u-int64",
+                                        "minimum": 0
+                                      },
+                                      "asset0": {
+                                        "$ref": "#/components/schemas/AssetId"
+                                      },
+                                      "asset1": {
+                                        "$ref": "#/components/schemas/AssetId"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "required": [
+                                  "BitcoinSats"
+                                ],
+                                "properties": {
+                                  "BitcoinSats": {
+                                    "$ref": "#/components/schemas/BitcoinContent"
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "required": [
+                                  "BitcoinWithdrawal"
+                                ],
+                                "properties": {
+                                  "BitcoinWithdrawal": {
+                                    "$ref": "#/components/schemas/WithdrawalOutputContent"
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "description": "BitAsset ID and coin value",
+                                "required": [
+                                  "BitAsset"
+                                ],
+                                "properties": {
+                                  "BitAsset": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    },
+                                    "description": "BitAsset ID and coin value",
+                                    "maxItems": 2,
+                                    "minItems": 2
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "required": [
+                                  "BitAssetControl"
+                                ],
+                                "properties": {
+                                  "BitAssetControl": {
+                                    "$ref": "#/components/schemas/BitAssetId"
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "description": "Reservation txid and commitment",
+                                "required": [
+                                  "BitAssetReservation"
+                                ],
+                                "properties": {
+                                  "BitAssetReservation": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    },
+                                    "description": "Reservation txid and commitment",
+                                    "maxItems": 2,
+                                    "minItems": 2
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "description": "Auction ID",
+                                "required": [
+                                  "DutchAuctionReceipt"
+                                ],
+                                "properties": {
+                                  "DutchAuctionReceipt": {
+                                    "$ref": "#/components/schemas/DutchAuctionId",
+                                    "description": "Auction ID"
+                                  }
+                                }
+                              }
+                            ],
+                            "description": "Representation of Output Content that includes asset type and/or\nreservation commitment"
+                          },
+                          "memo": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "format": "u-int8",
+                              "minimum": 0
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "get_wallet_addresses": {
       "post": {
         "description": "Get wallet addresses, sorted by base58 encoding",
@@ -1601,6 +1828,33 @@
                   "type": "integer",
                   "format": "u-int32",
                   "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "invalidate_block": {
+      "post": {
+        "description": "Invalidate a block and its descendants. If the tip descends from the\nblock, re-org to the parent of the block.",
+        "operationId": "invalidate_block",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
                 }
               }
             }
@@ -1873,6 +2127,52 @@
                           }
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mainchain_sync_progress": {
+      "post": {
+        "description": "Get the progress of the startup sync with the mainchain",
+        "operationId": "mainchain_sync_progress",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Progress of the startup sync with the mainchain",
+                  "required": [
+                    "phase",
+                    "done",
+                    "total",
+                    "tip_height"
+                  ],
+                  "properties": {
+                    "done": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    },
+                    "phase": {
+                      "$ref": "#/components/schemas/MainchainSyncPhase"
+                    },
+                    "tip_height": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "description": "Height of the mainchain tip that the sync moves to",
+                      "minimum": 0
+                    },
+                    "total": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
                     }
                   }
                 }
@@ -2633,11 +2933,227 @@
         }
       }
     },
+    "sign_transaction": {
+      "post": {
+        "description": "Sign a transaction, and optionally broadcast it.",
+        "operationId": "sign_transaction",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "broadcast": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "transaction": {
+                    "type": "object",
+                    "required": [
+                      "inputs",
+                      "outputs",
+                      "memo"
+                    ],
+                    "properties": {
+                      "data": {
+                        "oneOf": [
+                          {
+                            "type": "null"
+                          },
+                          {
+                            "$ref": "#/components/schemas/TxData"
+                          }
+                        ]
+                      },
+                      "inputs": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": [
+                                "Regular"
+                              ],
+                              "properties": {
+                                "Regular": {
+                                  "type": "object",
+                                  "required": [
+                                    "txid",
+                                    "vout"
+                                  ],
+                                  "properties": {
+                                    "txid": {
+                                      "$ref": "#/components/schemas/Txid"
+                                    },
+                                    "vout": {
+                                      "type": "integer",
+                                      "format": "u-int32",
+                                      "minimum": 0
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "required": [
+                                "Coinbase"
+                              ],
+                              "properties": {
+                                "Coinbase": {
+                                  "type": "object",
+                                  "required": [
+                                    "merkle_root",
+                                    "vout"
+                                  ],
+                                  "properties": {
+                                    "merkle_root": {
+                                      "$ref": "#/components/schemas/MerkleRoot"
+                                    },
+                                    "vout": {
+                                      "type": "integer",
+                                      "format": "u-int32",
+                                      "minimum": 0
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "required": [
+                                "Deposit"
+                              ],
+                              "properties": {
+                                "Deposit": {
+                                  "$ref": "#/components/schemas/bitcoin.OutPoint"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "memo": {
+                        "type": "string"
+                      },
+                      "outputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "address",
+                            "content",
+                            "memo"
+                          ],
+                          "properties": {
+                            "address": {
+                              "$ref": "#/components/schemas/Address"
+                            },
+                            "content": {
+                              "$ref": "#/components/schemas/OutputContent"
+                            },
+                            "memo": {
+                              "type": "array",
+                              "items": {
+                                "type": "integer",
+                                "format": "u-int8",
+                                "minimum": 0
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "transaction",
+                    "authorizations"
+                  ],
+                  "properties": {
+                    "authorizations": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Authorization"
+                      },
+                      "description": "Authorizations are called witnesses in Bitcoin."
+                    },
+                    "transaction": {
+                      "$ref": "#/components/schemas/Transaction"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "stop": {
       "post": {
         "description": "Stop the node",
         "operationId": "stop",
         "responses": {}
+      }
+    },
+    "submit_transaction": {
+      "post": {
+        "description": "Verify and broadcast a transaction",
+        "operationId": "submit_transaction",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "transaction",
+                  "authorizations"
+                ],
+                "properties": {
+                  "authorizations": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Authorization"
+                    },
+                    "description": "Authorizations are called witnesses in Bitcoin."
+                  },
+                  "transaction": {
+                    "$ref": "#/components/schemas/Transaction"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "transfer": {
@@ -2727,6 +3243,52 @@
                         "type": "string"
                       }
                     ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "transfer_many": {
+      "post": {
+        "description": "Transfer funds to each address in `dests`, which maps an address to a\nvalue in sats",
+        "operationId": "transfer_many",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dests": {
+                    "type": "object",
+                    "description": "Destinations of a transfer. Each address takes a value in sats.\nA repeated address is an error.",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "format": "u-int64",
+                      "minimum": 0
+                    },
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "fee_sats": {
+                    "type": "integer",
+                    "format": "u-int64",
+                    "minimum": 0
                   }
                 }
               }
@@ -3378,8 +3940,69 @@
           }
         }
       },
+      "InPoint": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Transaction input",
+            "required": [
+              "Regular"
+            ],
+            "properties": {
+              "Regular": {
+                "type": "object",
+                "description": "Transaction input",
+                "required": [
+                  "txid",
+                  "vin"
+                ],
+                "properties": {
+                  "txid": {
+                    "$ref": "#/components/schemas/Txid"
+                  },
+                  "vin": {
+                    "type": "integer",
+                    "format": "u-int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Withdrawal"
+            ],
+            "properties": {
+              "Withdrawal": {
+                "type": "object",
+                "required": [
+                  "m6id"
+                ],
+                "properties": {
+                  "m6id": {
+                    "$ref": "#/components/schemas/M6id"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "description": "Reference to a tx input."
+      },
       "M6id": {
         "type": "string"
+      },
+      "MainchainSyncPhase": {
+        "type": "string",
+        "description": "Step of the startup sync with the mainchain",
+        "enum": [
+          "idle",
+          "headers",
+          "writing",
+          "state"
+        ]
       },
       "MerkleRoot": {
         "type": "string"
@@ -3553,6 +4176,156 @@
       },
       "Signature": {
         "type": "string"
+      },
+      "SpentOutput": {
+        "type": "object",
+        "description": "Representation of a spent output",
+        "required": [
+          "output",
+          "inpoint"
+        ],
+        "properties": {
+          "inpoint": {
+            "$ref": "#/components/schemas/InPoint"
+          },
+          "output": {
+            "type": "object",
+            "required": [
+              "address",
+              "content",
+              "memo"
+            ],
+            "properties": {
+              "address": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "content": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "AmmLpToken"
+                    ],
+                    "properties": {
+                      "AmmLpToken": {
+                        "type": "object",
+                        "required": [
+                          "asset0",
+                          "asset1",
+                          "amount"
+                        ],
+                        "properties": {
+                          "amount": {
+                            "type": "integer",
+                            "format": "u-int64",
+                            "minimum": 0
+                          },
+                          "asset0": {
+                            "$ref": "#/components/schemas/AssetId"
+                          },
+                          "asset1": {
+                            "$ref": "#/components/schemas/AssetId"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "BitcoinSats"
+                    ],
+                    "properties": {
+                      "BitcoinSats": {
+                        "$ref": "#/components/schemas/BitcoinContent"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "BitcoinWithdrawal"
+                    ],
+                    "properties": {
+                      "BitcoinWithdrawal": {
+                        "$ref": "#/components/schemas/WithdrawalOutputContent"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "description": "BitAsset ID and coin value",
+                    "required": [
+                      "BitAsset"
+                    ],
+                    "properties": {
+                      "BitAsset": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "description": "BitAsset ID and coin value",
+                        "maxItems": 2,
+                        "minItems": 2
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "BitAssetControl"
+                    ],
+                    "properties": {
+                      "BitAssetControl": {
+                        "$ref": "#/components/schemas/BitAssetId"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "description": "Reservation txid and commitment",
+                    "required": [
+                      "BitAssetReservation"
+                    ],
+                    "properties": {
+                      "BitAssetReservation": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "description": "Reservation txid and commitment",
+                        "maxItems": 2,
+                        "minItems": 2
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "description": "Auction ID",
+                    "required": [
+                      "DutchAuctionReceipt"
+                    ],
+                    "properties": {
+                      "DutchAuctionReceipt": {
+                        "$ref": "#/components/schemas/DutchAuctionId",
+                        "description": "Auction ID"
+                      }
+                    }
+                  }
+                ],
+                "description": "Representation of Output Content that includes asset type and/or\nreservation commitment"
+              },
+              "memo": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "u-int8",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
       },
       "Transaction": {
         "type": "object",

--- a/sidechain-orchestrator/sidechain/bitnames/testdata/openapi_schema.json
+++ b/sidechain-orchestrator/sidechain/bitnames/testdata/openapi_schema.json
@@ -1344,6 +1344,33 @@
         }
       }
     },
+    "invalidate_block": {
+      "post": {
+        "description": "Invalidate a block, potentially re-orging to a valid ancestor of\nthe current tip.",
+        "operationId": "invalidate_block",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "latest_failed_withdrawal_bundle_height": {
       "post": {
         "description": "Get the height of the latest failed withdrawal bundle",
@@ -1509,6 +1536,52 @@
                       "output": {
                         "$ref": "#/components/schemas/FilledOutputContent"
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mainchain_sync_progress": {
+      "post": {
+        "description": "Get the progress of the startup sync with the mainchain",
+        "operationId": "mainchain_sync_progress",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Progress of the startup sync with the mainchain",
+                  "required": [
+                    "phase",
+                    "done",
+                    "total",
+                    "tip_height"
+                  ],
+                  "properties": {
+                    "done": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    },
+                    "phase": {
+                      "$ref": "#/components/schemas/MainchainSyncPhase"
+                    },
+                    "tip_height": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "description": "Height of the mainchain tip that the sync moves to",
+                      "minimum": 0
+                    },
+                    "total": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
                     }
                   }
                 }
@@ -2763,6 +2836,16 @@
       },
       "M6id": {
         "$ref": "#/components/schemas/bitcoin.OutPoint"
+      },
+      "MainchainSyncPhase": {
+        "type": "string",
+        "description": "Step of the startup sync with the mainchain",
+        "enum": [
+          "idle",
+          "headers",
+          "writing",
+          "state"
+        ]
       },
       "MerkleRoot": {
         "type": "string"

--- a/sidechain-orchestrator/sidechain/coinshift/testdata/openapi_schema.json
+++ b/sidechain-orchestrator/sidechain/coinshift/testdata/openapi_schema.json
@@ -969,6 +969,33 @@
         }
       }
     },
+    "invalidate_block": {
+      "post": {
+        "description": "Invalidate a block, potentially re-orging to a valid ancestor of the\ncurrent tip.",
+        "operationId": "invalidate_block",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "latest_failed_withdrawal_bundle_height": {
       "post": {
         "description": "Get the height of the latest failed withdrawal bundle",
@@ -1402,6 +1429,52 @@
         }
       }
     },
+    "mainchain_sync_progress": {
+      "post": {
+        "description": "Get the progress of the startup sync with the mainchain",
+        "operationId": "mainchain_sync_progress",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Progress of the startup sync with the mainchain",
+                  "required": [
+                    "phase",
+                    "done",
+                    "total",
+                    "tip_height"
+                  ],
+                  "properties": {
+                    "done": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    },
+                    "phase": {
+                      "$ref": "#/components/schemas/MainchainSyncPhase"
+                    },
+                    "tip_height": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "description": "Height of the mainchain tip that the sync moves to",
+                      "minimum": 0
+                    },
+                    "total": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "mine": {
       "post": {
         "description": "Attempt to mine a sidechain block",
@@ -1722,6 +1795,52 @@
         }
       }
     },
+    "transfer_many": {
+      "post": {
+        "description": "Transfer funds to each address in `dests`, which maps an address to a\nvalue in sats",
+        "operationId": "transfer_many",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dests": {
+                    "type": "object",
+                    "description": "Destinations of a transfer. Each address takes a value in sats.\nA repeated address is an error.",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "format": "u-int64",
+                      "minimum": 0
+                    },
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "fee_sats": {
+                    "type": "integer",
+                    "format": "u-int64",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "update_swap_l1_txid": {
       "post": {
         "description": "Update swap L1 transaction ID (called when L1 transaction is detected).\nFor open swaps, pass l2_claimer_address so the claim is only valid for that address.",
@@ -1889,6 +2008,16 @@
       },
       "M6id": {
         "type": "string"
+      },
+      "MainchainSyncPhase": {
+        "type": "string",
+        "description": "Step of the startup sync with the mainchain",
+        "enum": [
+          "idle",
+          "headers",
+          "writing",
+          "state"
+        ]
       },
       "MerkleRoot": {
         "type": "string"
@@ -2345,6 +2474,18 @@
             "$ref": "#/components/schemas/utreexo.Proof",
             "description": "Utreexo proof for inputs"
           }
+        }
+      },
+      "TransferDests": {
+        "type": "object",
+        "description": "Destinations of a transfer. Each address takes a value in sats.\nA repeated address is an error.",
+        "additionalProperties": {
+          "type": "integer",
+          "format": "u-int64",
+          "minimum": 0
+        },
+        "propertyNames": {
+          "type": "string"
         }
       },
       "TxData": {

--- a/sidechain-orchestrator/sidechain/jsonrpc_proxy.go
+++ b/sidechain-orchestrator/sidechain/jsonrpc_proxy.go
@@ -131,6 +131,36 @@ func (p *JSONRPCProxy) GetBmmInclusions(ctx context.Context, criticalHash string
 	return inclusions, nil
 }
 
+func (p *JSONRPCProxy) ChainHolds(ctx context.Context, criticalHash string, depth int) (bool, error) {
+	var next *string
+	if err := p.Client.Call(ctx, "get_best_sidechain_block_hash", nil, &next); err != nil {
+		return false, err
+	}
+	for range depth {
+		if next == nil {
+			return false, nil
+		}
+		if *next == criticalHash {
+			return true, nil
+		}
+		// Thunder and photon nest the header. The other chains flatten it.
+		var block struct {
+			Header struct {
+				PrevSideHash *string `json:"prev_side_hash"`
+			} `json:"header"`
+			PrevSideHash *string `json:"prev_side_hash"`
+		}
+		if err := p.Client.Call(ctx, "get_block", []string{*next}, &block); err != nil {
+			return false, err
+		}
+		next = block.Header.PrevSideHash
+		if next == nil {
+			next = block.PrevSideHash
+		}
+	}
+	return false, nil
+}
+
 func (p *JSONRPCProxy) GetPendingWithdrawalBundle(ctx context.Context) (json.RawMessage, error) {
 	return p.Client.CallRaw(ctx, "pending_withdrawal_bundle", nil)
 }

--- a/sidechain-orchestrator/sidechain/jsonrpc_proxy_test.go
+++ b/sidechain-orchestrator/sidechain/jsonrpc_proxy_test.go
@@ -1,0 +1,95 @@
+package sidechain
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chainServer answers a tip and the blocks under it. A nil blocks map fails
+// every get_block.
+func chainServer(t *testing.T, tip string, blocks map[string]string) *JSONRPCProxy {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string   `json:"method"`
+			Params []string `json:"params"`
+		}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("Content-Type", "application/json")
+		result := tip
+		if req.Method == "get_block" {
+			if blocks == nil {
+				_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"archive read failed"}}`))
+				assert.NoError(t, err)
+				return
+			}
+			result = blocks[req.Params[0]]
+		}
+		_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":` + result + `}`))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	host, portText, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	return NewJSONRPCProxy(host, port)
+}
+
+var nestedChain = map[string]string{
+	"d": `{"header":{"prev_side_hash":"c"},"body":{}}`,
+	"c": `{"header":{"prev_side_hash":"b"},"body":{}}`,
+	"b": `{"header":{"prev_side_hash":"a"},"body":{}}`,
+	"a": `{"header":{"prev_side_hash":null},"body":{}}`,
+}
+
+var flatChain = map[string]string{
+	"d": `{"prev_side_hash":"c","height":3}`,
+	"c": `{"prev_side_hash":"b","height":2}`,
+	"b": `{"prev_side_hash":"a","height":1}`,
+	"a": `{"prev_side_hash":null,"height":0}`,
+}
+
+func TestChainHoldsTheTip(t *testing.T) {
+	held, err := chainServer(t, `"d"`, nestedChain).ChainHolds(context.Background(), "d", 11)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+func TestChainHoldsABlockUnderANestedHeader(t *testing.T) {
+	held, err := chainServer(t, `"d"`, nestedChain).ChainHolds(context.Background(), "a", 11)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+func TestChainHoldsABlockUnderAFlatHeader(t *testing.T) {
+	held, err := chainServer(t, `"d"`, flatChain).ChainHolds(context.Background(), "a", 11)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+func TestChainHoldsStopsAtTheDepth(t *testing.T) {
+	held, err := chainServer(t, `"d"`, nestedChain).ChainHolds(context.Background(), "a", 3)
+	require.NoError(t, err)
+	assert.False(t, held, "a is 3 blocks under the tip, so a walk of 3 blocks misses it")
+}
+
+func TestChainHoldsNothingOnAnEmptyChain(t *testing.T) {
+	held, err := chainServer(t, `null`, nestedChain).ChainHolds(context.Background(), "a", 11)
+	require.NoError(t, err)
+	assert.False(t, held)
+}
+
+func TestChainHoldsReportsABlockReadFault(t *testing.T) {
+	_, err := chainServer(t, `"d"`, nil).ChainHolds(context.Background(), "a", 11)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "archive read failed")
+}

--- a/sidechain-orchestrator/sidechain/photon/testdata/openapi_schema.json
+++ b/sidechain-orchestrator/sidechain/photon/testdata/openapi_schema.json
@@ -41,7 +41,7 @@
     },
     "connect_block": {
       "post": {
-        "description": "Connect a block for which a BMM request was included in the specified\nmainchain block. Returns `true` if it was accepted as the new tip.",
+        "description": "Connect a block for which a BMM request was included in the\nspecified mainchain block. Returns `true` if it was accepted as the\nnew tip.",
         "operationId": "connect_block",
         "requestBody": {
           "content": {
@@ -853,6 +853,33 @@
         }
       }
     },
+    "invalidate_block": {
+      "post": {
+        "description": "Invalidate a block, potentially re-orging to a valid ancestor of\nthe current tip.",
+        "operationId": "invalidate_block",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "latest_failed_withdrawal_bundle_height": {
       "post": {
         "description": "Get the height of the latest failed withdrawal bundle",
@@ -985,6 +1012,52 @@
                       "output": {
                         "$ref": "#/components/schemas/Output"
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mainchain_sync_progress": {
+      "post": {
+        "description": "Get the progress of the startup sync with the mainchain",
+        "operationId": "mainchain_sync_progress",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Progress of the startup sync with the mainchain",
+                  "required": [
+                    "phase",
+                    "done",
+                    "total",
+                    "tip_height"
+                  ],
+                  "properties": {
+                    "done": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    },
+                    "phase": {
+                      "$ref": "#/components/schemas/MainchainSyncPhase"
+                    },
+                    "tip_height": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "description": "Height of the mainchain tip that the sync moves to",
+                      "minimum": 0
+                    },
+                    "total": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
                     }
                   }
                 }

--- a/sidechain-orchestrator/sidechain/proxy.go
+++ b/sidechain-orchestrator/sidechain/proxy.go
@@ -51,6 +51,10 @@ type BMMNode interface {
 
 	// GetBmmInclusions returns the mainchain blocks that carry a critical hash.
 	GetBmmInclusions(ctx context.Context, criticalHash string) ([]string, error)
+
+	// ChainHolds reports whether a critical hash names one of the depth blocks
+	// nearest the tip.
+	ChainHolds(ctx context.Context, criticalHash string, depth int) (bool, error)
 }
 
 // WithdrawalNode is a sidechain that proposes withdrawal bundles. A chain that

--- a/sidechain-orchestrator/sidechain/thunder/testdata/openapi_schema.json
+++ b/sidechain-orchestrator/sidechain/thunder/testdata/openapi_schema.json
@@ -420,7 +420,22 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                  "block_hash": {
+                    "type": "string"
+                  },
+                  "verbose": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  }
+                }
               }
             }
           }
@@ -436,19 +451,14 @@
                       "type": "null"
                     },
                     {
-                      "type": "object",
-                      "required": [
-                        "header",
-                        "body"
-                      ],
-                      "properties": {
-                        "body": {
-                          "$ref": "#/components/schemas/Body"
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/Block"
                         },
-                        "header": {
-                          "$ref": "#/components/schemas/Header"
+                        {
+                          "$ref": "#/components/schemas/BlockVerbose"
                         }
-                      }
+                      ]
                     }
                   ]
                 }
@@ -460,7 +470,7 @@
     },
     "get_block_hash": {
       "post": {
-        "description": "Get the block hash at the specified height in the current chain,\nif it exists",
+        "description": "Get the block hash at the specified height in the active chain,\nif it exists",
         "operationId": "get_block_hash",
         "requestBody": {
           "content": {
@@ -833,6 +843,52 @@
         }
       }
     },
+    "get_withdrawal_bundle": {
+      "post": {
+        "description": "Get withdrawal bundle by M6id",
+        "operationId": "get_withdrawal_bundle",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "info",
+                        "status"
+                      ],
+                      "properties": {
+                        "info": {
+                          "$ref": "#/components/schemas/WithdrawalBundleInfo"
+                        },
+                        "status": {
+                          "$ref": "#/components/schemas/WithdrawalBundleStatus"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "getblockcount": {
       "post": {
         "description": "Get the current block count",
@@ -1021,6 +1077,52 @@
         }
       }
     },
+    "mainchain_sync_progress": {
+      "post": {
+        "description": "Get the progress of the startup sync with the mainchain",
+        "operationId": "mainchain_sync_progress",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Progress of the startup sync with the mainchain",
+                  "required": [
+                    "phase",
+                    "done",
+                    "total",
+                    "tip_height"
+                  ],
+                  "properties": {
+                    "done": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    },
+                    "phase": {
+                      "$ref": "#/components/schemas/MainchainSyncPhase"
+                    },
+                    "tip_height": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "description": "Height of the mainchain tip that the sync moves to",
+                      "minimum": 0
+                    },
+                    "total": {
+                      "type": "integer",
+                      "format": "u-int32",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "mine": {
       "post": {
         "description": "Attempt to mine a sidechain block",
@@ -1178,7 +1280,7 @@
                                     "$ref": "#/components/schemas/Address"
                                   },
                                   "content": {
-                                    "$ref": "OutputContent"
+                                    "$ref": "#/components/schemas/OutputContent"
                                   }
                                 }
                               }
@@ -1480,6 +1582,263 @@
       "Address": {
         "type": "string"
       },
+      "Authorization": {
+        "type": "object",
+        "required": [
+          "verifying_key",
+          "signature"
+        ],
+        "properties": {
+          "signature": {
+            "type": "string"
+          },
+          "verifying_key": {
+            "type": "string"
+          }
+        }
+      },
+      "Block": {
+        "type": "object",
+        "required": [
+          "header",
+          "body"
+        ],
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/Body"
+          },
+          "header": {
+            "$ref": "#/components/schemas/Header"
+          }
+        }
+      },
+      "BlockHash": {
+        "type": "string"
+      },
+      "BlockIndexDeposit": {
+        "type": "object",
+        "description": "One output a mainchain deposit created",
+        "required": [
+          "outpoint",
+          "output"
+        ],
+        "properties": {
+          "outpoint": {
+            "$ref": "#/components/schemas/OutPoint"
+          },
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          }
+        }
+      },
+      "BlockIndexSpend": {
+        "type": "object",
+        "description": "One output a withdrawal bundle removed, with the bundle that took it",
+        "required": [
+          "outpoint",
+          "m6id"
+        ],
+        "properties": {
+          "m6id": {
+            "$ref": "#/components/schemas/M6id"
+          },
+          "outpoint": {
+            "$ref": "#/components/schemas/OutPoint"
+          }
+        }
+      },
+      "BlockIndexTx": {
+        "type": "object",
+        "description": "One transaction of a block, with the fields its body omits",
+        "required": [
+          "txid",
+          "size",
+          "raw"
+        ],
+        "properties": {
+          "raw": {
+            "type": "string",
+            "description": "Borsh encoding, as hex"
+          },
+          "size": {
+            "type": "integer",
+            "format": "u-int64",
+            "description": "Canonical size in bytes",
+            "minimum": 0
+          },
+          "txid": {
+            "$ref": "#/components/schemas/Txid"
+          }
+        }
+      },
+      "BlockVerbose": {
+        "type": "object",
+        "required": [
+          "header",
+          "body"
+        ],
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/BodyVerbose"
+          },
+          "header": {
+            "$ref": "#/components/schemas/Header"
+          }
+        }
+      },
+      "Body": {
+        "type": "object",
+        "required": [
+          "coinbase",
+          "transactions",
+          "authorizations"
+        ],
+        "properties": {
+          "authorizations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Authorization"
+            }
+          },
+          "coinbase": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            }
+          },
+          "transactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            }
+          }
+        }
+      },
+      "BodyVerbose": {
+        "type": "object",
+        "required": [
+          "coinbase",
+          "transactions",
+          "authorizations"
+        ],
+        "properties": {
+          "authorizations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Authorization"
+            }
+          },
+          "coinbase": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            }
+          },
+          "transactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionVerbose"
+            }
+          }
+        }
+      },
+      "Header": {
+        "type": "object",
+        "required": [
+          "merkle_root",
+          "prev_main_hash",
+          "roots"
+        ],
+        "properties": {
+          "merkle_root": {
+            "$ref": "#/components/schemas/MerkleRoot"
+          },
+          "prev_main_hash": {
+            "$ref": "#/components/schemas/bitcoin.BlockHash"
+          },
+          "prev_side_hash": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BlockHash"
+              }
+            ]
+          },
+          "roots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/utreexo.NodeHash"
+            },
+            "description": "Utreexo roots"
+          }
+        }
+      },
+      "InPoint": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Transaction input",
+            "required": [
+              "Regular"
+            ],
+            "properties": {
+              "Regular": {
+                "type": "object",
+                "description": "Transaction input",
+                "required": [
+                  "txid",
+                  "vin"
+                ],
+                "properties": {
+                  "txid": {
+                    "$ref": "#/components/schemas/Txid"
+                  },
+                  "vin": {
+                    "type": "integer",
+                    "format": "u-int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Withdrawal"
+            ],
+            "properties": {
+              "Withdrawal": {
+                "type": "object",
+                "required": [
+                  "m6id"
+                ],
+                "properties": {
+                  "m6id": {
+                    "$ref": "#/components/schemas/M6id"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "description": "Reference to a tx input."
+      },
+      "M6id": {
+        "type": "string"
+      },
+      "MainchainSyncPhase": {
+        "type": "string",
+        "description": "Step of the startup sync with the mainchain",
+        "enum": [
+          "idle",
+          "headers",
+          "writing",
+          "state"
+        ]
+      },
       "MerkleRoot": {
         "type": "string"
       },
@@ -1559,7 +1918,7 @@
             "$ref": "#/components/schemas/Address"
           },
           "content": {
-            "$ref": "OutputContent"
+            "$ref": "#/components/schemas/OutputContent"
           }
         }
       },
@@ -1612,17 +1971,398 @@
         ],
         "description": ""
       },
+      "PeerConnectionStatus": {
+        "type": "string",
+        "enum": [
+          "Connecting",
+          "Connected"
+        ]
+      },
+      "SpentOutput": {
+        "type": "object",
+        "description": "Representation of a spent output",
+        "required": [
+          "output",
+          "inpoint"
+        ],
+        "properties": {
+          "inpoint": {
+            "$ref": "#/components/schemas/InPoint"
+          },
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          }
+        }
+      },
+      "Transaction": {
+        "type": "object",
+        "required": [
+          "inputs",
+          "proof",
+          "outputs"
+        ],
+        "properties": {
+          "inputs": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": false,
+              "prefixItems": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "Regular"
+                      ],
+                      "properties": {
+                        "Regular": {
+                          "type": "object",
+                          "required": [
+                            "txid",
+                            "vout"
+                          ],
+                          "properties": {
+                            "txid": {
+                              "$ref": "#/components/schemas/Txid"
+                            },
+                            "vout": {
+                              "type": "integer",
+                              "format": "u-int32",
+                              "minimum": 0
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "Coinbase"
+                      ],
+                      "properties": {
+                        "Coinbase": {
+                          "type": "object",
+                          "required": [
+                            "merkle_root",
+                            "vout"
+                          ],
+                          "properties": {
+                            "merkle_root": {
+                              "$ref": "#/components/schemas/MerkleRoot"
+                            },
+                            "vout": {
+                              "type": "integer",
+                              "format": "u-int32",
+                              "minimum": 0
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "Deposit"
+                      ],
+                      "properties": {
+                        "Deposit": {
+                          "$ref": "#/components/schemas/bitcoin.OutPoint"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            }
+          },
+          "proof": {
+            "$ref": "#/components/schemas/utreexo.Proof",
+            "description": "Utreexo proof for inputs"
+          }
+        }
+      },
+      "TransactionVerbose": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          },
+          {
+            "type": "object",
+            "required": [
+              "canonical_bytes"
+            ],
+            "properties": {
+              "canonical_bytes": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "u-int8",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        ]
+      },
       "Txid": {
         "type": "string"
       },
+      "WithdrawalBundle": {
+        "type": "object",
+        "required": [
+          "spend_utxos",
+          "tx"
+        ],
+        "properties": {
+          "spend_utxos": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": false,
+              "prefixItems": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "Regular"
+                      ],
+                      "properties": {
+                        "Regular": {
+                          "type": "object",
+                          "required": [
+                            "txid",
+                            "vout"
+                          ],
+                          "properties": {
+                            "txid": {
+                              "$ref": "#/components/schemas/Txid"
+                            },
+                            "vout": {
+                              "type": "integer",
+                              "format": "u-int32",
+                              "minimum": 0
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "Coinbase"
+                      ],
+                      "properties": {
+                        "Coinbase": {
+                          "type": "object",
+                          "required": [
+                            "merkle_root",
+                            "vout"
+                          ],
+                          "properties": {
+                            "merkle_root": {
+                              "$ref": "#/components/schemas/MerkleRoot"
+                            },
+                            "vout": {
+                              "type": "integer",
+                              "format": "u-int32",
+                              "minimum": 0
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "Deposit"
+                      ],
+                      "properties": {
+                        "Deposit": {
+                          "$ref": "#/components/schemas/bitcoin.OutPoint"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "address",
+                    "content"
+                  ],
+                  "properties": {
+                    "address": {
+                      "$ref": "#/components/schemas/Address"
+                    },
+                    "content": {
+                      "$ref": "#/components/schemas/OutputContent"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "tx": {
+            "$ref": "#/components/schemas/bitcoin.Transaction"
+          }
+        }
+      },
+      "WithdrawalBundleInfo": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Withdrawal bundle is known",
+            "required": [
+              "Known"
+            ],
+            "properties": {
+              "Known": {
+                "$ref": "#/components/schemas/WithdrawalBundle",
+                "description": "Withdrawal bundle is known"
+              }
+            }
+          },
+          {
+            "type": "string",
+            "description": "Withdrawal bundle is unknown but unconfirmed / failed",
+            "enum": [
+              "Unknown"
+            ]
+          },
+          {
+            "type": "object",
+            "description": "If an unknown withdrawal bundle is confirmed, ALL UTXOs are\nconsidered spent.",
+            "required": [
+              "UnknownConfirmed"
+            ],
+            "properties": {
+              "UnknownConfirmed": {
+                "type": "object",
+                "description": "If an unknown withdrawal bundle is confirmed, ALL UTXOs are\nconsidered spent.",
+                "required": [
+                  "spend_utxos"
+                ],
+                "properties": {
+                  "spend_utxos": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "$ref": "#/components/schemas/Output"
+                    },
+                    "propertyNames": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "Regular"
+                          ],
+                          "properties": {
+                            "Regular": {
+                              "type": "object",
+                              "required": [
+                                "txid",
+                                "vout"
+                              ],
+                              "properties": {
+                                "txid": {
+                                  "$ref": "#/components/schemas/Txid"
+                                },
+                                "vout": {
+                                  "type": "integer",
+                                  "format": "u-int32",
+                                  "minimum": 0
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "Coinbase"
+                          ],
+                          "properties": {
+                            "Coinbase": {
+                              "type": "object",
+                              "required": [
+                                "merkle_root",
+                                "vout"
+                              ],
+                              "properties": {
+                                "merkle_root": {
+                                  "$ref": "#/components/schemas/MerkleRoot"
+                                },
+                                "vout": {
+                                  "type": "integer",
+                                  "format": "u-int32",
+                                  "minimum": 0
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "Deposit"
+                          ],
+                          "properties": {
+                            "Deposit": {
+                              "$ref": "#/components/schemas/bitcoin.OutPoint"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "description": "Information we have regarding a withdrawal bundle"
+      },
+      "WithdrawalBundleStatus": {
+        "type": "string",
+        "enum": [
+          "Confirmed",
+          "Dropped",
+          "Failed",
+          "Pending",
+          "Submitted",
+          "SubmittedUnexpected"
+        ]
+      },
       "bitcoin.Address": {
+        "type": "string"
+      },
+      "bitcoin.BlockHash": {
         "type": "string"
       },
       "bitcoin.OutPoint": {
         "type": "object"
       },
-      "bitcoin.Txid": {
+      "bitcoin.Transaction": {
+        "type": "object"
+      },
+      "net.SocketAddr": {
         "type": "string"
+      },
+      "utreexo.NodeHash": {
+        "type": "string"
+      },
+      "utreexo.Proof": {
+        "type": "object"
       }
     }
   }

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1706,6 +1706,39 @@ func (p *ElectrumBackend) Chain() ChainSource {
 	return esploraChain{client: p.client}
 }
 
+// TxStatus reads the chain status of txid from the history of an address it
+// touches. Electrum reports the status of a lone transaction from a cache that
+// lags a new block.
+func (p *ElectrumBackend) TxStatus(ctx context.Context, txid string) (EsploraStatus, error) {
+	tx, err := p.client.Tx(ctx, txid)
+	if err != nil {
+		return EsploraStatus{}, err
+	}
+	var addresses []string
+	for _, out := range tx.Vout {
+		addresses = append(addresses, out.ScriptPubKeyAddress)
+	}
+	for _, in := range tx.Vin {
+		if in.Prevout != nil {
+			addresses = append(addresses, in.Prevout.ScriptPubKeyAddress)
+		}
+	}
+	address, ok := lo.Find(addresses, func(a string) bool { return a != "" })
+	if !ok {
+		return EsploraStatus{}, fmt.Errorf("transaction %s touches no address", txid)
+	}
+	history, err := p.client.AddressTxs(ctx, address)
+	if err != nil {
+		return EsploraStatus{}, err
+	}
+	for _, h := range history {
+		if h.TxID == txid {
+			return h.Status, nil
+		}
+	}
+	return EsploraStatus{}, fmt.Errorf("the history of %s names no transaction %s", address, txid)
+}
+
 // ServerURL returns the wallet's current primary Esplora endpoint, or "" when
 // the backend's client does not expose one.
 func (p *ElectrumBackend) ServerURL() string {

--- a/sidechain-orchestrator/wallet/electrum_tx_status_test.go
+++ b/sidechain-orchestrator/wallet/electrum_tx_status_test.go
@@ -1,0 +1,34 @@
+package wallet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The lone transaction read carries no block, and the address history does.
+func TestElectrumTxStatusReadsTheAddressHistory(t *testing.T) {
+	fake := newFakeEsplora()
+	fake.txByID["bid"] = EsploraTx{TxID: "bid", Vout: []EsploraVout{{}, {ScriptPubKeyAddress: "change"}}}
+	fake.txs["change"] = []EsploraTx{{TxID: "bid", Status: EsploraStatus{Confirmed: true, BlockHeight: 997083}}}
+	p := NewElectrumBackend(newTestService(t), fake, StaticParams(&chaincfg.SigNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+
+	status, err := p.TxStatus(context.Background(), "bid")
+	require.NoError(t, err)
+	assert.True(t, status.Confirmed)
+	assert.Equal(t, 997083, status.BlockHeight)
+}
+
+// A history that names no such transaction proves nothing, so the read fails.
+func TestElectrumTxStatusFailsWhenTheHistoryOmitsIt(t *testing.T) {
+	fake := newFakeEsplora()
+	fake.txByID["bid"] = EsploraTx{TxID: "bid", Vin: []EsploraVin{{Prevout: &EsploraVout{ScriptPubKeyAddress: "coin"}}}}
+	p := NewElectrumBackend(newTestService(t), fake, StaticParams(&chaincfg.SigNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+
+	_, err := p.TxStatus(context.Background(), "bid")
+	require.Error(t, err)
+}

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -77,6 +77,15 @@ func (e *WalletEngine) electrumBackend() (*ElectrumBackend, error) {
 	return eb, nil
 }
 
+// TxStatus reads the chain status of one transaction from the electrum chain source.
+func (e *WalletEngine) TxStatus(ctx context.Context, txid string) (EsploraStatus, error) {
+	eb, err := e.electrumBackend()
+	if err != nil {
+		return EsploraStatus{}, err
+	}
+	return eb.TxStatus(ctx, txid)
+}
+
 // CreatePSBT builds an unsigned PSBT for a send from an electrum wallet.
 func (e *WalletEngine) CreatePSBT(ctx context.Context, walletID string, req SendRequest) (string, error) {
 	eb, err := e.electrumBackend()

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pb.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pb.dart
@@ -1524,6 +1524,7 @@ class ConnectBidResponse extends $pb.GeneratedMessage {
   factory ConnectBidResponse({
     $core.bool? connected,
     $core.String? mainBlockHash,
+    $core.bool? held,
   }) {
     final $result = create();
     if (connected != null) {
@@ -1531,6 +1532,9 @@ class ConnectBidResponse extends $pb.GeneratedMessage {
     }
     if (mainBlockHash != null) {
       $result.mainBlockHash = mainBlockHash;
+    }
+    if (held != null) {
+      $result.held = held;
     }
     return $result;
   }
@@ -1541,6 +1545,7 @@ class ConnectBidResponse extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectBidResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bmm.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'connected')
     ..aOS(2, _omitFieldNames ? '' : 'mainBlockHash')
+    ..aOB(3, _omitFieldNames ? '' : 'held')
     ..hasRequiredFields = false
   ;
 
@@ -1584,6 +1589,16 @@ class ConnectBidResponse extends $pb.GeneratedMessage {
   $core.bool hasMainBlockHash() => $_has(1);
   @$pb.TagNumber(2)
   void clearMainBlockHash() => clearField(2);
+
+  /// The sidechain's chain already holds the block, from a peer or an earlier call.
+  @$pb.TagNumber(3)
+  $core.bool get held => $_getBF(2);
+  @$pb.TagNumber(3)
+  set held($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasHeld() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearHeld() => clearField(3);
 }
 
 class ListBidsRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/bmm/v1/bmm.pbjson.dart
+++ b/sidechain_core/lib/gen/bmm/v1/bmm.pbjson.dart
@@ -310,13 +310,14 @@ const ConnectBidResponse$json = {
   '2': [
     {'1': 'connected', '3': 1, '4': 1, '5': 8, '10': 'connected'},
     {'1': 'main_block_hash', '3': 2, '4': 1, '5': 9, '10': 'mainBlockHash'},
+    {'1': 'held', '3': 3, '4': 1, '5': 8, '10': 'held'},
   ],
 };
 
 /// Descriptor for `ConnectBidResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List connectBidResponseDescriptor = $convert.base64Decode(
     'ChJDb25uZWN0QmlkUmVzcG9uc2USHAoJY29ubmVjdGVkGAEgASgIUgljb25uZWN0ZWQSJgoPbW'
-    'Fpbl9ibG9ja19oYXNoGAIgASgJUg1tYWluQmxvY2tIYXNo');
+    'Fpbl9ibG9ja19oYXNoGAIgASgJUg1tYWluQmxvY2tIYXNoEhIKBGhlbGQYAyABKAhSBGhlbGQ=');
 
 @$core.Deprecated('Use listBidsRequestDescriptor instead')
 const ListBidsRequest$json = {


### PR DESCRIPTION
This PR records a BMM win as won when the sidechain already has the block, so the bid history stops showing real wins as failed.