### PR TITLE
orchestrator: refuse a send without a fee estimate

### DIFF
--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -119,6 +119,25 @@ func (h *WalletHandler) expandBip47Destinations(
 	return expansion, nil
 }
 
+// resolveSendFeeRate fills in the rate a send pays when the caller names
+// neither a rate nor a fixed fee, so the caller can price the send before it
+// broadcasts anything. A backend that prices its own sends needs nothing.
+func (h *WalletHandler) resolveSendFeeRate(ctx context.Context, walletID string, req *wallet.SendRequest) error {
+	if req.FeeRateSatPerVB > 0 || req.FixedFeeSats > 0 {
+		return nil
+	}
+	rater, ok := h.engine.FeeRaterFor(walletID)
+	if !ok {
+		return nil
+	}
+	rate, err := rater.FeeRateForTarget(ctx, wallet.SendFeeTarget)
+	if err != nil {
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("no fee estimate for the payment: %w", err))
+	}
+	req.FeeRateSatPerVB = int64(math.Ceil(rate))
+	return nil
+}
+
 // releaseBip47Index gives back the per-payment index reserved for a send that
 // failed, so the retry derives the same address instead of burning an index.
 // No-op for passthrough (non-BIP47) expansions.

--- a/sidechain-orchestrator/api/bip47_send_fee_test.go
+++ b/sidechain-orchestrator/api/bip47_send_fee_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
+)
+
+// bip47TestChain funds one address and records every broadcast, so a
+// handler-level test can drive the real electrum backend with no REST server.
+type bip47TestChain struct {
+	addr      string
+	amount    int64
+	txid      string
+	feeRate   float64
+	feeErr    error
+	broadcast []string
+}
+
+func (c *bip47TestChain) AddressStats(_ context.Context, a string) (wallet.EsploraAddressStats, error) {
+	if a != c.addr {
+		return wallet.EsploraAddressStats{Address: a}, nil
+	}
+	return wallet.EsploraAddressStats{
+		Address:    a,
+		ChainStats: wallet.EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: c.amount, TxCount: 1},
+	}, nil
+}
+
+func (c *bip47TestChain) AddressUTXOs(_ context.Context, a string) ([]wallet.EsploraUTXO, error) {
+	if a != c.addr {
+		return nil, nil
+	}
+	return []wallet.EsploraUTXO{{
+		TxID: c.txid, Vout: 0, Value: c.amount,
+		Status: wallet.EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}, nil
+}
+
+func (c *bip47TestChain) AddressTxs(context.Context, string) ([]wallet.EsploraTx, error) {
+	return nil, nil
+}
+
+func (c *bip47TestChain) Tx(_ context.Context, txid string) (wallet.EsploraTx, error) {
+	if txid != c.txid {
+		return wallet.EsploraTx{}, errors.New("tx not found")
+	}
+	return wallet.EsploraTx{
+		TxID:   txid,
+		Vout:   []wallet.EsploraVout{{Value: c.amount, ScriptPubKeyAddress: c.addr}},
+		Status: wallet.EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}, nil
+}
+
+func (c *bip47TestChain) TxHex(context.Context, string) (string, error) {
+	return "", errors.New("tx hex not found")
+}
+
+func (c *bip47TestChain) Broadcast(_ context.Context, rawHex string) (string, error) {
+	c.broadcast = append(c.broadcast, rawHex)
+	return "broadcasttxid", nil
+}
+
+func (c *bip47TestChain) TipHeight(context.Context) (int, error) { return 110, nil }
+
+func (c *bip47TestChain) FeeRateForTarget(context.Context, int) (float64, error) {
+	if c.feeErr != nil {
+		return 0, c.feeErr
+	}
+	return c.feeRate, nil
+}
+
+// A first BIP47 payment publishes a notification transaction before the
+// payment. Without a fee estimate the payment cannot be built, so nothing at
+// all may go out: the notification alone spends a coin and pays no recipient.
+func TestSendTransactionBip47WithoutAFeeEstimateBroadcastsNothing(t *testing.T) {
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	svc := wallet.NewService(t.TempDir(), log)
+	svc.SetNetwork("signet")
+	require.NoError(t, svc.Init())
+	t.Cleanup(func() { svc.Close() })
+
+	w, err := svc.CreateElectrumWallet("E", nil, nil, "", "", "", "", 0, "")
+	require.NoError(t, err)
+
+	net := &chaincfg.SigNetParams
+	addrs, err := wallet.DeriveBIP84Addresses(w.Master.SeedHex, net, 0, 1)
+	require.NoError(t, err)
+
+	chain := &bip47TestChain{
+		addr:   addrs[0],
+		amount: 500_000,
+		txid:   "4444444444444444444444444444444444444444444444444444444444444444",
+		feeErr: errors.New("estimatefee: connection refused"),
+	}
+	eb := wallet.NewElectrumBackend(svc, chain, wallet.StaticParams(net), log)
+	engine := wallet.NewWalletEngine(svc, wallet.NewBackendRouter(svc, nil, eb), wallet.StaticParams(net), log)
+	store := bip47state.NewStore(t.TempDir())
+	h := NewWalletHandler(svc)
+	h.SetEngine(engine)
+	h.SetBip47StateStore(store)
+
+	recipient, err := bip47.PaymentCodeFromSeed(strings.Repeat("ab", 32), net)
+	require.NoError(t, err)
+	code := recipient.Base58()
+
+	ctx := context.Background()
+	send := &pb.SendTransactionRequest{
+		WalletId:     w.ID,
+		Destinations: map[string]int64{code: 50_000},
+	}
+
+	_, err = h.SendTransaction(ctx, connect.NewRequest(send))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fee estimate")
+	assert.Empty(t, chain.broadcast, "no notification may go out before the payment is priced")
+
+	state, err := store.GetState(w.ID, code)
+	require.NoError(t, err)
+	if state != nil {
+		assert.Nil(t, state.NotificationTxID, "an unsent notification leaves no record")
+	}
+
+	// The same send goes through once the chain answers, so the refusal above
+	// came from the missing estimate alone.
+	chain.feeErr = nil
+	chain.feeRate = 5
+	_, err = h.SendTransaction(ctx, connect.NewRequest(send))
+	require.NoError(t, err)
+	assert.Len(t, chain.broadcast, 2, "the notification and the payment both go out")
+
+	// A later payment to the same recipient sends no notification, but it still
+	// reserves an index. A missing estimate must give that index back, or a run
+	// of failures walks the payment past the recipient's gap limit.
+	state, err = store.GetState(w.ID, code)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	nextIndex := state.NextSendIndex
+
+	chain.feeErr = errors.New("estimatefee: connection refused")
+	_, err = h.SendTransaction(ctx, connect.NewRequest(send))
+	require.Error(t, err)
+	assert.Len(t, chain.broadcast, 2, "a payment the wallet cannot price sends nothing")
+
+	state, err = store.GetState(w.ID, code)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, nextIndex, state.NextSendIndex, "the reserved index comes back")
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -869,16 +869,6 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 		}
 	}
 
