### PR TITLE
bitwindow: mark your own change output

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -886,7 +886,7 @@ Future<void> rebootBitwindowBackend(Logger log) async {
   } catch (e) {
     log.w('REBOOT: drivechaind shutdown call failed: $e');
   }
-  await binaryProvider.stop(BitWindow(), expectRestart: true);
+  await binaryProvider.stop(BitWindow());
   await _awaitDrivechaindExit(log);
   await bootBitwindowBackend(log);
 }

--- a/bitwindow/lib/pages/explorer/block_explorer_dialog.dart
+++ b/bitwindow/lib/pages/explorer/block_explorer_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:bitwindow/dialogs/merkle_tree_dialog.dart';
 import 'package:bitwindow/pages/explorer/load_transaction_dialog.dart';
+import 'package:bitwindow/pages/explorer/widgets/output_owner.dart';
 import 'package:bitwindow/pages/explorer/widgets/transaction_flow_diagram.dart';
 import 'package:bitwindow/providers/blockchain_provider.dart';
 import 'package:flutter/foundation.dart';
@@ -740,6 +741,7 @@ class _OutputsTab extends StatelessWidget {
         SailTableHeaderCell(name: '#'),
         SailTableHeaderCell(name: 'Amount'),
         SailTableHeaderCell(name: 'Address'),
+        SailTableHeaderCell(name: 'Owner'),
         SailTableHeaderCell(name: 'Type'),
       ],
       rowBuilder: (_, i, _) {
@@ -758,6 +760,7 @@ class _OutputsTab extends StatelessWidget {
             monospace: true,
             copyValue: isOpReturn ? decodedData : (output.address.isNotEmpty ? output.address : null),
           ),
+          SailTableCell(value: outputOwnerLabel(output) ?? ''),
           SailTableCell(value: output.scriptType),
         ];
       },

--- a/bitwindow/lib/pages/explorer/widgets/output_owner.dart
+++ b/bitwindow/lib/pages/explorer/widgets/output_owner.dart
@@ -1,0 +1,12 @@
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+/// How the active wallet owns [output]. Null when it owns no part of it.
+String? outputOwnerLabel(TransactionOutput output) {
+  if (output.isChange) {
+    return 'Your change';
+  }
+  if (output.isMine) {
+    return 'Your address';
+  }
+  return null;
+}

--- a/bitwindow/lib/pages/explorer/widgets/transaction_flow_diagram.dart
+++ b/bitwindow/lib/pages/explorer/widgets/transaction_flow_diagram.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:bitwindow/pages/explorer/widgets/output_owner.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
@@ -418,6 +419,10 @@ class _TooltipContent extends StatelessWidget {
               'Address: ${_truncateAddress(output.address)}',
               monospace: true,
             ),
+            if (outputOwnerLabel(output) case final owner?) ...[
+              const SizedBox(height: 2),
+              SailText.primary12(owner),
+            ],
             const SizedBox(height: 2),
             SailText.secondary12('Type: ${output.scriptType}'),
           ],

--- a/bitwindow/lib/pages/wallet/wallet_utxos.dart
+++ b/bitwindow/lib/pages/wallet/wallet_utxos.dart
@@ -455,7 +455,10 @@ class _UTXOTableState extends State<UTXOTable> {
                       : const SizedBox(width: 14),
                 ),
                 SailTableCell(
-                  value: utxo.hasReceivedAt() ? formatDate(utxo.receivedAt.toDateTime().toLocal()) : '—',
+                  value: utxo.confirmations == 0
+                      ? 'Pending'
+                      : (utxo.hasReceivedAt() ? formatDate(utxo.receivedAt.toDateTime().toLocal()) : '—'),
+                  textColor: utxo.confirmations == 0 ? theme.colors.orange : null,
                 ),
                 SailTableCell(
                   value: '${utxo.output.substring(0, 6)}..:${utxo.output.split(':').last}',

--- a/bitwindow/lib/providers/transactions_provider.dart
+++ b/bitwindow/lib/providers/transactions_provider.dart
@@ -213,6 +213,7 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
                     derivationPath: utxo.derivationPath,
                     splittable: utxo.hasSplittable() ? utxo.splittable : null,
                     inputWeightUnits: utxo.inputWeightUnits,
+                    confirmations: utxo.confirmations,
                   ),
                 )
                 .toList();

