### PR TITLE
multi: keep every send off a frozen coin

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -293,6 +293,13 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   GetIt.I.registerSingleton<M4Provider>(M4Provider());
   NetworkScopedRegistry.register<AddressBookProvider>(AddressBookProvider());
   GetIt.I.registerSingleton<CoinSelectionProvider>(CoinSelectionProvider());
+  // Coin selection runs in drivechaind, so a send hands it the frozen set
+  // first. Every frontend send reaches it through this one client.
+  GetIt.I.get<OrchestratorRPC>().wallet.frozenCoins = () async {
+    final coins = GetIt.I.get<CoinSelectionProvider>();
+    await coins.refresh();
+    return coins.frozenOutpoints.toList();
+  };
   NetworkScopedRegistry.register<ConsolidationProvider>(ConsolidationProvider());
   GetIt.I.registerSingleton<MiningProvider>(MiningProvider());
   NetworkScopedRegistry.register<HDWalletProvider>(HDWalletProvider());

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -36,6 +36,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	dial "github.com/LayerTwo-Labs/sidesail/bitwindow/server/dial"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/utxometadata"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/bitdrive/v1/bitdrivev1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/bitwindowd/v1/bitwindowdv1connect"
@@ -185,6 +186,15 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 			s.svcs.OrchestratorAddr,
 			connect.WithInterceptors(localauth.Interceptor(s.svcs.BitwindowDir)),
 		))
+	}
+
+	// A coin the user froze belongs to no send of ours: not a news broadcast,
+	// not a timestamp, not a BitDrive write.
+	if rt.db != nil {
+		db := rt.db
+		rt.walletEngine.SetFrozenCoins(func(ctx context.Context) ([]string, error) {
+			return utxometadata.FrozenOutpoints(ctx, db)
+		})
 	}
 
 	rt.chequeChain = engines.NewElectrumChequeChain(rt.walletEngine)
@@ -371,6 +381,14 @@ func (rt *Runtime) Start(parent context.Context) {
 	go func() {
 		defer rt.wg.Done()
 		rt.autoUnlockWallet(rt.ctx)
+	}()
+
+	// Coin selection runs in drivechaind, and a restart of it drops the frozen
+	// set. Hand the set over again while this runtime lives.
+	rt.wg.Add(1)
+	go func() {
+		defer rt.wg.Done()
+		rt.walletEngine.KeepFrozenCoins(rt.ctx)
 	}()
 
 	rt.runEngine("bitcoin", rt.bitcoinEngine.Run, log)

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -15,6 +15,7 @@ import (
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const testWalletID = "test-wallet-id-1234"
@@ -29,6 +30,13 @@ type fakeOrchestrator struct {
 	// perCall serves a different answer per poll, for the poll-after-send case.
 	perCall func(n int32) []*orchpb.AddressUnspentOutput
 	calls   atomic.Int32
+}
+
+// The runtime hands over the frozen coins on a timer, whatever else runs.
+func (f *fakeOrchestrator) SetFrozenCoins(
+	context.Context, *connect.Request[orchpb.SetFrozenCoinsRequest],
+) (*connect.Response[emptypb.Empty], error) {
+	return connect.NewResponse(&emptypb.Empty{}), nil
 }
 
 // The pollers ask before each tick. A full-mode answer keeps them running,

--- a/bitwindow/server/api/wallet/frozen_send_test.go
+++ b/bitwindow/server/api/wallet/frozen_send_test.go
@@ -1,0 +1,93 @@
+package api_wallet_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
+	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+)
+
+// A send that names its inputs spends exactly those coins, so no lock reaches
+// them. A frozen one has to stop the send.
+func TestSendRefusesAFrozenRequiredInput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+	mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+	apitests.ExpectOrchestratorReads(mockOrch)
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithOrchestrator(mockOrch)))
+
+	ctx := context.Background()
+	frozen := true
+	_, err := cli.SetUTXOMetadata(ctx, connect.NewRequest(&walletv1.SetUTXOMetadataRequest{
+		Outpoint: "frozen:0",
+		IsFrozen: &frozen,
+	}))
+	require.NoError(t, err)
+
+	_, err = cli.SendTransaction(ctx, connect.NewRequest(&walletv1.SendTransactionRequest{
+		WalletId:       "test-wallet-id-1234",
+		Destinations:   map[string]uint64{"bcrt1qdest": 50_000},
+		RequiredInputs: []*walletv1.UnspentOutput{{Output: "frozen:0"}},
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is frozen")
+}
+
+// A freeze the daemon never learns is no freeze at all, so the write reports
+// the failure instead of success.
+func TestSetUTXOMetadataReportsAFailedPush(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+	mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+	apitests.ExpectOrchestratorReadsWithoutFrozenCoins(mockOrch)
+	mockOrch.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return((*connect.Response[emptypb.Empty])(nil), connect.NewError(connect.CodeUnavailable, assert.AnError))
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithOrchestrator(mockOrch)))
+
+	frozen := true
+	_, err := cli.SetUTXOMetadata(context.Background(), connect.NewRequest(&walletv1.SetUTXOMetadataRequest{
+		Outpoint: "aa:0",
+		IsFrozen: &frozen,
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set frozen coins")
+}
+
+// A caller can spell a vout with a leading zero, and a txid in either case.
+func TestSendRefusesAFrozenInputInAnySpelling(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+	mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+	apitests.ExpectOrchestratorReads(mockOrch)
+	cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithOrchestrator(mockOrch)))
+
+	ctx := context.Background()
+	frozen := true
+	_, err := cli.SetUTXOMetadata(ctx, connect.NewRequest(&walletv1.SetUTXOMetadataRequest{
+		Outpoint: "abcdef:1",
+		IsFrozen: &frozen,
+	}))
+	require.NoError(t, err)
+
+	for _, spelling := range []string{"ABCDEF:1", "abcdef:01", "ABCDEF:01"} {
+		_, err = cli.SendTransaction(ctx, connect.NewRequest(&walletv1.SendTransactionRequest{
+			WalletId:       "test-wallet-id-1234",
+			Destinations:   map[string]uint64{"bcrt1qdest": 50_000},
+			RequiredInputs: []*walletv1.UnspentOutput{{Output: spelling}},
+		}))
+		require.Error(t, err, spelling)
+		assert.Contains(t, err.Error(), "is frozen", spelling)
+	}
+}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -217,27 +217,25 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 		}), nil
 	}
 
-	sendReq := &corepb.SendRequest{
-		Destinations: destinations,
-		Wallet:       coreWalletName,
-	}
-
-	// Set fee rate if provided (Bitcoin Core expects sat/vB directly)
-	if c.Msg.FeeSatPerVbyte > 0 {
-		sendReq.FeeRate = float64(c.Msg.FeeSatPerVbyte)
-	}
-
-	resp, err := bitcoind.Send(ctx, connect.NewRequest(sendReq))
+	// Coin selection belongs to drivechaind, which locks the frozen coins for
+	// the length of a send. A second selector here would spend them.
+	txid, err := s.walletEngine.SendTransaction(ctx, &orchpb.SendTransactionRequest{
+		WalletId: walletId,
+		Destinations: lo.MapValues(c.Msg.Destinations, func(sats uint64, _ string) int64 {
+			return int64(sats)
+		}),
+		FeeRateSatPerVbyte: int64(c.Msg.FeeSatPerVbyte),
+		FixedFeeSats:       int64(c.Msg.FixedFeeSats),
+	})
 	if err != nil {
-		err = fmt.Errorf("bitcoin Core: send transaction: %w", err)
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not send transaction")
 		return nil, err
 	}
 
-	log.Info().Msgf("send tx: broadcast transaction (Bitcoin Core): %s", resp.Msg.Txid)
+	log.Info().Msgf("send tx: broadcast transaction: %s", txid)
 
 	return connect.NewResponse(&pb.SendTransactionResponse{
-		Txid: resp.Msg.Txid,
+		Txid: txid,
 	}), nil
 }
 
@@ -2363,51 +2361,39 @@ func formatBucketRange(minSats, maxSats uint64) string {
 // Uses Bitcoin Core's bumpfee command with automatic fee estimation.
 func (s *Server) BumpFee(ctx context.Context, c *connect.Request[pb.BumpFeeRequest]) (*connect.Response[pb.BumpFeeResponse], error) {
 	log := zerolog.Ctx(ctx)
-	txid := c.Msg.Txid
-
-	if txid == "" {
+	if c.Msg.Txid == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("txid required"))
 	}
 
-	bitcoind, err := s.bitcoind.Get(ctx)
+	// The caller names a txid alone, so try every wallet until one owns it.
+	// Each try runs where the frozen coins sit locked.
+	wallets, err := s.walletEngine.ListWalletIDs(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the list of loaded wallets to find one that owns this transaction
-	listResp, err := bitcoind.ListWallets(ctx, connect.NewRequest(&emptypb.Empty{}))
-	if err != nil {
-		return nil, fmt.Errorf("list wallets: %w", err)
-	}
-
-	// Try each wallet until one successfully bumps the fee
-	var bumpResp *connect.Response[corepb.BumpFeeResponse]
-	for _, walletName := range listResp.Msg.Wallets {
-		resp, err := bitcoind.BumpFee(ctx, connect.NewRequest(&corepb.BumpFeeRequest{
-			Wallet: walletName,
-			Txid:   txid,
-		}))
+	var resp *orchpb.BumpFeeResponse
+	for _, walletID := range append([]string{""}, wallets...) {
+		resp, err = s.walletEngine.BumpFee(ctx, &orchpb.BumpFeeRequest{
+			WalletId: walletID,
+			Txid:     c.Msg.Txid,
+		})
 		if err == nil {
-			bumpResp = resp
 			break
 		}
 	}
-
-	if bumpResp == nil {
-		return nil, fmt.Errorf("could not bump fee: transaction not found in any wallet")
+	if resp == nil {
+		return nil, fmt.Errorf("could not bump fee: transaction not found in any wallet: %w", err)
 	}
 
 	log.Info().
-		Str("old_txid", txid).
-		Str("new_txid", bumpResp.Msg.Txid).
-		Float64("original_fee", bumpResp.Msg.OriginalFee).
-		Float64("new_fee", bumpResp.Msg.NewFee).
-		Msg("RBF transaction broadcast via Core bumpfee")
+		Str("old_txid", c.Msg.Txid).
+		Str("new_txid", resp.NewTxid).
+		Msg("RBF transaction broadcast")
 
 	return connect.NewResponse(&pb.BumpFeeResponse{
-		Txid:        bumpResp.Msg.Txid,
-		OriginalFee: bumpResp.Msg.OriginalFee,
-		NewFee:      bumpResp.Msg.NewFee,
+		Txid:        resp.NewTxid,
+		OriginalFee: float64(resp.GetPlan().GetOldFeeSats()) / 1e8,
+		NewFee:      float64(resp.GetPlan().GetNewFeeSats()) / 1e8,
 	}), nil
 }
 

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -166,6 +166,24 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 		}
 	}
 
+	// A send that names its inputs spends those coins, so no lock reaches
+	// them. Refuse before any node call.
+	if len(c.Msg.RequiredInputs) > 0 {
+		frozen, err := utxometadata.FrozenOutpoints(ctx, s.database)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("read the frozen coins: %w", err))
+		}
+		// A caller can spell a txid in either case, and a vout with or without
+		// a leading zero, so compare one canonical form.
+		held := lo.SliceToMap(frozen, func(o string) (string, bool) { return canonicalOutpoint(o), true })
+		for _, input := range c.Msg.RequiredInputs {
+			if held[canonicalOutpoint(input.Output)] {
+				return nil, connect.NewError(connect.CodeFailedPrecondition,
+					fmt.Errorf("the output %s is frozen; unfreeze it to spend it", input.Output))
+			}
+		}
+	}
+
 	log := zerolog.Ctx(ctx)
 
 	// Get wallet type to determine routing
@@ -221,6 +239,21 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 	return connect.NewResponse(&pb.SendTransactionResponse{
 		Txid: resp.Msg.Txid,
 	}), nil
+}
+
+// canonicalOutpoint reads a txid:vout pair into one spelling: the txid in
+// lower case, and the vout with no leading zero. A string it cannot read comes
+// back trimmed and lowered, so two unreadable spellings still match.
+func canonicalOutpoint(outpoint string) string {
+	txid, voutText, found := strings.Cut(strings.ToLower(strings.TrimSpace(outpoint)), ":")
+	if !found {
+		return strings.ToLower(strings.TrimSpace(outpoint))
+	}
+	vout, err := strconv.Atoi(voutText)
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(outpoint))
+	}
+	return fmt.Sprintf("%s:%d", txid, vout)
 }
 
 // sendWithRequiredInputs parses the "txid:vout" required inputs and broadcasts
@@ -1941,6 +1974,15 @@ func (s *Server) SetUTXOMetadata(ctx context.Context, c *connect.Request[pb.SetU
 
 	if err := utxometadata.Set(ctx, s.database, c.Msg.Outpoint, isFrozen, label); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to set UTXO metadata: %w", err))
+	}
+
+	// Coin selection runs in drivechaind, so a freeze reaches it only when we
+	// hand the new set over. A caller that reads success must be able to
+	// believe the coin is safe.
+	if isFrozen != nil {
+		if err := s.walletEngine.PushFrozenCoins(ctx); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 	}
 
 	return connect.NewResponse(&emptypb.Empty{}), nil

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -289,9 +289,9 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *UTXO, denial 
 		if werr := e.rejectWatchOnly(ctx, walletId); werr != nil {
 			return werr
 		}
-		txid, err = e.sendBitcoinCoreTransaction(ctx, walletId, utxo, destinations, fee)
+		txid, err = e.sendTransaction(ctx, walletId, utxo, destinations, fee)
 	case WalletTypeElectrum:
-		txid, err = e.sendElectrumTransaction(ctx, walletId, utxo, destinations, fee)
+		txid, err = e.sendTransaction(ctx, walletId, utxo, destinations, fee)
 	default:
 		return fmt.Errorf("unknown wallet type: %s", walletType)
 	}
@@ -334,33 +334,9 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *UTXO, denial 
 	return nil
 }
 
-// sendBitcoinCoreTransaction sends a transaction via Bitcoin Core, spending the
-// chosen UTXO into the denial destinations.
-func (e *DeniabilityEngine) sendBitcoinCoreTransaction(
-	ctx context.Context,
-	walletId string,
-	utxo *UTXO,
-	destinations map[string]uint64,
-	fee uint64,
-) (string, error) {
-	coreWalletName, err := e.walletEngine.GetBitcoinCoreWalletName(ctx, walletId)
-	if err != nil {
-		return "", fmt.Errorf("get bitcoin core wallet name: %w", err)
-	}
-
-	bitcoind, err := e.bitcoind.Get(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get bitcoind client: %w", err)
-	}
-
-	return SendCoreWithRequiredInputs(ctx, bitcoind, coreWalletName, []CoreOutpoint{
-		{Txid: utxo.Txid, Vout: utxo.Vout},
-	}, destinations, 0, fee)
-}
-
-// sendElectrumTransaction sends a transaction via the orchestrator wallet
-// manager, spending the chosen UTXO into the denial destinations.
-func (e *DeniabilityEngine) sendElectrumTransaction(
+// sendTransaction spends the chosen UTXO into the denial destinations through
+// the orchestrator, which holds the frozen coins locked for the length of it.
+func (e *DeniabilityEngine) sendTransaction(
 	ctx context.Context,
 	walletId string,
 	utxo *UTXO,

--- a/bitwindow/server/engines/deniability_engine_test.go
+++ b/bitwindow/server/engines/deniability_engine_test.go
@@ -17,11 +17,14 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const denialWalletID = "80CEBA2163224572BDEADD2D2181C51B"
@@ -30,7 +33,9 @@ const denialWalletID = "80CEBA2163224572BDEADD2D2181C51B"
 // Passing nil here is what once pushed the empty-wallet-id tolerance into the
 // product, where it skipped the watch-only check and reached Core's loaded
 // wallet.
-func testDenialWalletEngine(t *testing.T, bitcoind corerpc.BitcoinServiceClient) *engines.WalletEngine {
+func testDenialWalletEngine(
+	t *testing.T, bitcoind corerpc.BitcoinServiceClient, orchestrator orchrpc.WalletManagerServiceClient,
+) *engines.WalletEngine {
 	t.Helper()
 
 	dir := t.TempDir()
@@ -48,11 +53,15 @@ func testDenialWalletEngine(t *testing.T, bitcoind corerpc.BitcoinServiceClient)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "wallet.json"), walletData, 0o600))
 
-	return engines.NewWalletEngine(
+	engine := engines.NewWalletEngine(
 		func(ctx context.Context) (corerpc.BitcoinServiceClient, error) { return bitcoind, nil },
 		dir,
 		&chaincfg.SigNetParams,
 	)
+	if orchestrator != nil {
+		engine.SetOrchestratorClient(orchestrator)
+	}
+	return engine
 }
 
 func TestDeniabilityEngine(t *testing.T) {
@@ -70,7 +79,7 @@ func TestDeniabilityEngine(t *testing.T) {
 		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
 			return mockBitcoind, nil
 		})
-		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind, nil))
 
 		// Create a denial with empty wallet_id (legacy behavior)
 		denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, nil)
@@ -109,7 +118,25 @@ func TestDeniabilityEngine(t *testing.T) {
 		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
 			return mockBitcoind, nil
 		})
-		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+		mockOrch := mocks.NewMockWalletManagerServiceClient(ctrl)
+		mockOrch.EXPECT().
+			SetFrozenCoins(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[emptypb.Empty]{Msg: &emptypb.Empty{}}, nil)
+		// With a client wired, the engine reads the Core wallet name there.
+		mockOrch.EXPECT().
+			CreateBitcoinCoreWallet(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[orchpb.CreateBitcoinCoreWalletResponse]{
+				Msg: &orchpb.CreateBitcoinCoreWalletResponse{CoreWalletName: "wallet_80CEBA21"},
+			}, nil)
+		mockOrch.EXPECT().
+			SendTransaction(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[orchpb.SendTransactionResponse]{
+				Msg: &orchpb.SendTransactionResponse{Txid: "new-txid"},
+			}, nil)
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind, mockOrch))
 
 		// Create a denial with empty wallet_id (legacy behavior)
 		denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, nil)
@@ -178,7 +205,7 @@ func TestDeniabilityEngine(t *testing.T) {
 		bitcoindService := service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
 			return mockBitcoind, nil
 		})
-		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind))
+		engine := engines.NewDeniability(bitcoindService, db, testDenialWalletEngine(t, mockBitcoind, nil))
 
 		// Create a denial with empty wallet_id (legacy behavior)
 		denial, err := deniability.Create(ctx, db, denialWalletID, "test-txid", 0, 1*time.Hour, 3, nil)

--- a/bitwindow/server/engines/frozen_coins_test.go
+++ b/bitwindow/server/engines/frozen_coins_test.go
@@ -141,3 +141,63 @@ func TestDepositHandsOverTheFrozenCoins(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "deposit-txid", txid)
 }
