### PR TITLE
Split the L1 and sidechain balance, and fit the sidechains row

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -251,6 +251,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
 
   GetIt.I.registerLazySingleton<BalanceProvider>(
     () => BalanceProvider(
+      mainConnection: bitwindow,
       connections: [
         bitwindow,
         GetIt.I.get<BitnamesRPC>(),

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -447,19 +447,25 @@ class _SidechainsTable extends ViewModelWidget<SidechainsViewModel> {
   ) {
     final colors = context.sailTheme.colors;
     final sidechain = viewModel.sidechains[slot];
-    final slotCell = SailTableCell(value: '$slot', width: 56, textColor: colors.textSecondary);
+    final slotCell = SailTableCell(
+      value: '$slot',
+      width: _slotColumnWidth,
+      padding: _tightCellPadding,
+      textColor: colors.textSecondary,
+    );
 
     if (sidechain == null) {
       return [
         slotCell,
         SailTableCell(value: ''),
-        SailTableCell(value: '', width: 130),
-        SailTableCell(value: '', width: 130),
-        SailTableCell(value: '', width: 300),
+        SailTableCell(value: '', hugContent: true, padding: _tightCellPadding),
+        SailTableCell(value: '', hugContent: true, padding: _tightCellPadding),
+        SailTableCell(value: '', width: _actionsColumnWidth),
       ];
     }
 
     final yourBalance = viewModel.yourBalance(slot);
+    final yourBalanceText = yourBalance == null ? '—' : formatter.formatBTC(yourBalance.confirmed);
 
     return [
       slotCell,
@@ -477,19 +483,27 @@ class _SidechainsTable extends ViewModelWidget<SidechainsViewModel> {
       ),
       SailTableCell(
         value: formatter.formatSats(sidechain.info.balanceSatoshi.toInt()),
-        width: 130,
+        hugContent: true,
+        padding: _tightCellPadding,
         alignment: Alignment.centerRight,
         textColor: colors.text,
       ),
       SailTableCell(
-        value: yourBalance == null ? '—' : formatter.formatBTC(yourBalance),
-        width: 130,
+        value: yourBalanceText,
+        hugContent: true,
+        padding: _tightCellPadding,
         alignment: Alignment.centerRight,
         textColor: yourBalance == null ? colors.textSecondary : colors.text,
+        child: yourBalance == null || yourBalance.pending == 0
+            ? null
+            : SailTooltip(
+                message: 'Pending ${formatter.formatBTC(yourBalance.pending)}',
+                child: SailText.primary13(yourBalanceText, color: colors.text),
+              ),
       ),
       SailTableCell(
         value: '',
-        width: 300,
+        width: _actionsColumnWidth,
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: SailStyleValues.padding12),
         child: _SidechainActions(viewModel: viewModel, slot: slot, sidechain: sidechain),
@@ -497,6 +511,16 @@ class _SidechainsTable extends ViewModelWidget<SidechainsViewModel> {
     ];
   }
 }
+
+/// Slot holds 1 to 3 digits, so it never needs the table's default minimum.
+const double _slotColumnWidth = 48;
+
+/// Update, Stop, the sync bar with its percent, Deposit and the settings icon.
+const double _actionsColumnWidth = 400;
+
+/// A balance cell carries a long number and its unit, so it keeps less padding
+/// than the rest of the row.
+const EdgeInsets _tightCellPadding = EdgeInsets.symmetric(horizontal: SailStyleValues.padding08);
 
 /// The main action, Deposit and the settings button of one sidechain row.
 class _SidechainActions extends StatelessWidget {
@@ -871,13 +895,13 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
   bool canDeposit(int slot) => isSidechainRunning(slot);
 
   /// The user's wallet balance in BTC on the chain in [slot], or null while the chain does not run.
-  double? yourBalance(int slot) {
+  ({double confirmed, double pending})? yourBalance(int slot) {
     final rpc = _sidechainRPC(slot);
     if (rpc == null || !rpc.connected || !_balanceProvider.connections.contains(rpc)) {
       return null;
     }
     final (confirmed, pending) = _balanceProvider.balanceFor(rpc);
-    return confirmed + pending;
+    return (confirmed: confirmed, pending: pending);
   }
 
   bool isSidechainRunning(int slot) => _sidechainRPC(slot)?.connected ?? false;
@@ -965,35 +989,27 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     }
 
     if (isRunning) {
-      // Running but indexing: the same SyncInfo the bottom nav reports.
-      final syncInfo = _syncInfoFor(sidechain);
-      if (syncInfo != null && syncInfo.mainchainSyncing) {
-        return SizedBox(
-          key: ValueKey('mainchain_sync_slot_${sidechain.slot}_${sidechain.name}'),
-          width: 160,
-          child: MainchainSyncStatus(syncInfo: syncInfo, compact: true),
-        );
-      }
-      if (syncInfo != null && !syncInfo.isSynced && syncInfo.progressGoal > 0) {
-        return _ActionProgress(
-          key: ValueKey('syncing_slot_${sidechain.slot}_${sidechain.name}'),
-          width: 96,
-          current: syncInfo.progressCurrent,
-          goal: syncInfo.progressGoal,
-          color: colors.orangeLight,
-          tooltip:
-              '${sidechain.name}\n'
-              'Current height ${formatProgress(syncInfo.progressCurrent, false)}\n'
-              'Header height ${formatProgress(syncInfo.progressGoal, false)}',
-        );
+      // A sync must never take the place of Stop: closing the chain's own
+      // window would then leave no way to stop the node.
+      final stop = SailButton(
+        key: ValueKey('stop_slot_${sidechain.slot}_${sidechain.name}'),
+        label: 'Stop',
+        variant: ButtonVariant.outline,
+        onPressed: () async => _binaryProvider.stop(sidechain),
+      );
+      final syncing = _syncingWidget(context, sidechain);
+      if (syncing == null) {
+        return _withUpdate(sidechain, stop);
       }
       return _withUpdate(
         sidechain,
-        SailButton(
-          key: ValueKey('stop_slot_${sidechain.slot}_${sidechain.name}'),
-          label: 'Stop',
-          variant: ButtonVariant.outline,
-          onPressed: () async => _binaryProvider.stop(sidechain),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            stop,
+            const SizedBox(width: SailStyleValues.padding08),
+            syncing,
+          ],
         ),
       );
     }
@@ -1031,6 +1047,36 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
         onPressed: () async => await _binaryProvider.start(sidechain),
       ),
     );
+  }
+
+  /// The sync bar that sits beside Stop, or null when the chain follows the tip.
+  Widget? _syncingWidget(BuildContext context, Sidechain sidechain) {
+    final colors = SailTheme.of(context).colors;
+    final syncInfo = _syncInfoFor(sidechain);
+    if (syncInfo == null) {
+      return null;
+    }
+    if (syncInfo.mainchainSyncing) {
+      return SizedBox(
+        key: ValueKey('mainchain_sync_slot_${sidechain.slot}_${sidechain.name}'),
+        width: 160,
+        child: MainchainSyncStatus(syncInfo: syncInfo, compact: true),
+      );
+    }
+    if (!syncInfo.isSynced && syncInfo.progressGoal > 0) {
+      return _ActionProgress(
+        key: ValueKey('syncing_slot_${sidechain.slot}_${sidechain.name}'),
+        width: 64,
+        current: syncInfo.progressCurrent,
+        goal: syncInfo.progressGoal,
+        color: colors.orangeLight,
+        tooltip:
+            '${sidechain.name}\n'
+            'Current height ${formatProgress(syncInfo.progressCurrent, false)}\n'
+            'Header height ${formatProgress(syncInfo.progressGoal, false)}',
+      );
+    }
+    return null;
   }
 
   Widget _withUpdate(Sidechain sidechain, Widget action) {

--- a/bitwindow/test/sidechains_table_test.dart
+++ b/bitwindow/test/sidechains_table_test.dart
@@ -247,6 +247,8 @@ void main() {
     expect(find.text('62%'), findsOneWidget);
     expect(find.text('Updating'), findsNothing);
     expect(_button('Download'), findsNothing);
+    // Nothing runs yet, so the bar keeps the place of the button.
+    expect(_button('Stop'), findsNothing);
   });
 
   testWidgets('an update puts a primary Update before an outline Start', (tester) async {
@@ -350,7 +352,13 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text(label), findsOneWidget);
       expect(find.text('41.3%'), findsOneWidget);
-      expect(_button('Stop'), findsNothing);
+      // A sync must not take the place of Stop: the chain's own window may be
+      // closed, and then the table is the only way to stop the node.
+      expect(_button('Stop'), findsOneWidget);
+      expect(
+        tester.getRect(_button('Stop')).right,
+        lessThanOrEqualTo(tester.getRect(find.byType(MainchainSyncStatus)).left),
+      );
       expect(
         tester.getRect(find.byType(MainchainSyncStatus)).right,
         lessThanOrEqualTo(tester.getRect(_button('Deposit')).left),
@@ -368,5 +376,93 @@ void main() {
 
     expect(find.byType(MainchainSyncStatus), findsNothing);
     expect(find.text('34%'), findsOneWidget);
+    expect(_button('Stop'), findsOneWidget);
   });
+
+  // A slot number is three characters at most, so the gap to the name was the
+  // table's default minimum, not the content.
+  testWidgets('the widest slot keeps Slot narrow and Name right after it', (tester) async {
+    setUpChain(_thunder());
+    GetIt.I.get<SidechainProvider>().sidechains[255] = SidechainOverview(
+      ListSidechainsResponse_Sidechain(title: 'CoinShift', slot: 255, balanceSatoshi: Int64(5000000)),
+      [],
+      [],
+    );
+    await pumpTable(tester);
+
+    final slot = tester.getRect(_cell('255'));
+    final name = tester.getRect(_cell('CoinShift'));
+    expect(slot.width, lessThanOrEqualTo(_headerWidth('Slot') + 25));
+    expect(name.left - slot.right, lessThanOrEqualTo(8));
+  });
+
+  testWidgets('the widest name and balance stay on one line', (tester) async {
+    setUpChain(_thunder());
+    GetIt.I.get<SidechainProvider>().sidechains[9] = SidechainOverview(
+      ListSidechainsResponse_Sidechain(title: 'Truthcoin', slot: 9, balanceSatoshi: Int64(11502555423)),
+      [],
+      [],
+    );
+    thunderRPC.wallet = (115.02555423, 0.0);
+    thunderRPC.setConnected(true);
+    await balances.fetch();
+    await pumpTable(tester);
+
+    final balance = GetIt.I.get<FormatterProvider>().formatBTC(115.02555423);
+    _expectOneUncutLine(tester, _cell('Truthcoin'), 'Truthcoin', dressing: 16);
+    _expectOneUncutLine(tester, _cell(balance), balance);
+  });
+
+  // Adding confirmed and pending into one figure made the cell disagree with
+  // the bottom nav, which shows the two apart.
+  testWidgets('Your balance shows the confirmed figure and holds pending in a tooltip', (tester) async {
+    setUpChain(_thunder());
+    thunderRPC.wallet = (2.01999, 1.0);
+    thunderRPC.setConnected(true);
+    await balances.fetch();
+    await pumpTable(tester);
+
+    final formatter = GetIt.I.get<FormatterProvider>();
+    expect(find.text(formatter.formatBTC(2.01999)), findsOneWidget);
+    expect(find.text(formatter.formatBTC(3.01999)), findsNothing);
+    expect(_tooltip('Pending ${formatter.formatBTC(1.0)}'), findsOneWidget);
+  });
+
+  testWidgets('a chain with nothing pending shows one number and no tooltip', (tester) async {
+    setUpChain(_thunder());
+    thunderRPC.wallet = (2.01999, 0.0);
+    thunderRPC.setConnected(true);
+    await balances.fetch();
+    await pumpTable(tester);
+
+    final formatter = GetIt.I.get<FormatterProvider>();
+    expect(find.text(formatter.formatBTC(2.01999)), findsOneWidget);
+    expect(_tooltip('Pending ${formatter.formatBTC(0.0)}'), findsNothing);
+  });
+}
+
+Finder _tooltip(String message) =>
+    find.byWidgetPredicate((widget) => widget is SailTooltip && widget.message == message);
+
+Finder _cell(String value) => find.byWidgetPredicate((widget) => widget is SailTableCell && widget.value == value);
+
+double _textWidth(String text, {bool bold = false}) {
+  final painter = TextPainter(
+    text: TextSpan(
+      text: text,
+      style: SailStyleValues.thirteen.copyWith(fontWeight: bold ? SailStyleValues.boldWeight : null),
+    ),
+    textDirection: TextDirection.ltr,
+  )..layout();
+  return painter.width;
+}
+
+double _headerWidth(String name) => _textWidth(name, bold: true);
+
+/// Fails when the column is narrower than the string plus its padding and
+/// [dressing], which is where an ellipsis or a second line comes from.
+void _expectOneUncutLine(WidgetTester tester, Finder cell, String text, {double dressing = 0}) {
+  for (final box in tester.widgetList(cell).indexed) {
+    expect(tester.getSize(cell.at(box.$1)).width, greaterThanOrEqualTo(_textWidth(text) + 16 + dressing));
+  }
 }

--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -373,7 +373,7 @@ class _SailTableState extends State<SailTable> {
       final cells = widget.rowBuilder(context, row, false);
       for (int col = 0; col < cells.length && col < _numColumns!; col++) {
         final cell = cells[col];
-        if (cell is SailTableCell && cell.width != null) {
+        if (cell is SailTableCell && (cell.width != null || cell.hugContent)) {
           fixedColumns[col] = true;
         }
         final cellWidth = _calculateColumnWidth(cell);
@@ -382,6 +382,9 @@ class _SailTableState extends State<SailTable> {
     }
 
     for (int i = 0; i < _numColumns!; i++) {
+      if (fixedColumns[i]) {
+        continue;
+      }
       columnWidths[i] = max(columnWidths[i], defaultMinColumnWidth);
     }
 
@@ -422,33 +425,37 @@ class _SailTableState extends State<SailTable> {
     String text = '';
     TextStyle? textStyle;
 
+    // A cell renders at thirteen, so a measurement at twelve leaves the widest
+    // value one ellipsis short of its own column.
     if (widget is SailTableCell) {
       if (widget.width != null) {
         return widget.width!;
       }
       text = widget.value;
-      textStyle = SailStyleValues.twelve.copyWith(
+      textStyle = SailStyleValues.thirteen.copyWith(
         fontFamily: widget.monospace ? 'IBMPlexMono' : 'Inter',
       );
+      return _calculateTextWidth(text, textStyle, widget.padding.horizontal);
     } else if (widget is SailTableHeaderCell) {
       text = widget.name;
-      textStyle = SailStyleValues.twelve.copyWith(
+      textStyle = SailStyleValues.thirteen.copyWith(
         fontFamily: 'Inter',
         fontWeight: SailStyleValues.boldWeight,
       );
+      return _calculateTextWidth(text, textStyle, widget.padding.horizontal);
     }
 
-    return _calculateTextWidth(text, textStyle ?? SailStyleValues.twelve);
+    return _calculateTextWidth(text, SailStyleValues.thirteen, 24);
   }
 
-  double _calculateTextWidth(String text, TextStyle textStyle) {
+  double _calculateTextWidth(String text, TextStyle textStyle, double padding) {
     if (text.isNotEmpty) {
       final textPainter = TextPainter(
         text: TextSpan(text: text, style: textStyle),
         textDirection: TextDirection.ltr,
       );
       textPainter.layout();
-      return textPainter.width + 25;
+      return textPainter.width + padding + 1;
     }
 
     return defaultMinColumnWidth;
@@ -727,6 +734,7 @@ class SailTableCell extends StatelessWidget {
     this.backgroundColor,
     this.monospace = false,
     this.italic = false,
+    this.hugContent = false,
     super.key,
   });
 
@@ -735,6 +743,10 @@ class SailTableCell extends StatelessWidget {
   final Widget? child;
   // Width override for cells whose child is wider than the value text.
   final double? width;
+
+  /// True keeps the column at the width its widest value needs, so the free
+  /// width of the table goes to the columns that can use it.
+  final bool hugContent;
   final Alignment alignment;
   final EdgeInsets padding;
   final SailSVGAsset? plainIconTheme;

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -109,6 +109,8 @@ class BottomNav extends StatelessWidget {
                   showUnconfirmed: model.showUnconfirmed,
                   onToggleUnconfirmed: model.toggleUnconfirmed,
                   usdBalance: model.usdBalance,
+                  sidechainBalance: model.sidechainBalance,
+                  sidechainPendingBalance: model.sidechainPendingBalance,
                 );
               },
             ),
@@ -802,6 +804,11 @@ class BalanceDisplay extends StatelessWidget {
   final VoidCallback onToggleUnconfirmed;
   final double? usdBalance;
 
+  /// The coins every other chain holds, apart from the figure above. Zero on
+  /// both hides the whole group.
+  final double sidechainBalance;
+  final double sidechainPendingBalance;
+
   const BalanceDisplay({
     super.key,
     required this.balance,
@@ -810,7 +817,11 @@ class BalanceDisplay extends StatelessWidget {
     required this.showUnconfirmed,
     required this.onToggleUnconfirmed,
     required this.usdBalance,
+    this.sidechainBalance = 0,
+    this.sidechainPendingBalance = 0,
   });
+
+  bool get _showSidechains => sidechainBalance > 0 || sidechainPendingBalance > 0;
 
   @override
   Widget build(BuildContext context) {
@@ -861,6 +872,22 @@ class BalanceDisplay extends StatelessWidget {
                   ),
                 ),
               ),
+            if (_showSidechains) const DividerDot(),
+            if (_showSidechains)
+              SailRow(
+                spacing: SailStyleValues.padding08,
+                children: [
+                  SailSVG.icon(
+                    SailSVGAsset.iconCoins,
+                    color: SailColorScheme.blue,
+                    width: SailStyleValues.iconSizeSecondary,
+                    height: SailStyleValues.iconSizeSecondary,
+                  ),
+                  SailText.secondary12('Sidechains ${formatBitcoin(sidechainBalance)}'),
+                  if (sidechainPendingBalance > 0) const DividerDot(),
+                  if (sidechainPendingBalance > 0) SailText.secondary12(formatBitcoin(sidechainPendingBalance)),
+                ],
+              ),
           ],
         ),
       ),
@@ -881,6 +908,8 @@ class BalanceDisplayViewModel extends BaseViewModel with ChangeTrackingMixin {
   void _onChange() {
     track('balance', balance);
     track('pendingBalance', pendingBalance);
+    track('sidechainBalance', sidechainBalance);
+    track('sidechainPendingBalance', sidechainPendingBalance);
     track('balanceSyncing', balanceSyncing);
     track('showUnconfirmed', showUnconfirmed);
     notifyIfChanged();
@@ -888,6 +917,8 @@ class BalanceDisplayViewModel extends BaseViewModel with ChangeTrackingMixin {
 
   double get balance => _balanceProvider.balance;
   double get pendingBalance => _balanceProvider.pendingBalance;
+  double get sidechainBalance => _balanceProvider.sidechainBalance;
+  double get sidechainPendingBalance => _balanceProvider.sidechainPendingBalance;
   bool get balanceSyncing => !_balanceProvider.initialized;
   bool get showUnconfirmed => _showUnconfirmed;
   double? get usdBalance => _priceProvider.btcToUsd(balance);

--- a/sail_ui/test/balance_display_test.dart
+++ b/sail_ui/test/balance_display_test.dart
@@ -7,7 +7,11 @@ Future<void> pumpBalance(
   required double balance,
   required double pendingBalance,
   required bool showUnconfirmed,
+  double sidechainBalance = 0,
+  double sidechainPendingBalance = 0,
 }) async {
+  await tester.binding.setSurfaceSize(const Size(1400, 400));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(
     MaterialApp(
       home: SailTheme(
@@ -20,6 +24,8 @@ Future<void> pumpBalance(
             showUnconfirmed: showUnconfirmed,
             onToggleUnconfirmed: () {},
             usdBalance: null,
+            sidechainBalance: sidechainBalance,
+            sidechainPendingBalance: sidechainPendingBalance,
           ),
         ),
       ),
@@ -31,6 +37,8 @@ Future<void> pumpBalance(
 Finder get unconfirmed => find.byWidgetPredicate(
   (widget) => widget is Tooltip && widget.message == 'Unconfirmed balance',
 );
+
+Finder get sidechainTotal => find.textContaining('Sidechains ');
 
 void main() {
   // A sidechain deposit waits hours for the mainchain block that carries it.
@@ -53,5 +61,43 @@ void main() {
     await pumpBalance(tester, balance: 1.5, pendingBalance: 0, showUnconfirmed: true);
 
     expect(unconfirmed, findsOneWidget);
+  });
+
+  // One number over L1 and the sidechains together reads as mainchain money
+  // the Send page can spend. It cannot.
+  testWidgets('a chain window with no sidechain balance shows one figure', (tester) async {
+    await pumpBalance(tester, balance: 1.5, pendingBalance: 0, showUnconfirmed: false);
+
+    expect(find.textContaining(formatBitcoin(1.5)), findsOneWidget);
+    expect(sidechainTotal, findsNothing);
+  });
+
+  testWidgets('a sidechain balance leaves the mainchain figure alone', (tester) async {
+    await pumpBalance(
+      tester,
+      balance: 0,
+      pendingBalance: 330.99479104,
+      showUnconfirmed: false,
+      sidechainBalance: 2.01999,
+      sidechainPendingBalance: 1,
+    );
+
+    expect(find.textContaining(formatBitcoin(0)), findsOneWidget);
+    expect(find.text(formatBitcoin(330.99479104)), findsOneWidget);
+    expect(find.text('Sidechains ${formatBitcoin(2.01999)}'), findsOneWidget);
+    expect(find.text(formatBitcoin(1)), findsOneWidget);
+  });
+
+  testWidgets('a sidechain figure with nothing pending shows one number', (tester) async {
+    await pumpBalance(
+      tester,
+      balance: 1,
+      pendingBalance: 0,
+      showUnconfirmed: false,
+      sidechainBalance: 2.5,
+    );
+
+    expect(find.text('Sidechains ${formatBitcoin(2.5)}'), findsOneWidget);
+    expect(find.text(formatBitcoin(0)), findsNothing);
   });
 }

--- a/sail_ui/test/sail_table_columns_test.dart
+++ b/sail_ui/test/sail_table_columns_test.dart
@@ -31,6 +31,38 @@ Widget _table({required bool withAddress}) {
   );
 }
 
+Widget _sizedTable({required double slotWidth, required bool hugAmount}) {
+  return MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: SizedBox(
+          width: 800,
+          height: 400,
+          child: SailTable(
+            key: ValueKey('$slotWidth-$hugAmount'),
+            getRowId: (index) => 'row$index',
+            headerBuilder: (context) => const [
+              SailTableHeaderCell(name: 'N'),
+              SailTableHeaderCell(name: 'Name'),
+              SailTableHeaderCell(name: 'Amount'),
+            ],
+            rowBuilder: (context, index, selected) => [
+              SailTableCell(value: '255', width: slotWidth),
+              const SailTableCell(value: 'Truthcoin'),
+              SailTableCell(value: '115.0255,5423 ECX', hugContent: hugAmount),
+            ],
+            rowCount: 1,
+            drawGrid: false,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Finder _cell(String value) => find.byWidgetPredicate((widget) => widget is SailTableCell && widget.value == value);
+
 void main() {
   // A source that names no address drops that column. A refresh can add it
   // back, and the table reads every width by column index.
@@ -48,5 +80,27 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
     expect(find.text('Address'), findsNothing);
+  });
+
+  // The default minimum used to win over the width a cell asked for, so a
+  // three-character column sat at 60 px with a gap after it.
+  testWidgets('a width under the default minimum holds', (tester) async {
+    await tester.pumpWidget(_sizedTable(slotWidth: 40, hugAmount: false));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(_cell('255')).width, lessThan(defaultMinColumnWidth));
+  });
+
+  testWidgets('a hugging column takes none of the free width', (tester) async {
+    await tester.pumpWidget(_sizedTable(slotWidth: 40, hugAmount: false));
+    await tester.pumpAndSettle();
+    final stretched = tester.getSize(_cell('115.0255,5423 ECX')).width;
+
+    await tester.pumpWidget(_sizedTable(slotWidth: 40, hugAmount: true));
+    await tester.pumpAndSettle();
+    final hugged = tester.getSize(_cell('115.0255,5423 ECX')).width;
+
+    expect(hugged, lessThan(stretched));
+    expect(tester.getSize(_cell('Truthcoin')).width, greaterThan(stretched));
   });
 }

--- a/sidechain_core/lib/providers/balance_provider.dart
+++ b/sidechain_core/lib/providers/balance_provider.dart
@@ -17,6 +17,11 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
   final log = GetIt.I.get<Logger>();
   final List<RPCConnection> connections;
 
+  /// The wallet the Send page spends. Its balance is the headline figure, and
+  /// every other connection counts as a sidechain. Defaults to the first
+  /// connection.
+  late final RPCConnection mainConnection;
+
   final Map<RPCConnection, (double confirmed, double pending)> _balances = {};
   String? error;
 
@@ -33,14 +38,19 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
       : null;
   String? _lastWalletId;
 
-  // Utility getters for total balances
-  double get balance => _balances.values.fold(0.0, (sum, b) => sum + b.$1);
-  double get pendingBalance => _balances.values.fold(0.0, (sum, b) => sum + b.$2);
+  double get balance => balanceFor(mainConnection).$1;
+  double get pendingBalance => balanceFor(mainConnection).$2;
+
+  double get sidechainBalance => _otherConnections.fold(0.0, (sum, rpc) => sum + balanceFor(rpc).$1);
+  double get sidechainPendingBalance => _otherConnections.fold(0.0, (sum, rpc) => sum + balanceFor(rpc).$2);
+
+  Iterable<RPCConnection> get _otherConnections => connections.where((rpc) => rpc != mainConnection);
 
   // Get balance for specific RPC
   (double confirmed, double pending) balanceFor(RPCConnection rpc) => _balances[rpc] ?? (0.0, 0.0);
 
-  BalanceProvider({required this.connections}) {
+  BalanceProvider({required this.connections, RPCConnection? mainConnection}) {
+    this.mainConnection = mainConnection ?? connections.first;
     // Add listeners for connection changes
     for (final rpc in connections) {
       rpc.addListener(_onConnectionChange);

--- a/sidechain_core/test/balance_split_test.dart
+++ b/sidechain_core/test/balance_split_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/mocks/mocks.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  late MockBitwindowRPC mainchain;
+  late MockThunderRPC thunder;
+  late MockBitnamesRPC bitnames;
+  late BalanceProvider provider;
+
+  setUp(() async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.off));
+    GetIt.I.registerSingleton<BinaryProvider>(MockBinaryProvider());
+    mainchain = MockBitwindowRPC();
+    thunder = MockThunderRPC();
+    bitnames = MockBitnamesRPC();
+    provider = BalanceProvider(
+      connections: [mainchain, thunder, bitnames],
+      mainConnection: mainchain,
+    );
+  });
+
+  tearDown(() async {
+    provider.dispose();
+    await GetIt.I.reset();
+  });
+
+  // A total over every chain reads as mainchain money the Send page can spend.
+  test('the headline balance holds the mainchain wallet alone', () {
+    provider.setBalance(mainchain, 0, 330.99479104);
+    provider.setBalance(thunder, 2.01999, 1);
+
+    expect(provider.balance, 0);
+    expect(provider.pendingBalance, 330.99479104);
+  });
+
+  test('the sidechain figure adds every chain but the mainchain one', () {
+    provider.setBalance(mainchain, 1, 0);
+    provider.setBalance(thunder, 2, 0.5);
+    provider.setBalance(bitnames, 0.25, 0);
+
+    expect(provider.sidechainBalance, 2.25);
+    expect(provider.sidechainPendingBalance, 0.5);
+  });
+
+  // A sidechain window holds one connection, so it owns the headline figure.
+  test('a lone connection drives the headline figure', () {
+    final lone = MockThunderRPC();
+    final chainProvider = BalanceProvider(connections: [lone]);
+    addTearDown(chainProvider.dispose);
+
+    chainProvider.setBalance(lone, 4, 2);
+
+    expect(chainProvider.balance, 4);
+    expect(chainProvider.pendingBalance, 2);
+    expect(chainProvider.sidechainBalance, 0);
+  });
+}


### PR DESCRIPTION
The bottom bar added the L1 wallet and every sidechain into one figure, so it read as mainchain money the Send page cannot spend. The bar now shows the L1 wallet alone, with a separate labelled sidechain figure that disappears when no chain holds coins.

In the Sidechains table, Your balance no longer adds confirmed and pending; the pending amount moved to a tooltip on the cell. Slot is narrow, the balance columns hug their content, and Name takes the free width, so no name or amount wraps.

A running chain keeps its Stop button while it syncs; the sync bar now sits beside Stop instead of replacing it.