### PR TITLE
Answer the review on the balance split

### DIFF
--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -369,15 +369,31 @@ class _SailTableState extends State<SailTable> {
       rowsToSample.addAll(List.generate(10, (i) => widget.rowCount - 10 + i));
     }
 
+    final hugging = List<bool>.filled(_numColumns!, false);
     for (int row in rowsToSample) {
       final cells = widget.rowBuilder(context, row, false);
       for (int col = 0; col < cells.length && col < _numColumns!; col++) {
         final cell = cells[col];
         if (cell is SailTableCell && (cell.width != null || cell.hugContent)) {
           fixedColumns[col] = true;
+          hugging[col] = hugging[col] || cell.hugContent;
         }
         final cellWidth = _calculateColumnWidth(cell);
         columnWidths[col] = max(columnWidths[col], cellWidth);
+      }
+    }
+
+    // A hugging column takes no spare width, so a row outside the sample would
+    // render in a column too narrow for it.
+    if (hugging.contains(true) && rowsToSample.length < widget.rowCount) {
+      for (int row = 0; row < widget.rowCount; row++) {
+        final cells = widget.rowBuilder(context, row, false);
+        for (int col = 0; col < cells.length && col < _numColumns!; col++) {
+          if (!hugging[col]) {
+            continue;
+          }
+          columnWidths[col] = max(columnWidths[col], _calculateColumnWidth(cells[col]));
+        }
       }
     }
 

--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -79,6 +79,7 @@ class _SailTableState extends State<SailTable> {
   BoxConstraints? _currentConstraints;
   double _startColumnWidth = 0;
   int? _numColumns;
+  TextScaler? _lastScaler;
 
   double get _totalColumnWidths => _widths.fold(0, (prev, e) => prev + e);
 
@@ -87,6 +88,18 @@ class _SailTableState extends State<SailTable> {
     super.initState();
     _initializeState();
     _verticalController.addListener(_checkScrollPosition);
+  }
+
+  // The font-size slider changes the scaler under a mounted table, and the
+  // widths hold the measurement of the previous scale.
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final scaler = MediaQuery.of(context).textScaler;
+    if (_lastScaler != null && _lastScaler != scaler && _currentConstraints != null) {
+      _resizeColumns(_currentConstraints!.maxWidth, force: true);
+    }
+    _lastScaler = scaler;
   }
 
   @override
@@ -469,6 +482,8 @@ class _SailTableState extends State<SailTable> {
       final textPainter = TextPainter(
         text: TextSpan(text: text, style: textStyle),
         textDirection: TextDirection.ltr,
+        // The same scaler SailText renders with, clamp included.
+        textScaler: MediaQuery.of(context).textScaler.clamp(maxScaleFactor: 2),
       );
       textPainter.layout();
       return textPainter.width + padding + 1;

--- a/sail_ui/test/sail_table_columns_test.dart
+++ b/sail_ui/test/sail_table_columns_test.dart
@@ -74,7 +74,6 @@ Widget _wideRowInTheMiddle({double textScale = 1.0}) {
             width: 800,
             height: 400,
             child: SailTable(
-              key: ValueKey(textScale),
               getRowId: (index) => 'row$index',
               headerBuilder: (context) => const [
                 SailTableHeaderCell(name: 'Name'),
@@ -153,5 +152,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.getSize(_cell('1 ECX').first).width, greaterThanOrEqualTo(_renderedWidth(_wideAmount, 1) + 24));
+  });
+
+  // The font-size slider changes the scale under a mounted table, so the
+  // widths must not stay at the measurement of the previous scale.
+  testWidgets('a hugging column follows a text scale the user changes', (tester) async {
+    await tester.pumpWidget(_wideRowInTheMiddle());
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(_wideRowInTheMiddle(textScale: 1.5));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(_cell('1 ECX').first).width, greaterThanOrEqualTo(_renderedWidth(_wideAmount, 1.5) + 24));
   });
 }

--- a/sail_ui/test/sail_table_columns_test.dart
+++ b/sail_ui/test/sail_table_columns_test.dart
@@ -61,6 +61,50 @@ Widget _sizedTable({required double slotWidth, required bool hugAmount}) {
   );
 }
 