--- a/bitwindow/server/gen/wallet/v1/wallet.pb.go
+++ b/bitwindow/server/gen/wallet/v1/wallet.pb.go
@@ -3616,8 +3616,12 @@ type TransactionOutput struct {
 	ScriptType      string                 `protobuf:"bytes,4,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
 	ScriptPubkeyAsm string                 `protobuf:"bytes,5,opt,name=script_pubkey_asm,json=scriptPubkeyAsm,proto3" json:"script_pubkey_asm,omitempty"`
 	ScriptPubkeyHex string                 `protobuf:"bytes,6,opt,name=script_pubkey_hex,json=scriptPubkeyHex,proto3" json:"script_pubkey_hex,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The output pays the wallet's own change chain.
+	IsChange bool `protobuf:"varint,7,opt,name=is_change,json=isChange,proto3" json:"is_change,omitempty"`
+	// The wallet owns the output's address.
+	IsMine        bool `protobuf:"varint,8,opt,name=is_mine,json=isMine,proto3" json:"is_mine,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TransactionOutput) Reset() {
@@ -3690,6 +3694,20 @@ func (x *TransactionOutput) GetScriptPubkeyHex() string {
 		return x.ScriptPubkeyHex
 	}
 	return ""
+}
+
+func (x *TransactionOutput) GetIsChange() bool {
+	if x != nil {
+		return x.IsChange
+	}
+	return false
+}
+
+func (x *TransactionOutput) GetIsMine() bool {
+	if x != nil {
+		return x.IsMine
+	}
+	return false
 }
 
 // UTXO Distribution - for chart visualization
@@ -4708,7 +4726,7 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"\bsequence\x18\t \x01(\x03R\bsequence\x12\x1f\n" +
 	"\vis_coinbase\x18\n" +
 	" \x01(\bR\n" +
-	"isCoinbase\"\xdb\x01\n" +
+	"isCoinbase\"\x91\x02\n" +
 	"\x11TransactionOutput\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\x05R\x05index\x12\x1d\n" +
 	"\n" +
@@ -4717,7 +4735,9 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"\vscript_type\x18\x04 \x01(\tR\n" +
 	"scriptType\x12*\n" +
 	"\x11script_pubkey_asm\x18\x05 \x01(\tR\x0fscriptPubkeyAsm\x12*\n" +
-	"\x11script_pubkey_hex\x18\x06 \x01(\tR\x0fscriptPubkeyHex\"Z\n" +
+	"\x11script_pubkey_hex\x18\x06 \x01(\tR\x0fscriptPubkeyHex\x12\x1b\n" +
+	"\tis_change\x18\a \x01(\bR\bisChange\x12\x17\n" +
+	"\ais_mine\x18\b \x01(\bR\x06isMine\"Z\n" +
 	"\x1aGetUTXODistributionRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x1f\n" +
 	"\vmax_buckets\x18\x02 \x01(\x05R\n" +

--- a/bitwindow/server/gen/wallet/v1/wallet.pb.go
+++ b/bitwindow/server/gen/wallet/v1/wallet.pb.go
@@ -768,8 +768,10 @@ type UnspentOutput struct {
 	// The largest weight, in weight units, that spending this output costs. 0
 	// when the backend cannot report the output's descriptor.
 	InputWeightUnits int32 `protobuf:"varint,11,opt,name=input_weight_units,json=inputWeightUnits,proto3" json:"input_weight_units,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Blocks that bury the output. 0 while it waits in the mempool.
+	Confirmations int32 `protobuf:"varint,12,opt,name=confirmations,proto3" json:"confirmations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UnspentOutput) Reset() {
@@ -875,6 +877,13 @@ func (x *UnspentOutput) GetHeight() int32 {
 func (x *UnspentOutput) GetInputWeightUnits() int32 {
 	if x != nil {
 		return x.InputWeightUnits
+	}
+	return 0
+}
+
+func (x *UnspentOutput) GetConfirmations() int32 {
+	if x != nil {
+		return x.Confirmations
 	}
 	return 0
 }
@@ -4487,7 +4496,7 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"\x11confirmed_satoshi\x18\x01 \x01(\x04R\x10confirmedSatoshi\x12'\n" +
 	"\x0fpending_satoshi\x18\x02 \x01(\x04R\x0ependingSatoshi\"\\\n" +
 	"\x18ListTransactionsResponse\x12@\n" +
-	"\ftransactions\x18\x01 \x03(\v2\x1c.wallet.v1.WalletTransactionR\ftransactions\"\xc4\x03\n" +
+	"\ftransactions\x18\x01 \x03(\v2\x1c.wallet.v1.WalletTransactionR\ftransactions\"\xea\x03\n" +
 	"\rUnspentOutput\x12\x16\n" +
 	"\x06output\x18\x01 \x01(\tR\x06output\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\x14\n" +
@@ -4505,7 +4514,8 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"splittable\x88\x01\x01\x12\x16\n" +
 	"\x06height\x18\n" +
 	" \x01(\x05R\x06height\x12,\n" +
-	"\x12input_weight_units\x18\v \x01(\x05R\x10inputWeightUnitsB\x0e\n" +
+	"\x12input_weight_units\x18\v \x01(\x05R\x10inputWeightUnits\x12$\n" +
+	"\rconfirmations\x18\f \x01(\x05R\rconfirmationsB\x0e\n" +
 	"\f_denial_infoB\r\n" +
 	"\v_splittable\"E\n" +
 	"\x13ListUnspentResponse\x12.\n" +

--- a/bitwindow/server/proto/wallet/v1/wallet.proto
+++ b/bitwindow/server/proto/wallet/v1/wallet.proto
@@ -512,6 +512,10 @@ message TransactionOutput {
   string script_type = 4;
   string script_pubkey_asm = 5;
   string script_pubkey_hex = 6;
+  // The output pays the wallet's own change chain.
+  bool is_change = 7;
+  // The wallet owns the output's address.
+  bool is_mine = 8;
 }
 
 // UTXO Distribution - for chart visualization

--- a/bitwindow/server/proto/wallet/v1/wallet.proto
+++ b/bitwindow/server/proto/wallet/v1/wallet.proto
@@ -164,6 +164,8 @@ message UnspentOutput {
   // The largest weight, in weight units, that spending this output costs. 0
   // when the backend cannot report the output's descriptor.
   int32 input_weight_units = 11;
+  // Blocks that bury the output. 0 while it waits in the mempool.
+  int32 confirmations = 12;
 }
 
 message ListUnspentResponse {

--- a/bitwindow/test/output_owner_test.dart
+++ b/bitwindow/test/output_owner_test.dart
@@ -1,0 +1,26 @@
+import 'package:bitwindow/pages/explorer/widgets/output_owner.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+void main() {
+  group('outputOwnerLabel', () {
+    test('an output the wallet does not own carries no label', () {
+      expect(outputOwnerLabel(TransactionOutput(address: 'stranger')), isNull);
+    });
+
+    test('the change output of a send says it comes back', () {
+      expect(
+        outputOwnerLabel(TransactionOutput(address: 'change', isMine: true, isChange: true)),
+        'Your change',
+      );
+    });
+
+    test('a decoded PSBT marks change without an ownership flag', () {
+      expect(outputOwnerLabel(TransactionOutput(address: 'change', isChange: true)), 'Your change');
+    });
+
+    test('a receive output names the wallet without calling it change', () {
+      expect(outputOwnerLabel(TransactionOutput(address: 'receive', isMine: true)), 'Your address');
+    });
+  });
+}

--- a/sail_ui/test/widgets/persistent_status_bar_test.dart
+++ b/sail_ui/test/widgets/persistent_status_bar_test.dart
@@ -50,7 +50,7 @@ class _FakeBinaryProvider extends BinaryProvider {
   }
 
   @override
-  Future<void> stop(Binary binary, {bool skipDownstream = false, bool expectRestart = false}) async {}
+  Future<void> stop(Binary binary, {bool skipDownstream = false}) async {}
 }
 
 class _FakeOrchestrator implements OrchestratorRPC {

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1157,9 +1157,11 @@ func (h *WalletHandler) GetTransactionDetails(ctx context.Context, req *connect.
 
 	outputs := make([]*pb.TransactionOutput, 0, len(rawTx.Vout))
 	totalOutputSats := int64(0)
+	addresses := make([]string, 0, len(rawTx.Vout))
 	for i, vout := range rawTx.Vout {
 		valueSats := int64(math.Round(vout.Value * 1e8))
 		totalOutputSats += valueSats
+		addresses = append(addresses, vout.ScriptPubKey.Address)
 		outputs = append(outputs, &pb.TransactionOutput{
 			Index:           int32(i),
 			ValueSats:       valueSats,
@@ -1168,6 +1170,16 @@ func (h *WalletHandler) GetTransactionDetails(ctx context.Context, req *connect.
 			ScriptPubkeyAsm: vout.ScriptPubKey.Asm,
 			ScriptPubkeyHex: vout.ScriptPubKey.Hex,
 		})
+	}
+
+	owned, err := h.engine.Backend().OwnedAddresses(ctx, walletID, addresses)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("read address ownership: %w", err))
+	}
+	for _, out := range outputs {
+		change, mine := owned[out.Address]
+		out.IsMine = mine
+		out.IsChange = change
 	}
 
 	feeSats := totalInputSats - totalOutputSats

--- a/sidechain-orchestrator/api/wallet_handler_txdetails_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_txdetails_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// detailsProvider answers the three reads GetTransactionDetails makes.
+type detailsProvider struct {
+	wallet.Backend
+	rawTx      *wallet.RawTransaction
+	owned      map[string]bool
+	ownedErr   error
+	askedOwned []string
+}
+
+func (f *detailsProvider) GetWalletTransaction(_ context.Context, _, txid string) (*wallet.WalletTx, error) {
+	return &wallet.WalletTx{TxID: txid, Amount: -0.5, Hex: "00"}, nil
+}
+
+func (f *detailsProvider) OwnedAddresses(_ context.Context, _ string, addresses []string) (map[string]bool, error) {
+	f.askedOwned = addresses
+	if f.ownedErr != nil {
+		return nil, f.ownedErr
+	}
+	return f.owned, nil
+}
+
+func (f *detailsProvider) Chain() wallet.ChainSource { return f }
+
+func (f *detailsProvider) GetRawTransaction(_ context.Context, _ string) (*wallet.RawTransaction, error) {
+	return f.rawTx, nil
+}
+
+func (f *detailsProvider) Broadcast(_ context.Context, _ string) (string, error) {
+	return "", errors.New("broadcast is out of scope")
+}
+
+// paymentWithChange is a send that pays a stranger, carries an OP_RETURN, and
+// returns the rest to the wallet's own change address.
+func paymentWithChange() *wallet.RawTransaction {
+	return &wallet.RawTransaction{
+		TxID:  "tx",
+		Vsize: 200,
+		Vin:   []wallet.RawTxIn{{TxID: "parent", Vout: 0}},
+		Vout: []wallet.RawTxOut{
+			{Value: 0.1, N: 0, ScriptPubKey: wallet.ScriptPubKey{Type: "witness_v0_keyhash", Address: "stranger"}},
+			{Value: 0, N: 1, ScriptPubKey: wallet.ScriptPubKey{Type: "nulldata"}},
+			{Value: 8.32, N: 2, ScriptPubKey: wallet.ScriptPubKey{Type: "witness_v0_keyhash", Address: "change"}},
+		},
+	}
+}
+
+func newDetailsHandler(t *testing.T, fake *detailsProvider) (*WalletHandler, string) {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	svc := wallet.NewService(t.TempDir(), log)
+	require.NoError(t, svc.Init())
+	t.Cleanup(func() { svc.Close() })
+
+	w, err := svc.GenerateWallet("Core", "", "", nil)
+	require.NoError(t, err)
+
+	router := wallet.NewBackendRouter(svc, fake, fake)
+	h := NewWalletHandler(svc)
+	h.SetEngine(wallet.NewWalletEngine(svc, router, nil, log))
+	return h, w.ID
+}
+
+func TestGetTransactionDetailsMarksTheChangeOutput(t *testing.T) {
+	fake := &detailsProvider{
+		rawTx: paymentWithChange(),
+		owned: map[string]bool{"change": true},
+	}
+	h, walletID := newDetailsHandler(t, fake)
+
+	resp, err := h.GetTransactionDetails(context.Background(), connect.NewRequest(&pb.GetTransactionDetailsRequest{
+		WalletId: walletID,
+		Txid:     "tx",
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Outputs, 3)
+
+	assert.False(t, resp.Msg.Outputs[0].IsMine, "the payment leaves the wallet")
+	assert.False(t, resp.Msg.Outputs[0].IsChange)
+	assert.False(t, resp.Msg.Outputs[1].IsMine, "an OP_RETURN output has no address")
+	assert.True(t, resp.Msg.Outputs[2].IsMine)
+	assert.True(t, resp.Msg.Outputs[2].IsChange)
+	assert.Equal(t, []string{"stranger", "", "change"}, fake.askedOwned)
+}
+
+func TestGetTransactionDetailsMarksAReceiveOutput(t *testing.T) {
+	fake := &detailsProvider{
+		rawTx: paymentWithChange(),
+		owned: map[string]bool{"stranger": false},
+	}
+	h, walletID := newDetailsHandler(t, fake)
+
+	resp, err := h.GetTransactionDetails(context.Background(), connect.NewRequest(&pb.GetTransactionDetailsRequest{
+		WalletId: walletID,
+		Txid:     "tx",
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Outputs, 3)
+
+	assert.True(t, resp.Msg.Outputs[0].IsMine)
+	assert.False(t, resp.Msg.Outputs[0].IsChange, "a receive address is not change")
+}
+
+func TestGetTransactionDetailsFailsOnAnOwnershipError(t *testing.T) {
+	fake := &detailsProvider{
+		rawTx:    paymentWithChange(),
+		ownedErr: errors.New("core is down"),
+	}
+	h, walletID := newDetailsHandler(t, fake)
+
+	_, err := h.GetTransactionDetails(context.Background(), connect.NewRequest(&pb.GetTransactionDetailsRequest{
+		WalletId: walletID,
+		Txid:     "tx",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+}

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -7738,9 +7738,10 @@ type TransactionOutput struct {
 	ScriptType      string                 `protobuf:"bytes,4,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
 	ScriptPubkeyAsm string                 `protobuf:"bytes,5,opt,name=script_pubkey_asm,json=scriptPubkeyAsm,proto3" json:"script_pubkey_asm,omitempty"`
 	ScriptPubkeyHex string                 `protobuf:"bytes,6,opt,name=script_pubkey_hex,json=scriptPubkeyHex,proto3" json:"script_pubkey_hex,omitempty"`
-	// PSBT-only: the output carries the wallet's derivation records, so it is
-	// the change output.
-	IsChange      bool `protobuf:"varint,7,opt,name=is_change,json=isChange,proto3" json:"is_change,omitempty"`
+	// The output pays the wallet's own change chain.
+	IsChange bool `protobuf:"varint,7,opt,name=is_change,json=isChange,proto3" json:"is_change,omitempty"`
+	// The wallet owns the output's address.
+	IsMine        bool `protobuf:"varint,8,opt,name=is_mine,json=isMine,proto3" json:"is_mine,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7820,6 +7821,13 @@ func (x *TransactionOutput) GetScriptPubkeyHex() string {
 func (x *TransactionOutput) GetIsChange() bool {
 	if x != nil {
 		return x.IsChange
+	}
+	return false
+}
+
+func (x *TransactionOutput) GetIsMine() bool {
+	if x != nil {
+		return x.IsMine
 	}
 	return false
 }
@@ -10634,7 +10642,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\bsequence\x18\t \x01(\x03R\bsequence\x12\x1f\n" +
 	"\vis_coinbase\x18\n" +
 	" \x01(\bR\n" +
-	"isCoinbase\"\xf8\x01\n" +
+	"isCoinbase\"\x91\x02\n" +
 	"\x11TransactionOutput\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\x05R\x05index\x12\x1d\n" +
 	"\n" +
@@ -10644,7 +10652,8 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"scriptType\x12*\n" +
 	"\x11script_pubkey_asm\x18\x05 \x01(\tR\x0fscriptPubkeyAsm\x12*\n" +
 	"\x11script_pubkey_hex\x18\x06 \x01(\tR\x0fscriptPubkeyHex\x12\x1b\n" +
-	"\tis_change\x18\a \x01(\bR\bisChange\"M\n" +
+	"\tis_change\x18\a \x01(\bR\bisChange\x12\x17\n" +
+	"\ais_mine\x18\b \x01(\bR\x06isMine\"M\n" +
 	"\x18DecodeTransactionRequest\x12\x14\n" +
 	"\x05input\x18\x01 \x01(\tR\x05input\x12\x1b\n" +
 	"\twallet_id\x18\x02 \x01(\tR\bwalletId\"\x9b\x05\n" +

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -1037,9 +1037,10 @@ message TransactionOutput {
   string script_type = 4;
   string script_pubkey_asm = 5;
   string script_pubkey_hex = 6;
-  // PSBT-only: the output carries the wallet's derivation records, so it is
-  // the change output.
+  // The output pays the wallet's own change chain.
   bool is_change = 7;
+  // The wallet owns the output's address.
+  bool is_mine = 8;
 }
 
 // DecodeTransaction inspects a pasted txid, raw transaction hex, or base64 PSBT

--- a/sidechain-orchestrator/wallet/backend.go
+++ b/sidechain-orchestrator/wallet/backend.go
@@ -33,6 +33,10 @@ type Backend interface {
 	GetWalletTransaction(ctx context.Context, walletID, txid string) (*WalletTx, error)
 	// AddressHDPath returns the BIP32 derivation path of a wallet address.
 	AddressHDPath(ctx context.Context, walletID, address string) (string, error)
+	// OwnedAddresses reports which of addresses the wallet owns. The map value
+	// is true for an address on the wallet's change chain. An address the
+	// wallet does not own is absent from the map.
+	OwnedAddresses(ctx context.Context, walletID string, addresses []string) (map[string]bool, error)
 
 	// NextReceiveAddress returns an unused receive address of the given script
 	// kind, minting one only when every existing address has received funds.

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -320,6 +320,31 @@ func (p *CoreBackend) AddressHDPath(ctx context.Context, walletID, address strin
 	return info.HDKeyPath, nil
 }
 
+func (p *CoreBackend) OwnedAddresses(ctx context.Context, walletID string, addresses []string) (map[string]bool, error) {
+	name, err := p.walletName(ctx, walletID)
+	if err != nil {
+		return nil, err
+	}
+	owned := make(map[string]bool, len(addresses))
+	for _, address := range addresses {
+		if address == "" {
+			continue
+		}
+		if _, done := owned[address]; done {
+			continue
+		}
+		info, err := p.rpc.GetAddressInfo(ctx, name, address)
+		if err != nil {
+			return nil, fmt.Errorf("get address info for %s: %w", address, err)
+		}
+		if !info.IsMine {
+			continue
+		}
+		owned[address] = info.IsChange
+	}
+	return owned, nil
+}
+
 // NextReceiveAddress returns an existing unused address from the wallet, or
 // mints a new one if every address has received funds. "Unused" = present in
 // listreceivedbyaddress with zero amount and no txids (minconf=0 also catches

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -265,7 +265,10 @@ func (p *CoreBackend) ListUnspent(ctx context.Context, walletID string) ([]UTXO,
 	if err != nil {
 		return nil, err
 	}
-	return p.rpc.ListUnspent(ctx, name)
+	// minconf 0: Core's default hides a coin that waits in the mempool, so a
+	// send emptied the coin list until it confirmed. The electrum backend
+	// lists that coin, and CPFP must find it.
+	return p.rpc.ListUnspentMinConf(ctx, name, 0)
 }
 
 func (p *CoreBackend) ListTransactions(ctx context.Context, walletID string, count int) ([]WalletTransaction, error) {

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -2332,3 +2332,37 @@ func TestAnyWalletCallDropsAWalletCoreUnloaded(t *testing.T) {
 	assert.Greater(t, len(fake.callsFor("createwallet")), before,
 		"the cached name was used, and Core no longer holds that wallet")
 }
+
+func TestCoreBackendOwnedAddressesReadsEachAddressOnce(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("getaddressinfo", func(c bitcoindCall) (any, string) {
+		address := mustString(t, c.Params[0])
+		return map[string]any{
+			"address":  address,
+			"ismine":   address != "stranger",
+			"ischange": address == "change",
+		}, ""
+	})
+
+	_, err := backend.Ensure(context.Background(), coreID)
+	require.NoError(t, err)
+	backend.bip47Imports.Wait()
+	before := len(fake.callsFor("getaddressinfo"))
+
+	owned, err := backend.OwnedAddresses(context.Background(), coreID,
+		[]string{"stranger", "", "change", "change", "receive"})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]bool{"change": true, "receive": false}, owned)
+	assert.Len(t, fake.callsFor("getaddressinfo"), before+3, "an empty address and a repeat cost no call")
+}
+
+func TestCoreBackendOwnedAddressesFailsOnACoreError(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("getaddressinfo", func(bitcoindCall) (any, string) { return nil, "Invalid address" })
+
+	_, err := backend.OwnedAddresses(context.Background(), coreID, []string{"change"})
+	require.ErrorContains(t, err, "get address info for change")
+}

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -2366,3 +2366,26 @@ func TestCoreBackendOwnedAddressesFailsOnACoreError(t *testing.T) {
 	_, err := backend.OwnedAddresses(context.Background(), coreID, []string{"change"})
 	require.ErrorContains(t, err, "get address info for change")
 }
+
+// A send spends the whole coin and returns the rest as unconfirmed change. At
+// Core's default minconf the coin list reads empty until that change confirms.
+func TestCoreBackendListUnspentShowsAMempoolCoin(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	fake.handle("listunspent", func(c bitcoindCall) (any, string) {
+		var minConf int
+		require.NoError(t, json.Unmarshal(c.Params[0], &minConf))
+		if minConf > 0 {
+			return []map[string]any{}, ""
+		}
+		return []map[string]any{
+			{"txid": "change", "vout": 1, "address": "bcrt1qchange", "amount": 8.32, "confirmations": 0, "spendable": true},
+		}, ""
+	})
+
+	utxos, err := backend.ListUnspent(context.Background(), coreID)
+	require.NoError(t, err)
+
+	require.Len(t, utxos, 1, "the pending change belongs to the wallet")
+	assert.Equal(t, 0, utxos[0].Confirmations)
+}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -475,6 +475,23 @@ func (p *ElectrumBackend) AddressHDPath(ctx context.Context, walletID, address s
 	return a.hdPath, nil
 }
 
+func (p *ElectrumBackend) OwnedAddresses(ctx context.Context, walletID string, addresses []string) (map[string]bool, error) {
+	scan, err := p.scanWallet(ctx, walletID)
+	if err != nil {
+		return nil, err
+	}
+	owned := make(map[string]bool, len(addresses))
+	for _, address := range addresses {
+		if address == "" {
+			continue
+		}
+		if a, ok := scan.byAddr[address]; ok {
+			owned[address] = a.change
+		}
+	}
+	return owned, nil
+}
+
 func (p *ElectrumBackend) NextReceiveAddress(ctx context.Context, walletID string, kind ScriptKind) (DerivedAddress, error) {
 	w := p.svc.GetWalletByID(walletID)
 	if w == nil {

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -3346,3 +3346,16 @@ func TestElectrumReplacementSparesASiblingOnAnotherCoin(t *testing.T) {
 		assert.NotEqual(t, bidOfSlotTwo, u.txid, "the other slot bids from a coin of its own")
 	}
 }
+
+func TestElectrumOwnedAddressesSeparatesChangeFromReceive(t *testing.T) {
+	p, _, w, recv := newElectrumFixture(t)
+	ctx := context.Background()
+
+	change, err := p.NextChangeAddress(ctx, w.ID)
+	require.NoError(t, err)
+
+	owned, err := p.OwnedAddresses(ctx, w.ID, []string{recv, "", change, "stranger"})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]bool{recv: false, change: true}, owned)
+}

--- a/sidechain-orchestrator/wallet/router.go
+++ b/sidechain-orchestrator/wallet/router.go
@@ -149,6 +149,14 @@ func (r *BackendRouter) AddressHDPath(ctx context.Context, walletID, address str
 	return p.AddressHDPath(ctx, walletID, address)
 }
 
+func (r *BackendRouter) OwnedAddresses(ctx context.Context, walletID string, addresses []string) (map[string]bool, error) {
+	p, err := r.pick(walletID)
+	if err != nil {
+		return nil, err
+	}
+	return p.OwnedAddresses(ctx, walletID, addresses)
+}
+
 func (r *BackendRouter) NextReceiveAddress(ctx context.Context, walletID string, kind ScriptKind) (DerivedAddress, error) {
 	p, err := r.pick(walletID)
 	if err != nil {

--- a/sidechain_core/lib/gen/wallet/v1/wallet.pb.dart
+++ b/sidechain_core/lib/gen/wallet/v1/wallet.pb.dart
@@ -700,6 +700,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
     $core.bool? splittable,
     $core.int? height,
     $core.int? inputWeightUnits,
+    $core.int? confirmations,
   }) {
     final $result = create();
     if (output != null) {
@@ -735,6 +736,9 @@ class UnspentOutput extends $pb.GeneratedMessage {
     if (inputWeightUnits != null) {
       $result.inputWeightUnits = inputWeightUnits;
     }
+    if (confirmations != null) {
+      $result.confirmations = confirmations;
+    }
     return $result;
   }
   UnspentOutput._() : super();
@@ -753,6 +757,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
     ..aOB(9, _omitFieldNames ? '' : 'splittable')
     ..a<$core.int>(10, _omitFieldNames ? '' : 'height', $pb.PbFieldType.O3)
     ..a<$core.int>(11, _omitFieldNames ? '' : 'inputWeightUnits', $pb.PbFieldType.O3)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'confirmations', $pb.PbFieldType.O3)
     ..hasRequiredFields = false
   ;
 
@@ -892,6 +897,16 @@ class UnspentOutput extends $pb.GeneratedMessage {
   $core.bool hasInputWeightUnits() => $_has(10);
   @$pb.TagNumber(11)
   void clearInputWeightUnits() => clearField(11);
+
+  /// Blocks that bury the output. 0 while it waits in the mempool.
+  @$pb.TagNumber(12)
+  $core.int get confirmations => $_getIZ(11);
+  @$pb.TagNumber(12)
+  set confirmations($core.int v) { $_setSignedInt32(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasConfirmations() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearConfirmations() => clearField(12);
 }
 
 class ListUnspentResponse extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/wallet/v1/wallet.pb.dart
+++ b/sidechain_core/lib/gen/wallet/v1/wallet.pb.dart
@@ -4535,6 +4535,8 @@ class TransactionOutput extends $pb.GeneratedMessage {
     $core.String? scriptType,
     $core.String? scriptPubkeyAsm,
     $core.String? scriptPubkeyHex,
+    $core.bool? isChange,
+    $core.bool? isMine,
   }) {
     final $result = create();
     if (index != null) {
@@ -4555,6 +4557,12 @@ class TransactionOutput extends $pb.GeneratedMessage {
     if (scriptPubkeyHex != null) {
       $result.scriptPubkeyHex = scriptPubkeyHex;
     }
+    if (isChange != null) {
+      $result.isChange = isChange;
+    }
+    if (isMine != null) {
+      $result.isMine = isMine;
+    }
     return $result;
   }
   TransactionOutput._() : super();
@@ -4568,6 +4576,8 @@ class TransactionOutput extends $pb.GeneratedMessage {
     ..aOS(4, _omitFieldNames ? '' : 'scriptType')
     ..aOS(5, _omitFieldNames ? '' : 'scriptPubkeyAsm')
     ..aOS(6, _omitFieldNames ? '' : 'scriptPubkeyHex')
+    ..aOB(7, _omitFieldNames ? '' : 'isChange')
+    ..aOB(8, _omitFieldNames ? '' : 'isMine')
     ..hasRequiredFields = false
   ;
 
@@ -4645,6 +4655,26 @@ class TransactionOutput extends $pb.GeneratedMessage {
   $core.bool hasScriptPubkeyHex() => $_has(5);
   @$pb.TagNumber(6)
   void clearScriptPubkeyHex() => clearField(6);
+
+  /// The output pays the wallet's own change chain.
+  @$pb.TagNumber(7)
+  $core.bool get isChange => $_getBF(6);
+  @$pb.TagNumber(7)
+  set isChange($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasIsChange() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearIsChange() => clearField(7);
+
+  /// The wallet owns the output's address.
+  @$pb.TagNumber(8)
+  $core.bool get isMine => $_getBF(7);
+  @$pb.TagNumber(8)
+  set isMine($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasIsMine() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearIsMine() => clearField(8);
 }
 
 /// UTXO Distribution - for chart visualization

--- a/sidechain_core/lib/gen/wallet/v1/wallet.pbjson.dart
+++ b/sidechain_core/lib/gen/wallet/v1/wallet.pbjson.dart
@@ -1023,6 +1023,8 @@ const TransactionOutput$json = {
     {'1': 'script_type', '3': 4, '4': 1, '5': 9, '10': 'scriptType'},
     {'1': 'script_pubkey_asm', '3': 5, '4': 1, '5': 9, '10': 'scriptPubkeyAsm'},
     {'1': 'script_pubkey_hex', '3': 6, '4': 1, '5': 9, '10': 'scriptPubkeyHex'},
+    {'1': 'is_change', '3': 7, '4': 1, '5': 8, '10': 'isChange'},
+    {'1': 'is_mine', '3': 8, '4': 1, '5': 8, '10': 'isMine'},
   ],
 };
 
@@ -1031,7 +1033,8 @@ final $typed_data.Uint8List transactionOutputDescriptor = $convert.base64Decode(
     'ChFUcmFuc2FjdGlvbk91dHB1dBIUCgVpbmRleBgBIAEoBVIFaW5kZXgSHQoKdmFsdWVfc2F0cx'
     'gCIAEoA1IJdmFsdWVTYXRzEhgKB2FkZHJlc3MYAyABKAlSB2FkZHJlc3MSHwoLc2NyaXB0X3R5'
     'cGUYBCABKAlSCnNjcmlwdFR5cGUSKgoRc2NyaXB0X3B1YmtleV9hc20YBSABKAlSD3NjcmlwdF'
-    'B1YmtleUFzbRIqChFzY3JpcHRfcHVia2V5X2hleBgGIAEoCVIPc2NyaXB0UHVia2V5SGV4');
+    'B1YmtleUFzbRIqChFzY3JpcHRfcHVia2V5X2hleBgGIAEoCVIPc2NyaXB0UHVia2V5SGV4EhsK'
+    'CWlzX2NoYW5nZRgHIAEoCFIIaXNDaGFuZ2USFwoHaXNfbWluZRgIIAEoCFIGaXNNaW5l');
 
 @$core.Deprecated('Use getUTXODistributionRequestDescriptor instead')
 const GetUTXODistributionRequest$json = {

--- a/sidechain_core/lib/gen/wallet/v1/wallet.pbjson.dart
+++ b/sidechain_core/lib/gen/wallet/v1/wallet.pbjson.dart
@@ -247,6 +247,7 @@ const UnspentOutput$json = {
     {'1': 'splittable', '3': 9, '4': 1, '5': 8, '9': 1, '10': 'splittable', '17': true},
     {'1': 'height', '3': 10, '4': 1, '5': 5, '10': 'height'},
     {'1': 'input_weight_units', '3': 11, '4': 1, '5': 5, '10': 'inputWeightUnits'},
+    {'1': 'confirmations', '3': 12, '4': 1, '5': 5, '10': 'confirmations'},
   ],
   '8': [
     {'1': '_denial_info'},
@@ -263,8 +264,8 @@ final $typed_data.Uint8List unspentOutputDescriptor = $convert.base64Decode(
     'bxgHIAEoCzIZLmJpdHdpbmRvd2QudjEuRGVuaWFsSW5mb0gAUgpkZW5pYWxJbmZviAEBEicKD2'
     'Rlcml2YXRpb25fcGF0aBgIIAEoCVIOZGVyaXZhdGlvblBhdGgSIwoKc3BsaXR0YWJsZRgJIAEo'
     'CEgBUgpzcGxpdHRhYmxliAEBEhYKBmhlaWdodBgKIAEoBVIGaGVpZ2h0EiwKEmlucHV0X3dlaW'
-    'dodF91bml0cxgLIAEoBVIQaW5wdXRXZWlnaHRVbml0c0IOCgxfZGVuaWFsX2luZm9CDQoLX3Nw'
-    'bGl0dGFibGU=');
+    'dodF91bml0cxgLIAEoBVIQaW5wdXRXZWlnaHRVbml0cxIkCg1jb25maXJtYXRpb25zGAwgASgF'
+    'Ug1jb25maXJtYXRpb25zQg4KDF9kZW5pYWxfaW5mb0INCgtfc3BsaXR0YWJsZQ==');
 
 @$core.Deprecated('Use listUnspentResponseDescriptor instead')
 const ListUnspentResponse$json = {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -9262,6 +9262,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
     $core.String? scriptPubkeyAsm,
     $core.String? scriptPubkeyHex,
     $core.bool? isChange,
+    $core.bool? isMine,
   }) {
     final $result = create();
     if (index != null) {
@@ -9285,6 +9286,9 @@ class TransactionOutput extends $pb.GeneratedMessage {
     if (isChange != null) {
       $result.isChange = isChange;
     }
+    if (isMine != null) {
+      $result.isMine = isMine;
+    }
     return $result;
   }
   TransactionOutput._() : super();
@@ -9299,6 +9303,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
     ..aOS(5, _omitFieldNames ? '' : 'scriptPubkeyAsm')
     ..aOS(6, _omitFieldNames ? '' : 'scriptPubkeyHex')
     ..aOB(7, _omitFieldNames ? '' : 'isChange')
+    ..aOB(8, _omitFieldNames ? '' : 'isMine')
     ..hasRequiredFields = false
   ;
 
@@ -9377,8 +9382,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   void clearScriptPubkeyHex() => clearField(6);
 
-  /// PSBT-only: the output carries the wallet's derivation records, so it is
-  /// the change output.
+  /// The output pays the wallet's own change chain.
   @$pb.TagNumber(7)
   $core.bool get isChange => $_getBF(6);
   @$pb.TagNumber(7)
@@ -9387,6 +9391,16 @@ class TransactionOutput extends $pb.GeneratedMessage {
   $core.bool hasIsChange() => $_has(6);
   @$pb.TagNumber(7)
   void clearIsChange() => clearField(7);
+
+  /// The wallet owns the output's address.
+  @$pb.TagNumber(8)
+  $core.bool get isMine => $_getBF(7);
+  @$pb.TagNumber(8)
+  set isMine($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasIsMine() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearIsMine() => clearField(8);
 }
 
 /// DecodeTransaction inspects a pasted txid, raw transaction hex, or base64 PSBT

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -2058,6 +2058,7 @@ const TransactionOutput$json = {
     {'1': 'script_pubkey_asm', '3': 5, '4': 1, '5': 9, '10': 'scriptPubkeyAsm'},
     {'1': 'script_pubkey_hex', '3': 6, '4': 1, '5': 9, '10': 'scriptPubkeyHex'},
     {'1': 'is_change', '3': 7, '4': 1, '5': 8, '10': 'isChange'},
+    {'1': 'is_mine', '3': 8, '4': 1, '5': 8, '10': 'isMine'},
   ],
 };
 
@@ -2067,7 +2068,7 @@ final $typed_data.Uint8List transactionOutputDescriptor = $convert.base64Decode(
     'gCIAEoA1IJdmFsdWVTYXRzEhgKB2FkZHJlc3MYAyABKAlSB2FkZHJlc3MSHwoLc2NyaXB0X3R5'
     'cGUYBCABKAlSCnNjcmlwdFR5cGUSKgoRc2NyaXB0X3B1YmtleV9hc20YBSABKAlSD3NjcmlwdF'
     'B1YmtleUFzbRIqChFzY3JpcHRfcHVia2V5X2hleBgGIAEoCVIPc2NyaXB0UHVia2V5SGV4EhsK'
-    'CWlzX2NoYW5nZRgHIAEoCFIIaXNDaGFuZ2U=');
+    'CWlzX2NoYW5nZRgHIAEoCFIIaXNDaGFuZ2USFwoHaXNfbWluZRgIIAEoCFIGaXNNaW5l');
 
 @$core.Deprecated('Use decodeTransactionRequestDescriptor instead')
 const DecodeTransactionRequest$json = {

--- a/sidechain_core/lib/providers/binaries/binary_provider.dart
+++ b/sidechain_core/lib/providers/binaries/binary_provider.dart
@@ -41,16 +41,19 @@ class BinaryProvider extends ChangeNotifier {
   /// True only for windows/apps that are allowed to initiate backend shutdown.
   final bool shutdownEnabled;
 
-  /// Manages daemon processes spawned directly by Flutter.
-  late final ProcessManager _processManager;
+  /// Manages daemon processes spawned directly by Flutter. A test may build a
+  /// provider without one.
+  ProcessManager? _ownedProcessManager;
+  ProcessManager get _processManager => _ownedProcessManager!;
 
   BinaryProvider._({
     required this.appDir,
     required this.binaries,
-    required this._processManager,
+    required ProcessManager processManager,
     required this.isSidechainApp,
     required this.shutdownEnabled,
   }) {
+    _ownedProcessManager = processManager;
     _processManager.addListener(notifyListeners);
     _startMetadataRefreshTimer();
   }
@@ -82,9 +85,13 @@ class BinaryProvider extends ChangeNotifier {
     }
   }
 
+  bool _disposed = false;
+
   @override
   void dispose() {
+    _disposed = true;
     _metadataRefreshTimer?.cancel();
+    _ownedProcessManager?.dispose();
     if (_settingsListener != null && GetIt.I.isRegistered<SettingsProvider>()) {
       GetIt.I.get<SettingsProvider>().removeListener(_settingsListener!);
     }
@@ -126,9 +133,12 @@ class BinaryProvider extends ChangeNotifier {
   BinaryProvider.test({
     required this.appDir,
     required this.binaries,
+    ProcessManager? processManager,
     this.isSidechainApp = false,
     this.shutdownEnabled = true,
-  });
+  }) {
+    _ownedProcessManager = processManager;
+  }
 
   OrchestratorRPC get _orchestrator => GetIt.I.get<OrchestratorRPC>();
 
@@ -217,13 +227,11 @@ class BinaryProvider extends ChangeNotifier {
     return _orchestrator.getSnapshotStatus();
   }
 
-  /// [expectRestart] silences the exit watchdog for this stop, so a caller that
-  /// owns the reboot isn't raced by an automatic one two seconds later.
-  Future<void> stop(Binary binary, {bool skipDownstream = false, bool expectRestart = false}) async {
+  /// A stop silences the exit watchdog, so the daemon stays down until a
+  /// caller starts it again.
+  Future<void> stop(Binary binary, {bool skipDownstream = false}) async {
     if (_isDaemonBinary(binary)) {
-      if (expectRestart) {
-        _expectedStops.add(binary.name);
-      }
+      _expectedStops.add(binary.name);
       await _stopDaemonBinary(binary);
       return;
     }
@@ -376,6 +384,12 @@ class BinaryProvider extends ChangeNotifier {
   /// Daemons stopped on purpose by a caller that will restart them itself.
   final Set<String> _expectedStops = {};
 
+  /// Daemons that already carry an exit listener.
+  final Set<String> _watchedDaemons = {};
+
+  /// Daemons that already carry a scheduled restart.
+  final Set<String> _pendingRestarts = {};
+
   /// Returns true for binaries that Flutter must spawn directly because
   /// the orchestrator can't manage itself.
   /// Adopt processes from a previous session by reading PID files.
@@ -387,12 +401,7 @@ class BinaryProvider extends ChangeNotifier {
         final pid = await _processManager.pidFileManager.readPidFile(binary);
         if (pid != null && await _processManager.pidFileManager.validatePid(pid, binary)) {
           log.i('Adopting ${binary.name} (PID $pid) from previous session');
-          _processManager.runningProcesses[binary.name] = SailProcess(
-            binary: binary,
-            pid: pid,
-            cleanup: () async {},
-            adopted: true,
-          );
+          _processManager.adopt(binary, pid);
         }
       }),
     );
@@ -422,6 +431,9 @@ class BinaryProvider extends ChangeNotifier {
     _expectedStops.remove(binary.name);
     if (_processManager.isRunning(binary)) {
       log.i('BinaryProvider: ${binary.name} already running');
+      // An adopted daemon drains its own stack and then exits. Watch it, or
+      // nothing starts a new one and the app keeps a dead backend.
+      _watchDaemonExit(binary);
       return;
     }
 
@@ -441,8 +453,33 @@ class BinaryProvider extends ChangeNotifier {
     // bitcoincore config flags). Fall back to extraBootArgs if no RPC.
     final args = rpc != null ? await rpc.binaryArgs() : binary.extraBootArgs;
 
+    // The read above yields, so a stop can arrive between the check at the top
+    // and the spawn.
+    if (_disposed || _expectedStops.contains(binary.name)) {
+      return;
+    }
+
     log.i('BinaryProvider: starting daemon ${binary.name} with args: $args');
-    await _processManager.start(binary, args, () async {
+    try {
+      await _startProcess(binary, args);
+    } catch (e) {
+      // A daemon that dies in its first moment usually met a port the
+      // previous process still holds. Nothing watches a process that never
+      // came up, so schedule the restart here.
+      log.w('${binary.name} did not stay up: $e');
+      _scheduleDaemonRestart(binary);
+      rethrow;
+    }
+
+    // Sync RPCConnection state — daemon is running.
+    _syncDaemonConnectionState(binary, running: true);
+    notifyListeners();
+
+    _watchDaemonExit(binary);
+  }
+
+  Future<void> _startProcess(Binary binary, List<String> args) {
+    return _processManager.start(binary, args, () async {
       final process = _processManager.runningProcesses[binary.name];
       if (process == null) {
         return;
@@ -461,18 +498,17 @@ class BinaryProvider extends ChangeNotifier {
         await Future.delayed(const Duration(milliseconds: 100));
       }
     });
-
-    // Sync RPCConnection state — daemon is running.
-    _syncDaemonConnectionState(binary, running: true);
-    notifyListeners();
-
-    _watchDaemonExit(binary);
   }
 
   /// Watch for daemon exit and auto-restart unless shutting down.
   void _watchDaemonExit(Binary binary) {
     final process = _processManager.runningProcesses[binary.name];
     if (process == null) {
+      return;
+    }
+    // The listener re-arms itself on every exit, so a second one only doubles
+    // the restarts.
+    if (!_watchedDaemons.add(binary.name)) {
       return;
     }
 
@@ -483,11 +519,26 @@ class BinaryProvider extends ChangeNotifier {
       if (!_processManager.isRunning(binary)) {
         _syncDaemonConnectionState(binary, running: false);
         log.w('${binary.name} exited unexpectedly, restarting in 2s');
-        Future.delayed(const Duration(seconds: 2), () {
-          if (!_shuttingDown && !_processManager.isRunning(binary)) {
-            _startDaemonBinary(binary);
-          }
-        });
+        _scheduleDaemonRestart(binary);
+      }
+    });
+  }
+
+  void _scheduleDaemonRestart(Binary binary) {
+    // The exit notification and a failed spawn both report the same death.
+    if (!_pendingRestarts.add(binary.name)) {
+      return;
+    }
+    Future.delayed(const Duration(seconds: 2), () async {
+      _pendingRestarts.remove(binary.name);
+      if (_disposed || _shuttingDown || _expectedStops.contains(binary.name) || _processManager.isRunning(binary)) {
+        return;
+      }
+      try {
+        await _startDaemonBinary(binary);
+      } catch (e) {
+        // The failed attempt already scheduled the next one.
+        log.w('restart of ${binary.name} failed: $e');
       }
     });
   }

--- a/sidechain_core/lib/providers/binaries/managers/process_manager.dart
+++ b/sidechain_core/lib/providers/binaries/managers/process_manager.dart
@@ -14,7 +14,14 @@ class ProcessManager extends ChangeNotifier {
   final Directory appDir;
   final PidFileManager pidFileManager;
 
-  ProcessManager({required this.appDir, required this.pidFileManager});
+  /// How often an adopted process gets checked for its death.
+  final Duration adoptedPollInterval;
+
+  ProcessManager({
+    required this.appDir,
+    required this.pidFileManager,
+    this.adoptedPollInterval = const Duration(seconds: 5),
+  });
 
   Logger get log => GetIt.I.get<Logger>();
   LogProvider get logProvider => GetIt.I.get<LogProvider>();
@@ -23,6 +30,9 @@ class ProcessManager extends ChangeNotifier {
   ExitTuple? exited(Binary binary) => _exitTuples[binary.name];
 
   final Map<String, SailProcess> runningProcesses = {};
+
+  final Map<String, Timer> _adoptedWatches = {};
+  bool _disposed = false;
 
   final Map<String, Stream<String>> _stdoutStreams = {};
   final Map<String, Stream<String>> _stderrStreams = {};
@@ -62,6 +72,63 @@ class ProcessManager extends ChangeNotifier {
     log.i('[${binary.name}] $cleanLine');
   }
 
+  /// Track a process a previous session started. This process holds no exit
+  /// code for us to await, so a poll of the pid reports its death instead.
+  void adopt(Binary binary, int pid) {
+    _cancelAdoptedWatch(binary);
+    runningProcesses[binary.name] = SailProcess(
+      binary: binary,
+      pid: pid,
+      cleanup: () async {},
+      adopted: true,
+    );
+    _adoptedWatches[binary.name] = Timer.periodic(adoptedPollInterval, (_) async {
+      if (!_holdsAdopted(binary, pid)) {
+        _cancelAdoptedWatch(binary);
+        return;
+      }
+      // The same check the adoption makes: a pid the OS gave to another
+      // process is not this daemon.
+      if (await pidFileManager.validatePid(pid, binary)) {
+        return;
+      }
+      // A start or a stop can replace the entry while the check runs.
+      if (!_holdsAdopted(binary, pid)) {
+        _cancelAdoptedWatch(binary);
+        return;
+      }
+      _cancelAdoptedWatch(binary);
+      log.w('adopted ${binary.name} (pid $pid) exited');
+      runningProcesses.remove(binary.name);
+      await pidFileManager.deletePidFile(binary);
+      logProvider.addExitMarker(binary.type, binary.name, null);
+      notifyListeners();
+    });
+    notifyListeners();
+  }
+
+  bool _holdsAdopted(Binary binary, int pid) {
+    if (_disposed) {
+      return false;
+    }
+    final process = runningProcesses[binary.name];
+    return process != null && process.adopted && process.pid == pid;
+  }
+
+  void _cancelAdoptedWatch(Binary binary) {
+    _adoptedWatches.remove(binary.name)?.cancel();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    for (final watch in _adoptedWatches.values) {
+      watch.cancel();
+    }
+    _adoptedWatches.clear();
+    super.dispose();
+  }
+
   Future<int> start(
     Binary binary,
     List<String> args,
@@ -69,6 +136,7 @@ class ProcessManager extends ChangeNotifier {
     // Environment variables passed to the process, e.g RUST_BACKTRACE: 1
     Map<String, String> environment = const {},
   }) async {
+    _cancelAdoptedWatch(binary);
     final file = await binary.resolveBinaryPath(appDir);
 
     // Windows doesn't do executable permissions
@@ -315,6 +383,7 @@ class ProcessManager extends ChangeNotifier {
       await killPid(process.pid);
     }
 
+    _cancelAdoptedWatch(process.binary);
     runningProcesses.remove(process.binary.name);
     await pidFileManager.deletePidFile(process.binary);
     notifyListeners();

--- a/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -768,6 +768,8 @@ class OrchestratorWalletRPC {
       scriptType: output.scriptType,
       scriptPubkeyAsm: output.scriptPubkeyAsm,
       scriptPubkeyHex: output.scriptPubkeyHex,
+      isChange: output.isChange,
+      isMine: output.isMine,
     );
   }
 }

--- a/sidechain_core/test/adopted_process_watch_test.dart
+++ b/sidechain_core/test/adopted_process_watch_test.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+/// A pid no process holds. macOS and Linux both keep pids below this.
+const _deadPid = 4000000;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+
+  // A poll that reads a pid outlives the test that started it, and it reads
+  // the logger through GetIt. A reset between tests makes that read throw.
+  setUpAll(() {
+    GetIt.instance.registerSingleton<Logger>(Logger(level: Level.off));
+    GetIt.instance.registerSingleton<LogProvider>(LogProvider());
+  });
+
+  tearDownAll(() async {
+    await GetIt.instance.reset();
+  });
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('adopted_process_watch');
+  });
+
+  ProcessManager manager() {
+    final made = ProcessManager(
+      appDir: dir,
+      pidFileManager: PidFileManager(pidDir: Directory('${dir.path}/pids')),
+      adoptedPollInterval: const Duration(milliseconds: 20),
+    );
+    addTearDown(made.dispose);
+    return made;
+  }
+
+  test('an adopted process counts as running', () {
+    final made = manager();
+    final binary = BitWindow();
+
+    made.adopt(binary, pid);
+
+    expect(made.isRunning(binary), isTrue);
+    expect(made.runningProcesses[binary.name]!.adopted, isTrue);
+  });
+
+  test('the death of an adopted process drops it and tells the listeners', () async {
+    final made = manager();
+    final binary = BitWindow();
+    await made.pidFileManager.writePidFile(binary, _deadPid);
+
+    final died = Completer<void>();
+    made.addListener(() {
+      if (!made.isRunning(binary) && !died.isCompleted) {
+        died.complete();
+      }
+    });
+
+    made.adopt(binary, _deadPid);
+    expect(made.isRunning(binary), isTrue, reason: 'the poll has not run yet');
+
+    await died.future.timeout(const Duration(seconds: 10));
+
+    expect(await made.pidFileManager.readPidFile(binary), isNull);
+  });
+
+  test('a live adopted process stays registered', () async {
+    final made = manager();
+    // The poll reads the process name, so the daemon here is a real process.
+    final binary = BitWindow(
+      metadata: MetadataConfig(
+        downloadConfig: const DownloadConfig(binary: 'sleep', files: {}),
+        updateable: false,
+        remoteTimestamp: null,
+        downloadedTimestamp: null,
+        binaryPath: null,
+      ),
+    );
+    final live = await Process.start('/bin/sleep', ['30']);
+    addTearDown(() => live.kill());
+
+    made.adopt(binary, live.pid);
+    await Future.delayed(const Duration(milliseconds: 120));
+
+    expect(made.isRunning(binary), isTrue);
+  }, skip: Platform.isWindows);
+
+  test('a pid the OS gave to another process drops the daemon', () async {
+    final made = manager();
+    final binary = BitWindow();
+
+    final died = Completer<void>();
+    made.addListener(() {
+      if (!made.isRunning(binary) && !died.isCompleted) {
+        died.complete();
+      }
+    });
+
+    // This process lives, but it is not the daemon.
+    made.adopt(binary, pid);
+
+    await died.future.timeout(const Duration(seconds: 10));
+  });
+
+  test('a stopped process leaves no poll behind', () async {
+    final made = manager();
+    final binary = BitWindow();
+
+    made.adopt(binary, _deadPid);
+    await made.kill(binary);
+    var notified = 0;
+    made.addListener(() => notified++);
+
+    await Future.delayed(const Duration(milliseconds: 120));
+
+    expect(notified, 0, reason: 'the cancelled poll must not report the exit twice');
+  });
+}

--- a/sidechain_core/test/daemon_start_retry_test.dart
+++ b/sidechain_core/test/daemon_start_retry_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+
+  // The scheduled restart outlives the test that started it, and it reads the
+  // logger through GetIt. A reset between tests makes that read throw.
+  setUpAll(() {
+    GetIt.instance.registerSingleton<Logger>(Logger(level: Level.off));
+    GetIt.instance.registerSingleton<LogProvider>(LogProvider());
+  });
+
+  tearDownAll(() async {
+    await GetIt.instance.reset();
+  });
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('daemon_start_retry');
+  });
+
+  BinaryProvider provider(Binary binary) {
+    final made = BinaryProvider.test(
+      appDir: dir,
+      binaries: [binary],
+      processManager: ProcessManager(
+        appDir: dir,
+        pidFileManager: PidFileManager(pidDir: Directory('${dir.path}/pids')),
+      ),
+    );
+    addTearDown(made.dispose);
+    return made;
+  }
+
+  test('a daemon that never comes up gets another try', () async {
+    final binary = BitWindow();
+    final made = provider(binary);
+
+    // The binary is absent from the temp directory, so every spawn fails the
+    // way a held port fails: the process never comes up.
+    await expectLater(made.start(binary), throwsA(anything));
+    expect(binary.startupLogs.length, 1);
+
+    await Future.delayed(const Duration(milliseconds: 2500));
+
+    expect(binary.startupLogs.length, greaterThan(1), reason: 'the app must not keep a dead backend');
+  });
+
+  test('a disposed provider stops its process manager', () {
+    final manager = ProcessManager(
+      appDir: dir,
+      pidFileManager: PidFileManager(pidDir: Directory('${dir.path}/pids')),
+    );
+    BinaryProvider.test(appDir: dir, binaries: [BitWindow()], processManager: manager).dispose();
+
+    // A live poll on a disposed provider reports an exit nobody listens to.
+    expect(() => manager.addListener(() {}), throwsFlutterError);
+  });
+
+  test('a stop keeps the daemon down', () async {
+    final binary = BitWindow();
+    final made = provider(binary);
+
+    await expectLater(made.start(binary), throwsA(anything));
+    await made.stop(binary);
+
+    await Future.delayed(const Duration(milliseconds: 2500));
+
+    expect(binary.startupLogs.length, 1, reason: 'the user asked for the daemon to stay down');
+  });
+}


### PR DESCRIPTION
An OP_RETURN send returns the rest of the input to the wallet's change address. The explorer showed that output as a plain address, so it read as a payment to a stranger.

The transaction view marks each output the wallet owns, and names the change one. A second fix restarts an adopted bitwindowd: the app adopted the pid of the old daemon on a fast restart, never watched it, and kept a dead backend when it exited.