+
+// A bump reaches for another coin when the change cannot pay the raise, so it
+// hands the frozen set over first.
+func TestBumpFeeHandsOverTheFrozenCoins(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return []string{"aa:0"}, nil
+	})
+
+	client.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[emptypb.Empty]{Msg: &emptypb.Empty{}}, nil)
+	client.EXPECT().
+		BumpFee(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[orchpb.BumpFeeResponse]{
+			Msg: &orchpb.BumpFeeResponse{NewTxid: "bumped"},
+		}, nil)
+
+	resp, err := engine.BumpFee(context.Background(), &orchpb.BumpFeeRequest{Txid: "old"})
+	require.NoError(t, err)
+	assert.Equal(t, "bumped", resp.NewTxid)
+}
+
+// A deniability job spends the coin it names, and the user can freeze that
+// coin. The job runs through the orchestrator, which refuses it there.
+func TestDeniabilitySendHandsOverTheFrozenCoins(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return []string{"tip:0"}, nil
+	})
+
+	var sent *orchpb.SetFrozenCoinsRequest
+	client.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		Times(1).
+		DoAndReturn(func(_ context.Context, req *connect.Request[orchpb.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+			sent = req.Msg
+			return nil, nil
+		})
+	client.EXPECT().
+		SendTransaction(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[orchpb.SendTransactionResponse]{
+			Msg: &orchpb.SendTransactionResponse{Txid: "denied"},
+		}, nil)
+
+	txid, err := engine.SendTransaction(context.Background(), &orchpb.SendTransactionRequest{
+		WalletId:       "wallet-1",
+		RequiredInputs: []*orchpb.UnspentOutput{{Txid: "tip", Vout: 0}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "denied", txid)
+	require.NotNil(t, sent)
+	require.Len(t, sent.Outpoints, 1)
+	assert.Equal(t, "tip", sent.Outpoints[0].Txid)
+}

--- a/bitwindow/server/engines/frozen_coins_test.go
+++ b/bitwindow/server/engines/frozen_coins_test.go
@@ -1,0 +1,143 @@
+package engines_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func engineWithClient(t *testing.T, client *mocks.MockWalletManagerServiceClient) *engines.WalletEngine {
+	t.Helper()
+	engine := engines.NewWalletEngine(nil, t.TempDir(), &chaincfg.RegressionNetParams)
+	engine.SetOrchestratorClient(client)
+	return engine
+}
+
+// A send this server makes must never take a coin the user froze, so it hands
+// the orchestrator the whole frozen set first.
+func TestSendHandsOverTheFrozenCoins(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return []string{"aa:0", "bb:12"}, nil
+	})
+
+	var sent *orchpb.SetFrozenCoinsRequest
+	client.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		Times(1).
+		DoAndReturn(func(_ context.Context, req *connect.Request[orchpb.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+			sent = req.Msg
+			return nil, nil
+		})
+	client.EXPECT().
+		SendTransaction(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[orchpb.SendTransactionResponse]{
+			Msg: &orchpb.SendTransactionResponse{Txid: "txid"},
+		}, nil)
+
+	txid, err := engine.SendTransaction(context.Background(), &orchpb.SendTransactionRequest{
+		WalletId:    "wallet-1",
+		OpReturnHex: "beef",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "txid", txid)
+
+	require.NotNil(t, sent)
+	require.Len(t, sent.Outpoints, 2)
+	assert.Equal(t, "aa", sent.Outpoints[0].Txid)
+	assert.Equal(t, int32(0), sent.Outpoints[0].Vout)
+	assert.Equal(t, "bb", sent.Outpoints[1].Txid)
+	assert.Equal(t, int32(12), sent.Outpoints[1].Vout)
+}
+
+// A frozen set this server cannot read leaves it blind to the coins the user
+// protects, so the send stops instead.
+func TestSendStopsWhenTheFrozenSetFails(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return nil, errors.New("the database is closed")
+	})
+
+	_, err := engine.SendTransaction(context.Background(), &orchpb.SendTransactionRequest{WalletId: "wallet-1"})
+	require.ErrorContains(t, err, "read the frozen coins")
+}
+
+func TestSendStopsOnAnOutpointItCannotRead(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return []string{"no-vout-here"}, nil
+	})
+
+	_, err := engine.SendTransaction(context.Background(), &orchpb.SendTransactionRequest{WalletId: "wallet-1"})
+	require.ErrorContains(t, err, "is not a txid:vout")
+}
+
+// A drivechaind restart drops the set it holds, and nothing here sees that
+// restart. The engine hands the set over again while it runs.
+func TestKeepFrozenCoinsHandsTheSetOverAgain(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return []string{"aa:0"}, nil
+	})
+
+	pushes := make(chan struct{}, 4)
+	client.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(context.Context, *connect.Request[orchpb.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+			pushes <- struct{}{}
+			return nil, nil
+		})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go engine.KeepFrozenCoins(ctx)
+
+	select {
+	case <-pushes:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the engine handed over no frozen set")
+	}
+}
+
+// A deposit funds the treasury from the wallet, so it hands the frozen set
+// over the same way a send does.
+func TestDepositHandsOverTheFrozenCoins(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	engine := engineWithClient(t, client)
+	engine.SetFrozenCoins(func(context.Context) ([]string, error) {
+		return []string{"aa:0"}, nil
+	})
+
+	client.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[emptypb.Empty]{Msg: &emptypb.Empty{}}, nil)
+	client.EXPECT().
+		CreateDeposit(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[orchpb.CreateDepositResponse]{
+			Msg: &orchpb.CreateDepositResponse{Txid: "deposit-txid"},
+		}, nil)
+
+	txid, err := engine.CreateDeposit(context.Background(), &orchpb.CreateDepositRequest{WalletId: "wallet-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "deposit-txid", txid)
+}

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -993,6 +993,34 @@ func (e *WalletEngine) SendTransaction(ctx context.Context, req *orchpb.SendTran
 	return resp.Msg.Txid, nil
 }
 
+// ListWalletIDs names every wallet the orchestrator holds.
+func (e *WalletEngine) ListWalletIDs(ctx context.Context) ([]string, error) {
+	if e.orchClient == nil {
+		return nil, fmt.Errorf("orchestrator wallet client not connected")
+	}
+	resp, err := e.orchClient.ListWallets(ctx, connect.NewRequest(&orchpb.ListWalletsRequest{}))
+	if err != nil {
+		return nil, fmt.Errorf("list wallets: %w", err)
+	}
+	return lo.Map(resp.Msg.Wallets, func(w *orchpb.WalletMetadata, _ int) string { return w.Id }), nil
+}
+
+// BumpFee replaces a transaction with one that pays more. Coin selection runs
+// in the orchestrator, which locks the frozen coins for the length of the call.
+func (e *WalletEngine) BumpFee(ctx context.Context, req *orchpb.BumpFeeRequest) (*orchpb.BumpFeeResponse, error) {
+	if e.orchClient == nil {
+		return nil, fmt.Errorf("orchestrator wallet client not connected")
+	}
+	if err := e.pushFrozenCoins(ctx); err != nil {
+		return nil, err
+	}
+	resp, err := e.orchClient.BumpFee(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("bump fee: %w", err)
+	}
+	return resp.Msg, nil
+}
+
 // CreateDeposit builds and broadcasts a BIP300 M5 deposit from any wallet.
 func (e *WalletEngine) CreateDeposit(ctx context.Context, req *orchpb.CreateDepositRequest) (string, error) {
 	if e.orchClient == nil {

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -88,6 +89,11 @@ type WalletEngine struct {
 	isUnlocked     bool
 	unlockCond     *sync.Cond
 
+	// frozenCoins names the coins the user froze, so no send of ours takes one.
+	frozenCoins FrozenCoinsFunc
+	// frozenPushMu runs one hand-over at a time, newest set last.
+	frozenPushMu sync.Mutex
+
 	// Maps walletId -> Bitcoin Core wallet name (cache)
 	coreWallets map[string]string
 
@@ -140,6 +146,97 @@ func NewWalletEngine(
 	}
 
 	return e
+}
+
+// FrozenCoinsFunc names the coins the user froze, as txid:vout.
+type FrozenCoinsFunc func(ctx context.Context) ([]string, error)
+
+// SetFrozenCoins wires the source that names the coins the user froze. Every
+// send this server makes leaves those coins alone.
+func (e *WalletEngine) SetFrozenCoins(fn FrozenCoinsFunc) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.frozenCoins = fn
+}
+
+// frozenCoinsInterval is how often the set goes over again. A drivechaind
+// restart drops the set it holds, and nothing here sees that restart. The
+// orchestrator picks coins for its own work too, so the window stays short.
+const frozenCoinsInterval = 10 * time.Second
+
+// KeepFrozenCoins hands the orchestrator the frozen set, and hands it over
+// again while ctx runs. Coin selection lives in drivechaind, and a restart of
+// it leaves the set behind.
+func (e *WalletEngine) KeepFrozenCoins(ctx context.Context) {
+	ticker := time.NewTicker(frozenCoinsInterval)
+	defer ticker.Stop()
+	for {
+		if err := e.PushFrozenCoins(ctx); err != nil {
+			zerolog.Ctx(ctx).Debug().Err(err).Msg("could not hand over the frozen coins")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// PushFrozenCoins hands over the whole frozen set of this install.
+func (e *WalletEngine) PushFrozenCoins(ctx context.Context) error {
+	return e.pushFrozenCoins(ctx)
+}
+
+// pushFrozenCoins hands the orchestrator the coins no send may take. It runs
+// before every send, so a drivechaind restart cannot leave the set behind.
+//
+// One push runs at a time. The set is read and sent under the same lock, so a
+// slow push cannot land after a newer one and put the older set back.
+func (e *WalletEngine) pushFrozenCoins(ctx context.Context) error {
+	e.mu.RLock()
+	fn := e.frozenCoins
+	e.mu.RUnlock()
+	if fn == nil || e.orchClient == nil {
+		return nil
+	}
+
+	e.frozenPushMu.Lock()
+	defer e.frozenPushMu.Unlock()
+
+	outpoints, err := fn(ctx)
+	if err != nil {
+		return fmt.Errorf("read the frozen coins: %w", err)
+	}
+
+	coins := make([]*orchpb.FrozenOutpoint, 0, len(outpoints))
+	for _, outpoint := range outpoints {
+		txid, vout, ok := splitOutpoint(outpoint)
+		if !ok {
+			return fmt.Errorf("frozen coin %q is not a txid:vout", outpoint)
+		}
+		coins = append(coins, &orchpb.FrozenOutpoint{Txid: txid, Vout: int32(vout)})
+	}
+
+	_, err = e.orchClient.SetFrozenCoins(ctx, connect.NewRequest(&orchpb.SetFrozenCoinsRequest{
+		Outpoints: coins,
+	}))
+	if err != nil {
+		return fmt.Errorf("set frozen coins: %w", err)
+	}
+	return nil
+}
+
+// splitOutpoint reads a txid:vout pair.
+func splitOutpoint(outpoint string) (string, int, bool) {
+	txid, voutText, found := strings.Cut(outpoint, ":")
+	if !found || txid == "" {
+		return "", 0, false
+	}
+	vout, err := strconv.Atoi(voutText)
+	if err != nil || vout < 0 {
+		return "", 0, false
+	}
+	return txid, vout, true
 }
 
 // SetOrchestratorClient sets the orchestrator WalletManagerService client.
@@ -886,6 +983,9 @@ func (e *WalletEngine) SendTransaction(ctx context.Context, req *orchpb.SendTran
 	if e.orchClient == nil {
 		return "", fmt.Errorf("orchestrator wallet client not connected")
 	}
+	if err := e.pushFrozenCoins(ctx); err != nil {
+		return "", err
+	}
 	resp, err := e.orchClient.SendTransaction(ctx, connect.NewRequest(req))
 	if err != nil {
 		return "", fmt.Errorf("send transaction: %w", err)
@@ -897,6 +997,9 @@ func (e *WalletEngine) SendTransaction(ctx context.Context, req *orchpb.SendTran
 func (e *WalletEngine) CreateDeposit(ctx context.Context, req *orchpb.CreateDepositRequest) (string, error) {
 	if e.orchClient == nil {
 		return "", fmt.Errorf("orchestrator wallet client not connected")
+	}
+	if err := e.pushFrozenCoins(ctx); err != nil {
+		return "", err
 	}
 	resp, err := e.orchClient.CreateDeposit(ctx, connect.NewRequest(req))
 	if err != nil {

--- a/bitwindow/server/models/utxometadata/utxometadata.go
+++ b/bitwindow/server/models/utxometadata/utxometadata.go
@@ -140,3 +140,24 @@ func GetFrozenOutpoints(ctx context.Context, db *sql.DB) ([]string, error) {
 	}
 	return outpoints, rows.Err()
 }
+
+// FrozenOutpoints names every outpoint the user froze, as txid:vout.
+func FrozenOutpoints(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT outpoint FROM utxo_metadata WHERE is_frozen = 1`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer database.SafeDefer(ctx, rows.Close)
+
+	var outpoints []string
+	for rows.Next() {
+		var outpoint string
+		if err := rows.Scan(&outpoint); err != nil {
+			return nil, err
+		}
+		outpoints = append(outpoints, outpoint)
+	}
+	return outpoints, rows.Err()
+}

--- a/bitwindow/server/tests/apitests/apitests.go
+++ b/bitwindow/server/tests/apitests/apitests.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type configg struct {
@@ -329,6 +330,16 @@ func ExpectCoreWalletSetup(mock *mocks.MockBitcoinServiceClient) {
 // Note the node mode it reports is FULL, so a test that exercises light mode
 // must set its own GetNodeMode expectation.
 func ExpectOrchestratorReads(mock *mocks.MockWalletManagerServiceClient) {
+	expectOrchestratorReads(mock)
+
+	// Every send hands over the coins the user froze first.
+	mock.EXPECT().
+		SetFrozenCoins(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[emptypb.Empty]{Msg: &emptypb.Empty{}}, nil).
+		AnyTimes()
+}
+
+func expectOrchestratorReads(mock *mocks.MockWalletManagerServiceClient) {
 	seedHex := "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
 		"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
 
@@ -366,4 +377,10 @@ func ExpectOrchestratorReads(mock *mocks.MockWalletManagerServiceClient) {
 			Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_FULL},
 		}, nil).
 		AnyTimes()
+}
+
+// ExpectOrchestratorReadsWithoutFrozenCoins is ExpectOrchestratorReads for a
+// test that answers SetFrozenCoins itself.
+func ExpectOrchestratorReadsWithoutFrozenCoins(mock *mocks.MockWalletManagerServiceClient) {
+	expectOrchestratorReads(mock)
 }

--- a/bitwindow/server/tests/mocks/mock_walletmanager.go
+++ b/bitwindow/server/tests/mocks/mock_walletmanager.go
@@ -913,6 +913,21 @@ func (mr *MockWalletManagerServiceClientMockRecorder) SetElectrumServer(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetElectrumServer", reflect.TypeOf((*MockWalletManagerServiceClient)(nil).SetElectrumServer), arg0, arg1)
 }
 
+// SetFrozenCoins mocks base method.
+func (m *MockWalletManagerServiceClient) SetFrozenCoins(arg0 context.Context, arg1 *connect.Request[walletmanagerv1.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetFrozenCoins", arg0, arg1)
+	ret0, _ := ret[0].(*connect.Response[emptypb.Empty])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetFrozenCoins indicates an expected call of SetFrozenCoins.
+func (mr *MockWalletManagerServiceClientMockRecorder) SetFrozenCoins(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFrozenCoins", reflect.TypeOf((*MockWalletManagerServiceClient)(nil).SetFrozenCoins), arg0, arg1)
+}
+
 // SetNodeMode mocks base method.
 func (m *MockWalletManagerServiceClient) SetNodeMode(arg0 context.Context, arg1 *connect.Request[walletmanagerv1.SetNodeModeRequest]) (*connect.Response[walletmanagerv1.SetNodeModeResponse], error) {
 	m.ctrl.T.Helper()
@@ -1969,6 +1984,21 @@ func (m *MockWalletManagerServiceHandler) SetElectrumServer(arg0 context.Context
 func (mr *MockWalletManagerServiceHandlerMockRecorder) SetElectrumServer(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetElectrumServer", reflect.TypeOf((*MockWalletManagerServiceHandler)(nil).SetElectrumServer), arg0, arg1)
+}
+
+// SetFrozenCoins mocks base method.
+func (m *MockWalletManagerServiceHandler) SetFrozenCoins(arg0 context.Context, arg1 *connect.Request[walletmanagerv1.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetFrozenCoins", arg0, arg1)
+	ret0, _ := ret[0].(*connect.Response[emptypb.Empty])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetFrozenCoins indicates an expected call of SetFrozenCoins.
+func (mr *MockWalletManagerServiceHandlerMockRecorder) SetFrozenCoins(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFrozenCoins", reflect.TypeOf((*MockWalletManagerServiceHandler)(nil).SetFrozenCoins), arg0, arg1)
 }
 
 // SetNodeMode mocks base method.

--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
@@ -147,6 +148,15 @@ func (h *WalletHandler) buildBip47NotificationTx(
 		return "", "", connect.NewError(connect.CodeInternal, fmt.Errorf("list unspent: %w", err))
 	}
 
+	// The pick below becomes a required input, which Core spends as it is
+	// told. A coin the user froze has to leave the list here.
+	frozen, err := h.svc.FrozenCoins(ctx, walletID, lo.Map(utxos, func(u wallet.UTXO, _ int) wallet.Outpoint {
+		return wallet.Outpoint{TxID: u.TxID, Vout: u.Vout, Confirmed: u.Confirmations > 0}
+	}))
+	if err != nil {
+		return "", "", connect.NewError(connect.CodeInternal, err)
+	}
+
 	const dustSats int64 = 546
 	feeSats := bip47send.EstimateNotificationFee(2)
 	minRequired := dustSats + feeSats + dustSats
@@ -154,6 +164,9 @@ func (h *WalletHandler) buildBip47NotificationTx(
 	var picked *wallet.UTXO
 	for i, u := range utxos {
 		if !u.Spendable {
+			continue
+		}
+		if frozen[(wallet.Outpoint{TxID: u.TxID, Vout: u.Vout}).Key()] {
 			continue
 		}
 		amountSats := int64(math.Round(u.Amount * 1e8))

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -53,6 +53,9 @@ const (
 type bidWallet interface {
 	// ResolveWalletID names the wallet an empty id means.
 	ResolveWalletID(walletID string) (string, error)
+	// HeldCoins names the coins the user froze, keyed txid:vout. A bid picks
+	// its coin by hand and pins it, so the coin has to leave the list here.
+	HeldCoins() map[string]bool
 	ListUnspent(
 		context.Context, *connect.Request[wpb.ListUnspentRequest],
 	) (*connect.Response[wpb.ListUnspentResponse], error)
@@ -879,12 +882,17 @@ func (h *BMMHandler) readWalletCoins(
 		return nil, err
 	}
 
+	frozen := h.wallet.HeldCoins()
+
 	out := &walletCoins{held: held}
 	for _, u := range unspent.Msg.Utxos {
 		if !u.Spendable {
 			continue
 		}
 		if spent[(wallet.Outpoint{TxID: u.Txid, Vout: int(u.Vout)}).Key()] {
+			continue
+		}
+		if frozen[(wallet.Outpoint{TxID: u.Txid, Vout: int(u.Vout)}).Key()] {
 			continue
 		}
 		if u.Confirmations > 0 {

--- a/sidechain-orchestrator/api/bmm_slot_coin_test.go
+++ b/sidechain-orchestrator/api/bmm_slot_coin_test.go
@@ -123,6 +123,8 @@ type fakeBidWallet struct {
 	addresses int
 	sends     []*wpb.SendTransactionRequest
 	sendTxid  string
+	// heldCoins names the coins the user froze, keyed txid:vout.
+	heldCoins map[string]bool
 	// details answers GetTransactionDetails, and txs answers ListTransactions.
 	details map[string]*wpb.GetTransactionDetailsResponse
 	txs     []*wpb.TransactionEntry
@@ -169,6 +171,9 @@ func (w *fakeBidWallet) ListTransactions(
 	}
 	return connect.NewResponse(&wpb.ListTransactionsResponse{Transactions: txs}), nil
 }
+
+// heldCoins names the coins a test froze, keyed txid:vout.
+func (w *fakeBidWallet) HeldCoins() map[string]bool { return w.heldCoins }
 
 func (w *fakeBidWallet) ResolveWalletID(walletID string) (string, error) {
 	if walletID == "" {
@@ -780,4 +785,25 @@ func TestPrepareBMMSkipsABidDescendant(t *testing.T) {
 	require.Len(t, wallet.sends, 1)
 	require.Len(t, wallet.sends[0].RequiredInputs, 1)
 	assert.Equal(t, oldBlock, wallet.sends[0].RequiredInputs[0].Txid)
+}
+
+// A bid pins the coin it picks, and Core spends a pinned coin as it is told.
+// A coin the user froze has to leave the list before the pick.
+func TestSlotCoinSkipsACoinTheUserFroze(t *testing.T) {
+	const frozen = "6666666666666666666666666666666666666666666666666666666666666666"
+	const free = "7777777777777777777777777777777777777777777777777777777777777777"
+
+	wallet := &fakeBidWallet{
+		utxos: []*wpb.UnspentOutput{
+			{Txid: frozen, Vout: 0, AmountSats: 3_000_000, Spendable: true, Confirmations: 6},
+			{Txid: free, Vout: 0, AmountSats: 2_000_000, Spendable: true, Confirmations: 6},
+		},
+		heldCoins: map[string]bool{frozen + ":0": true},
+	}
+	h := slotCoinHandler(t, &fakeSlotMempool{}, wallet)
+
+	coin, err := h.slotCoin(context.Background(), bidRequest(), 1, 10_000)
+	require.NoError(t, err)
+
+	assert.Equal(t, free, coin.Txid, "the bid takes the coin the user left free")
 }

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -637,6 +637,12 @@ func (h *WalletHandler) BroadcastTransaction(ctx context.Context, req *connect.R
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	// A saved draft spends the coins it named when the user built it. The user
+	// can freeze one of them before this call, so read the inputs again.
+	if err := h.refuseFrozenRawInputs(req.Msg.TxHex); err != nil {
+		return nil, err
+	}
+
 	txid, err := h.engine.ChainForWallet(walletID).Broadcast(ctx, req.Msg.TxHex)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("broadcast: %w", err))
@@ -832,6 +838,67 @@ func mapExternalInputs(exts []*pb.ExternalInput) []wallet.ExternalInput {
 	})
 }
 
+// refuseFrozenRawInputs stops a broadcast of a transaction that spends a coin
+// the user froze. A raw transaction names its inputs, so no lock reaches them.
+func (h *WalletHandler) refuseFrozenRawInputs(txHex string) error {
+	held := h.svc.HeldCoins()
+	if len(held) == 0 {
+		return nil
+	}
+	decoded, err := wallet.DecodeTransaction(txHex, h.engine.Network())
+	if err != nil {
+		// An unreadable transaction fails at the node, with its own words.
+		return nil
+	}
+	for _, in := range decoded.Inputs {
+		outpoint := wallet.Outpoint{TxID: in.PrevTxID, Vout: in.PrevVout}
+		if held[outpoint.Key()] {
+			return connect.NewError(connect.CodeFailedPrecondition,
+				fmt.Errorf("the output %s is frozen; unfreeze it to spend it", outpoint.Key()))
+		}
+	}
+	return nil
+}
+
+// refuseFrozenInputs stops a send that names a coin the user froze.
+func (h *WalletHandler) refuseFrozenInputs(inputs []*pb.UnspentOutput) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	held := h.svc.HeldCoins()
+	if len(held) == 0 {
+		return nil
+	}
+	for _, in := range inputs {
+		outpoint := wallet.Outpoint{TxID: in.Txid, Vout: int(in.Vout)}
+		if held[outpoint.Key()] {
+			return connect.NewError(connect.CodeFailedPrecondition,
+				fmt.Errorf("the output %s is frozen; unfreeze it to spend it", outpoint.Key()))
+		}
+	}
+	return nil
+}
+
+// HeldCoins names the coins the frontend froze.
+func (h *WalletHandler) HeldCoins() map[string]bool {
+	return h.svc.HeldCoins()
+}
+
+// SetFrozenCoins records the coins the frontend froze, so every later send
+// leaves them alone.
+func (h *WalletHandler) SetFrozenCoins(ctx context.Context, req *connect.Request[pb.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+	coins := make([]wallet.Outpoint, 0, len(req.Msg.Outpoints))
+	for _, out := range req.Msg.Outpoints {
+		if out.Txid == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a frozen coin needs a txid"))
+		}
+		coins = append(coins, wallet.Outpoint{TxID: out.Txid, Vout: int(out.Vout)})
+	}
+	h.svc.SetHeldCoins(coins)
+
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}
+
 func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Request[pb.SendTransactionRequest]) (*connect.Response[pb.SendTransactionResponse], error) {
 	// A transaction needs at least one output, but it doesn't have to be a
 	// payment: an OP_RETURN-only broadcast (e.g. coinnews) or a raw-script
@@ -851,6 +918,13 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 	walletID, err := h.engine.ResolveWalletID(req.Msg.WalletId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	// A required input is spent as it is given, so no lock reaches it. The
+	// set here is the user's alone: a bid raise pins the coin its own bid
+	// holds, and that coin has to stay spendable.
+	if err := h.refuseFrozenInputs(req.Msg.RequiredInputs); err != nil {
+		return nil, err
 	}
 
 	// Resolve any BIP47 payment-code destinations into per-payment addresses
@@ -1507,6 +1581,14 @@ func (h *WalletHandler) CreateCpfp(ctx context.Context, req *connect.Request[pb.
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
+	// The child spends the parent output the caller names, so a freeze has to
+	// stop the call. No lock reaches an outpoint a caller pins by hand.
+	parent := wallet.Outpoint{TxID: req.Msg.ParentTxid, Vout: int(req.Msg.ParentVout)}
+	if h.svc.HeldCoins()[parent.Key()] {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("the output %s is frozen; unfreeze it to spend it", parent.Key()))
+	}
+
 	childTxID, err := h.engine.Backend().CreateCpfp(ctx, walletID, wallet.CpfpRequest{
 		ParentTxID: req.Msg.ParentTxid,
 		ParentVout: int(req.Msg.ParentVout),
@@ -2080,6 +2162,9 @@ func (h *WalletHandler) CreatePsbt(ctx context.Context, req *connect.Request[pb.
 		OpReturnHex:           req.Msg.OpReturnHex,
 		SubtractFeeFromAmount: req.Msg.SubtractFeeFromAmount,
 		AllowReplay:           req.Msg.AllowReplay,
+	}
+	if err := h.refuseFrozenInputs(req.Msg.RequiredInputs); err != nil {
+		return nil, err
 	}
 	sendReq.RequiredInputs = lo.Map(req.Msg.RequiredInputs, func(u *pb.UnspentOutput, _ int) wallet.RequiredInput {
 		return wallet.RequiredInput{

--- a/sidechain-orchestrator/api/wallet_handler_txdetails_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_txdetails_test.go
@@ -1,11 +1,16 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +25,7 @@ type detailsProvider struct {
 	rawTx      *wallet.RawTransaction
 	owned      map[string]bool
 	ownedErr   error
+	utxos      []wallet.UTXO
 	askedOwned []string
 }
 
@@ -33,6 +39,14 @@ func (f *detailsProvider) OwnedAddresses(_ context.Context, _ string, addresses 
 		return nil, f.ownedErr
 	}
 	return f.owned, nil
+}
+
+func (f *detailsProvider) ListUnspent(context.Context, string) ([]wallet.UTXO, error) {
+	return f.utxos, nil
+}
+
+func (f *detailsProvider) Send(context.Context, string, wallet.SendRequest) (string, error) {
+	return "", errors.New("this fake broadcasts nothing")
 }
 
 func (f *detailsProvider) Chain() wallet.ChainSource { return f }
@@ -129,4 +143,129 @@ func TestGetTransactionDetailsFailsOnAnOwnershipError(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+}
+
+func TestSetFrozenCoinsRecordsTheWholeSet(t *testing.T) {
+	fake := &detailsProvider{rawTx: paymentWithChange()}
+	h, _ := newDetailsHandler(t, fake)
+	ctx := context.Background()
+
+	_, err := h.SetFrozenCoins(ctx, connect.NewRequest(&pb.SetFrozenCoinsRequest{
+		Outpoints: []*pb.FrozenOutpoint{{Txid: "held", Vout: 1}},
+	}))
+	require.NoError(t, err)
+
+	held := h.svc.HeldCoins()
+	assert.True(t, held[wallet.Outpoint{TxID: "held", Vout: 1}.Key()])
+
+	// An unfreeze arrives as a smaller set, and it must free the coin.
+	_, err = h.SetFrozenCoins(ctx, connect.NewRequest(&pb.SetFrozenCoinsRequest{}))
+	require.NoError(t, err)
+	assert.Empty(t, h.svc.HeldCoins())
+}
+
+func TestSetFrozenCoinsRefusesACoinWithoutATxid(t *testing.T) {
+	fake := &detailsProvider{rawTx: paymentWithChange()}
+	h, _ := newDetailsHandler(t, fake)
+
+	_, err := h.SetFrozenCoins(context.Background(), connect.NewRequest(&pb.SetFrozenCoinsRequest{
+		Outpoints: []*pb.FrozenOutpoint{{Vout: 1}},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// A BIP47 notification pins the coin it picks, so a frozen coin has to leave
+// the list before the pick.
+func TestBip47NotificationSkipsAFrozenCoin(t *testing.T) {
+	fake := &detailsProvider{
+		rawTx: paymentWithChange(),
+		utxos: []wallet.UTXO{
+			{TxID: "frozen", Vout: 0, Address: "a", Amount: 0.01, Confirmations: 6, Spendable: true},
+		},
+	}
+	h, walletID := newDetailsHandler(t, fake)
+	h.svc.SetHeldCoins([]wallet.Outpoint{{TxID: "frozen", Vout: 0}})
+
+	_, _, err := h.buildBip47NotificationTx(
+		context.Background(), walletID, "00", nil, &chaincfg.RegressionNetParams,
+	)
+	require.ErrorContains(t, err, "no spendable UTXO")
+}
+
+// A CPFP child spends the parent output the caller names. No lock reaches an
+// outpoint a caller pins, so the call has to refuse a frozen one.
+func TestCreateCpfpRefusesAFrozenParent(t *testing.T) {
+	fake := &detailsProvider{rawTx: paymentWithChange()}
+	h, walletID := newDetailsHandler(t, fake)
+	h.svc.SetHeldCoins([]wallet.Outpoint{{TxID: "parent", Vout: 1}})
+
+	_, err := h.CreateCpfp(context.Background(), connect.NewRequest(&pb.CreateCpfpRequest{
+		WalletId:      walletID,
+		ParentTxid:    "parent",
+		ParentVout:    1,
+		TargetFeeRate: 10,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "is frozen")
+}
+
+// A required input is spent as it is given, so no lock reaches it.
+func TestSendRefusesAFrozenRequiredInput(t *testing.T) {
+	fake := &detailsProvider{rawTx: paymentWithChange()}
+	h, walletID := newDetailsHandler(t, fake)
+	h.svc.SetHeldCoins([]wallet.Outpoint{{TxID: "frozen", Vout: 0}})
+
+	_, err := h.SendTransaction(context.Background(), connect.NewRequest(&pb.SendTransactionRequest{
+		WalletId:       walletID,
+		Destinations:   map[string]int64{"bcrt1qdest": 50_000},
+		RequiredInputs: []*pb.UnspentOutput{{Txid: "frozen", Vout: 0}},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "is frozen")
+}
+
+// A bid raise pins the coin its own bid holds, and that coin stays spendable.
+func TestSendAllowsAPinThatIsNotFrozen(t *testing.T) {
+	fake := &detailsProvider{rawTx: paymentWithChange()}
+	h, walletID := newDetailsHandler(t, fake)
+	h.svc.SetHeldCoins([]wallet.Outpoint{{TxID: "frozen", Vout: 0}})
+
+	_, err := h.SendTransaction(context.Background(), connect.NewRequest(&pb.SendTransactionRequest{
+		WalletId:       walletID,
+		Destinations:   map[string]int64{"bcrt1qdest": 50_000},
+		RequiredInputs: []*pb.UnspentOutput{{Txid: "free", Vout: 0}},
+	}))
+	// The fake backend cannot send, so the call fails later than the check.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "is frozen")
+}
+
+// A saved draft names its inputs. The user can freeze one of them before the
+// broadcast, so the broadcast reads them again.
+func TestBroadcastRefusesAFrozenInput(t *testing.T) {
+	fake := &detailsProvider{rawTx: paymentWithChange()}
+	h, walletID := newDetailsHandler(t, fake)
+
+	// One input, spending frozenCoinTxid:1.
+	tx := wire.NewMsgTx(wire.TxVersion)
+	parent, err := chainhash.NewHashFromStr(
+		"1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: *wire.NewOutPoint(parent, 1)})
+	tx.AddTxOut(&wire.TxOut{Value: 1_000, PkScript: []byte{0x51}})
+	var raw bytes.Buffer
+	require.NoError(t, tx.Serialize(&raw))
+
+	h.svc.SetHeldCoins([]wallet.Outpoint{{TxID: parent.String(), Vout: 1}})
+
+	_, err = h.BroadcastTransaction(context.Background(), connect.NewRequest(&pb.BroadcastTransactionRequest{
+		WalletId: walletID,
+		TxHex:    hex.EncodeToString(raw.Bytes()),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "is frozen")
 }

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -4633,6 +4633,104 @@ func (x *SendTransactionResponse) GetTxid() string {
 	return ""
 }
 
+type SetFrozenCoinsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The whole frozen set of this install. An outpoint names one coin of one
+	// wallet, so the set covers every wallet at once. An empty list frees all.
+	Outpoints     []*FrozenOutpoint `protobuf:"bytes,1,rep,name=outpoints,proto3" json:"outpoints,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetFrozenCoinsRequest) Reset() {
+	*x = SetFrozenCoinsRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetFrozenCoinsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetFrozenCoinsRequest) ProtoMessage() {}
+
+func (x *SetFrozenCoinsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetFrozenCoinsRequest.ProtoReflect.Descriptor instead.
+func (*SetFrozenCoinsRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *SetFrozenCoinsRequest) GetOutpoints() []*FrozenOutpoint {
+	if x != nil {
+		return x.Outpoints
+	}
+	return nil
+}
+
+type FrozenOutpoint struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	Vout          int32                  `protobuf:"varint,2,opt,name=vout,proto3" json:"vout,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FrozenOutpoint) Reset() {
+	*x = FrozenOutpoint{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FrozenOutpoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FrozenOutpoint) ProtoMessage() {}
+
+func (x *FrozenOutpoint) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FrozenOutpoint.ProtoReflect.Descriptor instead.
+func (*FrozenOutpoint) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{79}
+}
+
+func (x *FrozenOutpoint) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *FrozenOutpoint) GetVout() int32 {
+	if x != nil {
+		return x.Vout
+	}
+	return 0
+}
+
 // RawOutput is a transaction output with a caller-supplied scriptPubKey.
 type RawOutput struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4644,7 +4742,7 @@ type RawOutput struct {
 
 func (x *RawOutput) Reset() {
 	*x = RawOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4656,7 +4754,7 @@ func (x *RawOutput) String() string {
 func (*RawOutput) ProtoMessage() {}
 
 func (x *RawOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4669,7 +4767,7 @@ func (x *RawOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RawOutput.ProtoReflect.Descriptor instead.
 func (*RawOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{78}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *RawOutput) GetValueSats() int64 {
@@ -4700,7 +4798,7 @@ type ExternalInput struct {
 
 func (x *ExternalInput) Reset() {
 	*x = ExternalInput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4712,7 +4810,7 @@ func (x *ExternalInput) String() string {
 func (*ExternalInput) ProtoMessage() {}
 
 func (x *ExternalInput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4725,7 +4823,7 @@ func (x *ExternalInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalInput.ProtoReflect.Descriptor instead.
 func (*ExternalInput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{79}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ExternalInput) GetTxid() string {
@@ -4777,7 +4875,7 @@ type CreatePsbtRequest struct {
 
 func (x *CreatePsbtRequest) Reset() {
 	*x = CreatePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4789,7 +4887,7 @@ func (x *CreatePsbtRequest) String() string {
 func (*CreatePsbtRequest) ProtoMessage() {}
 
 func (x *CreatePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4802,7 +4900,7 @@ func (x *CreatePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePsbtRequest.ProtoReflect.Descriptor instead.
 func (*CreatePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{80}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *CreatePsbtRequest) GetWalletId() string {
@@ -4884,7 +4982,7 @@ type CreatePsbtResponse struct {
 
 func (x *CreatePsbtResponse) Reset() {
 	*x = CreatePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4896,7 +4994,7 @@ func (x *CreatePsbtResponse) String() string {
 func (*CreatePsbtResponse) ProtoMessage() {}
 
 func (x *CreatePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4909,7 +5007,7 @@ func (x *CreatePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePsbtResponse.ProtoReflect.Descriptor instead.
 func (*CreatePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{81}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *CreatePsbtResponse) GetPsbtBase64() string {
@@ -4929,7 +5027,7 @@ type SignPsbtRequest struct {
 
 func (x *SignPsbtRequest) Reset() {
 	*x = SignPsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4941,7 +5039,7 @@ func (x *SignPsbtRequest) String() string {
 func (*SignPsbtRequest) ProtoMessage() {}
 
 func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4954,7 +5052,7 @@ func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtRequest.ProtoReflect.Descriptor instead.
 func (*SignPsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{82}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *SignPsbtRequest) GetWalletId() string {
@@ -4980,7 +5078,7 @@ type SignPsbtResponse struct {
 
 func (x *SignPsbtResponse) Reset() {
 	*x = SignPsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4992,7 +5090,7 @@ func (x *SignPsbtResponse) String() string {
 func (*SignPsbtResponse) ProtoMessage() {}
 
 func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5005,7 +5103,7 @@ func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtResponse.ProtoReflect.Descriptor instead.
 func (*SignPsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{83}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *SignPsbtResponse) GetPsbtBase64() string {
@@ -5026,7 +5124,7 @@ type SignPsbtWithCosignerRequest struct {
 
 func (x *SignPsbtWithCosignerRequest) Reset() {
 	*x = SignPsbtWithCosignerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5038,7 +5136,7 @@ func (x *SignPsbtWithCosignerRequest) String() string {
 func (*SignPsbtWithCosignerRequest) ProtoMessage() {}
 
 func (x *SignPsbtWithCosignerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5051,7 +5149,7 @@ func (x *SignPsbtWithCosignerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtWithCosignerRequest.ProtoReflect.Descriptor instead.
 func (*SignPsbtWithCosignerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{84}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *SignPsbtWithCosignerRequest) GetWalletId() string {
@@ -5084,7 +5182,7 @@ type SignPsbtWithCosignerResponse struct {
 
 func (x *SignPsbtWithCosignerResponse) Reset() {
 	*x = SignPsbtWithCosignerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5096,7 +5194,7 @@ func (x *SignPsbtWithCosignerResponse) String() string {
 func (*SignPsbtWithCosignerResponse) ProtoMessage() {}
 
 func (x *SignPsbtWithCosignerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5109,7 +5207,7 @@ func (x *SignPsbtWithCosignerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtWithCosignerResponse.ProtoReflect.Descriptor instead.
 func (*SignPsbtWithCosignerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{85}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *SignPsbtWithCosignerResponse) GetPsbtBase64() string {
@@ -5128,7 +5226,7 @@ type CombinePsbtRequest struct {
 
 func (x *CombinePsbtRequest) Reset() {
 	*x = CombinePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5140,7 +5238,7 @@ func (x *CombinePsbtRequest) String() string {
 func (*CombinePsbtRequest) ProtoMessage() {}
 
 func (x *CombinePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5153,7 +5251,7 @@ func (x *CombinePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombinePsbtRequest.ProtoReflect.Descriptor instead.
 func (*CombinePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{86}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *CombinePsbtRequest) GetPsbtBase64() []string {
@@ -5172,7 +5270,7 @@ type CombinePsbtResponse struct {
 
 func (x *CombinePsbtResponse) Reset() {
 	*x = CombinePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5184,7 +5282,7 @@ func (x *CombinePsbtResponse) String() string {
 func (*CombinePsbtResponse) ProtoMessage() {}
 
 func (x *CombinePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5197,7 +5295,7 @@ func (x *CombinePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombinePsbtResponse.ProtoReflect.Descriptor instead.
 func (*CombinePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{87}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *CombinePsbtResponse) GetPsbtBase64() string {
@@ -5216,7 +5314,7 @@ type FinalizePsbtRequest struct {
 
 func (x *FinalizePsbtRequest) Reset() {
 	*x = FinalizePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5228,7 +5326,7 @@ func (x *FinalizePsbtRequest) String() string {
 func (*FinalizePsbtRequest) ProtoMessage() {}
 
 func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5241,7 +5339,7 @@ func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtRequest.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{88}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *FinalizePsbtRequest) GetPsbtBase64() string {
@@ -5260,7 +5358,7 @@ type FinalizePsbtResponse struct {
 
 func (x *FinalizePsbtResponse) Reset() {
 	*x = FinalizePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5272,7 +5370,7 @@ func (x *FinalizePsbtResponse) String() string {
 func (*FinalizePsbtResponse) ProtoMessage() {}
 
 func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5285,7 +5383,7 @@ func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtResponse.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{89}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *FinalizePsbtResponse) GetRawTxHex() string {
@@ -5305,7 +5403,7 @@ type MultisigPsbtStatusRequest struct {
 
 func (x *MultisigPsbtStatusRequest) Reset() {
 	*x = MultisigPsbtStatusRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5317,7 +5415,7 @@ func (x *MultisigPsbtStatusRequest) String() string {
 func (*MultisigPsbtStatusRequest) ProtoMessage() {}
 
 func (x *MultisigPsbtStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5330,7 +5428,7 @@ func (x *MultisigPsbtStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultisigPsbtStatusRequest.ProtoReflect.Descriptor instead.
 func (*MultisigPsbtStatusRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{90}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *MultisigPsbtStatusRequest) GetWalletId() string {
@@ -5360,7 +5458,7 @@ type MultisigPsbtStatusResponse struct {
 
 func (x *MultisigPsbtStatusResponse) Reset() {
 	*x = MultisigPsbtStatusResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5372,7 +5470,7 @@ func (x *MultisigPsbtStatusResponse) String() string {
 func (*MultisigPsbtStatusResponse) ProtoMessage() {}
 
 func (x *MultisigPsbtStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5385,7 +5483,7 @@ func (x *MultisigPsbtStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultisigPsbtStatusResponse.ProtoReflect.Descriptor instead.
 func (*MultisigPsbtStatusResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{91}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *MultisigPsbtStatusResponse) GetThreshold() uint32 {
@@ -5426,7 +5524,7 @@ type BroadcastTransactionRequest struct {
 
 func (x *BroadcastTransactionRequest) Reset() {
 	*x = BroadcastTransactionRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5438,7 +5536,7 @@ func (x *BroadcastTransactionRequest) String() string {
 func (*BroadcastTransactionRequest) ProtoMessage() {}
 
 func (x *BroadcastTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5451,7 +5549,7 @@ func (x *BroadcastTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BroadcastTransactionRequest.ProtoReflect.Descriptor instead.
 func (*BroadcastTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{92}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *BroadcastTransactionRequest) GetWalletId() string {
@@ -5477,7 +5575,7 @@ type BroadcastTransactionResponse struct {
 
 func (x *BroadcastTransactionResponse) Reset() {
 	*x = BroadcastTransactionResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5489,7 +5587,7 @@ func (x *BroadcastTransactionResponse) String() string {
 func (*BroadcastTransactionResponse) ProtoMessage() {}
 
 func (x *BroadcastTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5502,7 +5600,7 @@ func (x *BroadcastTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BroadcastTransactionResponse.ProtoReflect.Descriptor instead.
 func (*BroadcastTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{93}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *BroadcastTransactionResponse) GetTxid() string {
@@ -5521,7 +5619,7 @@ type GetAddressUnspentRequest struct {
 
 func (x *GetAddressUnspentRequest) Reset() {
 	*x = GetAddressUnspentRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5533,7 +5631,7 @@ func (x *GetAddressUnspentRequest) String() string {
 func (*GetAddressUnspentRequest) ProtoMessage() {}
 
 func (x *GetAddressUnspentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5546,7 +5644,7 @@ func (x *GetAddressUnspentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAddressUnspentRequest.ProtoReflect.Descriptor instead.
 func (*GetAddressUnspentRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{94}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetAddressUnspentRequest) GetAddress() string {
@@ -5569,7 +5667,7 @@ type AddressUnspentOutput struct {
 
 func (x *AddressUnspentOutput) Reset() {
 	*x = AddressUnspentOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5581,7 +5679,7 @@ func (x *AddressUnspentOutput) String() string {
 func (*AddressUnspentOutput) ProtoMessage() {}
 
 func (x *AddressUnspentOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5594,7 +5692,7 @@ func (x *AddressUnspentOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddressUnspentOutput.ProtoReflect.Descriptor instead.
 func (*AddressUnspentOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{95}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *AddressUnspentOutput) GetTxid() string {
@@ -5642,7 +5740,7 @@ type GetAddressUnspentResponse struct {
 
 func (x *GetAddressUnspentResponse) Reset() {
 	*x = GetAddressUnspentResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5654,7 +5752,7 @@ func (x *GetAddressUnspentResponse) String() string {
 func (*GetAddressUnspentResponse) ProtoMessage() {}
 
 func (x *GetAddressUnspentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5667,7 +5765,7 @@ func (x *GetAddressUnspentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAddressUnspentResponse.ProtoReflect.Descriptor instead.
 func (*GetAddressUnspentResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{96}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *GetAddressUnspentResponse) GetUtxos() []*AddressUnspentOutput {
@@ -5693,7 +5791,7 @@ type BroadcastElectrumTransactionRequest struct {
 
 func (x *BroadcastElectrumTransactionRequest) Reset() {
 	*x = BroadcastElectrumTransactionRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5705,7 +5803,7 @@ func (x *BroadcastElectrumTransactionRequest) String() string {
 func (*BroadcastElectrumTransactionRequest) ProtoMessage() {}
 
 func (x *BroadcastElectrumTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5718,7 +5816,7 @@ func (x *BroadcastElectrumTransactionRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use BroadcastElectrumTransactionRequest.ProtoReflect.Descriptor instead.
 func (*BroadcastElectrumTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{97}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *BroadcastElectrumTransactionRequest) GetTxHex() string {
@@ -5737,7 +5835,7 @@ type BroadcastElectrumTransactionResponse struct {
 
 func (x *BroadcastElectrumTransactionResponse) Reset() {
 	*x = BroadcastElectrumTransactionResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5749,7 +5847,7 @@ func (x *BroadcastElectrumTransactionResponse) String() string {
 func (*BroadcastElectrumTransactionResponse) ProtoMessage() {}
 
 func (x *BroadcastElectrumTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5762,7 +5860,7 @@ func (x *BroadcastElectrumTransactionResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use BroadcastElectrumTransactionResponse.ProtoReflect.Descriptor instead.
 func (*BroadcastElectrumTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{98}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *BroadcastElectrumTransactionResponse) GetTxid() string {
@@ -5792,7 +5890,7 @@ type HardwareDevice struct {
 
 func (x *HardwareDevice) Reset() {
 	*x = HardwareDevice{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5804,7 +5902,7 @@ func (x *HardwareDevice) String() string {
 func (*HardwareDevice) ProtoMessage() {}
 
 func (x *HardwareDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5817,7 +5915,7 @@ func (x *HardwareDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HardwareDevice.ProtoReflect.Descriptor instead.
 func (*HardwareDevice) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{99}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *HardwareDevice) GetType() string {
@@ -5896,7 +5994,7 @@ type HardwareDeviceSelector struct {
 
 func (x *HardwareDeviceSelector) Reset() {
 	*x = HardwareDeviceSelector{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5908,7 +6006,7 @@ func (x *HardwareDeviceSelector) String() string {
 func (*HardwareDeviceSelector) ProtoMessage() {}
 
 func (x *HardwareDeviceSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5921,7 +6019,7 @@ func (x *HardwareDeviceSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HardwareDeviceSelector.ProtoReflect.Descriptor instead.
 func (*HardwareDeviceSelector) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{100}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *HardwareDeviceSelector) GetType() string {
@@ -5961,7 +6059,7 @@ type EnumerateHardwareDevicesRequest struct {
 
 func (x *EnumerateHardwareDevicesRequest) Reset() {
 	*x = EnumerateHardwareDevicesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5973,7 +6071,7 @@ func (x *EnumerateHardwareDevicesRequest) String() string {
 func (*EnumerateHardwareDevicesRequest) ProtoMessage() {}
 
 func (x *EnumerateHardwareDevicesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5986,7 +6084,7 @@ func (x *EnumerateHardwareDevicesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnumerateHardwareDevicesRequest.ProtoReflect.Descriptor instead.
 func (*EnumerateHardwareDevicesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{101}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *EnumerateHardwareDevicesRequest) GetPassphrase() string {
@@ -6005,7 +6103,7 @@ type EnumerateHardwareDevicesResponse struct {
 
 func (x *EnumerateHardwareDevicesResponse) Reset() {
 	*x = EnumerateHardwareDevicesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6017,7 +6115,7 @@ func (x *EnumerateHardwareDevicesResponse) String() string {
 func (*EnumerateHardwareDevicesResponse) ProtoMessage() {}
 
 func (x *EnumerateHardwareDevicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6030,7 +6128,7 @@ func (x *EnumerateHardwareDevicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnumerateHardwareDevicesResponse.ProtoReflect.Descriptor instead.
 func (*EnumerateHardwareDevicesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{102}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *EnumerateHardwareDevicesResponse) GetDevices() []*HardwareDevice {
@@ -6050,7 +6148,7 @@ type GetHardwareXpubRequest struct {
 
 func (x *GetHardwareXpubRequest) Reset() {
 	*x = GetHardwareXpubRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[103]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6062,7 +6160,7 @@ func (x *GetHardwareXpubRequest) String() string {
 func (*GetHardwareXpubRequest) ProtoMessage() {}
 
 func (x *GetHardwareXpubRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[103]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6075,7 +6173,7 @@ func (x *GetHardwareXpubRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHardwareXpubRequest.ProtoReflect.Descriptor instead.
 func (*GetHardwareXpubRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{103}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *GetHardwareXpubRequest) GetDevice() *HardwareDeviceSelector {
@@ -6101,7 +6199,7 @@ type GetHardwareXpubResponse struct {
 
 func (x *GetHardwareXpubResponse) Reset() {
 	*x = GetHardwareXpubResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[104]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6113,7 +6211,7 @@ func (x *GetHardwareXpubResponse) String() string {
 func (*GetHardwareXpubResponse) ProtoMessage() {}
 
 func (x *GetHardwareXpubResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[104]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6126,7 +6224,7 @@ func (x *GetHardwareXpubResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHardwareXpubResponse.ProtoReflect.Descriptor instead.
 func (*GetHardwareXpubResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{104}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *GetHardwareXpubResponse) GetXpub() string {
@@ -6146,7 +6244,7 @@ type SignPsbtWithDeviceRequest struct {
 
 func (x *SignPsbtWithDeviceRequest) Reset() {
 	*x = SignPsbtWithDeviceRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[105]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6158,7 +6256,7 @@ func (x *SignPsbtWithDeviceRequest) String() string {
 func (*SignPsbtWithDeviceRequest) ProtoMessage() {}
 
 func (x *SignPsbtWithDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[105]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6171,7 +6269,7 @@ func (x *SignPsbtWithDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtWithDeviceRequest.ProtoReflect.Descriptor instead.
 func (*SignPsbtWithDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{105}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *SignPsbtWithDeviceRequest) GetDevice() *HardwareDeviceSelector {
@@ -6197,7 +6295,7 @@ type SignPsbtWithDeviceResponse struct {
 
 func (x *SignPsbtWithDeviceResponse) Reset() {
 	*x = SignPsbtWithDeviceResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[106]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6209,7 +6307,7 @@ func (x *SignPsbtWithDeviceResponse) String() string {
 func (*SignPsbtWithDeviceResponse) ProtoMessage() {}
 
 func (x *SignPsbtWithDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[106]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6222,7 +6320,7 @@ func (x *SignPsbtWithDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtWithDeviceResponse.ProtoReflect.Descriptor instead.
 func (*SignPsbtWithDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{106}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *SignPsbtWithDeviceResponse) GetPsbtBase64() string {
@@ -6241,7 +6339,7 @@ type PromptDevicePinRequest struct {
 
 func (x *PromptDevicePinRequest) Reset() {
 	*x = PromptDevicePinRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[107]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6253,7 +6351,7 @@ func (x *PromptDevicePinRequest) String() string {
 func (*PromptDevicePinRequest) ProtoMessage() {}
 
 func (x *PromptDevicePinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[107]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6266,7 +6364,7 @@ func (x *PromptDevicePinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromptDevicePinRequest.ProtoReflect.Descriptor instead.
 func (*PromptDevicePinRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{107}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *PromptDevicePinRequest) GetDevice() *HardwareDeviceSelector {
@@ -6284,7 +6382,7 @@ type PromptDevicePinResponse struct {
 
 func (x *PromptDevicePinResponse) Reset() {
 	*x = PromptDevicePinResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[108]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6296,7 +6394,7 @@ func (x *PromptDevicePinResponse) String() string {
 func (*PromptDevicePinResponse) ProtoMessage() {}
 
 func (x *PromptDevicePinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[108]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6309,7 +6407,7 @@ func (x *PromptDevicePinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromptDevicePinResponse.ProtoReflect.Descriptor instead.
 func (*PromptDevicePinResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{108}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{110}
 }
 
 type SendDevicePinRequest struct {
@@ -6322,7 +6420,7 @@ type SendDevicePinRequest struct {
 
 func (x *SendDevicePinRequest) Reset() {
 	*x = SendDevicePinRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[109]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6334,7 +6432,7 @@ func (x *SendDevicePinRequest) String() string {
 func (*SendDevicePinRequest) ProtoMessage() {}
 
 func (x *SendDevicePinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[109]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6347,7 +6445,7 @@ func (x *SendDevicePinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendDevicePinRequest.ProtoReflect.Descriptor instead.
 func (*SendDevicePinRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{109}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *SendDevicePinRequest) GetDevice() *HardwareDeviceSelector {
@@ -6372,7 +6470,7 @@ type SendDevicePinResponse struct {
 
 func (x *SendDevicePinResponse) Reset() {
 	*x = SendDevicePinResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[110]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6384,7 +6482,7 @@ func (x *SendDevicePinResponse) String() string {
 func (*SendDevicePinResponse) ProtoMessage() {}
 
 func (x *SendDevicePinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[110]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6397,7 +6495,7 @@ func (x *SendDevicePinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendDevicePinResponse.ProtoReflect.Descriptor instead.
 func (*SendDevicePinResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{110}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{112}
 }
 
 type CloseDeviceRequest struct {
@@ -6409,7 +6507,7 @@ type CloseDeviceRequest struct {
 
 func (x *CloseDeviceRequest) Reset() {
 	*x = CloseDeviceRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[111]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6421,7 +6519,7 @@ func (x *CloseDeviceRequest) String() string {
 func (*CloseDeviceRequest) ProtoMessage() {}
 
 func (x *CloseDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[111]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6434,7 +6532,7 @@ func (x *CloseDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseDeviceRequest.ProtoReflect.Descriptor instead.
 func (*CloseDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{111}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *CloseDeviceRequest) GetDevice() *HardwareDeviceSelector {
@@ -6452,7 +6550,7 @@ type CloseDeviceResponse struct {
 
 func (x *CloseDeviceResponse) Reset() {
 	*x = CloseDeviceResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[112]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6464,7 +6562,7 @@ func (x *CloseDeviceResponse) String() string {
 func (*CloseDeviceResponse) ProtoMessage() {}
 
 func (x *CloseDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[112]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6477,7 +6575,7 @@ func (x *CloseDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseDeviceResponse.ProtoReflect.Descriptor instead.
 func (*CloseDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{112}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{114}
 }
 
 // DeriveKeystoreRequest carries one source plus the intent to derive from.
@@ -6501,7 +6599,7 @@ type DeriveKeystoreRequest struct {
 
 func (x *DeriveKeystoreRequest) Reset() {
 	*x = DeriveKeystoreRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[113]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6513,7 +6611,7 @@ func (x *DeriveKeystoreRequest) String() string {
 func (*DeriveKeystoreRequest) ProtoMessage() {}
 
 func (x *DeriveKeystoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[113]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6526,7 +6624,7 @@ func (x *DeriveKeystoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveKeystoreRequest.ProtoReflect.Descriptor instead.
 func (*DeriveKeystoreRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{113}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *DeriveKeystoreRequest) GetMnemonic() string {
@@ -6598,7 +6696,7 @@ type DeriveKeystoreResponse struct {
 
 func (x *DeriveKeystoreResponse) Reset() {
 	*x = DeriveKeystoreResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[114]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6610,7 +6708,7 @@ func (x *DeriveKeystoreResponse) String() string {
 func (*DeriveKeystoreResponse) ProtoMessage() {}
 
 func (x *DeriveKeystoreResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[114]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6623,7 +6721,7 @@ func (x *DeriveKeystoreResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveKeystoreResponse.ProtoReflect.Descriptor instead.
 func (*DeriveKeystoreResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{114}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *DeriveKeystoreResponse) GetXpub() string {
@@ -6664,7 +6762,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[115]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6676,7 +6774,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[115]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6689,7 +6787,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{115}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *ListTransactionsRequest) GetWalletId() string {
@@ -6729,7 +6827,7 @@ type TransactionEntry struct {
 
 func (x *TransactionEntry) Reset() {
 	*x = TransactionEntry{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[116]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6741,7 +6839,7 @@ func (x *TransactionEntry) String() string {
 func (*TransactionEntry) ProtoMessage() {}
 
 func (x *TransactionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[116]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6754,7 +6852,7 @@ func (x *TransactionEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionEntry.ProtoReflect.Descriptor instead.
 func (*TransactionEntry) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{116}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *TransactionEntry) GetTxid() string {
@@ -6871,7 +6969,7 @@ type BmmBid struct {
 
 func (x *BmmBid) Reset() {
 	*x = BmmBid{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6883,7 +6981,7 @@ func (x *BmmBid) String() string {
 func (*BmmBid) ProtoMessage() {}
 
 func (x *BmmBid) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[117]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6896,7 +6994,7 @@ func (x *BmmBid) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BmmBid.ProtoReflect.Descriptor instead.
 func (*BmmBid) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{117}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *BmmBid) GetSlot() uint32 {
@@ -6936,7 +7034,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6948,7 +7046,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[118]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6961,7 +7059,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{118}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionEntry {
@@ -6980,7 +7078,7 @@ type ListUnspentRequest struct {
 
 func (x *ListUnspentRequest) Reset() {
 	*x = ListUnspentRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6992,7 +7090,7 @@ func (x *ListUnspentRequest) String() string {
 func (*ListUnspentRequest) ProtoMessage() {}
 
 func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[119]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7005,7 +7103,7 @@ func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentRequest.ProtoReflect.Descriptor instead.
 func (*ListUnspentRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{119}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *ListUnspentRequest) GetWalletId() string {
@@ -7046,7 +7144,7 @@ type UnspentOutput struct {
 
 func (x *UnspentOutput) Reset() {
 	*x = UnspentOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7058,7 +7156,7 @@ func (x *UnspentOutput) String() string {
 func (*UnspentOutput) ProtoMessage() {}
 
 func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[120]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7071,7 +7169,7 @@ func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnspentOutput.ProtoReflect.Descriptor instead.
 func (*UnspentOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{120}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *UnspentOutput) GetTxid() string {
@@ -7181,7 +7279,7 @@ type ListUnspentResponse struct {
 
 func (x *ListUnspentResponse) Reset() {
 	*x = ListUnspentResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7193,7 +7291,7 @@ func (x *ListUnspentResponse) String() string {
 func (*ListUnspentResponse) ProtoMessage() {}
 
 func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[121]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7206,7 +7304,7 @@ func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentResponse.ProtoReflect.Descriptor instead.
 func (*ListUnspentResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{121}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *ListUnspentResponse) GetUtxos() []*UnspentOutput {
@@ -7225,7 +7323,7 @@ type ListReceiveAddressesRequest struct {
 
 func (x *ListReceiveAddressesRequest) Reset() {
 	*x = ListReceiveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7237,7 +7335,7 @@ func (x *ListReceiveAddressesRequest) String() string {
 func (*ListReceiveAddressesRequest) ProtoMessage() {}
 
 func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[122]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7250,7 +7348,7 @@ func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{122}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *ListReceiveAddressesRequest) GetWalletId() string {
@@ -7277,7 +7375,7 @@ type ReceiveAddress struct {
 
 func (x *ReceiveAddress) Reset() {
 	*x = ReceiveAddress{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7289,7 +7387,7 @@ func (x *ReceiveAddress) String() string {
 func (*ReceiveAddress) ProtoMessage() {}
 
 func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[123]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7302,7 +7400,7 @@ func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAddress.ProtoReflect.Descriptor instead.
 func (*ReceiveAddress) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{123}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *ReceiveAddress) GetAddress() string {
@@ -7363,7 +7461,7 @@ type ListReceiveAddressesResponse struct {
 
 func (x *ListReceiveAddressesResponse) Reset() {
 	*x = ListReceiveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7375,7 +7473,7 @@ func (x *ListReceiveAddressesResponse) String() string {
 func (*ListReceiveAddressesResponse) ProtoMessage() {}
 
 func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[124]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7388,7 +7486,7 @@ func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{124}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *ListReceiveAddressesResponse) GetAddresses() []*ReceiveAddress {
@@ -7408,7 +7506,7 @@ type GetTransactionDetailsRequest struct {
 
 func (x *GetTransactionDetailsRequest) Reset() {
 	*x = GetTransactionDetailsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7420,7 +7518,7 @@ func (x *GetTransactionDetailsRequest) String() string {
 func (*GetTransactionDetailsRequest) ProtoMessage() {}
 
 func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[125]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7433,7 +7531,7 @@ func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{125}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *GetTransactionDetailsRequest) GetWalletId() string {
@@ -7474,7 +7572,7 @@ type GetTransactionDetailsResponse struct {
 
 func (x *GetTransactionDetailsResponse) Reset() {
 	*x = GetTransactionDetailsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7486,7 +7584,7 @@ func (x *GetTransactionDetailsResponse) String() string {
 func (*GetTransactionDetailsResponse) ProtoMessage() {}
 
 func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[126]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7499,7 +7597,7 @@ func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{126}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *GetTransactionDetailsResponse) GetTransaction() *TransactionEntry {
@@ -7632,7 +7730,7 @@ type TransactionInput struct {
 
 func (x *TransactionInput) Reset() {
 	*x = TransactionInput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7644,7 +7742,7 @@ func (x *TransactionInput) String() string {
 func (*TransactionInput) ProtoMessage() {}
 
 func (x *TransactionInput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[127]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7657,7 +7755,7 @@ func (x *TransactionInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionInput.ProtoReflect.Descriptor instead.
 func (*TransactionInput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{127}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *TransactionInput) GetIndex() int32 {
@@ -7748,7 +7846,7 @@ type TransactionOutput struct {
 
 func (x *TransactionOutput) Reset() {
 	*x = TransactionOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7760,7 +7858,7 @@ func (x *TransactionOutput) String() string {
 func (*TransactionOutput) ProtoMessage() {}
 
 func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[128]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7773,7 +7871,7 @@ func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionOutput.ProtoReflect.Descriptor instead.
 func (*TransactionOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{128}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *TransactionOutput) GetIndex() int32 {
@@ -7849,7 +7947,7 @@ type DecodeTransactionRequest struct {
 
 func (x *DecodeTransactionRequest) Reset() {
 	*x = DecodeTransactionRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7861,7 +7959,7 @@ func (x *DecodeTransactionRequest) String() string {
 func (*DecodeTransactionRequest) ProtoMessage() {}
 
 func (x *DecodeTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[129]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7874,7 +7972,7 @@ func (x *DecodeTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecodeTransactionRequest.ProtoReflect.Descriptor instead.
 func (*DecodeTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{129}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *DecodeTransactionRequest) GetInput() string {
@@ -7920,7 +8018,7 @@ type DecodeTransactionResponse struct {
 
 func (x *DecodeTransactionResponse) Reset() {
 	*x = DecodeTransactionResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7932,7 +8030,7 @@ func (x *DecodeTransactionResponse) String() string {
 func (*DecodeTransactionResponse) ProtoMessage() {}
 
 func (x *DecodeTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[130]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7945,7 +8043,7 @@ func (x *DecodeTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecodeTransactionResponse.ProtoReflect.Descriptor instead.
 func (*DecodeTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{130}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *DecodeTransactionResponse) GetForm() DecodedForm {
@@ -8088,7 +8186,7 @@ type BumpFeeRequest struct {
 
 func (x *BumpFeeRequest) Reset() {
 	*x = BumpFeeRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8100,7 +8198,7 @@ func (x *BumpFeeRequest) String() string {
 func (*BumpFeeRequest) ProtoMessage() {}
 
 func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[131]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8113,7 +8211,7 @@ func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{131}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *BumpFeeRequest) GetWalletId() string {
@@ -8154,7 +8252,7 @@ type BumpFeeResponse struct {
 
 func (x *BumpFeeResponse) Reset() {
 	*x = BumpFeeResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8166,7 +8264,7 @@ func (x *BumpFeeResponse) String() string {
 func (*BumpFeeResponse) ProtoMessage() {}
 
 func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8179,7 +8277,7 @@ func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{132}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *BumpFeeResponse) GetNewTxid() string {
@@ -8208,7 +8306,7 @@ type PreviewBumpFeeRequest struct {
 
 func (x *PreviewBumpFeeRequest) Reset() {
 	*x = PreviewBumpFeeRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8220,7 +8318,7 @@ func (x *PreviewBumpFeeRequest) String() string {
 func (*PreviewBumpFeeRequest) ProtoMessage() {}
 
 func (x *PreviewBumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8233,7 +8331,7 @@ func (x *PreviewBumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewBumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*PreviewBumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{133}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *PreviewBumpFeeRequest) GetWalletId() string {
@@ -8293,7 +8391,7 @@ type PreviewBumpFeeResponse struct {
 
 func (x *PreviewBumpFeeResponse) Reset() {
 	*x = PreviewBumpFeeResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8305,7 +8403,7 @@ func (x *PreviewBumpFeeResponse) String() string {
 func (*PreviewBumpFeeResponse) ProtoMessage() {}
 
 func (x *PreviewBumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8318,7 +8416,7 @@ func (x *PreviewBumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewBumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*PreviewBumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{134}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *PreviewBumpFeeResponse) GetInputCount() int32 {
@@ -8417,7 +8515,7 @@ type BumpFeeOutput struct {
 
 func (x *BumpFeeOutput) Reset() {
 	*x = BumpFeeOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8429,7 +8527,7 @@ func (x *BumpFeeOutput) String() string {
 func (*BumpFeeOutput) ProtoMessage() {}
 
 func (x *BumpFeeOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8442,7 +8540,7 @@ func (x *BumpFeeOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeOutput.ProtoReflect.Descriptor instead.
 func (*BumpFeeOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{135}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *BumpFeeOutput) GetVout() int32 {
@@ -8509,7 +8607,7 @@ type BumpFeePlan struct {
 
 func (x *BumpFeePlan) Reset() {
 	*x = BumpFeePlan{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8521,7 +8619,7 @@ func (x *BumpFeePlan) String() string {
 func (*BumpFeePlan) ProtoMessage() {}
 
 func (x *BumpFeePlan) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8534,7 +8632,7 @@ func (x *BumpFeePlan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeePlan.ProtoReflect.Descriptor instead.
 func (*BumpFeePlan) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{136}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *BumpFeePlan) GetOldFeeSats() int64 {
@@ -8612,7 +8710,7 @@ type CreateCpfpRequest struct {
 
 func (x *CreateCpfpRequest) Reset() {
 	*x = CreateCpfpRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8624,7 +8722,7 @@ func (x *CreateCpfpRequest) String() string {
 func (*CreateCpfpRequest) ProtoMessage() {}
 
 func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8637,7 +8735,7 @@ func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpRequest.ProtoReflect.Descriptor instead.
 func (*CreateCpfpRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{137}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *CreateCpfpRequest) GetWalletId() string {
@@ -8677,7 +8775,7 @@ type CreateCpfpResponse struct {
 
 func (x *CreateCpfpResponse) Reset() {
 	*x = CreateCpfpResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8689,7 +8787,7 @@ func (x *CreateCpfpResponse) String() string {
 func (*CreateCpfpResponse) ProtoMessage() {}
 
 func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8702,7 +8800,7 @@ func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpResponse.ProtoReflect.Descriptor instead.
 func (*CreateCpfpResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{138}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *CreateCpfpResponse) GetChildTxid() string {
@@ -8723,7 +8821,7 @@ type DeriveAddressesRequest struct {
 
 func (x *DeriveAddressesRequest) Reset() {
 	*x = DeriveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8735,7 +8833,7 @@ func (x *DeriveAddressesRequest) String() string {
 func (*DeriveAddressesRequest) ProtoMessage() {}
 
 func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8748,7 +8846,7 @@ func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{139}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *DeriveAddressesRequest) GetWalletId() string {
@@ -8781,7 +8879,7 @@ type DeriveAddressesResponse struct {
 
 func (x *DeriveAddressesResponse) Reset() {
 	*x = DeriveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8793,7 +8891,7 @@ func (x *DeriveAddressesResponse) String() string {
 func (*DeriveAddressesResponse) ProtoMessage() {}
 
 func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8806,7 +8904,7 @@ func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{140}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *DeriveAddressesResponse) GetAddresses() []string {
@@ -8837,7 +8935,7 @@ type PreviewWalletFromEntropyRequest struct {
 
 func (x *PreviewWalletFromEntropyRequest) Reset() {
 	*x = PreviewWalletFromEntropyRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8849,7 +8947,7 @@ func (x *PreviewWalletFromEntropyRequest) String() string {
 func (*PreviewWalletFromEntropyRequest) ProtoMessage() {}
 
 func (x *PreviewWalletFromEntropyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8862,7 +8960,7 @@ func (x *PreviewWalletFromEntropyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewWalletFromEntropyRequest.ProtoReflect.Descriptor instead.
 func (*PreviewWalletFromEntropyRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{141}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *PreviewWalletFromEntropyRequest) GetEntropy() []byte {
@@ -8918,7 +9016,7 @@ type PreviewWalletFromEntropyResponse struct {
 
 func (x *PreviewWalletFromEntropyResponse) Reset() {
 	*x = PreviewWalletFromEntropyResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8930,7 +9028,7 @@ func (x *PreviewWalletFromEntropyResponse) String() string {
 func (*PreviewWalletFromEntropyResponse) ProtoMessage() {}
 
 func (x *PreviewWalletFromEntropyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8943,7 +9041,7 @@ func (x *PreviewWalletFromEntropyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewWalletFromEntropyResponse.ProtoReflect.Descriptor instead.
 func (*PreviewWalletFromEntropyResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{142}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *PreviewWalletFromEntropyResponse) GetEntropyHex() string {
@@ -9011,7 +9109,7 @@ type GetWalletSeedRequest struct {
 
 func (x *GetWalletSeedRequest) Reset() {
 	*x = GetWalletSeedRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9023,7 +9121,7 @@ func (x *GetWalletSeedRequest) String() string {
 func (*GetWalletSeedRequest) ProtoMessage() {}
 
 func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9036,7 +9134,7 @@ func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{143}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *GetWalletSeedRequest) GetWalletId() string {
@@ -9057,7 +9155,7 @@ type GetWalletSeedResponse struct {
 
 func (x *GetWalletSeedResponse) Reset() {
 	*x = GetWalletSeedResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9069,7 +9167,7 @@ func (x *GetWalletSeedResponse) String() string {
 func (*GetWalletSeedResponse) ProtoMessage() {}
 
 func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9082,7 +9180,7 @@ func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{144}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *GetWalletSeedResponse) GetSeedHex() string {
@@ -9107,7 +9205,7 @@ type ListCoreVariantsRequest struct {
 
 func (x *ListCoreVariantsRequest) Reset() {
 	*x = ListCoreVariantsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9119,7 +9217,7 @@ func (x *ListCoreVariantsRequest) String() string {
 func (*ListCoreVariantsRequest) ProtoMessage() {}
 
 func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9132,7 +9230,7 @@ func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsRequest.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{145}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{147}
 }
 
 type CoreVariant struct {
@@ -9146,7 +9244,7 @@ type CoreVariant struct {
 
 func (x *CoreVariant) Reset() {
 	*x = CoreVariant{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9158,7 +9256,7 @@ func (x *CoreVariant) String() string {
 func (*CoreVariant) ProtoMessage() {}
 
 func (x *CoreVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9171,7 +9269,7 @@ func (x *CoreVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreVariant.ProtoReflect.Descriptor instead.
 func (*CoreVariant) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{146}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *CoreVariant) GetId() string {
@@ -9205,7 +9303,7 @@ type ListCoreVariantsResponse struct {
 
 func (x *ListCoreVariantsResponse) Reset() {
 	*x = ListCoreVariantsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9217,7 +9315,7 @@ func (x *ListCoreVariantsResponse) String() string {
 func (*ListCoreVariantsResponse) ProtoMessage() {}
 
 func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9230,7 +9328,7 @@ func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsResponse.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{147}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *ListCoreVariantsResponse) GetVariants() []*CoreVariant {
@@ -9255,7 +9353,7 @@ type GetCoreVariantRequest struct {
 
 func (x *GetCoreVariantRequest) Reset() {
 	*x = GetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9267,7 +9365,7 @@ func (x *GetCoreVariantRequest) String() string {
 func (*GetCoreVariantRequest) ProtoMessage() {}
 
 func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9280,7 +9378,7 @@ func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{148}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{150}
 }
 
 type GetCoreVariantResponse struct {
@@ -9292,7 +9390,7 @@ type GetCoreVariantResponse struct {
 
 func (x *GetCoreVariantResponse) Reset() {
 	*x = GetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9304,7 +9402,7 @@ func (x *GetCoreVariantResponse) String() string {
 func (*GetCoreVariantResponse) ProtoMessage() {}
 
 func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9317,7 +9415,7 @@ func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{149}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *GetCoreVariantResponse) GetId() string {
@@ -9336,7 +9434,7 @@ type SetCoreVariantRequest struct {
 
 func (x *SetCoreVariantRequest) Reset() {
 	*x = SetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9348,7 +9446,7 @@ func (x *SetCoreVariantRequest) String() string {
 func (*SetCoreVariantRequest) ProtoMessage() {}
 
 func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9361,7 +9459,7 @@ func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{150}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *SetCoreVariantRequest) GetId() string {
@@ -9379,7 +9477,7 @@ type SetCoreVariantResponse struct {
 
 func (x *SetCoreVariantResponse) Reset() {
 	*x = SetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9391,7 +9489,7 @@ func (x *SetCoreVariantResponse) String() string {
 func (*SetCoreVariantResponse) ProtoMessage() {}
 
 func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9404,7 +9502,7 @@ func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{151}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{153}
 }
 
 type GetElectrumServerRequest struct {
@@ -9415,7 +9513,7 @@ type GetElectrumServerRequest struct {
 
 func (x *GetElectrumServerRequest) Reset() {
 	*x = GetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9427,7 +9525,7 @@ func (x *GetElectrumServerRequest) String() string {
 func (*GetElectrumServerRequest) ProtoMessage() {}
 
 func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9440,7 +9538,7 @@ func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{152}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{154}
 }
 
 type GetElectrumServerResponse struct {
@@ -9457,7 +9555,7 @@ type GetElectrumServerResponse struct {
 
 func (x *GetElectrumServerResponse) Reset() {
 	*x = GetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9469,7 +9567,7 @@ func (x *GetElectrumServerResponse) String() string {
 func (*GetElectrumServerResponse) ProtoMessage() {}
 
 func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9482,7 +9580,7 @@ func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{153}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *GetElectrumServerResponse) GetUrl() string {
@@ -9516,7 +9614,7 @@ type SetElectrumServerRequest struct {
 
 func (x *SetElectrumServerRequest) Reset() {
 	*x = SetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9528,7 +9626,7 @@ func (x *SetElectrumServerRequest) String() string {
 func (*SetElectrumServerRequest) ProtoMessage() {}
 
 func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9541,7 +9639,7 @@ func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{154}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *SetElectrumServerRequest) GetUrl() string {
@@ -9563,7 +9661,7 @@ type SetElectrumServerResponse struct {
 
 func (x *SetElectrumServerResponse) Reset() {
 	*x = SetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9575,7 +9673,7 @@ func (x *SetElectrumServerResponse) String() string {
 func (*SetElectrumServerResponse) ProtoMessage() {}
 
 func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9588,7 +9686,7 @@ func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{155}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *SetElectrumServerResponse) GetUrl() string {
@@ -9613,7 +9711,7 @@ type GetTorConfigRequest struct {
 
 func (x *GetTorConfigRequest) Reset() {
 	*x = GetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9625,7 +9723,7 @@ func (x *GetTorConfigRequest) String() string {
 func (*GetTorConfigRequest) ProtoMessage() {}
 
 func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9638,7 +9736,7 @@ func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{156}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{158}
 }
 
 type GetTorConfigResponse struct {
@@ -9655,7 +9753,7 @@ type GetTorConfigResponse struct {
 
 func (x *GetTorConfigResponse) Reset() {
 	*x = GetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9667,7 +9765,7 @@ func (x *GetTorConfigResponse) String() string {
 func (*GetTorConfigResponse) ProtoMessage() {}
 
 func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9680,7 +9778,7 @@ func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{157}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *GetTorConfigResponse) GetEnabled() bool {
@@ -9716,7 +9814,7 @@ type SetTorConfigRequest struct {
 
 func (x *SetTorConfigRequest) Reset() {
 	*x = SetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9728,7 +9826,7 @@ func (x *SetTorConfigRequest) String() string {
 func (*SetTorConfigRequest) ProtoMessage() {}
 
 func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9741,7 +9839,7 @@ func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{158}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *SetTorConfigRequest) GetEnabled() bool {
@@ -9771,7 +9869,7 @@ type SetTorConfigResponse struct {
 
 func (x *SetTorConfigResponse) Reset() {
 	*x = SetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9783,7 +9881,7 @@ func (x *SetTorConfigResponse) String() string {
 func (*SetTorConfigResponse) ProtoMessage() {}
 
 func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9796,7 +9894,7 @@ func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*SetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{159}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *SetTorConfigResponse) GetEnabled() bool {
@@ -9845,7 +9943,7 @@ type WatchWalletDataResponse struct {
 
 func (x *WatchWalletDataResponse) Reset() {
 	*x = WatchWalletDataResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9857,7 +9955,7 @@ func (x *WatchWalletDataResponse) String() string {
 func (*WatchWalletDataResponse) ProtoMessage() {}
 
 func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9870,7 +9968,7 @@ func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchWalletDataResponse.ProtoReflect.Descriptor instead.
 func (*WatchWalletDataResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{160}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *WatchWalletDataResponse) GetHasWallet() bool {
@@ -9954,7 +10052,7 @@ type CreateDepositRequest struct {
 
 func (x *CreateDepositRequest) Reset() {
 	*x = CreateDepositRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9966,7 +10064,7 @@ func (x *CreateDepositRequest) String() string {
 func (*CreateDepositRequest) ProtoMessage() {}
 
 func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9979,7 +10077,7 @@ func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositRequest.ProtoReflect.Descriptor instead.
 func (*CreateDepositRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{161}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *CreateDepositRequest) GetSlot() int32 {
@@ -10028,7 +10126,7 @@ type CreateDepositResponse struct {
 
 func (x *CreateDepositResponse) Reset() {
 	*x = CreateDepositResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[162]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10040,7 +10138,7 @@ func (x *CreateDepositResponse) String() string {
 func (*CreateDepositResponse) ProtoMessage() {}
 
 func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[162]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10053,7 +10151,7 @@ func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositResponse.ProtoReflect.Descriptor instead.
 func (*CreateDepositResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{162}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *CreateDepositResponse) GetTxid() string {
@@ -10382,7 +10480,12 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01J\x04\b\b\x10\t\"-\n" +
 	"\x17SendTransactionResponse\x12\x12\n" +
-	"\x04txid\x18\x01 \x01(\tR\x04txid\"I\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\"W\n" +
+	"\x15SetFrozenCoinsRequest\x12>\n" +
+	"\toutpoints\x18\x01 \x03(\v2 .walletmanager.v1.FrozenOutpointR\toutpoints\"8\n" +
+	"\x0eFrozenOutpoint\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
+	"\x04vout\x18\x02 \x01(\x05R\x04vout\"I\n" +
 	"\tRawOutput\x12\x1d\n" +
 	"\n" +
 	"value_sats\x18\x01 \x01(\x03R\tvalueSats\x12\x1d\n" +
@@ -10860,7 +10963,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x18DECODED_FORM_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11DECODED_FORM_TXID\x10\x01\x12\x17\n" +
 	"\x13DECODED_FORM_RAW_TX\x10\x02\x12\x15\n" +
-	"\x11DECODED_FORM_PSBT\x10\x032\xaa9\n" +
+	"\x11DECODED_FORM_PSBT\x10\x032\xfd9\n" +
 	"\x14WalletManagerService\x12f\n" +
 	"\x0fGetWalletStatus\x12(.walletmanager.v1.GetWalletStatusRequest\x1a).walletmanager.v1.GetWalletStatusResponse\x12x\n" +
 	"\x15ListSidechainDeposits\x12..walletmanager.v1.ListSidechainDepositsRequest\x1a/.walletmanager.v1.ListSidechainDepositsResponse\x12\x84\x01\n" +
@@ -10896,7 +10999,8 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\fRescanWallet\x12%.walletmanager.v1.RescanWalletRequest\x1a&.walletmanager.v1.RescanWalletResponse\x12Z\n" +
 	"\vEstimateFee\x12$.walletmanager.v1.EstimateFeeRequest\x1a%.walletmanager.v1.EstimateFeeResponse\x12`\n" +
 	"\rGetNewAddress\x12&.walletmanager.v1.GetNewAddressRequest\x1a'.walletmanager.v1.GetNewAddressResponse\x12f\n" +
-	"\x0fSendTransaction\x12(.walletmanager.v1.SendTransactionRequest\x1a).walletmanager.v1.SendTransactionResponse\x12`\n" +
+	"\x0fSendTransaction\x12(.walletmanager.v1.SendTransactionRequest\x1a).walletmanager.v1.SendTransactionResponse\x12Q\n" +
+	"\x0eSetFrozenCoins\x12'.walletmanager.v1.SetFrozenCoinsRequest\x1a\x16.google.protobuf.Empty\x12`\n" +
 	"\rCreateDeposit\x12&.walletmanager.v1.CreateDepositRequest\x1a'.walletmanager.v1.CreateDepositResponse\x12i\n" +
 	"\x10ListTransactions\x12).walletmanager.v1.ListTransactionsRequest\x1a*.walletmanager.v1.ListTransactionsResponse\x12Z\n" +
 	"\vListUnspent\x12$.walletmanager.v1.ListUnspentRequest\x1a%.walletmanager.v1.ListUnspentResponse\x12u\n" +
@@ -10950,7 +11054,7 @@ func file_walletmanager_v1_walletmanager_proto_rawDescGZIP() []byte {
 }
 
 var file_walletmanager_v1_walletmanager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 165)
+var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 167)
 var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(NodeMode)(0),                                // 0: walletmanager.v1.NodeMode
 	(WalletType)(0),                              // 1: walletmanager.v1.WalletType
@@ -11035,96 +11139,98 @@ var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(*GetNewAddressResponse)(nil),                // 80: walletmanager.v1.GetNewAddressResponse
 	(*SendTransactionRequest)(nil),               // 81: walletmanager.v1.SendTransactionRequest
 	(*SendTransactionResponse)(nil),              // 82: walletmanager.v1.SendTransactionResponse
-	(*RawOutput)(nil),                            // 83: walletmanager.v1.RawOutput
-	(*ExternalInput)(nil),                        // 84: walletmanager.v1.ExternalInput
-	(*CreatePsbtRequest)(nil),                    // 85: walletmanager.v1.CreatePsbtRequest
-	(*CreatePsbtResponse)(nil),                   // 86: walletmanager.v1.CreatePsbtResponse
-	(*SignPsbtRequest)(nil),                      // 87: walletmanager.v1.SignPsbtRequest
-	(*SignPsbtResponse)(nil),                     // 88: walletmanager.v1.SignPsbtResponse
-	(*SignPsbtWithCosignerRequest)(nil),          // 89: walletmanager.v1.SignPsbtWithCosignerRequest
-	(*SignPsbtWithCosignerResponse)(nil),         // 90: walletmanager.v1.SignPsbtWithCosignerResponse
-	(*CombinePsbtRequest)(nil),                   // 91: walletmanager.v1.CombinePsbtRequest
-	(*CombinePsbtResponse)(nil),                  // 92: walletmanager.v1.CombinePsbtResponse
-	(*FinalizePsbtRequest)(nil),                  // 93: walletmanager.v1.FinalizePsbtRequest
-	(*FinalizePsbtResponse)(nil),                 // 94: walletmanager.v1.FinalizePsbtResponse
-	(*MultisigPsbtStatusRequest)(nil),            // 95: walletmanager.v1.MultisigPsbtStatusRequest
-	(*MultisigPsbtStatusResponse)(nil),           // 96: walletmanager.v1.MultisigPsbtStatusResponse
-	(*BroadcastTransactionRequest)(nil),          // 97: walletmanager.v1.BroadcastTransactionRequest
-	(*BroadcastTransactionResponse)(nil),         // 98: walletmanager.v1.BroadcastTransactionResponse
-	(*GetAddressUnspentRequest)(nil),             // 99: walletmanager.v1.GetAddressUnspentRequest
-	(*AddressUnspentOutput)(nil),                 // 100: walletmanager.v1.AddressUnspentOutput
-	(*GetAddressUnspentResponse)(nil),            // 101: walletmanager.v1.GetAddressUnspentResponse
-	(*BroadcastElectrumTransactionRequest)(nil),  // 102: walletmanager.v1.BroadcastElectrumTransactionRequest
-	(*BroadcastElectrumTransactionResponse)(nil), // 103: walletmanager.v1.BroadcastElectrumTransactionResponse
-	(*HardwareDevice)(nil),                       // 104: walletmanager.v1.HardwareDevice
-	(*HardwareDeviceSelector)(nil),               // 105: walletmanager.v1.HardwareDeviceSelector
-	(*EnumerateHardwareDevicesRequest)(nil),      // 106: walletmanager.v1.EnumerateHardwareDevicesRequest
-	(*EnumerateHardwareDevicesResponse)(nil),     // 107: walletmanager.v1.EnumerateHardwareDevicesResponse
-	(*GetHardwareXpubRequest)(nil),               // 108: walletmanager.v1.GetHardwareXpubRequest
-	(*GetHardwareXpubResponse)(nil),              // 109: walletmanager.v1.GetHardwareXpubResponse
-	(*SignPsbtWithDeviceRequest)(nil),            // 110: walletmanager.v1.SignPsbtWithDeviceRequest
-	(*SignPsbtWithDeviceResponse)(nil),           // 111: walletmanager.v1.SignPsbtWithDeviceResponse
-	(*PromptDevicePinRequest)(nil),               // 112: walletmanager.v1.PromptDevicePinRequest
-	(*PromptDevicePinResponse)(nil),              // 113: walletmanager.v1.PromptDevicePinResponse
-	(*SendDevicePinRequest)(nil),                 // 114: walletmanager.v1.SendDevicePinRequest
-	(*SendDevicePinResponse)(nil),                // 115: walletmanager.v1.SendDevicePinResponse
-	(*CloseDeviceRequest)(nil),                   // 116: walletmanager.v1.CloseDeviceRequest
-	(*CloseDeviceResponse)(nil),                  // 117: walletmanager.v1.CloseDeviceResponse
-	(*DeriveKeystoreRequest)(nil),                // 118: walletmanager.v1.DeriveKeystoreRequest
-	(*DeriveKeystoreResponse)(nil),               // 119: walletmanager.v1.DeriveKeystoreResponse
-	(*ListTransactionsRequest)(nil),              // 120: walletmanager.v1.ListTransactionsRequest
-	(*TransactionEntry)(nil),                     // 121: walletmanager.v1.TransactionEntry
-	(*BmmBid)(nil),                               // 122: walletmanager.v1.BmmBid
-	(*ListTransactionsResponse)(nil),             // 123: walletmanager.v1.ListTransactionsResponse
-	(*ListUnspentRequest)(nil),                   // 124: walletmanager.v1.ListUnspentRequest
-	(*UnspentOutput)(nil),                        // 125: walletmanager.v1.UnspentOutput
-	(*ListUnspentResponse)(nil),                  // 126: walletmanager.v1.ListUnspentResponse
-	(*ListReceiveAddressesRequest)(nil),          // 127: walletmanager.v1.ListReceiveAddressesRequest
-	(*ReceiveAddress)(nil),                       // 128: walletmanager.v1.ReceiveAddress
-	(*ListReceiveAddressesResponse)(nil),         // 129: walletmanager.v1.ListReceiveAddressesResponse
-	(*GetTransactionDetailsRequest)(nil),         // 130: walletmanager.v1.GetTransactionDetailsRequest
-	(*GetTransactionDetailsResponse)(nil),        // 131: walletmanager.v1.GetTransactionDetailsResponse
-	(*TransactionInput)(nil),                     // 132: walletmanager.v1.TransactionInput
-	(*TransactionOutput)(nil),                    // 133: walletmanager.v1.TransactionOutput
-	(*DecodeTransactionRequest)(nil),             // 134: walletmanager.v1.DecodeTransactionRequest
-	(*DecodeTransactionResponse)(nil),            // 135: walletmanager.v1.DecodeTransactionResponse
-	(*BumpFeeRequest)(nil),                       // 136: walletmanager.v1.BumpFeeRequest
-	(*BumpFeeResponse)(nil),                      // 137: walletmanager.v1.BumpFeeResponse
-	(*PreviewBumpFeeRequest)(nil),                // 138: walletmanager.v1.PreviewBumpFeeRequest
-	(*PreviewBumpFeeResponse)(nil),               // 139: walletmanager.v1.PreviewBumpFeeResponse
-	(*BumpFeeOutput)(nil),                        // 140: walletmanager.v1.BumpFeeOutput
-	(*BumpFeePlan)(nil),                          // 141: walletmanager.v1.BumpFeePlan
-	(*CreateCpfpRequest)(nil),                    // 142: walletmanager.v1.CreateCpfpRequest
-	(*CreateCpfpResponse)(nil),                   // 143: walletmanager.v1.CreateCpfpResponse
-	(*DeriveAddressesRequest)(nil),               // 144: walletmanager.v1.DeriveAddressesRequest
-	(*DeriveAddressesResponse)(nil),              // 145: walletmanager.v1.DeriveAddressesResponse
-	(*PreviewWalletFromEntropyRequest)(nil),      // 146: walletmanager.v1.PreviewWalletFromEntropyRequest
-	(*PreviewWalletFromEntropyResponse)(nil),     // 147: walletmanager.v1.PreviewWalletFromEntropyResponse
-	(*GetWalletSeedRequest)(nil),                 // 148: walletmanager.v1.GetWalletSeedRequest
-	(*GetWalletSeedResponse)(nil),                // 149: walletmanager.v1.GetWalletSeedResponse
-	(*ListCoreVariantsRequest)(nil),              // 150: walletmanager.v1.ListCoreVariantsRequest
-	(*CoreVariant)(nil),                          // 151: walletmanager.v1.CoreVariant
-	(*ListCoreVariantsResponse)(nil),             // 152: walletmanager.v1.ListCoreVariantsResponse
-	(*GetCoreVariantRequest)(nil),                // 153: walletmanager.v1.GetCoreVariantRequest
-	(*GetCoreVariantResponse)(nil),               // 154: walletmanager.v1.GetCoreVariantResponse
-	(*SetCoreVariantRequest)(nil),                // 155: walletmanager.v1.SetCoreVariantRequest
-	(*SetCoreVariantResponse)(nil),               // 156: walletmanager.v1.SetCoreVariantResponse
-	(*GetElectrumServerRequest)(nil),             // 157: walletmanager.v1.GetElectrumServerRequest
-	(*GetElectrumServerResponse)(nil),            // 158: walletmanager.v1.GetElectrumServerResponse
-	(*SetElectrumServerRequest)(nil),             // 159: walletmanager.v1.SetElectrumServerRequest
-	(*SetElectrumServerResponse)(nil),            // 160: walletmanager.v1.SetElectrumServerResponse
-	(*GetTorConfigRequest)(nil),                  // 161: walletmanager.v1.GetTorConfigRequest
-	(*GetTorConfigResponse)(nil),                 // 162: walletmanager.v1.GetTorConfigResponse
-	(*SetTorConfigRequest)(nil),                  // 163: walletmanager.v1.SetTorConfigRequest
-	(*SetTorConfigResponse)(nil),                 // 164: walletmanager.v1.SetTorConfigResponse
-	(*WatchWalletDataResponse)(nil),              // 165: walletmanager.v1.WatchWalletDataResponse
-	(*CreateDepositRequest)(nil),                 // 166: walletmanager.v1.CreateDepositRequest
-	(*CreateDepositResponse)(nil),                // 167: walletmanager.v1.CreateDepositResponse
-	nil,                                          // 168: walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	nil,                                          // 169: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	(v1.BinaryType)(0),                           // 170: orchestrator.v1.BinaryType
-	(*timestamppb.Timestamp)(nil),                // 171: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                        // 172: google.protobuf.Empty
+	(*SetFrozenCoinsRequest)(nil),                // 83: walletmanager.v1.SetFrozenCoinsRequest
+	(*FrozenOutpoint)(nil),                       // 84: walletmanager.v1.FrozenOutpoint
+	(*RawOutput)(nil),                            // 85: walletmanager.v1.RawOutput
+	(*ExternalInput)(nil),                        // 86: walletmanager.v1.ExternalInput
+	(*CreatePsbtRequest)(nil),                    // 87: walletmanager.v1.CreatePsbtRequest
+	(*CreatePsbtResponse)(nil),                   // 88: walletmanager.v1.CreatePsbtResponse
+	(*SignPsbtRequest)(nil),                      // 89: walletmanager.v1.SignPsbtRequest
+	(*SignPsbtResponse)(nil),                     // 90: walletmanager.v1.SignPsbtResponse
+	(*SignPsbtWithCosignerRequest)(nil),          // 91: walletmanager.v1.SignPsbtWithCosignerRequest
+	(*SignPsbtWithCosignerResponse)(nil),         // 92: walletmanager.v1.SignPsbtWithCosignerResponse
+	(*CombinePsbtRequest)(nil),                   // 93: walletmanager.v1.CombinePsbtRequest
+	(*CombinePsbtResponse)(nil),                  // 94: walletmanager.v1.CombinePsbtResponse
+	(*FinalizePsbtRequest)(nil),                  // 95: walletmanager.v1.FinalizePsbtRequest
+	(*FinalizePsbtResponse)(nil),                 // 96: walletmanager.v1.FinalizePsbtResponse
+	(*MultisigPsbtStatusRequest)(nil),            // 97: walletmanager.v1.MultisigPsbtStatusRequest
+	(*MultisigPsbtStatusResponse)(nil),           // 98: walletmanager.v1.MultisigPsbtStatusResponse
+	(*BroadcastTransactionRequest)(nil),          // 99: walletmanager.v1.BroadcastTransactionRequest
+	(*BroadcastTransactionResponse)(nil),         // 100: walletmanager.v1.BroadcastTransactionResponse
+	(*GetAddressUnspentRequest)(nil),             // 101: walletmanager.v1.GetAddressUnspentRequest
+	(*AddressUnspentOutput)(nil),                 // 102: walletmanager.v1.AddressUnspentOutput
+	(*GetAddressUnspentResponse)(nil),            // 103: walletmanager.v1.GetAddressUnspentResponse
+	(*BroadcastElectrumTransactionRequest)(nil),  // 104: walletmanager.v1.BroadcastElectrumTransactionRequest
+	(*BroadcastElectrumTransactionResponse)(nil), // 105: walletmanager.v1.BroadcastElectrumTransactionResponse
+	(*HardwareDevice)(nil),                       // 106: walletmanager.v1.HardwareDevice
+	(*HardwareDeviceSelector)(nil),               // 107: walletmanager.v1.HardwareDeviceSelector
+	(*EnumerateHardwareDevicesRequest)(nil),      // 108: walletmanager.v1.EnumerateHardwareDevicesRequest
+	(*EnumerateHardwareDevicesResponse)(nil),     // 109: walletmanager.v1.EnumerateHardwareDevicesResponse
+	(*GetHardwareXpubRequest)(nil),               // 110: walletmanager.v1.GetHardwareXpubRequest
+	(*GetHardwareXpubResponse)(nil),              // 111: walletmanager.v1.GetHardwareXpubResponse
+	(*SignPsbtWithDeviceRequest)(nil),            // 112: walletmanager.v1.SignPsbtWithDeviceRequest
+	(*SignPsbtWithDeviceResponse)(nil),           // 113: walletmanager.v1.SignPsbtWithDeviceResponse
+	(*PromptDevicePinRequest)(nil),               // 114: walletmanager.v1.PromptDevicePinRequest
+	(*PromptDevicePinResponse)(nil),              // 115: walletmanager.v1.PromptDevicePinResponse
+	(*SendDevicePinRequest)(nil),                 // 116: walletmanager.v1.SendDevicePinRequest
+	(*SendDevicePinResponse)(nil),                // 117: walletmanager.v1.SendDevicePinResponse
+	(*CloseDeviceRequest)(nil),                   // 118: walletmanager.v1.CloseDeviceRequest
+	(*CloseDeviceResponse)(nil),                  // 119: walletmanager.v1.CloseDeviceResponse
+	(*DeriveKeystoreRequest)(nil),                // 120: walletmanager.v1.DeriveKeystoreRequest
+	(*DeriveKeystoreResponse)(nil),               // 121: walletmanager.v1.DeriveKeystoreResponse
+	(*ListTransactionsRequest)(nil),              // 122: walletmanager.v1.ListTransactionsRequest
+	(*TransactionEntry)(nil),                     // 123: walletmanager.v1.TransactionEntry
+	(*BmmBid)(nil),                               // 124: walletmanager.v1.BmmBid
+	(*ListTransactionsResponse)(nil),             // 125: walletmanager.v1.ListTransactionsResponse
+	(*ListUnspentRequest)(nil),                   // 126: walletmanager.v1.ListUnspentRequest
+	(*UnspentOutput)(nil),                        // 127: walletmanager.v1.UnspentOutput
+	(*ListUnspentResponse)(nil),                  // 128: walletmanager.v1.ListUnspentResponse
+	(*ListReceiveAddressesRequest)(nil),          // 129: walletmanager.v1.ListReceiveAddressesRequest
+	(*ReceiveAddress)(nil),                       // 130: walletmanager.v1.ReceiveAddress
+	(*ListReceiveAddressesResponse)(nil),         // 131: walletmanager.v1.ListReceiveAddressesResponse
+	(*GetTransactionDetailsRequest)(nil),         // 132: walletmanager.v1.GetTransactionDetailsRequest
+	(*GetTransactionDetailsResponse)(nil),        // 133: walletmanager.v1.GetTransactionDetailsResponse
+	(*TransactionInput)(nil),                     // 134: walletmanager.v1.TransactionInput
+	(*TransactionOutput)(nil),                    // 135: walletmanager.v1.TransactionOutput
+	(*DecodeTransactionRequest)(nil),             // 136: walletmanager.v1.DecodeTransactionRequest
+	(*DecodeTransactionResponse)(nil),            // 137: walletmanager.v1.DecodeTransactionResponse
+	(*BumpFeeRequest)(nil),                       // 138: walletmanager.v1.BumpFeeRequest
+	(*BumpFeeResponse)(nil),                      // 139: walletmanager.v1.BumpFeeResponse
+	(*PreviewBumpFeeRequest)(nil),                // 140: walletmanager.v1.PreviewBumpFeeRequest
+	(*PreviewBumpFeeResponse)(nil),               // 141: walletmanager.v1.PreviewBumpFeeResponse
+	(*BumpFeeOutput)(nil),                        // 142: walletmanager.v1.BumpFeeOutput
+	(*BumpFeePlan)(nil),                          // 143: walletmanager.v1.BumpFeePlan
+	(*CreateCpfpRequest)(nil),                    // 144: walletmanager.v1.CreateCpfpRequest
+	(*CreateCpfpResponse)(nil),                   // 145: walletmanager.v1.CreateCpfpResponse
+	(*DeriveAddressesRequest)(nil),               // 146: walletmanager.v1.DeriveAddressesRequest
+	(*DeriveAddressesResponse)(nil),              // 147: walletmanager.v1.DeriveAddressesResponse
+	(*PreviewWalletFromEntropyRequest)(nil),      // 148: walletmanager.v1.PreviewWalletFromEntropyRequest
+	(*PreviewWalletFromEntropyResponse)(nil),     // 149: walletmanager.v1.PreviewWalletFromEntropyResponse
+	(*GetWalletSeedRequest)(nil),                 // 150: walletmanager.v1.GetWalletSeedRequest
+	(*GetWalletSeedResponse)(nil),                // 151: walletmanager.v1.GetWalletSeedResponse
+	(*ListCoreVariantsRequest)(nil),              // 152: walletmanager.v1.ListCoreVariantsRequest
+	(*CoreVariant)(nil),                          // 153: walletmanager.v1.CoreVariant
+	(*ListCoreVariantsResponse)(nil),             // 154: walletmanager.v1.ListCoreVariantsResponse
+	(*GetCoreVariantRequest)(nil),                // 155: walletmanager.v1.GetCoreVariantRequest
+	(*GetCoreVariantResponse)(nil),               // 156: walletmanager.v1.GetCoreVariantResponse
+	(*SetCoreVariantRequest)(nil),                // 157: walletmanager.v1.SetCoreVariantRequest
+	(*SetCoreVariantResponse)(nil),               // 158: walletmanager.v1.SetCoreVariantResponse
+	(*GetElectrumServerRequest)(nil),             // 159: walletmanager.v1.GetElectrumServerRequest
+	(*GetElectrumServerResponse)(nil),            // 160: walletmanager.v1.GetElectrumServerResponse
+	(*SetElectrumServerRequest)(nil),             // 161: walletmanager.v1.SetElectrumServerRequest
+	(*SetElectrumServerResponse)(nil),            // 162: walletmanager.v1.SetElectrumServerResponse
+	(*GetTorConfigRequest)(nil),                  // 163: walletmanager.v1.GetTorConfigRequest
+	(*GetTorConfigResponse)(nil),                 // 164: walletmanager.v1.GetTorConfigResponse
+	(*SetTorConfigRequest)(nil),                  // 165: walletmanager.v1.SetTorConfigRequest
+	(*SetTorConfigResponse)(nil),                 // 166: walletmanager.v1.SetTorConfigResponse
+	(*WatchWalletDataResponse)(nil),              // 167: walletmanager.v1.WatchWalletDataResponse
+	(*CreateDepositRequest)(nil),                 // 168: walletmanager.v1.CreateDepositRequest
+	(*CreateDepositResponse)(nil),                // 169: walletmanager.v1.CreateDepositResponse
+	nil,                                          // 170: walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	nil,                                          // 171: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	(v1.BinaryType)(0),                           // 172: orchestrator.v1.BinaryType
+	(*timestamppb.Timestamp)(nil),                // 173: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                        // 174: google.protobuf.Empty
 }
 var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	8,   // 0: walletmanager.v1.ListSidechainDepositsResponse.deposits:type_name -> walletmanager.v1.SidechainDeposit
@@ -11136,9 +11242,9 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	3,   // 6: walletmanager.v1.WalletMetadata.receive_address_types:type_name -> walletmanager.v1.AddressType
 	30,  // 7: walletmanager.v1.MultisigInfo.cosigners:type_name -> walletmanager.v1.MultisigCosignerInfo
 	28,  // 8: walletmanager.v1.ListWalletsResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	170, // 9: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
-	171, // 10: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
-	171, // 11: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
+	172, // 9: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
+	173, // 10: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
+	173, // 11: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
 	43,  // 12: walletmanager.v1.WalletBackup.wallets:type_name -> walletmanager.v1.BackupWalletSummary
 	42,  // 13: walletmanager.v1.WalletBackup.latest_known_balance:type_name -> walletmanager.v1.BalanceSnapshot
 	44,  // 14: walletmanager.v1.ListWalletBackupsResponse.backups:type_name -> walletmanager.v1.WalletBackup
@@ -11150,181 +11256,184 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	66,  // 20: walletmanager.v1.ListDerivationPathsResponse.options:type_name -> walletmanager.v1.DerivationPathOption
 	60,  // 21: walletmanager.v1.ValidateDescriptorResponse.keys:type_name -> walletmanager.v1.ParsedCosigner
 	3,   // 22: walletmanager.v1.GetNewAddressRequest.address_type:type_name -> walletmanager.v1.AddressType
-	168, // 23: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	125, // 24: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
-	83,  // 25: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
-	84,  // 26: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
-	169, // 27: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	125, // 28: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
-	83,  // 29: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
-	84,  // 30: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
-	100, // 31: walletmanager.v1.GetAddressUnspentResponse.utxos:type_name -> walletmanager.v1.AddressUnspentOutput
-	104, // 32: walletmanager.v1.EnumerateHardwareDevicesResponse.devices:type_name -> walletmanager.v1.HardwareDevice
-	105, // 33: walletmanager.v1.GetHardwareXpubRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	105, // 34: walletmanager.v1.SignPsbtWithDeviceRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	105, // 35: walletmanager.v1.PromptDevicePinRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	105, // 36: walletmanager.v1.SendDevicePinRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	105, // 37: walletmanager.v1.CloseDeviceRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	105, // 38: walletmanager.v1.DeriveKeystoreRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
-	122, // 39: walletmanager.v1.TransactionEntry.bmm_bid:type_name -> walletmanager.v1.BmmBid
-	121, // 40: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
-	171, // 41: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
-	125, // 42: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
-	128, // 43: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
-	121, // 44: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
-	132, // 45: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	133, // 46: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	4,   // 47: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
-	132, // 48: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	133, // 49: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	141, // 50: walletmanager.v1.BumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
-	140, // 51: walletmanager.v1.PreviewBumpFeeResponse.outputs:type_name -> walletmanager.v1.BumpFeeOutput
-	141, // 52: walletmanager.v1.PreviewBumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
-	151, // 53: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
-	28,  // 54: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	5,   // 55: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
-	7,   // 56: walletmanager.v1.WalletManagerService.ListSidechainDeposits:input_type -> walletmanager.v1.ListSidechainDepositsRequest
-	10,  // 57: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:input_type -> walletmanager.v1.GetSidechainDepositTotalsRequest
-	12,  // 58: walletmanager.v1.WalletManagerService.GetNodeMode:input_type -> walletmanager.v1.GetNodeModeRequest
-	14,  // 59: walletmanager.v1.WalletManagerService.SetNodeMode:input_type -> walletmanager.v1.SetNodeModeRequest
-	16,  // 60: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
-	18,  // 61: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
-	20,  // 62: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
-	22,  // 63: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
-	24,  // 64: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
-	26,  // 65: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
-	32,  // 66: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
-	34,  // 67: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
-	36,  // 68: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
-	38,  // 69: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
-	40,  // 70: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
-	45,  // 71: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
-	47,  // 72: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	47,  // 73: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	52,  // 74: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
-	54,  // 75: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
-	57,  // 76: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
-	59,  // 77: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
-	62,  // 78: walletmanager.v1.WalletManagerService.ValidateDescriptor:input_type -> walletmanager.v1.ValidateDescriptorRequest
-	63,  // 79: walletmanager.v1.WalletManagerService.ValidateDerivationPath:input_type -> walletmanager.v1.ValidateDerivationPathRequest
-	65,  // 80: walletmanager.v1.WalletManagerService.ListDerivationPaths:input_type -> walletmanager.v1.ListDerivationPathsRequest
-	69,  // 81: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
-	71,  // 82: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
-	73,  // 83: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
-	74,  // 84: walletmanager.v1.WalletManagerService.RescanWallet:input_type -> walletmanager.v1.RescanWalletRequest
-	76,  // 85: walletmanager.v1.WalletManagerService.EstimateFee:input_type -> walletmanager.v1.EstimateFeeRequest
-	79,  // 86: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
-	81,  // 87: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
-	166, // 88: walletmanager.v1.WalletManagerService.CreateDeposit:input_type -> walletmanager.v1.CreateDepositRequest
-	120, // 89: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
-	124, // 90: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
-	127, // 91: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
-	130, // 92: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
-	134, // 93: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
-	136, // 94: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
-	138, // 95: walletmanager.v1.WalletManagerService.PreviewBumpFee:input_type -> walletmanager.v1.PreviewBumpFeeRequest
-	142, // 96: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
-	144, // 97: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
-	85,  // 98: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
-	87,  // 99: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
-	89,  // 100: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
-	91,  // 101: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
-	93,  // 102: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
-	95,  // 103: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
-	97,  // 104: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
-	99,  // 105: walletmanager.v1.WalletManagerService.GetAddressUnspent:input_type -> walletmanager.v1.GetAddressUnspentRequest
-	102, // 106: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:input_type -> walletmanager.v1.BroadcastElectrumTransactionRequest
-	106, // 107: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:input_type -> walletmanager.v1.EnumerateHardwareDevicesRequest
-	108, // 108: walletmanager.v1.WalletManagerService.GetHardwareXpub:input_type -> walletmanager.v1.GetHardwareXpubRequest
-	110, // 109: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:input_type -> walletmanager.v1.SignPsbtWithDeviceRequest
-	112, // 110: walletmanager.v1.WalletManagerService.PromptDevicePin:input_type -> walletmanager.v1.PromptDevicePinRequest
-	114, // 111: walletmanager.v1.WalletManagerService.SendDevicePin:input_type -> walletmanager.v1.SendDevicePinRequest
-	116, // 112: walletmanager.v1.WalletManagerService.CloseDevice:input_type -> walletmanager.v1.CloseDeviceRequest
-	118, // 113: walletmanager.v1.WalletManagerService.DeriveKeystore:input_type -> walletmanager.v1.DeriveKeystoreRequest
-	146, // 114: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:input_type -> walletmanager.v1.PreviewWalletFromEntropyRequest
-	148, // 115: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
-	150, // 116: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
-	153, // 117: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
-	155, // 118: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
-	157, // 119: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
-	159, // 120: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
-	161, // 121: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
-	163, // 122: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
-	172, // 123: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
-	6,   // 124: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
-	9,   // 125: walletmanager.v1.WalletManagerService.ListSidechainDeposits:output_type -> walletmanager.v1.ListSidechainDepositsResponse
-	11,  // 126: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:output_type -> walletmanager.v1.GetSidechainDepositTotalsResponse
-	13,  // 127: walletmanager.v1.WalletManagerService.GetNodeMode:output_type -> walletmanager.v1.GetNodeModeResponse
-	15,  // 128: walletmanager.v1.WalletManagerService.SetNodeMode:output_type -> walletmanager.v1.SetNodeModeResponse
-	17,  // 129: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
-	19,  // 130: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
-	21,  // 131: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
-	23,  // 132: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
-	25,  // 133: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
-	27,  // 134: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
-	33,  // 135: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
-	35,  // 136: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
-	37,  // 137: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
-	39,  // 138: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
-	41,  // 139: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
-	46,  // 140: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
-	48,  // 141: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
-	51,  // 142: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
-	53,  // 143: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
-	55,  // 144: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
-	58,  // 145: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
-	61,  // 146: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
-	68,  // 147: walletmanager.v1.WalletManagerService.ValidateDescriptor:output_type -> walletmanager.v1.ValidateDescriptorResponse
-	64,  // 148: walletmanager.v1.WalletManagerService.ValidateDerivationPath:output_type -> walletmanager.v1.ValidateDerivationPathResponse
-	67,  // 149: walletmanager.v1.WalletManagerService.ListDerivationPaths:output_type -> walletmanager.v1.ListDerivationPathsResponse
-	70,  // 150: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
-	72,  // 151: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
-	78,  // 152: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
-	75,  // 153: walletmanager.v1.WalletManagerService.RescanWallet:output_type -> walletmanager.v1.RescanWalletResponse
-	77,  // 154: walletmanager.v1.WalletManagerService.EstimateFee:output_type -> walletmanager.v1.EstimateFeeResponse
-	80,  // 155: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
-	82,  // 156: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
-	167, // 157: walletmanager.v1.WalletManagerService.CreateDeposit:output_type -> walletmanager.v1.CreateDepositResponse
-	123, // 158: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
-	126, // 159: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
-	129, // 160: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
-	131, // 161: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
-	135, // 162: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
-	137, // 163: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
-	139, // 164: walletmanager.v1.WalletManagerService.PreviewBumpFee:output_type -> walletmanager.v1.PreviewBumpFeeResponse
-	143, // 165: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
-	145, // 166: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
-	86,  // 167: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
-	88,  // 168: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
-	90,  // 169: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
-	92,  // 170: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
-	94,  // 171: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
-	96,  // 172: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
-	98,  // 173: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
-	101, // 174: walletmanager.v1.WalletManagerService.GetAddressUnspent:output_type -> walletmanager.v1.GetAddressUnspentResponse
-	103, // 175: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:output_type -> walletmanager.v1.BroadcastElectrumTransactionResponse
-	107, // 176: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:output_type -> walletmanager.v1.EnumerateHardwareDevicesResponse
-	109, // 177: walletmanager.v1.WalletManagerService.GetHardwareXpub:output_type -> walletmanager.v1.GetHardwareXpubResponse
-	111, // 178: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:output_type -> walletmanager.v1.SignPsbtWithDeviceResponse
-	113, // 179: walletmanager.v1.WalletManagerService.PromptDevicePin:output_type -> walletmanager.v1.PromptDevicePinResponse
-	115, // 180: walletmanager.v1.WalletManagerService.SendDevicePin:output_type -> walletmanager.v1.SendDevicePinResponse
-	117, // 181: walletmanager.v1.WalletManagerService.CloseDevice:output_type -> walletmanager.v1.CloseDeviceResponse
-	119, // 182: walletmanager.v1.WalletManagerService.DeriveKeystore:output_type -> walletmanager.v1.DeriveKeystoreResponse
-	147, // 183: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:output_type -> walletmanager.v1.PreviewWalletFromEntropyResponse
-	149, // 184: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
-	152, // 185: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
-	154, // 186: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
-	156, // 187: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
-	158, // 188: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
-	160, // 189: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
-	162, // 190: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
-	164, // 191: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
-	165, // 192: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
-	124, // [124:193] is the sub-list for method output_type
-	55,  // [55:124] is the sub-list for method input_type
-	55,  // [55:55] is the sub-list for extension type_name
-	55,  // [55:55] is the sub-list for extension extendee
-	0,   // [0:55] is the sub-list for field type_name
+	170, // 23: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	127, // 24: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	85,  // 25: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
+	86,  // 26: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
+	84,  // 27: walletmanager.v1.SetFrozenCoinsRequest.outpoints:type_name -> walletmanager.v1.FrozenOutpoint
+	171, // 28: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	127, // 29: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	85,  // 30: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
+	86,  // 31: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
+	102, // 32: walletmanager.v1.GetAddressUnspentResponse.utxos:type_name -> walletmanager.v1.AddressUnspentOutput
+	106, // 33: walletmanager.v1.EnumerateHardwareDevicesResponse.devices:type_name -> walletmanager.v1.HardwareDevice
+	107, // 34: walletmanager.v1.GetHardwareXpubRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
+	107, // 35: walletmanager.v1.SignPsbtWithDeviceRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
+	107, // 36: walletmanager.v1.PromptDevicePinRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
+	107, // 37: walletmanager.v1.SendDevicePinRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
+	107, // 38: walletmanager.v1.CloseDeviceRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
+	107, // 39: walletmanager.v1.DeriveKeystoreRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
+	124, // 40: walletmanager.v1.TransactionEntry.bmm_bid:type_name -> walletmanager.v1.BmmBid
+	123, // 41: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
+	173, // 42: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
+	127, // 43: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
+	130, // 44: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
+	123, // 45: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
+	134, // 46: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	135, // 47: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	4,   // 48: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
+	134, // 49: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	135, // 50: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	143, // 51: walletmanager.v1.BumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
+	142, // 52: walletmanager.v1.PreviewBumpFeeResponse.outputs:type_name -> walletmanager.v1.BumpFeeOutput
+	143, // 53: walletmanager.v1.PreviewBumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
+	153, // 54: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
+	28,  // 55: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
+	5,   // 56: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
+	7,   // 57: walletmanager.v1.WalletManagerService.ListSidechainDeposits:input_type -> walletmanager.v1.ListSidechainDepositsRequest
+	10,  // 58: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:input_type -> walletmanager.v1.GetSidechainDepositTotalsRequest
+	12,  // 59: walletmanager.v1.WalletManagerService.GetNodeMode:input_type -> walletmanager.v1.GetNodeModeRequest
+	14,  // 60: walletmanager.v1.WalletManagerService.SetNodeMode:input_type -> walletmanager.v1.SetNodeModeRequest
+	16,  // 61: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
+	18,  // 62: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
+	20,  // 63: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
+	22,  // 64: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
+	24,  // 65: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
+	26,  // 66: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
+	32,  // 67: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
+	34,  // 68: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
+	36,  // 69: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
+	38,  // 70: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
+	40,  // 71: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
+	45,  // 72: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
+	47,  // 73: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	47,  // 74: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	52,  // 75: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
+	54,  // 76: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
+	57,  // 77: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
+	59,  // 78: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
+	62,  // 79: walletmanager.v1.WalletManagerService.ValidateDescriptor:input_type -> walletmanager.v1.ValidateDescriptorRequest
+	63,  // 80: walletmanager.v1.WalletManagerService.ValidateDerivationPath:input_type -> walletmanager.v1.ValidateDerivationPathRequest
+	65,  // 81: walletmanager.v1.WalletManagerService.ListDerivationPaths:input_type -> walletmanager.v1.ListDerivationPathsRequest
+	69,  // 82: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
+	71,  // 83: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
+	73,  // 84: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
+	74,  // 85: walletmanager.v1.WalletManagerService.RescanWallet:input_type -> walletmanager.v1.RescanWalletRequest
+	76,  // 86: walletmanager.v1.WalletManagerService.EstimateFee:input_type -> walletmanager.v1.EstimateFeeRequest
+	79,  // 87: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
+	81,  // 88: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
+	83,  // 89: walletmanager.v1.WalletManagerService.SetFrozenCoins:input_type -> walletmanager.v1.SetFrozenCoinsRequest
+	168, // 90: walletmanager.v1.WalletManagerService.CreateDeposit:input_type -> walletmanager.v1.CreateDepositRequest
+	122, // 91: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
+	126, // 92: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
+	129, // 93: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
+	132, // 94: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
+	136, // 95: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
+	138, // 96: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
+	140, // 97: walletmanager.v1.WalletManagerService.PreviewBumpFee:input_type -> walletmanager.v1.PreviewBumpFeeRequest
+	144, // 98: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
+	146, // 99: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
+	87,  // 100: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
+	89,  // 101: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
+	91,  // 102: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
+	93,  // 103: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
+	95,  // 104: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
+	97,  // 105: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
+	99,  // 106: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
+	101, // 107: walletmanager.v1.WalletManagerService.GetAddressUnspent:input_type -> walletmanager.v1.GetAddressUnspentRequest
+	104, // 108: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:input_type -> walletmanager.v1.BroadcastElectrumTransactionRequest
+	108, // 109: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:input_type -> walletmanager.v1.EnumerateHardwareDevicesRequest
+	110, // 110: walletmanager.v1.WalletManagerService.GetHardwareXpub:input_type -> walletmanager.v1.GetHardwareXpubRequest
+	112, // 111: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:input_type -> walletmanager.v1.SignPsbtWithDeviceRequest
+	114, // 112: walletmanager.v1.WalletManagerService.PromptDevicePin:input_type -> walletmanager.v1.PromptDevicePinRequest
+	116, // 113: walletmanager.v1.WalletManagerService.SendDevicePin:input_type -> walletmanager.v1.SendDevicePinRequest
+	118, // 114: walletmanager.v1.WalletManagerService.CloseDevice:input_type -> walletmanager.v1.CloseDeviceRequest
+	120, // 115: walletmanager.v1.WalletManagerService.DeriveKeystore:input_type -> walletmanager.v1.DeriveKeystoreRequest
+	148, // 116: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:input_type -> walletmanager.v1.PreviewWalletFromEntropyRequest
+	150, // 117: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
+	152, // 118: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
+	155, // 119: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
+	157, // 120: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
+	159, // 121: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
+	161, // 122: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
+	163, // 123: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
+	165, // 124: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
+	174, // 125: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
+	6,   // 126: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
+	9,   // 127: walletmanager.v1.WalletManagerService.ListSidechainDeposits:output_type -> walletmanager.v1.ListSidechainDepositsResponse
+	11,  // 128: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:output_type -> walletmanager.v1.GetSidechainDepositTotalsResponse
+	13,  // 129: walletmanager.v1.WalletManagerService.GetNodeMode:output_type -> walletmanager.v1.GetNodeModeResponse
+	15,  // 130: walletmanager.v1.WalletManagerService.SetNodeMode:output_type -> walletmanager.v1.SetNodeModeResponse
+	17,  // 131: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
+	19,  // 132: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
+	21,  // 133: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
+	23,  // 134: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
+	25,  // 135: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
+	27,  // 136: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
+	33,  // 137: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
+	35,  // 138: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
+	37,  // 139: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
+	39,  // 140: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
+	41,  // 141: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
+	46,  // 142: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
+	48,  // 143: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
+	51,  // 144: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
+	53,  // 145: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
+	55,  // 146: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
+	58,  // 147: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
+	61,  // 148: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
+	68,  // 149: walletmanager.v1.WalletManagerService.ValidateDescriptor:output_type -> walletmanager.v1.ValidateDescriptorResponse
+	64,  // 150: walletmanager.v1.WalletManagerService.ValidateDerivationPath:output_type -> walletmanager.v1.ValidateDerivationPathResponse
+	67,  // 151: walletmanager.v1.WalletManagerService.ListDerivationPaths:output_type -> walletmanager.v1.ListDerivationPathsResponse
+	70,  // 152: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
+	72,  // 153: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
+	78,  // 154: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
+	75,  // 155: walletmanager.v1.WalletManagerService.RescanWallet:output_type -> walletmanager.v1.RescanWalletResponse
+	77,  // 156: walletmanager.v1.WalletManagerService.EstimateFee:output_type -> walletmanager.v1.EstimateFeeResponse
+	80,  // 157: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
+	82,  // 158: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
+	174, // 159: walletmanager.v1.WalletManagerService.SetFrozenCoins:output_type -> google.protobuf.Empty
+	169, // 160: walletmanager.v1.WalletManagerService.CreateDeposit:output_type -> walletmanager.v1.CreateDepositResponse
+	125, // 161: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
+	128, // 162: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
+	131, // 163: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
+	133, // 164: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
+	137, // 165: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
+	139, // 166: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
+	141, // 167: walletmanager.v1.WalletManagerService.PreviewBumpFee:output_type -> walletmanager.v1.PreviewBumpFeeResponse
+	145, // 168: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
+	147, // 169: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
+	88,  // 170: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
+	90,  // 171: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
+	92,  // 172: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
+	94,  // 173: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
+	96,  // 174: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
+	98,  // 175: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
+	100, // 176: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
+	103, // 177: walletmanager.v1.WalletManagerService.GetAddressUnspent:output_type -> walletmanager.v1.GetAddressUnspentResponse
+	105, // 178: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:output_type -> walletmanager.v1.BroadcastElectrumTransactionResponse
+	109, // 179: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:output_type -> walletmanager.v1.EnumerateHardwareDevicesResponse
+	111, // 180: walletmanager.v1.WalletManagerService.GetHardwareXpub:output_type -> walletmanager.v1.GetHardwareXpubResponse
+	113, // 181: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:output_type -> walletmanager.v1.SignPsbtWithDeviceResponse
+	115, // 182: walletmanager.v1.WalletManagerService.PromptDevicePin:output_type -> walletmanager.v1.PromptDevicePinResponse
+	117, // 183: walletmanager.v1.WalletManagerService.SendDevicePin:output_type -> walletmanager.v1.SendDevicePinResponse
+	119, // 184: walletmanager.v1.WalletManagerService.CloseDevice:output_type -> walletmanager.v1.CloseDeviceResponse
+	121, // 185: walletmanager.v1.WalletManagerService.DeriveKeystore:output_type -> walletmanager.v1.DeriveKeystoreResponse
+	149, // 186: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:output_type -> walletmanager.v1.PreviewWalletFromEntropyResponse
+	151, // 187: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
+	154, // 188: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
+	156, // 189: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
+	158, // 190: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
+	160, // 191: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
+	162, // 192: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
+	164, // 193: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
+	166, // 194: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
+	167, // 195: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
+	126, // [126:196] is the sub-list for method output_type
+	56,  // [56:126] is the sub-list for method input_type
+	56,  // [56:56] is the sub-list for extension type_name
+	56,  // [56:56] is the sub-list for extension extendee
+	0,   // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_walletmanager_v1_walletmanager_proto_init() }
@@ -11332,16 +11441,16 @@ func file_walletmanager_v1_walletmanager_proto_init() {
 	if File_walletmanager_v1_walletmanager_proto != nil {
 		return
 	}
-	file_walletmanager_v1_walletmanager_proto_msgTypes[120].OneofWrappers = []any{}
-	file_walletmanager_v1_walletmanager_proto_msgTypes[131].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[122].OneofWrappers = []any{}
 	file_walletmanager_v1_walletmanager_proto_msgTypes[133].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[135].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_walletmanager_v1_walletmanager_proto_rawDesc), len(file_walletmanager_v1_walletmanager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   165,
+			NumMessages:   167,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect/walletmanager.connect.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect/walletmanager.connect.go
@@ -133,6 +133,9 @@ const (
 	// WalletManagerServiceSendTransactionProcedure is the fully-qualified name of the
 	// WalletManagerService's SendTransaction RPC.
 	WalletManagerServiceSendTransactionProcedure = "/walletmanager.v1.WalletManagerService/SendTransaction"
+	// WalletManagerServiceSetFrozenCoinsProcedure is the fully-qualified name of the
+	// WalletManagerService's SetFrozenCoins RPC.
+	WalletManagerServiceSetFrozenCoinsProcedure = "/walletmanager.v1.WalletManagerService/SetFrozenCoins"
 	// WalletManagerServiceCreateDepositProcedure is the fully-qualified name of the
 	// WalletManagerService's CreateDeposit RPC.
 	WalletManagerServiceCreateDepositProcedure = "/walletmanager.v1.WalletManagerService/CreateDeposit"
@@ -295,6 +298,10 @@ type WalletManagerServiceClient interface {
 	EstimateFee(context.Context, *connect.Request[v1.EstimateFeeRequest]) (*connect.Response[v1.EstimateFeeResponse], error)
 	GetNewAddress(context.Context, *connect.Request[v1.GetNewAddressRequest]) (*connect.Response[v1.GetNewAddressResponse], error)
 	SendTransaction(context.Context, *connect.Request[v1.SendTransactionRequest]) (*connect.Response[v1.SendTransactionResponse], error)
+	// SetFrozenCoins records the coins the frontend froze. Every send after it
+	// leaves those coins alone, and Bitcoin Core holds them locked for the
+	// length of a send so its own coin selection skips them too.
+	SetFrozenCoins(context.Context, *connect.Request[v1.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error)
 	// CreateDeposit funds a BIP300 M5 deposit to a sidechain from any wallet.
 	CreateDeposit(context.Context, *connect.Request[v1.CreateDepositRequest]) (*connect.Response[v1.CreateDepositResponse], error)
 	ListTransactions(context.Context, *connect.Request[v1.ListTransactionsRequest]) (*connect.Response[v1.ListTransactionsResponse], error)
@@ -571,6 +578,12 @@ func NewWalletManagerServiceClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(walletManagerServiceMethods.ByName("SendTransaction")),
 			connect.WithClientOptions(opts...),
 		),
+		setFrozenCoins: connect.NewClient[v1.SetFrozenCoinsRequest, emptypb.Empty](
+			httpClient,
+			baseURL+WalletManagerServiceSetFrozenCoinsProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("SetFrozenCoins")),
+			connect.WithClientOptions(opts...),
+		),
 		createDeposit: connect.NewClient[v1.CreateDepositRequest, v1.CreateDepositResponse](
 			httpClient,
 			baseURL+WalletManagerServiceCreateDepositProcedure,
@@ -825,6 +838,7 @@ type walletManagerServiceClient struct {
 	estimateFee                  *connect.Client[v1.EstimateFeeRequest, v1.EstimateFeeResponse]
 	getNewAddress                *connect.Client[v1.GetNewAddressRequest, v1.GetNewAddressResponse]
 	sendTransaction              *connect.Client[v1.SendTransactionRequest, v1.SendTransactionResponse]
+	setFrozenCoins               *connect.Client[v1.SetFrozenCoinsRequest, emptypb.Empty]
 	createDeposit                *connect.Client[v1.CreateDepositRequest, v1.CreateDepositResponse]
 	listTransactions             *connect.Client[v1.ListTransactionsRequest, v1.ListTransactionsResponse]
 	listUnspent                  *connect.Client[v1.ListUnspentRequest, v1.ListUnspentResponse]
@@ -1026,6 +1040,11 @@ func (c *walletManagerServiceClient) GetNewAddress(ctx context.Context, req *con
 // SendTransaction calls walletmanager.v1.WalletManagerService.SendTransaction.
 func (c *walletManagerServiceClient) SendTransaction(ctx context.Context, req *connect.Request[v1.SendTransactionRequest]) (*connect.Response[v1.SendTransactionResponse], error) {
 	return c.sendTransaction.CallUnary(ctx, req)
+}
+
+// SetFrozenCoins calls walletmanager.v1.WalletManagerService.SetFrozenCoins.
+func (c *walletManagerServiceClient) SetFrozenCoins(ctx context.Context, req *connect.Request[v1.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+	return c.setFrozenCoins.CallUnary(ctx, req)
 }
 
 // CreateDeposit calls walletmanager.v1.WalletManagerService.CreateDeposit.
@@ -1262,6 +1281,10 @@ type WalletManagerServiceHandler interface {
 	EstimateFee(context.Context, *connect.Request[v1.EstimateFeeRequest]) (*connect.Response[v1.EstimateFeeResponse], error)
 	GetNewAddress(context.Context, *connect.Request[v1.GetNewAddressRequest]) (*connect.Response[v1.GetNewAddressResponse], error)
 	SendTransaction(context.Context, *connect.Request[v1.SendTransactionRequest]) (*connect.Response[v1.SendTransactionResponse], error)
+	// SetFrozenCoins records the coins the frontend froze. Every send after it
+	// leaves those coins alone, and Bitcoin Core holds them locked for the
+	// length of a send so its own coin selection skips them too.
+	SetFrozenCoins(context.Context, *connect.Request[v1.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error)
 	// CreateDeposit funds a BIP300 M5 deposit to a sidechain from any wallet.
 	CreateDeposit(context.Context, *connect.Request[v1.CreateDepositRequest]) (*connect.Response[v1.CreateDepositResponse], error)
 	ListTransactions(context.Context, *connect.Request[v1.ListTransactionsRequest]) (*connect.Response[v1.ListTransactionsResponse], error)
@@ -1532,6 +1555,12 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 		WalletManagerServiceSendTransactionProcedure,
 		svc.SendTransaction,
 		connect.WithSchema(walletManagerServiceMethods.ByName("SendTransaction")),
+		connect.WithHandlerOptions(opts...),
+	)
+	walletManagerServiceSetFrozenCoinsHandler := connect.NewUnaryHandler(
+		WalletManagerServiceSetFrozenCoinsProcedure,
+		svc.SetFrozenCoins,
+		connect.WithSchema(walletManagerServiceMethods.ByName("SetFrozenCoins")),
 		connect.WithHandlerOptions(opts...),
 	)
 	walletManagerServiceCreateDepositHandler := connect.NewUnaryHandler(
@@ -1818,6 +1847,8 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 			walletManagerServiceGetNewAddressHandler.ServeHTTP(w, r)
 		case WalletManagerServiceSendTransactionProcedure:
 			walletManagerServiceSendTransactionHandler.ServeHTTP(w, r)
+		case WalletManagerServiceSetFrozenCoinsProcedure:
+			walletManagerServiceSetFrozenCoinsHandler.ServeHTTP(w, r)
 		case WalletManagerServiceCreateDepositProcedure:
 			walletManagerServiceCreateDepositHandler.ServeHTTP(w, r)
 		case WalletManagerServiceListTransactionsProcedure:
@@ -2029,6 +2060,10 @@ func (UnimplementedWalletManagerServiceHandler) GetNewAddress(context.Context, *
 
 func (UnimplementedWalletManagerServiceHandler) SendTransaction(context.Context, *connect.Request[v1.SendTransactionRequest]) (*connect.Response[v1.SendTransactionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.SendTransaction is not implemented"))
+}
+
+func (UnimplementedWalletManagerServiceHandler) SetFrozenCoins(context.Context, *connect.Request[v1.SetFrozenCoinsRequest]) (*connect.Response[emptypb.Empty], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.SetFrozenCoins is not implemented"))
 }
 
 func (UnimplementedWalletManagerServiceHandler) CreateDeposit(context.Context, *connect.Request[v1.CreateDepositRequest]) (*connect.Response[v1.CreateDepositResponse], error) {

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -59,6 +59,10 @@ service WalletManagerService {
   rpc EstimateFee(EstimateFeeRequest) returns (EstimateFeeResponse);
   rpc GetNewAddress(GetNewAddressRequest) returns (GetNewAddressResponse);
   rpc SendTransaction(SendTransactionRequest) returns (SendTransactionResponse);
+  // SetFrozenCoins records the coins the frontend froze. Every send after it
+  // leaves those coins alone, and Bitcoin Core holds them locked for the
+  // length of a send so its own coin selection skips them too.
+  rpc SetFrozenCoins(SetFrozenCoinsRequest) returns (google.protobuf.Empty);
 
   // CreateDeposit funds a BIP300 M5 deposit to a sidechain from any wallet.
   rpc CreateDeposit(CreateDepositRequest) returns (CreateDepositResponse);
@@ -687,6 +691,17 @@ message SendTransactionRequest {
 
 message SendTransactionResponse {
   string txid = 1;
+}
+
+message SetFrozenCoinsRequest {
+  // The whole frozen set of this install. An outpoint names one coin of one
+  // wallet, so the set covers every wallet at once. An empty list frees all.
+  repeated FrozenOutpoint outpoints = 1;
+}
+
+message FrozenOutpoint {
+  string txid = 1;
+  int32 vout = 2;
 }
 
 // RawOutput is a transaction output with a caller-supplied scriptPubKey.

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -46,6 +46,10 @@ type CoreBackend struct {
 	mu          sync.Mutex
 	coreWallets map[string]string // walletID -> Core wallet name
 
+	// holdMu guards frozenHolds, and it is never held across an RPC.
+	holdMu      sync.Mutex
+	frozenHolds map[string]*frozenHold // Core wallet name -> the sends that hold its frozen coins
+
 	// staleMu guards staleWallets, and it is never held across an RPC. The
 	// error hook runs inside a call that may already hold mu, so the two locks
 	// stay apart.

--- a/sidechain-orchestrator/wallet/frozen_coins.go
+++ b/sidechain-orchestrator/wallet/frozen_coins.go
@@ -3,10 +3,21 @@ package wallet
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
 )
+
+// frozenHold counts the sends of one wallet that hold the frozen coins locked,
+// and names the coins the first of them locked. mu runs the lock step of one
+// send at a time, so a second send waits for the lock instead of racing it.
+type frozenHold struct {
+	mu      sync.Mutex
+	senders int
+	coins   []RawInput
+}
 
 // Outpoint names one transaction output, and says whether a block holds it.
 type Outpoint struct {
@@ -15,8 +26,9 @@ type Outpoint struct {
 	Confirmed bool
 }
 
-// Key names the outpoint as txid:vout.
-func (o Outpoint) Key() string { return fmt.Sprintf("%s:%d", o.TxID, o.Vout) }
+// Key names the outpoint as txid:vout. A txid is hexadecimal, and a caller can
+// spell it in either case, so the key holds one spelling.
+func (o Outpoint) Key() string { return fmt.Sprintf("%s:%d", strings.ToLower(o.TxID), o.Vout) }
 
 // FrozenCoinsFunc names the candidates a live BMM bid can take away, keyed
 // txid:vout. A coin the bid created dies with a replacement of that bid, and a
@@ -32,25 +44,66 @@ func (s *Service) SetFrozenCoins(fn FrozenCoinsFunc) {
 	s.frozenCoins = fn
 }
 
-// FreezesCoins says whether a source of frozen coins is wired.
+// SetHeldCoins records the coins a frontend froze. The set replaces the one
+// before it, so an unfreeze reaches coin selection too. An outpoint names one
+// coin of one wallet, so this one set covers every wallet.
+func (s *Service) SetHeldCoins(coins []Outpoint) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	held := make(map[string]bool, len(coins))
+	for _, coin := range coins {
+		held[coin.Key()] = true
+	}
+	s.heldCoins = held
+}
+
+// HeldCoins names the coins a frontend froze.
+func (s *Service) HeldCoins() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.heldCoins
+}
+
+// FreezesCoins says whether any source of frozen coins is wired.
 func (s *Service) FreezesCoins() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.frozenCoins != nil
+	return s.frozenCoins != nil || len(s.heldCoins) > 0
 }
 
-// FrozenCoins names the candidates a live BMM bid holds. It names none while no
-// source is wired.
+// FrozenCoins names the candidates no send may take: the coins a live BMM bid
+// holds, and the coins a frontend froze. It names none while no source is
+// wired.
 func (s *Service) FrozenCoins(ctx context.Context, walletID string, candidates []Outpoint) (map[string]bool, error) {
 	s.mu.RLock()
 	fn := s.frozenCoins
+	held := s.heldCoins
 	s.mu.RUnlock()
-	if fn == nil || len(candidates) == 0 {
+	if len(candidates) == 0 {
 		return nil, nil
 	}
-	frozen, err := fn(ctx, walletID, candidates)
-	if err != nil {
-		return nil, fmt.Errorf("read the coins a bmm bid holds: %w", err)
+
+	frozen := make(map[string]bool, len(held))
+	for _, candidate := range candidates {
+		if held[candidate.Key()] {
+			frozen[candidate.Key()] = true
+		}
+	}
+
+	if fn != nil {
+		bid, err := fn(ctx, walletID, candidates)
+		if err != nil {
+			return nil, fmt.Errorf("read the coins a bmm bid holds: %w", err)
+		}
+		for key, isFrozen := range bid {
+			if isFrozen {
+				frozen[key] = true
+			}
+		}
+	}
+
+	if len(frozen) == 0 {
+		return nil, nil
 	}
 	return frozen, nil
 }
@@ -69,41 +122,87 @@ func (p *ElectrumBackend) dropFrozenCoins(
 	}), nil
 }
 
-// lockFrozenCoins locks the coins a live BMM bid holds for the length of one
-// send, because Core picks the coins itself on most of its send paths. The
-// caller unlocks them with the function it gets back.
+// lockFrozenCoins locks the coins no send may take for the length of one send,
+// because Core picks the coins itself on most of its send paths. The caller
+// unlocks them with the function it gets back.
+//
+// Every step of one wallet's freeze runs under the wallet's own hold, so a
+// second send waits for the first to lock, and waits again for it to unlock.
+// It then locks whatever Core still shows frozen, which covers a coin the user
+// froze while the first send ran.
 func (p *CoreBackend) lockFrozenCoins(ctx context.Context, walletID, walletName string) (func(), error) {
 	if !p.svc.FreezesCoins() {
 		return func() {}, nil
 	}
-	// The coin a live bid holds is its own change, and Core hides an
-	// unconfirmed coin from listunspent unless the call asks for it.
+	hold := p.holdFor(walletName)
+	hold.mu.Lock()
+	defer hold.mu.Unlock()
+	hold.senders++
+
+	// A coin an earlier send locked is already out of this list, and a coin
+	// the user froze a moment ago is still in it. Core hides an unconfirmed
+	// coin too, unless the call asks for it.
 	utxos, err := p.rpc.ListUnspentMinConf(ctx, walletName, 0)
 	if err != nil {
+		hold.senders--
 		return nil, fmt.Errorf("list unspent: %w", err)
 	}
 	frozen, err := p.svc.FrozenCoins(ctx, walletID, lo.Map(utxos, func(u UTXO, _ int) Outpoint {
 		return Outpoint{TxID: u.TxID, Vout: u.Vout, Confirmed: u.Confirmations > 0}
 	}))
 	if err != nil {
+		hold.senders--
 		return nil, err
 	}
 	held := lo.FilterMap(utxos, func(u UTXO, _ int) (RawInput, bool) {
 		return RawInput{TxID: u.TxID, Vout: u.Vout}, frozen[Outpoint{TxID: u.TxID, Vout: u.Vout}.Key()]
 	})
-	if len(held) == 0 {
-		return func() {}, nil
-	}
-	if err := p.rpc.LockUnspent(ctx, walletName, false, held); err != nil {
-		return nil, err
-	}
-	return func() {
-		// A canceled send must still give the coins back, or they stay locked
-		// until the next restart.
-		free, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		if err := p.rpc.LockUnspent(free, walletName, true, held); err != nil {
-			p.log.Warn().Err(err).Msg("unlock the coins a bmm bid holds")
+	if len(held) > 0 {
+		if err := p.rpc.LockUnspent(ctx, walletName, false, held); err != nil {
+			hold.senders--
+			return nil, err
 		}
-	}, nil
+		hold.coins = append(hold.coins, held...)
+	}
+	return func() { p.leaveFrozenHold(ctx, walletName) }, nil
+}
+
+// holdFor returns the hold of one wallet, and makes one on the first call.
+func (p *CoreBackend) holdFor(walletName string) *frozenHold {
+	p.holdMu.Lock()
+	defer p.holdMu.Unlock()
+	if p.frozenHolds == nil {
+		p.frozenHolds = make(map[string]*frozenHold)
+	}
+	hold, ok := p.frozenHolds[walletName]
+	if !ok {
+		hold = &frozenHold{}
+		p.frozenHolds[walletName] = hold
+	}
+	return hold
+}
+
+// leaveFrozenHold takes this send out, and gives the coins back once the last
+// send leaves. It holds the wallet's hold across the unlock, so the next send
+// reads a list that already shows those coins again.
+func (p *CoreBackend) leaveFrozenHold(ctx context.Context, walletName string) {
+	hold := p.holdFor(walletName)
+	hold.mu.Lock()
+	defer hold.mu.Unlock()
+
+	hold.senders--
+	if hold.senders > 0 || len(hold.coins) == 0 {
+		return
+	}
+	// A canceled send must still give the coins back, or they stay locked
+	// until the next restart.
+	free, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := p.rpc.LockUnspent(free, walletName, true, hold.coins); err != nil {
+		// Core hides a locked coin from listunspent, so this record is the
+		// only way back to it. The next send out tries the unlock again.
+		p.log.Warn().Err(err).Msg("unlock the coins no send may take")
+		return
+	}
+	hold.coins = nil
 }

--- a/sidechain-orchestrator/wallet/held_coins_test.go
+++ b/sidechain-orchestrator/wallet/held_coins_test.go
@@ -1,0 +1,389 @@
+package wallet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeldCoinsJoinTheCoinsABidHolds(t *testing.T) {
+	svc := newTestService(t)
+	candidates := []Outpoint{
+		{TxID: frozenCoinTxid, Vout: 1},
+		{TxID: freeCoinTxid, Vout: 0},
+	}
+
+	svc.SetHeldCoins([]Outpoint{{TxID: freeCoinTxid, Vout: 0}})
+	svc.SetFrozenCoins(func(context.Context, string, []Outpoint) (map[string]bool, error) {
+		return map[string]bool{Outpoint{TxID: frozenCoinTxid, Vout: 1}.Key(): true}, nil
+	})
+
+	frozen, err := svc.FrozenCoins(context.Background(), "wallet-1", candidates)
+	require.NoError(t, err)
+
+	assert.True(t, frozen[Outpoint{TxID: freeCoinTxid, Vout: 0}.Key()], "the user froze this coin")
+	assert.True(t, frozen[Outpoint{TxID: frozenCoinTxid, Vout: 1}.Key()], "a live bid holds this coin")
+}
+
+// An outpoint names one coin of one wallet, so the set covers every wallet.
+// A BMM target can name a wallet the user does not run right now.
+func TestHeldCoinsCoverEveryWallet(t *testing.T) {
+	svc := newTestService(t)
+	coin := Outpoint{TxID: freeCoinTxid, Vout: 0}
+
+	svc.SetHeldCoins([]Outpoint{coin})
+
+	assert.True(t, svc.FreezesCoins(), "a held coin is a source of its own")
+	for _, walletID := range []string{"wallet-1", "wallet-2"} {
+		frozen, err := svc.FrozenCoins(context.Background(), walletID, []Outpoint{coin})
+		require.NoError(t, err)
+		assert.True(t, frozen[coin.Key()], "the coin is frozen whichever wallet asks")
+	}
+}
+
+func TestSetHeldCoinsReplacesTheSetBefore(t *testing.T) {
+	svc := newTestService(t)
+	coin := Outpoint{TxID: freeCoinTxid, Vout: 0}
+	svc.SetHeldCoins([]Outpoint{coin})
+
+	// The user unfroze the coin, so the new set is empty.
+	svc.SetHeldCoins(nil)
+
+	frozen, err := svc.FrozenCoins(context.Background(), "wallet-1", []Outpoint{coin})
+	require.NoError(t, err)
+	assert.Empty(t, frozen)
+	assert.False(t, svc.FreezesCoins())
+}
+
+// Core picks the coins on most of its send paths, so a held coin has to sit
+// locked for as long as the send runs.
+func TestCoreSendLocksAHeldCoin(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0x21), net)
+	change := p2wpkhAddr(t, fixedKey(0x22), net)
+	// Core hides a locked output from listunspent, which is how one lock keeps
+	// every one of its selection paths off the coin.
+	locked := map[string]bool{}
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		coins := []map[string]any{}
+		for _, coin := range []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "address": change, "amount": 0.04, "confirmations": 0, "spendable": true},
+			{"txid": freeCoinTxid, "vout": 0, "address": change, "amount": 0.01, "confirmations": 6, "spendable": true},
+		} {
+			if !locked[fmt.Sprintf("%s:%d", coin["txid"], coin["vout"])] {
+				coins = append(coins, coin)
+			}
+		}
+		return coins, ""
+	})
+	fake.handle("getrawchangeaddress", func(bitcoindCall) (any, string) { return change, "" })
+	var selected []RawInput
+	fake.handle("createrawtransaction", func(c bitcoindCall) (any, string) {
+		require.NoError(t, json.Unmarshal(c.Params[0], &selected))
+		return "deadbeef00112233", ""
+	})
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		return map[string]any{"hex": mustString(t, c.Params[0]), "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "txid-held", "" })
+	var locks []bitcoindCall
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		locks = append(locks, c)
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		var outputs []RawInput
+		require.NoError(t, json.Unmarshal(c.Params[1], &outputs))
+		for _, o := range outputs {
+			locked[fmt.Sprintf("%s:%d", o.TxID, o.Vout)] = !unlock
+		}
+		return true, ""
+	})
+
+	backend.svc.SetHeldCoins([]Outpoint{{TxID: frozenCoinTxid, Vout: 1}})
+
+	_, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, selected, 1)
+	assert.Equal(t, freeCoinTxid, selected[0].TxID, "the send spends the coin the user left free")
+
+	require.Len(t, locks, 2)
+	var unlock bool
+	require.NoError(t, json.Unmarshal(locks[0].Params[0], &unlock))
+	assert.False(t, unlock, "the send locks first")
+	var held []RawInput
+	require.NoError(t, json.Unmarshal(locks[0].Params[1], &held))
+	require.Len(t, held, 1)
+	assert.Equal(t, fmt.Sprintf("%s:%d", frozenCoinTxid, 1), fmt.Sprintf("%s:%d", held[0].TxID, held[0].Vout))
+	require.NoError(t, json.Unmarshal(locks[1].Params[0], &unlock))
+	assert.True(t, unlock, "the send unlocks when it ends")
+}
+
+func TestElectrumSendSkipsAHeldCoin(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 2, FundedTxoSum: 5_000_000, TxCount: 2},
+	}
+	fake.utxos[addr] = []EsploraUTXO{
+		{TxID: frozenCoinTxid, Vout: 1, Value: 4_000_000, Status: EsploraStatus{Confirmed: true, BlockHeight: 90}},
+		{TxID: freeCoinTxid, Vout: 0, Value: 1_000_000, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}},
+	}
+	p.svc.SetHeldCoins([]Outpoint{{TxID: frozenCoinTxid, Vout: 1}})
+
+	dest := p2wpkhAddr(t, fixedKey(0x31), &chaincfg.SigNetParams)
+	_, err := p.Send(context.Background(), w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 100_000},
+		FeeRateSatPerVB:  1,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{freeCoinTxid}, inputTxids(broadcastTx(t, fake)))
+}
+
+// Two sends of one wallet can run at the same time. The second reads a list
+// that already hides the locked coins, so it locks nothing of its own. The
+// first must not give the coins back while the second still runs.
+func TestOverlappingSendsHoldTheLockToTheEnd(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	name := "wallet_" + coreID[:8]
+
+	locked := map[string]bool{}
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		coins := []map[string]any{}
+		for _, coin := range []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "amount": 0.04, "spendable": true},
+			{"txid": freeCoinTxid, "vout": 0, "amount": 0.01, "spendable": true},
+		} {
+			if !locked[fmt.Sprintf("%s:%d", coin["txid"], coin["vout"])] {
+				coins = append(coins, coin)
+			}
+		}
+		return coins, ""
+	})
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		var outputs []RawInput
+		require.NoError(t, json.Unmarshal(c.Params[1], &outputs))
+		for _, o := range outputs {
+			locked[fmt.Sprintf("%s:%d", o.TxID, o.Vout)] = !unlock
+		}
+		return true, ""
+	})
+	backend.svc.SetHeldCoins([]Outpoint{{TxID: frozenCoinTxid, Vout: 1}})
+
+	ctx := context.Background()
+	first, err := backend.lockFrozenCoins(ctx, coreID, name)
+	require.NoError(t, err)
+	require.True(t, locked[fmt.Sprintf("%s:%d", frozenCoinTxid, 1)], "the first send locks the coin")
+
+	second, err := backend.lockFrozenCoins(ctx, coreID, name)
+	require.NoError(t, err)
+
+	first()
+	assert.True(t, locked[fmt.Sprintf("%s:%d", frozenCoinTxid, 1)],
+		"the second send still runs, so the coin stays locked")
+
+	second()
+	assert.False(t, locked[fmt.Sprintf("%s:%d", frozenCoinTxid, 1)],
+		"the last send out gives the coin back")
+}
+
+// A send that arrives while the first one still locks has to wait. Core would
+// pick the coin the first send is about to lock.
+func TestASecondSendWaitsForTheFirstLock(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	name := "wallet_" + coreID[:8]
+
+	// Core hides a locked output from listunspent, so the second send sees
+	// nothing left to lock.
+	var lockMu sync.Mutex
+	locked := map[string]bool{}
+	listing := make(chan struct{})
+	release := make(chan struct{})
+	var listed atomic.Int32
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		if listed.Add(1) == 1 {
+			close(listing)
+			<-release
+		}
+		lockMu.Lock()
+		defer lockMu.Unlock()
+		coins := []map[string]any{}
+		for _, coin := range []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "amount": 0.04, "spendable": true},
+		} {
+			if !locked[fmt.Sprintf("%s:%d", coin["txid"], coin["vout"])] {
+				coins = append(coins, coin)
+			}
+		}
+		return coins, ""
+	})
+	var locks atomic.Int32
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		locks.Add(1)
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		var outputs []RawInput
+		require.NoError(t, json.Unmarshal(c.Params[1], &outputs))
+		lockMu.Lock()
+		defer lockMu.Unlock()
+		for _, o := range outputs {
+			locked[fmt.Sprintf("%s:%d", o.TxID, o.Vout)] = !unlock
+		}
+		return true, ""
+	})
+	backend.svc.SetHeldCoins([]Outpoint{{TxID: frozenCoinTxid, Vout: 1}})
+
+	ctx := context.Background()
+	firstDone := make(chan func(), 1)
+	go func() {
+		unlock, err := backend.lockFrozenCoins(ctx, coreID, name)
+		assert.NoError(t, err)
+		firstDone <- unlock
+	}()
+
+	<-listing
+	secondDone := make(chan func(), 1)
+	go func() {
+		unlock, err := backend.lockFrozenCoins(ctx, coreID, name)
+		assert.NoError(t, err)
+		secondDone <- unlock
+	}()
+
+	// The second send must hold here: the first one has not locked yet.
+	select {
+	case <-secondDone:
+		t.Fatal("the second send ran before the first send locked the coin")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release)
+	first := <-firstDone
+	second := <-secondDone
+	assert.Equal(t, int32(1), locks.Load(), "the coin is locked, so the second send adds nothing")
+
+	first()
+	second()
+}
+
+// The user can freeze a coin while a send runs. The next send locks that coin
+// too, instead of joining a hold that never covered it.
+func TestALaterSendLocksACoinFrozenMeanwhile(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	name := "wallet_" + coreID[:8]
+
+	locked := map[string]bool{}
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		coins := []map[string]any{}
+		for _, coin := range []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "amount": 0.04, "spendable": true},
+			{"txid": freeCoinTxid, "vout": 0, "amount": 0.01, "spendable": true},
+		} {
+			if !locked[fmt.Sprintf("%s:%d", coin["txid"], coin["vout"])] {
+				coins = append(coins, coin)
+			}
+		}
+		return coins, ""
+	})
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		var outputs []RawInput
+		require.NoError(t, json.Unmarshal(c.Params[1], &outputs))
+		for _, o := range outputs {
+			locked[fmt.Sprintf("%s:%d", o.TxID, o.Vout)] = !unlock
+		}
+		return true, ""
+	})
+
+	ctx := context.Background()
+	backend.svc.SetHeldCoins([]Outpoint{{TxID: frozenCoinTxid, Vout: 1}})
+	first, err := backend.lockFrozenCoins(ctx, coreID, name)
+	require.NoError(t, err)
+
+	// The user freezes the other coin while the first send still runs.
+	backend.svc.SetHeldCoins([]Outpoint{
+		{TxID: frozenCoinTxid, Vout: 1},
+		{TxID: freeCoinTxid, Vout: 0},
+	})
+	second, err := backend.lockFrozenCoins(ctx, coreID, name)
+	require.NoError(t, err)
+
+	assert.True(t, locked[fmt.Sprintf("%s:%d", freeCoinTxid, 0)], "the new coin is locked too")
+
+	first()
+	second()
+	assert.False(t, locked[fmt.Sprintf("%s:%d", frozenCoinTxid, 1)], "the last send gives both back")
+	assert.False(t, locked[fmt.Sprintf("%s:%d", freeCoinTxid, 0)])
+}
+
+// Core hides a locked coin from listunspent, so the hold is the only way back
+// to it. A failed unlock keeps that record for the next send.
+func TestAFailedUnlockKeepsTheCoins(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	name := "wallet_" + coreID[:8]
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		return []map[string]any{
+			{"txid": frozenCoinTxid, "vout": 1, "amount": 0.04, "spendable": true},
+		}, ""
+	})
+	var unlocks int
+	fake.handle("lockunspent", func(c bitcoindCall) (any, string) {
+		var unlock bool
+		require.NoError(t, json.Unmarshal(c.Params[0], &unlock))
+		if !unlock {
+			return true, ""
+		}
+		unlocks++
+		if unlocks == 1 {
+			return nil, "Core is busy"
+		}
+		return true, ""
+	})
+	backend.svc.SetHeldCoins([]Outpoint{{TxID: frozenCoinTxid, Vout: 1}})
+
+	ctx := context.Background()
+	first, err := backend.lockFrozenCoins(ctx, coreID, name)
+	require.NoError(t, err)
+	first()
+	assert.Equal(t, 1, unlocks, "the first unlock failed")
+
+	second, err := backend.lockFrozenCoins(ctx, coreID, name)
+	require.NoError(t, err)
+	second()
+	assert.Equal(t, 2, unlocks, "the next send tries the unlock again")
+}
+
+// A txid is hexadecimal, and an RPC client can spell it in either case.
+func TestAFrozenCoinReadsInEitherCase(t *testing.T) {
+	svc := newTestService(t)
+	upper := "AABBCC"
+	lower := "aabbcc"
+
+	svc.SetHeldCoins([]Outpoint{{TxID: upper, Vout: 1}})
+
+	held := svc.HeldCoins()
+	assert.True(t, held[Outpoint{TxID: lower, Vout: 1}.Key()], "the lowercase spelling names the same coin")
+	assert.True(t, held[Outpoint{TxID: upper, Vout: 1}.Key()])
+}

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -58,6 +58,10 @@ type Service struct {
 	// leaves them alone.
 	frozenCoins FrozenCoinsFunc
 
+	// heldCoins names the coins a frontend froze, keyed txid:vout. An outpoint
+	// belongs to one wallet, so one set covers them all.
+	heldCoins map[string]bool
+
 	// Callbacks
 	// Dart: deleteAllWallets stops all binaries before wiping (L560-575)
 	OnStopAllBinaries func() error

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
@@ -587,6 +587,26 @@ extension type WalletManagerServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// SetFrozenCoins records the coins the frontend froze. Every send after it
+  /// leaves those coins alone, and Bitcoin Core holds them locked for the
+  /// length of a send so its own coin selection skips them too.
+  Future<googleprotobufempty.Empty> setFrozenCoins(
+    walletmanagerv1walletmanager.SetFrozenCoinsRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.setFrozenCoins,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// CreateDeposit funds a BIP300 M5 deposit to a sidechain from any wallet.
   Future<walletmanagerv1walletmanager.CreateDepositResponse> createDeposit(
     walletmanagerv1walletmanager.CreateDepositRequest input, {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.spec.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.spec.dart
@@ -259,6 +259,16 @@ abstract final class WalletManagerService {
     walletmanagerv1walletmanager.SendTransactionResponse.new,
   );
 
+  /// SetFrozenCoins records the coins the frontend froze. Every send after it
+  /// leaves those coins alone, and Bitcoin Core holds them locked for the
+  /// length of a send so its own coin selection skips them too.
+  static const setFrozenCoins = connect.Spec(
+    '/$name/SetFrozenCoins',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.SetFrozenCoinsRequest.new,
+    googleprotobufempty.Empty.new,
+  );
+
   /// CreateDeposit funds a BIP300 M5 deposit to a sidechain from any wallet.
   static const createDeposit = connect.Spec(
     '/$name/CreateDeposit',

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -5286,6 +5286,116 @@ class SendTransactionResponse extends $pb.GeneratedMessage {
   void clearTxid() => clearField(1);
 }
 
+class SetFrozenCoinsRequest extends $pb.GeneratedMessage {
+  factory SetFrozenCoinsRequest({
+    $core.Iterable<FrozenOutpoint>? outpoints,
+  }) {
+    final $result = create();
+    if (outpoints != null) {
+      $result.outpoints.addAll(outpoints);
+    }
+    return $result;
+  }
+  SetFrozenCoinsRequest._() : super();
+  factory SetFrozenCoinsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetFrozenCoinsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetFrozenCoinsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..pc<FrozenOutpoint>(1, _omitFieldNames ? '' : 'outpoints', $pb.PbFieldType.PM, subBuilder: FrozenOutpoint.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SetFrozenCoinsRequest clone() => SetFrozenCoinsRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetFrozenCoinsRequest copyWith(void Function(SetFrozenCoinsRequest) updates) => super.copyWith((message) => updates(message as SetFrozenCoinsRequest)) as SetFrozenCoinsRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SetFrozenCoinsRequest create() => SetFrozenCoinsRequest._();
+  SetFrozenCoinsRequest createEmptyInstance() => create();
+  static $pb.PbList<SetFrozenCoinsRequest> createRepeated() => $pb.PbList<SetFrozenCoinsRequest>();
+  @$core.pragma('dart2js:noInline')
+  static SetFrozenCoinsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetFrozenCoinsRequest>(create);
+  static SetFrozenCoinsRequest? _defaultInstance;
+
+  /// The whole frozen set of this install. An outpoint names one coin of one
+  /// wallet, so the set covers every wallet at once. An empty list frees all.
+  @$pb.TagNumber(1)
+  $core.List<FrozenOutpoint> get outpoints => $_getList(0);
+}
+
+class FrozenOutpoint extends $pb.GeneratedMessage {
+  factory FrozenOutpoint({
+    $core.String? txid,
+    $core.int? vout,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (vout != null) {
+      $result.vout = vout;
+    }
+    return $result;
+  }
+  FrozenOutpoint._() : super();
+  factory FrozenOutpoint.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FrozenOutpoint.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FrozenOutpoint', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FrozenOutpoint clone() => FrozenOutpoint()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FrozenOutpoint copyWith(void Function(FrozenOutpoint) updates) => super.copyWith((message) => updates(message as FrozenOutpoint)) as FrozenOutpoint;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FrozenOutpoint create() => FrozenOutpoint._();
+  FrozenOutpoint createEmptyInstance() => create();
+  static $pb.PbList<FrozenOutpoint> createRepeated() => $pb.PbList<FrozenOutpoint>();
+  @$core.pragma('dart2js:noInline')
+  static FrozenOutpoint getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FrozenOutpoint>(create);
+  static FrozenOutpoint? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get vout => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set vout($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVout() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVout() => clearField(2);
+}
+
 /// RawOutput is a transaction output with a caller-supplied scriptPubKey.
 class RawOutput extends $pb.GeneratedMessage {
   factory RawOutput({
@@ -12399,6 +12509,9 @@ class WalletManagerServiceApi {
   ;
   $async.Future<SendTransactionResponse> sendTransaction($pb.ClientContext? ctx, SendTransactionRequest request) =>
     _client.invoke<SendTransactionResponse>(ctx, 'WalletManagerService', 'SendTransaction', request, SendTransactionResponse())
+  ;
+  $async.Future<$17.Empty> setFrozenCoins($pb.ClientContext? ctx, SetFrozenCoinsRequest request) =>
+    _client.invoke<$17.Empty>(ctx, 'WalletManagerService', 'SetFrozenCoins', request, $17.Empty())
   ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
     _client.invoke<CreateDepositResponse>(ctx, 'WalletManagerService', 'CreateDeposit', request, CreateDepositResponse())

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -1235,6 +1235,33 @@ const SendTransactionResponse$json = {
 final $typed_data.Uint8List sendTransactionResponseDescriptor = $convert.base64Decode(
     'ChdTZW5kVHJhbnNhY3Rpb25SZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
+@$core.Deprecated('Use setFrozenCoinsRequestDescriptor instead')
+const SetFrozenCoinsRequest$json = {
+  '1': 'SetFrozenCoinsRequest',
+  '2': [
+    {'1': 'outpoints', '3': 1, '4': 3, '5': 11, '6': '.walletmanager.v1.FrozenOutpoint', '10': 'outpoints'},
+  ],
+};
+
+/// Descriptor for `SetFrozenCoinsRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List setFrozenCoinsRequestDescriptor = $convert.base64Decode(
+    'ChVTZXRGcm96ZW5Db2luc1JlcXVlc3QSPgoJb3V0cG9pbnRzGAEgAygLMiAud2FsbGV0bWFuYW'
+    'dlci52MS5Gcm96ZW5PdXRwb2ludFIJb3V0cG9pbnRz');
+
+@$core.Deprecated('Use frozenOutpointDescriptor instead')
+const FrozenOutpoint$json = {
+  '1': 'FrozenOutpoint',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'vout', '3': 2, '4': 1, '5': 5, '10': 'vout'},
+  ],
+};
+
+/// Descriptor for `FrozenOutpoint`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List frozenOutpointDescriptor = $convert.base64Decode(
+    'Cg5Gcm96ZW5PdXRwb2ludBISCgR0eGlkGAEgASgJUgR0eGlkEhIKBHZvdXQYAiABKAVSBHZvdX'
+    'Q=');
+
 @$core.Deprecated('Use rawOutputDescriptor instead')
 const RawOutput$json = {
   '1': 'RawOutput',
@@ -2659,6 +2686,7 @@ const $core.Map<$core.String, $core.dynamic> WalletManagerServiceBase$json = {
     {'1': 'EstimateFee', '2': '.walletmanager.v1.EstimateFeeRequest', '3': '.walletmanager.v1.EstimateFeeResponse'},
     {'1': 'GetNewAddress', '2': '.walletmanager.v1.GetNewAddressRequest', '3': '.walletmanager.v1.GetNewAddressResponse'},
     {'1': 'SendTransaction', '2': '.walletmanager.v1.SendTransactionRequest', '3': '.walletmanager.v1.SendTransactionResponse'},
+    {'1': 'SetFrozenCoins', '2': '.walletmanager.v1.SetFrozenCoinsRequest', '3': '.google.protobuf.Empty'},
     {'1': 'CreateDeposit', '2': '.walletmanager.v1.CreateDepositRequest', '3': '.walletmanager.v1.CreateDepositResponse'},
     {'1': 'ListTransactions', '2': '.walletmanager.v1.ListTransactionsRequest', '3': '.walletmanager.v1.ListTransactionsResponse'},
     {'1': 'ListUnspent', '2': '.walletmanager.v1.ListUnspentRequest', '3': '.walletmanager.v1.ListUnspentResponse'},
@@ -2783,6 +2811,9 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.RawOutput': RawOutput$json,
   '.walletmanager.v1.ExternalInput': ExternalInput$json,
   '.walletmanager.v1.SendTransactionResponse': SendTransactionResponse$json,
+  '.walletmanager.v1.SetFrozenCoinsRequest': SetFrozenCoinsRequest$json,
+  '.walletmanager.v1.FrozenOutpoint': FrozenOutpoint$json,
+  '.google.protobuf.Empty': $17.Empty$json,
   '.walletmanager.v1.CreateDepositRequest': CreateDepositRequest$json,
   '.walletmanager.v1.CreateDepositResponse': CreateDepositResponse$json,
   '.walletmanager.v1.ListTransactionsRequest': ListTransactionsRequest$json,
@@ -2865,7 +2896,6 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.GetTorConfigResponse': GetTorConfigResponse$json,
   '.walletmanager.v1.SetTorConfigRequest': SetTorConfigRequest$json,
   '.walletmanager.v1.SetTorConfigResponse': SetTorConfigResponse$json,
-  '.google.protobuf.Empty': $17.Empty$json,
   '.walletmanager.v1.WatchWalletDataResponse': WatchWalletDataResponse$json,
 };
 
@@ -2935,73 +2965,74 @@ final $typed_data.Uint8List walletManagerServiceDescriptor = $convert.base64Deco
     'MSJi53YWxsZXRtYW5hZ2VyLnYxLkdldE5ld0FkZHJlc3NSZXF1ZXN0Gicud2FsbGV0bWFuYWdl'
     'ci52MS5HZXROZXdBZGRyZXNzUmVzcG9uc2USZgoPU2VuZFRyYW5zYWN0aW9uEigud2FsbGV0bW'
     'FuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25SZXF1ZXN0Gikud2FsbGV0bWFuYWdlci52MS5TZW5k'
-    'VHJhbnNhY3Rpb25SZXNwb25zZRJgCg1DcmVhdGVEZXBvc2l0EiYud2FsbGV0bWFuYWdlci52MS'
-    '5DcmVhdGVEZXBvc2l0UmVxdWVzdBonLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlRGVwb3NpdFJl'
-    'c3BvbnNlEmkKEExpc3RUcmFuc2FjdGlvbnMSKS53YWxsZXRtYW5hZ2VyLnYxLkxpc3RUcmFuc2'
-    'FjdGlvbnNSZXF1ZXN0Gioud2FsbGV0bWFuYWdlci52MS5MaXN0VHJhbnNhY3Rpb25zUmVzcG9u'
-    'c2USWgoLTGlzdFVuc3BlbnQSJC53YWxsZXRtYW5hZ2VyLnYxLkxpc3RVbnNwZW50UmVxdWVzdB'
-    'olLndhbGxldG1hbmFnZXIudjEuTGlzdFVuc3BlbnRSZXNwb25zZRJ1ChRMaXN0UmVjZWl2ZUFk'
-    'ZHJlc3NlcxItLndhbGxldG1hbmFnZXIudjEuTGlzdFJlY2VpdmVBZGRyZXNzZXNSZXF1ZXN0Gi'
-    '4ud2FsbGV0bWFuYWdlci52MS5MaXN0UmVjZWl2ZUFkZHJlc3Nlc1Jlc3BvbnNlEngKFUdldFRy'
-    'YW5zYWN0aW9uRGV0YWlscxIuLndhbGxldG1hbmFnZXIudjEuR2V0VHJhbnNhY3Rpb25EZXRhaW'
-    'xzUmVxdWVzdBovLndhbGxldG1hbmFnZXIudjEuR2V0VHJhbnNhY3Rpb25EZXRhaWxzUmVzcG9u'
-    'c2USbAoRRGVjb2RlVHJhbnNhY3Rpb24SKi53YWxsZXRtYW5hZ2VyLnYxLkRlY29kZVRyYW5zYW'
-    'N0aW9uUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuRGVjb2RlVHJhbnNhY3Rpb25SZXNwb25z'
-    'ZRJOCgdCdW1wRmVlEiAud2FsbGV0bWFuYWdlci52MS5CdW1wRmVlUmVxdWVzdBohLndhbGxldG'
-    '1hbmFnZXIudjEuQnVtcEZlZVJlc3BvbnNlEmMKDlByZXZpZXdCdW1wRmVlEicud2FsbGV0bWFu'
-    'YWdlci52MS5QcmV2aWV3QnVtcEZlZVJlcXVlc3QaKC53YWxsZXRtYW5hZ2VyLnYxLlByZXZpZX'
-    'dCdW1wRmVlUmVzcG9uc2USVwoKQ3JlYXRlQ3BmcBIjLndhbGxldG1hbmFnZXIudjEuQ3JlYXRl'
-    'Q3BmcFJlcXVlc3QaJC53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZUNwZnBSZXNwb25zZRJmCg9EZX'
-    'JpdmVBZGRyZXNzZXMSKC53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUFkZHJlc3Nlc1JlcXVlc3Qa'
-    'KS53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUFkZHJlc3Nlc1Jlc3BvbnNlElcKCkNyZWF0ZVBzYn'
-    'QSIy53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZVBzYnRSZXF1ZXN0GiQud2FsbGV0bWFuYWdlci52'
-    'MS5DcmVhdGVQc2J0UmVzcG9uc2USUQoIU2lnblBzYnQSIS53YWxsZXRtYW5hZ2VyLnYxLlNpZ2'
-    '5Qc2J0UmVxdWVzdBoiLndhbGxldG1hbmFnZXIudjEuU2lnblBzYnRSZXNwb25zZRJ1ChRTaWdu'
-    'UHNidFdpdGhDb3NpZ25lchItLndhbGxldG1hbmFnZXIudjEuU2lnblBzYnRXaXRoQ29zaWduZX'
-    'JSZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5TaWduUHNidFdpdGhDb3NpZ25lclJlc3BvbnNl'
-    'EloKC0NvbWJpbmVQc2J0EiQud2FsbGV0bWFuYWdlci52MS5Db21iaW5lUHNidFJlcXVlc3QaJS'
-    '53YWxsZXRtYW5hZ2VyLnYxLkNvbWJpbmVQc2J0UmVzcG9uc2USXQoMRmluYWxpemVQc2J0EiUu'
-    'd2FsbGV0bWFuYWdlci52MS5GaW5hbGl6ZVBzYnRSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52MS'
-    '5GaW5hbGl6ZVBzYnRSZXNwb25zZRJvChJNdWx0aXNpZ1BzYnRTdGF0dXMSKy53YWxsZXRtYW5h'
-    'Z2VyLnYxLk11bHRpc2lnUHNidFN0YXR1c1JlcXVlc3QaLC53YWxsZXRtYW5hZ2VyLnYxLk11bH'
-    'Rpc2lnUHNidFN0YXR1c1Jlc3BvbnNlEnUKFEJyb2FkY2FzdFRyYW5zYWN0aW9uEi0ud2FsbGV0'
-    'bWFuYWdlci52MS5Ccm9hZGNhc3RUcmFuc2FjdGlvblJlcXVlc3QaLi53YWxsZXRtYW5hZ2VyLn'
-    'YxLkJyb2FkY2FzdFRyYW5zYWN0aW9uUmVzcG9uc2USbAoRR2V0QWRkcmVzc1Vuc3BlbnQSKi53'
-    'YWxsZXRtYW5hZ2VyLnYxLkdldEFkZHJlc3NVbnNwZW50UmVxdWVzdBorLndhbGxldG1hbmFnZX'
-    'IudjEuR2V0QWRkcmVzc1Vuc3BlbnRSZXNwb25zZRKNAQocQnJvYWRjYXN0RWxlY3RydW1UcmFu'
-    'c2FjdGlvbhI1LndhbGxldG1hbmFnZXIudjEuQnJvYWRjYXN0RWxlY3RydW1UcmFuc2FjdGlvbl'
-    'JlcXVlc3QaNi53YWxsZXRtYW5hZ2VyLnYxLkJyb2FkY2FzdEVsZWN0cnVtVHJhbnNhY3Rpb25S'
-    'ZXNwb25zZRKBAQoYRW51bWVyYXRlSGFyZHdhcmVEZXZpY2VzEjEud2FsbGV0bWFuYWdlci52MS'
-    '5FbnVtZXJhdGVIYXJkd2FyZURldmljZXNSZXF1ZXN0GjIud2FsbGV0bWFuYWdlci52MS5FbnVt'
-    'ZXJhdGVIYXJkd2FyZURldmljZXNSZXNwb25zZRJmCg9HZXRIYXJkd2FyZVhwdWISKC53YWxsZX'
-    'RtYW5hZ2VyLnYxLkdldEhhcmR3YXJlWHB1YlJlcXVlc3QaKS53YWxsZXRtYW5hZ2VyLnYxLkdl'
-    'dEhhcmR3YXJlWHB1YlJlc3BvbnNlEm8KElNpZ25Qc2J0V2l0aERldmljZRIrLndhbGxldG1hbm'
-    'FnZXIudjEuU2lnblBzYnRXaXRoRGV2aWNlUmVxdWVzdBosLndhbGxldG1hbmFnZXIudjEuU2ln'
-    'blBzYnRXaXRoRGV2aWNlUmVzcG9uc2USZgoPUHJvbXB0RGV2aWNlUGluEigud2FsbGV0bWFuYW'
-    'dlci52MS5Qcm9tcHREZXZpY2VQaW5SZXF1ZXN0Gikud2FsbGV0bWFuYWdlci52MS5Qcm9tcHRE'
-    'ZXZpY2VQaW5SZXNwb25zZRJgCg1TZW5kRGV2aWNlUGluEiYud2FsbGV0bWFuYWdlci52MS5TZW'
-    '5kRGV2aWNlUGluUmVxdWVzdBonLndhbGxldG1hbmFnZXIudjEuU2VuZERldmljZVBpblJlc3Bv'
-    'bnNlEloKC0Nsb3NlRGV2aWNlEiQud2FsbGV0bWFuYWdlci52MS5DbG9zZURldmljZVJlcXVlc3'
-    'QaJS53YWxsZXRtYW5hZ2VyLnYxLkNsb3NlRGV2aWNlUmVzcG9uc2USYwoORGVyaXZlS2V5c3Rv'
-    'cmUSJy53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUtleXN0b3JlUmVxdWVzdBooLndhbGxldG1hbm'
-    'FnZXIudjEuRGVyaXZlS2V5c3RvcmVSZXNwb25zZRKBAQoYUHJldmlld1dhbGxldEZyb21FbnRy'
-    'b3B5EjEud2FsbGV0bWFuYWdlci52MS5QcmV2aWV3V2FsbGV0RnJvbUVudHJvcHlSZXF1ZXN0Gj'
-    'Iud2FsbGV0bWFuYWdlci52MS5QcmV2aWV3V2FsbGV0RnJvbUVudHJvcHlSZXNwb25zZRJgCg1H'
-    'ZXRXYWxsZXRTZWVkEiYud2FsbGV0bWFuYWdlci52MS5HZXRXYWxsZXRTZWVkUmVxdWVzdBonLn'
-    'dhbGxldG1hbmFnZXIudjEuR2V0V2FsbGV0U2VlZFJlc3BvbnNlEmkKEExpc3RDb3JlVmFyaWFu'
-    'dHMSKS53YWxsZXRtYW5hZ2VyLnYxLkxpc3RDb3JlVmFyaWFudHNSZXF1ZXN0Gioud2FsbGV0bW'
-    'FuYWdlci52MS5MaXN0Q29yZVZhcmlhbnRzUmVzcG9uc2USYwoOR2V0Q29yZVZhcmlhbnQSJy53'
-    'YWxsZXRtYW5hZ2VyLnYxLkdldENvcmVWYXJpYW50UmVxdWVzdBooLndhbGxldG1hbmFnZXIudj'
-    'EuR2V0Q29yZVZhcmlhbnRSZXNwb25zZRJjCg5TZXRDb3JlVmFyaWFudBInLndhbGxldG1hbmFn'
-    'ZXIudjEuU2V0Q29yZVZhcmlhbnRSZXF1ZXN0Gigud2FsbGV0bWFuYWdlci52MS5TZXRDb3JlVm'
-    'FyaWFudFJlc3BvbnNlEmwKEUdldEVsZWN0cnVtU2VydmVyEioud2FsbGV0bWFuYWdlci52MS5H'
-    'ZXRFbGVjdHJ1bVNlcnZlclJlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLkdldEVsZWN0cnVtU2'
-    'VydmVyUmVzcG9uc2USbAoRU2V0RWxlY3RydW1TZXJ2ZXISKi53YWxsZXRtYW5hZ2VyLnYxLlNl'
-    'dEVsZWN0cnVtU2VydmVyUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuU2V0RWxlY3RydW1TZX'
-    'J2ZXJSZXNwb25zZRJdCgxHZXRUb3JDb25maWcSJS53YWxsZXRtYW5hZ2VyLnYxLkdldFRvckNv'
-    'bmZpZ1JlcXVlc3QaJi53YWxsZXRtYW5hZ2VyLnYxLkdldFRvckNvbmZpZ1Jlc3BvbnNlEl0KDF'
-    'NldFRvckNvbmZpZxIlLndhbGxldG1hbmFnZXIudjEuU2V0VG9yQ29uZmlnUmVxdWVzdBomLndh'
-    'bGxldG1hbmFnZXIudjEuU2V0VG9yQ29uZmlnUmVzcG9uc2USVgoPV2F0Y2hXYWxsZXREYXRhEh'
-    'YuZ29vZ2xlLnByb3RvYnVmLkVtcHR5Gikud2FsbGV0bWFuYWdlci52MS5XYXRjaFdhbGxldERh'
-    'dGFSZXNwb25zZTAB');
+    'VHJhbnNhY3Rpb25SZXNwb25zZRJRCg5TZXRGcm96ZW5Db2lucxInLndhbGxldG1hbmFnZXIudj'
+    'EuU2V0RnJvemVuQ29pbnNSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EmAKDUNyZWF0'
+    'ZURlcG9zaXQSJi53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZURlcG9zaXRSZXF1ZXN0Gicud2FsbG'
+    'V0bWFuYWdlci52MS5DcmVhdGVEZXBvc2l0UmVzcG9uc2USaQoQTGlzdFRyYW5zYWN0aW9ucxIp'
+    'LndhbGxldG1hbmFnZXIudjEuTGlzdFRyYW5zYWN0aW9uc1JlcXVlc3QaKi53YWxsZXRtYW5hZ2'
+    'VyLnYxLkxpc3RUcmFuc2FjdGlvbnNSZXNwb25zZRJaCgtMaXN0VW5zcGVudBIkLndhbGxldG1h'
+    'bmFnZXIudjEuTGlzdFVuc3BlbnRSZXF1ZXN0GiUud2FsbGV0bWFuYWdlci52MS5MaXN0VW5zcG'
+    'VudFJlc3BvbnNlEnUKFExpc3RSZWNlaXZlQWRkcmVzc2VzEi0ud2FsbGV0bWFuYWdlci52MS5M'
+    'aXN0UmVjZWl2ZUFkZHJlc3Nlc1JlcXVlc3QaLi53YWxsZXRtYW5hZ2VyLnYxLkxpc3RSZWNlaX'
+    'ZlQWRkcmVzc2VzUmVzcG9uc2USeAoVR2V0VHJhbnNhY3Rpb25EZXRhaWxzEi4ud2FsbGV0bWFu'
+    'YWdlci52MS5HZXRUcmFuc2FjdGlvbkRldGFpbHNSZXF1ZXN0Gi8ud2FsbGV0bWFuYWdlci52MS'
+    '5HZXRUcmFuc2FjdGlvbkRldGFpbHNSZXNwb25zZRJsChFEZWNvZGVUcmFuc2FjdGlvbhIqLndh'
+    'bGxldG1hbmFnZXIudjEuRGVjb2RlVHJhbnNhY3Rpb25SZXF1ZXN0Gisud2FsbGV0bWFuYWdlci'
+    '52MS5EZWNvZGVUcmFuc2FjdGlvblJlc3BvbnNlEk4KB0J1bXBGZWUSIC53YWxsZXRtYW5hZ2Vy'
+    'LnYxLkJ1bXBGZWVSZXF1ZXN0GiEud2FsbGV0bWFuYWdlci52MS5CdW1wRmVlUmVzcG9uc2USYw'
+    'oOUHJldmlld0J1bXBGZWUSJy53YWxsZXRtYW5hZ2VyLnYxLlByZXZpZXdCdW1wRmVlUmVxdWVz'
+    'dBooLndhbGxldG1hbmFnZXIudjEuUHJldmlld0J1bXBGZWVSZXNwb25zZRJXCgpDcmVhdGVDcG'
+    'ZwEiMud2FsbGV0bWFuYWdlci52MS5DcmVhdGVDcGZwUmVxdWVzdBokLndhbGxldG1hbmFnZXIu'
+    'djEuQ3JlYXRlQ3BmcFJlc3BvbnNlEmYKD0Rlcml2ZUFkZHJlc3NlcxIoLndhbGxldG1hbmFnZX'
+    'IudjEuRGVyaXZlQWRkcmVzc2VzUmVxdWVzdBopLndhbGxldG1hbmFnZXIudjEuRGVyaXZlQWRk'
+    'cmVzc2VzUmVzcG9uc2USVwoKQ3JlYXRlUHNidBIjLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlUH'
+    'NidFJlcXVlc3QaJC53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZVBzYnRSZXNwb25zZRJRCghTaWdu'
+    'UHNidBIhLndhbGxldG1hbmFnZXIudjEuU2lnblBzYnRSZXF1ZXN0GiIud2FsbGV0bWFuYWdlci'
+    '52MS5TaWduUHNidFJlc3BvbnNlEnUKFFNpZ25Qc2J0V2l0aENvc2lnbmVyEi0ud2FsbGV0bWFu'
+    'YWdlci52MS5TaWduUHNidFdpdGhDb3NpZ25lclJlcXVlc3QaLi53YWxsZXRtYW5hZ2VyLnYxLl'
+    'NpZ25Qc2J0V2l0aENvc2lnbmVyUmVzcG9uc2USWgoLQ29tYmluZVBzYnQSJC53YWxsZXRtYW5h'
+    'Z2VyLnYxLkNvbWJpbmVQc2J0UmVxdWVzdBolLndhbGxldG1hbmFnZXIudjEuQ29tYmluZVBzYn'
+    'RSZXNwb25zZRJdCgxGaW5hbGl6ZVBzYnQSJS53YWxsZXRtYW5hZ2VyLnYxLkZpbmFsaXplUHNi'
+    'dFJlcXVlc3QaJi53YWxsZXRtYW5hZ2VyLnYxLkZpbmFsaXplUHNidFJlc3BvbnNlEm8KEk11bH'
+    'Rpc2lnUHNidFN0YXR1cxIrLndhbGxldG1hbmFnZXIudjEuTXVsdGlzaWdQc2J0U3RhdHVzUmVx'
+    'dWVzdBosLndhbGxldG1hbmFnZXIudjEuTXVsdGlzaWdQc2J0U3RhdHVzUmVzcG9uc2USdQoUQn'
+    'JvYWRjYXN0VHJhbnNhY3Rpb24SLS53YWxsZXRtYW5hZ2VyLnYxLkJyb2FkY2FzdFRyYW5zYWN0'
+    'aW9uUmVxdWVzdBouLndhbGxldG1hbmFnZXIudjEuQnJvYWRjYXN0VHJhbnNhY3Rpb25SZXNwb2'
+    '5zZRJsChFHZXRBZGRyZXNzVW5zcGVudBIqLndhbGxldG1hbmFnZXIudjEuR2V0QWRkcmVzc1Vu'
+    'c3BlbnRSZXF1ZXN0Gisud2FsbGV0bWFuYWdlci52MS5HZXRBZGRyZXNzVW5zcGVudFJlc3Bvbn'
+    'NlEo0BChxCcm9hZGNhc3RFbGVjdHJ1bVRyYW5zYWN0aW9uEjUud2FsbGV0bWFuYWdlci52MS5C'
+    'cm9hZGNhc3RFbGVjdHJ1bVRyYW5zYWN0aW9uUmVxdWVzdBo2LndhbGxldG1hbmFnZXIudjEuQn'
+    'JvYWRjYXN0RWxlY3RydW1UcmFuc2FjdGlvblJlc3BvbnNlEoEBChhFbnVtZXJhdGVIYXJkd2Fy'
+    'ZURldmljZXMSMS53YWxsZXRtYW5hZ2VyLnYxLkVudW1lcmF0ZUhhcmR3YXJlRGV2aWNlc1JlcX'
+    'Vlc3QaMi53YWxsZXRtYW5hZ2VyLnYxLkVudW1lcmF0ZUhhcmR3YXJlRGV2aWNlc1Jlc3BvbnNl'
+    'EmYKD0dldEhhcmR3YXJlWHB1YhIoLndhbGxldG1hbmFnZXIudjEuR2V0SGFyZHdhcmVYcHViUm'
+    'VxdWVzdBopLndhbGxldG1hbmFnZXIudjEuR2V0SGFyZHdhcmVYcHViUmVzcG9uc2USbwoSU2ln'
+    'blBzYnRXaXRoRGV2aWNlEisud2FsbGV0bWFuYWdlci52MS5TaWduUHNidFdpdGhEZXZpY2VSZX'
+    'F1ZXN0Giwud2FsbGV0bWFuYWdlci52MS5TaWduUHNidFdpdGhEZXZpY2VSZXNwb25zZRJmCg9Q'
+    'cm9tcHREZXZpY2VQaW4SKC53YWxsZXRtYW5hZ2VyLnYxLlByb21wdERldmljZVBpblJlcXVlc3'
+    'QaKS53YWxsZXRtYW5hZ2VyLnYxLlByb21wdERldmljZVBpblJlc3BvbnNlEmAKDVNlbmREZXZp'
+    'Y2VQaW4SJi53YWxsZXRtYW5hZ2VyLnYxLlNlbmREZXZpY2VQaW5SZXF1ZXN0Gicud2FsbGV0bW'
+    'FuYWdlci52MS5TZW5kRGV2aWNlUGluUmVzcG9uc2USWgoLQ2xvc2VEZXZpY2USJC53YWxsZXRt'
+    'YW5hZ2VyLnYxLkNsb3NlRGV2aWNlUmVxdWVzdBolLndhbGxldG1hbmFnZXIudjEuQ2xvc2VEZX'
+    'ZpY2VSZXNwb25zZRJjCg5EZXJpdmVLZXlzdG9yZRInLndhbGxldG1hbmFnZXIudjEuRGVyaXZl'
+    'S2V5c3RvcmVSZXF1ZXN0Gigud2FsbGV0bWFuYWdlci52MS5EZXJpdmVLZXlzdG9yZVJlc3Bvbn'
+    'NlEoEBChhQcmV2aWV3V2FsbGV0RnJvbUVudHJvcHkSMS53YWxsZXRtYW5hZ2VyLnYxLlByZXZp'
+    'ZXdXYWxsZXRGcm9tRW50cm9weVJlcXVlc3QaMi53YWxsZXRtYW5hZ2VyLnYxLlByZXZpZXdXYW'
+    'xsZXRGcm9tRW50cm9weVJlc3BvbnNlEmAKDUdldFdhbGxldFNlZWQSJi53YWxsZXRtYW5hZ2Vy'
+    'LnYxLkdldFdhbGxldFNlZWRSZXF1ZXN0Gicud2FsbGV0bWFuYWdlci52MS5HZXRXYWxsZXRTZW'
+    'VkUmVzcG9uc2USaQoQTGlzdENvcmVWYXJpYW50cxIpLndhbGxldG1hbmFnZXIudjEuTGlzdENv'
+    'cmVWYXJpYW50c1JlcXVlc3QaKi53YWxsZXRtYW5hZ2VyLnYxLkxpc3RDb3JlVmFyaWFudHNSZX'
+    'Nwb25zZRJjCg5HZXRDb3JlVmFyaWFudBInLndhbGxldG1hbmFnZXIudjEuR2V0Q29yZVZhcmlh'
+    'bnRSZXF1ZXN0Gigud2FsbGV0bWFuYWdlci52MS5HZXRDb3JlVmFyaWFudFJlc3BvbnNlEmMKDl'
+    'NldENvcmVWYXJpYW50Eicud2FsbGV0bWFuYWdlci52MS5TZXRDb3JlVmFyaWFudFJlcXVlc3Qa'
+    'KC53YWxsZXRtYW5hZ2VyLnYxLlNldENvcmVWYXJpYW50UmVzcG9uc2USbAoRR2V0RWxlY3RydW'
+    '1TZXJ2ZXISKi53YWxsZXRtYW5hZ2VyLnYxLkdldEVsZWN0cnVtU2VydmVyUmVxdWVzdBorLndh'
+    'bGxldG1hbmFnZXIudjEuR2V0RWxlY3RydW1TZXJ2ZXJSZXNwb25zZRJsChFTZXRFbGVjdHJ1bV'
+    'NlcnZlchIqLndhbGxldG1hbmFnZXIudjEuU2V0RWxlY3RydW1TZXJ2ZXJSZXF1ZXN0Gisud2Fs'
+    'bGV0bWFuYWdlci52MS5TZXRFbGVjdHJ1bVNlcnZlclJlc3BvbnNlEl0KDEdldFRvckNvbmZpZx'
+    'IlLndhbGxldG1hbmFnZXIudjEuR2V0VG9yQ29uZmlnUmVxdWVzdBomLndhbGxldG1hbmFnZXIu'
+    'djEuR2V0VG9yQ29uZmlnUmVzcG9uc2USXQoMU2V0VG9yQ29uZmlnEiUud2FsbGV0bWFuYWdlci'
+    '52MS5TZXRUb3JDb25maWdSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52MS5TZXRUb3JDb25maWdS'
+    'ZXNwb25zZRJWCg9XYXRjaFdhbGxldERhdGESFi5nb29nbGUucHJvdG9idWYuRW1wdHkaKS53YW'
+    'xsZXRtYW5hZ2VyLnYxLldhdGNoV2FsbGV0RGF0YVJlc3BvbnNlMAE=');
 

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
@@ -55,6 +55,7 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
   $async.Future<$18.EstimateFeeResponse> estimateFee($pb.ServerContext ctx, $18.EstimateFeeRequest request);
   $async.Future<$18.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $18.GetNewAddressRequest request);
   $async.Future<$18.SendTransactionResponse> sendTransaction($pb.ServerContext ctx, $18.SendTransactionRequest request);
+  $async.Future<$17.Empty> setFrozenCoins($pb.ServerContext ctx, $18.SetFrozenCoinsRequest request);
   $async.Future<$18.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $18.CreateDepositRequest request);
   $async.Future<$18.ListTransactionsResponse> listTransactions($pb.ServerContext ctx, $18.ListTransactionsRequest request);
   $async.Future<$18.ListUnspentResponse> listUnspent($pb.ServerContext ctx, $18.ListUnspentRequest request);
@@ -127,6 +128,7 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'EstimateFee': return $18.EstimateFeeRequest();
       case 'GetNewAddress': return $18.GetNewAddressRequest();
       case 'SendTransaction': return $18.SendTransactionRequest();
+      case 'SetFrozenCoins': return $18.SetFrozenCoinsRequest();
       case 'CreateDeposit': return $18.CreateDepositRequest();
       case 'ListTransactions': return $18.ListTransactionsRequest();
       case 'ListUnspent': return $18.ListUnspentRequest();
@@ -202,6 +204,7 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'EstimateFee': return this.estimateFee(ctx, request as $18.EstimateFeeRequest);
       case 'GetNewAddress': return this.getNewAddress(ctx, request as $18.GetNewAddressRequest);
       case 'SendTransaction': return this.sendTransaction(ctx, request as $18.SendTransactionRequest);
+      case 'SetFrozenCoins': return this.setFrozenCoins(ctx, request as $18.SetFrozenCoinsRequest);
       case 'CreateDeposit': return this.createDeposit(ctx, request as $18.CreateDepositRequest);
       case 'ListTransactions': return this.listTransactions(ctx, request as $18.ListTransactionsRequest);
       case 'ListUnspent': return this.listUnspent(ctx, request as $18.ListUnspentRequest);

--- a/sidechain_core/lib/providers/binaries/managers/process_manager.dart
+++ b/sidechain_core/lib/providers/binaries/managers/process_manager.dart
@@ -102,9 +102,9 @@ class ProcessManager extends ChangeNotifier {
       runningProcesses.remove(binary.name);
       await pidFileManager.deletePidFile(binary);
       logProvider.addExitMarker(binary.type, binary.name, null);
-      notifyListeners();
+      _notify();
     });
-    notifyListeners();
+    _notify();
   }
 
   bool _holdsAdopted(Binary binary, int pid) {
@@ -113,6 +113,15 @@ class ProcessManager extends ChangeNotifier {
     }
     final process = runningProcesses[binary.name];
     return process != null && process.adopted && process.pid == pid;
+  }
+
+  /// A spawned process reports its exit whenever it ends, and an adopted one
+  /// polls. Both can outlive the dispose.
+  void _notify() {
+    if (_disposed) {
+      return;
+    }
+    notifyListeners();
   }
 
   void _cancelAdoptedWatch(Binary binary) {
@@ -310,7 +319,7 @@ class ProcessManager extends ChangeNotifier {
           _stdoutStreams.remove(binary.name);
           _finalErr.remove(binary.name);
         } finally {
-          notifyListeners();
+          _notify();
         }
       }),
     );
@@ -333,7 +342,7 @@ class ProcessManager extends ChangeNotifier {
     // Write PID file so we can find this process after hot restart/crash
     await pidFileManager.writePidFile(binary, process.pid);
 
-    notifyListeners();
+    _notify();
     return process.pid;
   }
 
@@ -386,7 +395,7 @@ class ProcessManager extends ChangeNotifier {
     _cancelAdoptedWatch(process.binary);
     runningProcesses.remove(process.binary.name);
     await pidFileManager.deletePidFile(process.binary);
-    notifyListeners();
+    _notify();
   }
 
   /// Check if a PID is still alive

--- a/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -13,11 +13,27 @@ import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wm
 /// when wallet/runtime ownership lives in orchestrator. Splits unary
 /// (HTTP/1.1) and streaming (HTTP/2) over two transports — see
 /// [OrchestratorRPC] for why.
+/// Runs one task at a time, in the order the callers arrive.
+class SerialQueue {
+  Future<void> _tail = Future<void>.value();
+
+  Future<T> add<T>(Future<T> Function() task) {
+    final result = _tail.then((_) => task());
+    // A failed task must not fail every task after it.
+    _tail = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+}
+
 class OrchestratorWalletRPC {
   late WalletManagerServiceClient _unaryClient;
   late WalletManagerServiceClient _streamClient;
 
   static const _defaultTransactionCount = 100;
+
+  /// Names the coins the user froze, as txid:vout. An app that holds no
+  /// frozen set leaves this null.
+  Future<List<String>> Function()? frozenCoins;
 
   /// Create from the two transports owned by [OrchestratorRPC]. Unary RPCs
   /// go to [unary], server-streaming RPCs (currently just `watchWalletData`)
@@ -28,6 +44,43 @@ class OrchestratorWalletRPC {
   }) {
     _unaryClient = WalletManagerServiceClient(unary);
     _streamClient = WalletManagerServiceClient(stream);
+  }
+
+  final SerialQueue _frozenPushes = SerialQueue();
+
+  /// Hands the orchestrator the coins no send may take. Coin selection runs
+  /// there, so it acts on the set this call leaves behind.
+  ///
+  /// One hand-over runs at a time. The set is read and sent in that order, so
+  /// a slow one cannot land after a newer one and put the older set back.
+  Future<void> pushFrozenCoins() {
+    return _frozenPushes.add(_pushFrozenCoins);
+  }
+
+  Future<void> _pushFrozenCoins() async {
+    final source = frozenCoins;
+    if (source == null) {
+      return;
+    }
+    final outpoints = await source();
+    await _unaryClient.setFrozenCoins(
+      wmpb.SetFrozenCoinsRequest(
+        outpoints: outpoints.map(frozenOutpointOf).toList(),
+      ),
+    );
+  }
+
+  /// Reads a txid:vout pair into the shape the orchestrator takes.
+  static wmpb.FrozenOutpoint frozenOutpointOf(String outpoint) {
+    final parts = outpoint.split(':');
+    if (parts.length != 2) {
+      throw ArgumentError('frozen coin "$outpoint" is not a txid:vout');
+    }
+    final vout = int.tryParse(parts[1]);
+    if (parts[0].isEmpty || vout == null || vout < 0) {
+      throw ArgumentError('frozen coin "$outpoint" is not a txid:vout');
+    }
+    return wmpb.FrozenOutpoint(txid: parts[0], vout: vout);
   }
 
   Future<wmpb.GetWalletStatusResponse> getWalletStatus() {
@@ -279,10 +332,11 @@ class OrchestratorWalletRPC {
     String? opReturnHex,
     List<bwpb.UnspentOutput>? requiredInputs,
     bool allowReplay = false,
-  }) {
+  }) async {
     final resolvedOpReturnHex =
         opReturnHex ?? (opReturnMessage == null ? null : _bytesToHex(utf8.encode(opReturnMessage)));
 
+    await pushFrozenCoins();
     return _unaryClient.sendTransaction(
       wmpb.SendTransactionRequest(
         walletId: walletId,
@@ -315,6 +369,7 @@ class OrchestratorWalletRPC {
     final resolvedOpReturnHex =
         opReturnHex ?? (opReturnMessage == null ? null : _bytesToHex(utf8.encode(opReturnMessage)));
 
+    await pushFrozenCoins();
     final response = await _unaryClient.createPsbt(
       wmpb.CreatePsbtRequest(
         walletId: walletId,
@@ -625,7 +680,9 @@ class OrchestratorWalletRPC {
     required String txid,
     int? newFeeRate,
     int? feeFromVout,
-  }) {
+  }) async {
+    // A bump reaches for another coin when the change cannot pay the raise.
+    await pushFrozenCoins();
     return _unaryClient.bumpFee(
       wmpb.BumpFeeRequest(
         walletId: walletId,
@@ -659,7 +716,9 @@ class OrchestratorWalletRPC {
     required String parentTxid,
     required int parentVout,
     required int targetFeeRate,
-  }) {
+  }) async {
+    // The child pays the parent's fee, and it funds that from another coin.
+    await pushFrozenCoins();
     return _unaryClient.createCpfp(
       wmpb.CreateCpfpRequest(
         walletId: walletId,

--- a/sidechain_core/test/frozen_coins_push_test.dart
+++ b/sidechain_core/test/frozen_coins_push_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sidechain_core/sidechain_core.dart';
+
+/// Reads the outpoint a [OrchestratorWalletRPC] would hand over, without a
+/// transport. The mapper is the part that can turn a stored outpoint into a
+/// request the orchestrator refuses.
+wmpb.FrozenOutpoint map(String outpoint) {
+  return OrchestratorWalletRPC.frozenOutpointOf(outpoint);
+}
+
+void main() {
+  group('a frozen outpoint', () {
+    test('reads a txid and a vout', () {
+      final coin = map('aa:12');
+      expect(coin.txid, 'aa');
+      expect(coin.vout, 12);
+    });
+
+    test('refuses a string with no vout', () {
+      expect(() => map('aa'), throwsArgumentError);
+    });
+
+    test('refuses a vout that is not a number', () {
+      expect(() => map('aa:x'), throwsArgumentError);
+    });
+
+    test('refuses an empty txid', () {
+      expect(() => map(':0'), throwsArgumentError);
+    });
+
+    test('refuses a negative vout', () {
+      expect(() => map('aa:-1'), throwsArgumentError);
+    });
+  });
+}

--- a/sidechain_core/test/serial_queue_test.dart
+++ b/sidechain_core/test/serial_queue_test.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+void main() {
+  group('SerialQueue', () {
+    test('runs one task at a time, in the order the callers arrive', () async {
+      final queue = SerialQueue();
+      final ran = <String>[];
+      final slow = Completer<void>();
+
+      final first = queue.add(() async {
+        await slow.future;
+        ran.add('slow');
+      });
+      final second = queue.add(() async => ran.add('quick'));
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(ran, isEmpty, reason: 'the first task holds the queue');
+
+      slow.complete();
+      await Future.wait([first, second]);
+      expect(ran, ['slow', 'quick'], reason: 'the newest task lands last');
+    });
+
+    test('a failed task leaves the queue running', () async {
+      final queue = SerialQueue();
+
+      await expectLater(queue.add(() async => throw StateError('boom')), throwsStateError);
+      expect(await queue.add(() async => 'done'), 'done');
+    });
+  });
+}


### PR DESCRIPTION
A coin the user froze reached only the send page. The news, vote, timestamp and BitDrive senders picked any coin, because drivechaind never learned the frozen set.

BitWindow hands the set to drivechaind, which locks those coins in Core for the length of a send and drops them from the electrum pool. Core keeps fundrawtransaction; the lock is what keeps it off the coin.