+/// A 100-row table where only row 50 carries the wide amount, so the sample of
+/// the first and last ten rows never sees it.
+Widget _wideRowInTheMiddle({double textScale = 1.0}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+      child: SailTheme(
+        data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+        child: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 400,
+            child: SailTable(
+              key: ValueKey(textScale),
+              getRowId: (index) => 'row$index',
+              headerBuilder: (context) => const [
+                SailTableHeaderCell(name: 'Name'),
+                SailTableHeaderCell(name: 'Amount'),
+              ],
+              rowBuilder: (context, index, selected) => [
+                const SailTableCell(value: 'Truthcoin'),
+                SailTableCell(value: index == 50 ? _wideAmount : '1 ECX', hugContent: true),
+              ],
+              rowCount: 100,
+              drawGrid: false,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+const _wideAmount = '115.0255,5423 ECX';
+
+double _renderedWidth(String text, double scale) {
+  final painter = TextPainter(
+    text: TextSpan(text: text, style: SailStyleValues.thirteen),
+    textDirection: TextDirection.ltr,
+    textScaler: TextScaler.linear(scale),
+  )..layout();
+  return painter.width;
+}
+
 Finder _cell(String value) => find.byWidgetPredicate((widget) => widget is SailTableCell && widget.value == value);
 
 void main() {
@@ -102,5 +146,12 @@ void main() {
 
     expect(hugged, lessThan(stretched));
     expect(tester.getSize(_cell('Truthcoin')).width, greaterThan(stretched));
+  });
+
+  testWidgets('a hugging column fits a row outside the sample', (tester) async {
+    await tester.pumpWidget(_wideRowInTheMiddle());
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(_cell('1 ECX').first).width, greaterThanOrEqualTo(_renderedWidth(_wideAmount, 1) + 24));
   });
 }

--- a/sidechain_core/lib/providers/balance_provider.dart
+++ b/sidechain_core/lib/providers/balance_provider.dart
@@ -25,7 +25,12 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
   final Map<RPCConnection, (double confirmed, double pending)> _balances = {};
   String? error;
 
-  bool initialized = false;
+  final Set<RPCConnection> _reported = {};
+
+  /// True once the headline connection answered. A sidechain answer must not
+  /// clear the loading state, or the bar shows an unread zero as the balance.
+  bool get initialized => _reported.contains(mainConnection);
+
   bool _isFetching = false;
   Timer? _fetchTimer;
 
@@ -81,9 +86,9 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
   // Write a balance fetched elsewhere in the same batch as utxos/transactions,
   // so the displayed number can't drift from the list it belongs to.
   void setBalance(RPCConnection rpc, double confirmed, double pending) {
-    final changed = _balances[rpc] != (confirmed, pending) || !initialized;
+    final changed = _balances[rpc] != (confirmed, pending) || !_reported.contains(rpc);
     _balances[rpc] = (confirmed, pending);
-    initialized = true;
+    _reported.add(rpc);
     if (changed) {
       error = null;
       notifyListeners();
@@ -94,7 +99,7 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
     for (final rpc in connections) {
       _balances[rpc] = (0.0, 0.0);
     }
-    initialized = false;
+    _reported.clear();
     _lastWalletId = _walletReader?.activeWalletId;
     error = null;
     notifyListeners();
@@ -128,10 +133,9 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
           continue;
         }
         final (confirmed, pending) = balances;
-        if (!initialized) {
+        if (_reported.add(rpc)) {
           // wen't from not initialized to initialized, make sure to notify
           changed = true;
-          initialized = true;
         }
 
         if (_balances[rpc] != (confirmed, pending)) {

--- a/sidechain_core/test/balance_split_test.dart
+++ b/sidechain_core/test/balance_split_test.dart
@@ -46,6 +46,16 @@ void main() {
     expect(provider.sidechainPendingBalance, 0.5);
   });
 
+  // The bar stops its loading skeleton on initialized. A sidechain answer with
+  // no mainchain answer would leave an unread zero reading as the balance.
+  test('a sidechain answer alone leaves the provider uninitialized', () {
+    provider.setBalance(thunder, 2, 0);
+    expect(provider.initialized, isFalse);
+
+    provider.setBalance(mainchain, 0, 0);
+    expect(provider.initialized, isTrue);
+  });
+
   // A sidechain window holds one connection, so it owns the headline figure.
   test('a lone connection drives the headline figure', () {
     final lone = MockThunderRPC();


### PR DESCRIPTION
Three points from the review of #2279, which merged before I could push them.

The bottom bar stopped its loading skeleton on any chain's answer, so an unread zero could read as the L1 balance; initialized now follows the wallet the bar shows. A hugging table column now measures every row, not the sampled twenty, and it measures at the active text scale, so a wide amount outside the sample no longer clips.