-	if expansion.notificationTxHex != "" {
-		notifTxID, err := h.broadcastBip47Notification(ctx, walletID, expansion.recipientCode, expansion.notificationTxHex, req.Msg.AllowReplay)
-		if err != nil {
-			// The payment never went out, so its index is still free.
-			h.releaseBip47Index(walletID, expansion)
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("broadcast bip47 notification: %w", err))
-		}
-		_ = notifTxID
-	}
-
 	sendReq := wallet.SendRequest{
 		DestinationsSats:      req.Msg.Destinations,
 		FeeRateSatPerVB:       req.Msg.FeeRateSatPerVbyte,
@@ -887,6 +877,27 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 		SubtractFeeFromAmount: req.Msg.SubtractFeeFromAmount,
 		AllowReplay:           req.Msg.AllowReplay,
 		Replaceable:           req.Msg.Replaceable,
+	}
+
+	// A BIP47 payment holds a reserved index, and its first send also publishes
+	// a notification that spends a real coin. Price the payment before either,
+	// so a wallet that cannot price it gives the index back and leaves the
+	// chain untouched.
+	if expansion.recipientCode != "" {
+		if err := h.resolveSendFeeRate(ctx, walletID, &sendReq); err != nil {
+			h.releaseBip47Index(walletID, expansion)
+			return nil, err
+		}
+	}
+
+	if expansion.notificationTxHex != "" {
+		notifTxID, err := h.broadcastBip47Notification(ctx, walletID, expansion.recipientCode, expansion.notificationTxHex, req.Msg.AllowReplay)
+		if err != nil {
+			// The payment never went out, so its index is still free.
+			h.releaseBip47Index(walletID, expansion)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("broadcast bip47 notification: %w", err))
+		}
+		_ = notifTxID
 	}
 	sendReq.RequiredInputs = lo.Map(req.Msg.RequiredInputs, func(u *pb.UnspentOutput, _ int) wallet.RequiredInput {
 		return wallet.RequiredInput{

--- a/sidechain-orchestrator/api/wallet_handler_psbt_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_psbt_test.go
@@ -47,8 +47,8 @@ func (e *psbtTestEsplora) TxHex(context.Context, string) (string, error) {
 }
 func (e *psbtTestEsplora) Broadcast(context.Context, string) (string, error) { return "txid", nil }
 func (e *psbtTestEsplora) TipHeight(context.Context) (int, error)            { return 110, nil }
-func (e *psbtTestEsplora) FeeRateForTarget(context.Context, int, float64) float64 {
-	return 2
+func (e *psbtTestEsplora) FeeRateForTarget(context.Context, int) (float64, error) {
+	return 2, nil
 }
 
 // TestWalletHandlerPSBTRoundTrip drives the exposed PSBT RPCs through the real

--- a/sidechain-orchestrator/engines/wallet_sync_engine_test.go
+++ b/sidechain-orchestrator/engines/wallet_sync_engine_test.go
@@ -2,6 +2,7 @@ package engines
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -37,8 +38,8 @@ func (c *countingChain) Tx(context.Context, string) (wallet.EsploraTx, error) {
 func (c *countingChain) TxHex(context.Context, string) (string, error)     { return "", nil }
 func (c *countingChain) Broadcast(context.Context, string) (string, error) { return "", nil }
 func (c *countingChain) TipHeight(context.Context) (int, error)            { return 110, nil }
-func (c *countingChain) FeeRateForTarget(_ context.Context, _ int, fallback float64) float64 {
-	return fallback
+func (c *countingChain) FeeRateForTarget(context.Context, int) (float64, error) {
+	return 0, errors.New("no fee estimate")
 }
 
 func newSyncFixture(t *testing.T) (*WalletSyncEngine, *wallet.Service, *wallet.WalletEngine, *countingChain) {

--- a/sidechain-orchestrator/wallet/backend.go
+++ b/sidechain-orchestrator/wallet/backend.go
@@ -72,6 +72,17 @@ type Bip47Backend interface {
 	EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error
 }
 
+// SendFeeTarget is the confirmation target, in blocks, a send prices at when
+// the caller names no rate.
+const SendFeeTarget = 6
+
+// FeeRater is a Backend that takes a send's fee rate from a chain estimate, so
+// a caller can read that rate before it broadcasts anything. A backend that
+// prices its own sends (Core) does not implement it.
+type FeeRater interface {
+	FeeRateForTarget(ctx context.Context, target int) (float64, error)
+}
+
 // DepositBackend is a backend that builds the BIP300 M5 itself, so the caller
 // hands it the slot and the destination instead of a raw treasury output.
 type DepositBackend interface {

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -196,9 +196,10 @@ func (p *ElectrumBackend) ResetNetworkState() {
 	p.log.Info().Msg("dropped wallet chain state after network switch")
 }
 
-// FeeRateForTarget returns the esplora sat/vB fee estimate for a confirmation target.
-func (p *ElectrumBackend) FeeRateForTarget(ctx context.Context, target int) float64 {
-	return p.client.FeeRateForTarget(ctx, target, 1.0)
+// FeeRateForTarget returns the chain source's sat/vB estimate for a
+// confirmation target, and errors when the source has none.
+func (p *ElectrumBackend) FeeRateForTarget(ctx context.Context, target int) (float64, error) {
+	return p.client.FeeRateForTarget(ctx, target)
 }
 
 // scannedAddr is one derived (or watched) address with its key and current
@@ -969,12 +970,15 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 	}
 	sort.Slice(remaining, func(i, j int) bool { return remaining[i].amountSats > remaining[j].amountSats })
 
+	// A rate the caller did not set must come from the chain, never from a
+	// stand-in: a send at a made-up rate cannot confirm on a busy chain.
 	feeRate := float64(req.FeeRateSatPerVB)
-	if feeRate <= 0 {
-		feeRate = p.client.FeeRateForTarget(ctx, 6, 1.0)
-		if feeRate < 1 {
-			feeRate = 1
+	if feeRate <= 0 && req.FixedFeeSats <= 0 {
+		estimate, err := p.client.FeeRateForTarget(ctx, SendFeeTarget)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("no fee estimate for %d blocks: %w", SendFeeTarget, err)
 		}
+		feeRate = max(estimate, float64(minRelayFeeRate))
 	}
 
 	// Per-type sizing: input vsize from the wallet descriptor (accurate for
@@ -1461,9 +1465,12 @@ func (p *ElectrumBackend) previewBumpFee(ctx context.Context, scan *electrumScan
 		outputs = append(outputs, out)
 	}
 
-	suggested := int64(math.Ceil(p.FeeRateForTarget(ctx, electrumBumpFeeTarget)))
-	if floor := minBumpFeeRate(tx.Fee, vsize, len(tx.Vin)); suggested < floor {
-		suggested = floor
+	// No estimate leaves the suggestion empty: the preview still reports what
+	// the user needs to name a rate or to pay a child instead.
+	var suggested int64
+	estimate, estimateErr := p.FeeRateForTarget(ctx, electrumBumpFeeTarget)
+	if estimateErr == nil {
+		suggested = max(int64(math.Ceil(estimate)), minBumpFeeRate(tx.Fee, vsize, len(tx.Vin)))
 	}
 	preview := &BumpFeePreview{
 		InputCount:    len(tx.Vin),
@@ -1494,6 +1501,10 @@ func (p *ElectrumBackend) previewBumpFee(ctx context.Context, scan *electrumScan
 
 	rate := req.NewFeeRate
 	if rate <= 0 {
+		if suggested == 0 {
+			preview.Reason = fmt.Sprintf("no fee estimate for %d blocks: %v", electrumBumpFeeTarget, estimateErr)
+			return preview, nil
+		}
 		rate = suggested
 	}
 	target, err := pickBumpFeeOutput(outputs, req.FeeFromVout)

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -58,6 +58,8 @@ type fakeEsplora struct {
 	hexByID   map[string]string
 	tip       int
 	feeRate   float64
+	feeErr    error
+	feeCalls  int
 	broadcast []string
 }
 
@@ -149,13 +151,17 @@ func (f *fakeEsplora) TipHeight(_ context.Context) (int, error) {
 	return f.tip, nil
 }
 
-func (f *fakeEsplora) FeeRateForTarget(_ context.Context, _ int, fallback float64) float64 {
+func (f *fakeEsplora) FeeRateForTarget(_ context.Context, target int) (float64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.feeRate > 0 {
-		return f.feeRate
+	f.feeCalls++
+	if f.feeErr != nil {
+		return 0, f.feeErr
 	}
-	return fallback
+	if f.feeRate <= 0 {
+		return 0, fmt.Errorf("no fee estimate for %d blocks", target)
+	}
+	return f.feeRate, nil
 }
 
 func newElectrumFixture(t *testing.T) (*ElectrumBackend, *fakeEsplora, *WalletData, string) {

--- a/sidechain-orchestrator/wallet/electrum_client.go
+++ b/sidechain-orchestrator/wallet/electrum_client.go
@@ -574,14 +574,17 @@ func (c *ElectrumClient) TipHeight(ctx context.Context) (int, error) {
 	return head.Height, nil
 }
 
-// FeeRateForTarget maps Electrum's estimatefee (BTC/kB) to sat/vB, falling back
-// when the server has no estimate (it returns a negative number).
-func (c *ElectrumClient) FeeRateForTarget(ctx context.Context, target int, fallback float64) float64 {
+// FeeRateForTarget maps Electrum's estimatefee (BTC/kB) to sat/vB. A server
+// with no estimate answers a number at or below zero, which is an error here.
+func (c *ElectrumClient) FeeRateForTarget(ctx context.Context, target int) (float64, error) {
 	var btcPerKB float64
-	if err := c.call(ctx, &btcPerKB, "blockchain.estimatefee", target); err != nil || btcPerKB <= 0 {
-		return fallback
+	if err := c.call(ctx, &btcPerKB, "blockchain.estimatefee", target); err != nil {
+		return 0, fmt.Errorf("electrum estimatefee %d: %w", target, err)
 	}
-	return btcPerKB * 1e8 / 1000.0
+	if btcPerKB <= 0 {
+		return 0, fmt.Errorf("electrum server has no fee estimate for %d blocks", target)
+	}
+	return btcPerKB * 1e8 / 1000.0, nil
 }
 
 // buildTx fetches a raw transaction, decodes it, resolves each input's prevout,

--- a/sidechain-orchestrator/wallet/electrum_client_test.go
+++ b/sidechain-orchestrator/wallet/electrum_client_test.go
@@ -226,15 +226,25 @@ func TestElectrumClientFeeRateConversion(t *testing.T) {
 		return nil
 	})
 	c := NewElectrumClient(url, zerolog.Nop(), &chaincfg.SigNetParams)
-	assert.InDelta(t, 2.0, c.FeeRateForTarget(ctx, 6, 1), 1e-9)
+	rate, err := c.FeeRateForTarget(ctx, 6)
+	require.NoError(t, err)
+	assert.InDelta(t, 2.0, rate, 1e-9)
+}
 
-	// A server with no estimate (negative) falls back.
-	url2 := startFakeElectrum(t, func(method string, _ []json.RawMessage) interface{} {
-		if method == "blockchain.estimatefee" {
-			return -1
-		}
-		return nil
-	})
-	c2 := NewElectrumClient(url2, zerolog.Nop(), &chaincfg.SigNetParams)
-	assert.Equal(t, 5.0, c2.FeeRateForTarget(ctx, 6, 5))
+// A server with no estimate answers a negative number. The old code turned
+// that into 1 sat/vB, which builds a transaction the chain never confirms.
+func TestElectrumClientFeeRateRefusesAMissingEstimate(t *testing.T) {
+	ctx := context.Background()
+	for _, answer := range []interface{}{-1, 0} {
+		url := startFakeElectrum(t, func(method string, _ []json.RawMessage) interface{} {
+			if method == "blockchain.estimatefee" {
+				return answer
+			}
+			return nil
+		})
+		c := NewElectrumClient(url, zerolog.Nop(), &chaincfg.SigNetParams)
+		rate, err := c.FeeRateForTarget(ctx, 6)
+		require.Error(t, err)
+		assert.Zero(t, rate)
+	}
 }

--- a/sidechain-orchestrator/wallet/electrum_fee_test.go
+++ b/sidechain-orchestrator/wallet/electrum_fee_test.go
@@ -1,0 +1,183 @@
+package wallet
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const feeTestWalletSats = int64(200_000)
+
+// fundFeeTestWallet gives the fixture one confirmed coin to spend.
+func fundFeeTestWallet(fake *fakeEsplora, addr string) {
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: feeTestWalletSats, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "7777777777777777777777777777777777777777777777777777777777777777",
+		Vout: 0, Value: feeTestWalletSats,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+}
+
+// broadcastFeeRate is the sat/vB the broadcast transaction pays.
+func broadcastFeeRate(t *testing.T, rawHex string) float64 {
+	t.Helper()
+	raw, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+
+	out := int64(0)
+	for _, o := range tx.TxOut {
+		out += o.Value
+	}
+	weight := tx.SerializeSizeStripped()*3 + tx.SerializeSize()
+	vsize := math.Ceil(float64(weight) / 4)
+	return float64(feeTestWalletSats-out) / vsize
+}
+
+// A send with no fee rate takes the chain's estimate. The chain cannot answer,
+// so the send must fail: a 1 sat/vB stand-in leaves the coins stuck.
+func TestElectrumSendRefusesAFailedFeeEstimate(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fundFeeTestWallet(fake, addr)
+	fake.feeErr = errors.New("estimatefee: connection refused")
+
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no fee estimate")
+	assert.Empty(t, fake.broadcast, "a send without a rate must build no transaction")
+}
+
+// A server that answers zero (or a negative number) has no estimate either.
+func TestElectrumSendRefusesAZeroFeeEstimate(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fundFeeTestWallet(fake, addr)
+	fake.feeRate = 0
+
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no fee estimate")
+	assert.Empty(t, fake.broadcast, "a send without a rate must build no transaction")
+}
+
+// The chain answers, so the send pays what it answered.
+func TestElectrumSendPaysTheEstimatedRate(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fundFeeTestWallet(fake, addr)
+	fake.feeRate = 401.5
+
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+	assert.InDelta(t, 401.5, broadcastFeeRate(t, fake.broadcast[0]), 10)
+}
+
+// The user names the rate, so the wallet pays it and asks no server.
+func TestElectrumSendKeepsTheRateTheUserNamed(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fundFeeTestWallet(fake, addr)
+	fake.feeRate = 401.5
+
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FeeRateSatPerVB:  3,
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+	assert.InDelta(t, 3, broadcastFeeRate(t, fake.broadcast[0]), 0.5)
+	assert.Zero(t, fake.feeCalls, "a named rate needs no estimate")
+}
+
+// A server-side OP_RETURN sender passes no fee at all. It gets an error it can
+// try again on, never a transaction at a made-up rate.
+func TestElectrumSendOpReturnRefusesAFailedFeeEstimate(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fundFeeTestWallet(fake, addr)
+	fake.feeErr = errors.New("estimatefee: connection refused")
+
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		OpReturnHex: hex.EncodeToString([]byte("coinnews: hello world")),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no fee estimate")
+	assert.Empty(t, fake.broadcast)
+
+	fake.feeRate = 401.5
+	fake.feeErr = nil
+	_, err = p.Send(context.Background(), w.ID, SendRequest{
+		OpReturnHex: hex.EncodeToString([]byte("coinnews: hello world")),
+	})
+	require.NoError(t, err, "the caller can try again once the server answers")
+	require.Len(t, fake.broadcast, 1)
+}
+
+// Without an estimate the preview still reports the transaction, so the user
+// can name a rate or pay a child. It carries no suggested rate.
+func TestElectrumPreviewBumpFeeWithoutAnEstimateStillPreviews(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	fake.feeErr = errors.New("estimatefee: connection refused")
+
+	preview, err := p.PreviewBumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid})
+	require.NoError(t, err)
+	require.NotNil(t, preview)
+	assert.True(t, preview.CanReplace)
+	assert.Zero(t, preview.SuggestedRate)
+	assert.Len(t, preview.Outputs, 2)
+	assert.Equal(t, int64(151), preview.OldFeeSats)
+	assert.Nil(t, preview.Plan)
+	assert.Contains(t, preview.Reason, "fee estimate")
+}
+
+// A bump that asks the code to pick the rate needs the estimate.
+func TestElectrumBumpFeeWithoutAnEstimateRefusesToPickTheRate(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	fake.feeErr = errors.New("estimatefee: connection refused")
+
+	_, err := p.BumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fee estimate")
+	assert.Empty(t, fake.broadcast)
+}
+
+// The user names the rate, so the bump goes out with no estimate at all.
+func TestElectrumBumpFeeWithoutAnEstimateTakesANamedRate(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	fake.feeErr = errors.New("estimatefee: connection refused")
+
+	result, err := p.BumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1510), result.Plan.NewFeeSats)
+	require.Len(t, fake.broadcast, 1)
+}
+
+// A fixed fee names the whole fee, so a dead estimate must not stop a CPFP
+// child or a deposit.
+func TestElectrumSendWithAFixedFeeNeedsNoEstimate(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fundFeeTestWallet(fake, addr)
+	fake.feeErr = errors.New("estimatefee: connection refused")
+
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FixedFeeSats:     1_000,
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+	assert.Zero(t, fake.feeCalls, "a fixed fee needs no estimate")
+}

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -56,6 +56,16 @@ func (e *WalletEngine) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
 	return b, ok
 }
 
+// FeeRaterFor returns the wallet's backend as a FeeRater when it prices a send
+// from a chain estimate, so a caller can read that rate before it broadcasts.
+func (e *WalletEngine) FeeRaterFor(walletID string) (FeeRater, bool) {
+	if r, ok := e.backend.(*BackendRouter); ok {
+		return r.FeeRaterFor(walletID)
+	}
+	f, ok := e.backend.(FeeRater)
+	return f, ok
+}
+
 // ChainForWallet returns the chain source for a wallet's backend, dispatching
 // by wallet type so electrum wallets read/broadcast over Esplora.
 func (e *WalletEngine) ChainForWallet(walletID string) ChainSource {
@@ -127,7 +137,7 @@ func (e *WalletEngine) EstimateFeeRate(ctx context.Context, confTarget int) (flo
 	if err != nil {
 		return 0, err
 	}
-	return eb.FeeRateForTarget(ctx, confTarget), nil
+	return eb.FeeRateForTarget(ctx, confTarget)
 }
 
 // SyncElectrumWallet brings a wallet's cached scan up to the chain tip, serving

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -34,7 +34,9 @@ type ChainDataSource interface {
 	TxHex(ctx context.Context, txid string) (string, error)
 	Broadcast(ctx context.Context, rawHex string) (string, error)
 	TipHeight(ctx context.Context) (int, error)
-	FeeRateForTarget(ctx context.Context, target int, fallback float64) float64
+	// FeeRateForTarget is the sat/vB rate that confirms within target blocks.
+	// A source with no estimate answers an error, never a substitute rate.
+	FeeRateForTarget(ctx context.Context, target int) (float64, error)
 }
 
 // EsploraClient talks to a Blockstream-style Esplora REST API. It serves the
@@ -599,19 +601,19 @@ func (c *EsploraClient) FeeEstimates(ctx context.Context) (map[string]float64, e
 }
 
 // FeeRateForTarget returns the sat/vB fee rate for the given confirmation
-// target, falling back to the nearest available estimate, then to fallback.
-func (c *EsploraClient) FeeRateForTarget(ctx context.Context, target int, fallback float64) float64 {
+// target, or the nearest target the server estimates.
+func (c *EsploraClient) FeeRateForTarget(ctx context.Context, target int) (float64, error) {
 	est, err := c.FeeEstimates(ctx)
-	if err != nil || len(est) == 0 {
-		return fallback
+	if err != nil {
+		return 0, fmt.Errorf("esplora fee estimates: %w", err)
 	}
 	if rate, ok := est[strconv.Itoa(target)]; ok && rate > 0 {
-		return rate
+		return rate, nil
 	}
 	best, bestDelta := 0.0, 1<<30
 	for k, rate := range est {
 		blocks, err := strconv.Atoi(k)
-		if err != nil {
+		if err != nil || rate <= 0 {
 			continue
 		}
 		if delta := abs(blocks - target); delta < bestDelta {
@@ -619,9 +621,9 @@ func (c *EsploraClient) FeeRateForTarget(ctx context.Context, target int, fallba
 		}
 	}
 	if best > 0 {
-		return best
+		return best, nil
 	}
-	return fallback
+	return 0, fmt.Errorf("esplora has no fee estimate for %d blocks", target)
 }
 
 func abs(n int) int {

--- a/sidechain-orchestrator/wallet/fallback_chain_source.go
+++ b/sidechain-orchestrator/wallet/fallback_chain_source.go
@@ -158,15 +158,24 @@ func (f *fallbackChainSource) TipHeight(ctx context.Context) (int, error) {
 	return out, err
 }
 
-// FeeRateForTarget reports no error, so a source that hands back the caller's
-// own fallback value counts as a miss and the next source gets a turn.
-func (f *fallbackChainSource) FeeRateForTarget(ctx context.Context, target int, fallback float64) float64 {
+// FeeRateForTarget asks each source in turn. A server with no estimate still
+// serves reads and pushes, so a miss here leaves its health state alone.
+func (f *fallbackChainSource) FeeRateForTarget(ctx context.Context, target int) (float64, error) {
+	var errs []error
 	for _, i := range f.order() {
-		if rate := f.sources[i].FeeRateForTarget(ctx, target, fallback); rate != fallback {
-			return rate
+		if err := ctx.Err(); err != nil {
+			return 0, err
 		}
+		rate, err := f.sources[i].FeeRateForTarget(ctx, target)
+		if err == nil {
+			return rate, nil
+		}
+		errs = append(errs, err)
 	}
-	return fallback
+	if len(errs) == 0 {
+		return 0, errors.New("no chain source configured")
+	}
+	return 0, errors.Join(errs...)
 }
 
 // BaseURLs reports every endpoint behind this source, best first.

--- a/sidechain-orchestrator/wallet/fallback_chain_source_test.go
+++ b/sidechain-orchestrator/wallet/fallback_chain_source_test.go
@@ -56,12 +56,12 @@ func (s *stubChainSource) TipHeight(context.Context) (int, error) {
 	return s.height, nil
 }
 
-func (s *stubChainSource) FeeRateForTarget(_ context.Context, _ int, fallback float64) float64 {
+func (s *stubChainSource) FeeRateForTarget(context.Context, int) (float64, error) {
 	s.calls++
 	if s.fee == 0 {
-		return fallback
+		return 0, errors.New("no fee estimate")
 	}
-	return s.fee
+	return s.fee, nil
 }
 
 // A dead Fulcrum server must not stop the wallet: the next source serves.
@@ -117,14 +117,39 @@ func TestFallbackChainSourceReportsEverySourceFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "esplora down")
 }
 
-// A source that cannot estimate hands back the caller's own fallback, so the
-// next source gets a turn instead of the wallet using a static fee.
+// A source that cannot estimate errors, so the next source gets a turn
+// instead of the wallet using a static fee.
 func TestFallbackChainSourceFeeRateFallsThrough(t *testing.T) {
 	fulcrum := &stubChainSource{}
 	esplora := &stubChainSource{fee: 12.5}
 
 	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
-	assert.Equal(t, 12.5, f.FeeRateForTarget(context.Background(), 6, 1))
+	rate, err := f.FeeRateForTarget(context.Background(), 6)
+	require.NoError(t, err)
+	assert.Equal(t, 12.5, rate)
+}
+
+// A server with no fee estimate still serves reads and pushes, so the miss
+// must not send the next read to the slower source.
+func TestFallbackChainSourceFeeRateMissKeepsThePrimary(t *testing.T) {
+	fulcrum := &stubChainSource{height: 840000}
+	esplora := &stubChainSource{fee: 12.5}
+
+	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
+	_, err := f.FeeRateForTarget(context.Background(), 6)
+	require.NoError(t, err)
+
+	_, err = f.TipHeight(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, fulcrum.calls, "the primary must still take the next read")
+}
+
+// No source can estimate, so the read fails. A wallet must not send at a rate
+// the chain never gave.
+func TestFallbackChainSourceFeeRateErrorsWhenNoSourceEstimates(t *testing.T) {
+	f := newFallbackChainSource([]ChainDataSource{&stubChainSource{}, &stubChainSource{}}, zerolog.Nop())
+	_, err := f.FeeRateForTarget(context.Background(), 6)
+	require.Error(t, err)
 }
 
 // A cancelled read must stop, not walk the whole source list.

--- a/sidechain-orchestrator/wallet/network_chain_source.go
+++ b/sidechain-orchestrator/wallet/network_chain_source.go
@@ -245,12 +245,12 @@ func (s *NetworkChainSource) TipHeight(ctx context.Context) (int, error) {
 	return c.TipHeight(ctx)
 }
 
-func (s *NetworkChainSource) FeeRateForTarget(ctx context.Context, target int, fallback float64) float64 {
+func (s *NetworkChainSource) FeeRateForTarget(ctx context.Context, target int) (float64, error) {
 	c, err := s.current()
 	if err != nil {
-		return fallback
+		return 0, err
 	}
-	return c.FeeRateForTarget(ctx, target, fallback)
+	return c.FeeRateForTarget(ctx, target)
 }
 
 // Notifications relays the active client's push stream when it has one.

--- a/sidechain-orchestrator/wallet/network_chain_source_test.go
+++ b/sidechain-orchestrator/wallet/network_chain_source_test.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -270,8 +271,8 @@ func (c *switchOnTipClient) AddressTxs(context.Context, string) ([]EsploraTx, er
 func (c *switchOnTipClient) Tx(context.Context, string) (EsploraTx, error)     { return EsploraTx{}, nil }
 func (c *switchOnTipClient) TxHex(context.Context, string) (string, error)     { return "", nil }
 func (c *switchOnTipClient) Broadcast(context.Context, string) (string, error) { return "", nil }
-func (c *switchOnTipClient) FeeRateForTarget(_ context.Context, _ int, fallback float64) float64 {
-	return fallback
+func (c *switchOnTipClient) FeeRateForTarget(context.Context, int) (float64, error) {
+	return 0, errors.New("no fee estimate")
 }
 
 // consumerOnce bound to the first client meant an Esplora-first process could

--- a/sidechain-orchestrator/wallet/router.go
+++ b/sidechain-orchestrator/wallet/router.go
@@ -56,6 +56,17 @@ func (r *BackendRouter) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
 	return b, ok
 }
 
+// FeeRaterFor returns the wallet's backend as a FeeRater when it prices a send
+// from a chain estimate. ok is false when the backend prices its own sends.
+func (r *BackendRouter) FeeRaterFor(walletID string) (FeeRater, bool) {
+	p, err := r.pick(walletID)
+	if err != nil {
+		return nil, false
+	}
+	f, ok := p.(FeeRater)
+	return f, ok
+}
+
 func (r *BackendRouter) pick(walletID string) (Backend, error) {
 	w := r.svc.GetWalletByID(walletID)
 	if w == nil {


### PR DESCRIPTION
A failed fee estimate made the wallet build a send at 1 sat/vB, which a busy chain never confirms. The send now fails and the caller can try again.

A rate the user names still goes through unchanged.