### PR TITLE
orchestrator: send sidechain rpc params in node order

### DIFF
--- a/sidechain-orchestrator/sidechain/bitassets/client.go
+++ b/sidechain-orchestrator/sidechain/bitassets/client.go
@@ -244,7 +244,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/bitassets/handler.go
+++ b/sidechain-orchestrator/sidechain/bitassets/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil
@@ -331,7 +331,7 @@ func (h *Handler) EncryptMsg(ctx context.Context, req *connect.Request[pb.Encryp
 
 func (h *Handler) SignArbitraryMsg(ctx context.Context, req *connect.Request[pb.SignArbitraryMsgRequest]) (*connect.Response[pb.SignArbitraryMsgResponse], error) {
 	var signature string
-	params := []any{req.Msg.Msg, req.Msg.VerifyingKey}
+	params := []any{req.Msg.VerifyingKey, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg", params, &signature); err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func (h *Handler) SignArbitraryMsgAsAddr(ctx context.Context, req *connect.Reque
 		VerifyingKey string `json:"verifying_key"`
 		Signature    string `json:"signature"`
 	}
-	params := []any{req.Msg.Msg, req.Msg.Address}
+	params := []any{req.Msg.Address, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg_as_addr", params, &result); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/client.go
+++ b/sidechain-orchestrator/sidechain/bitnames/client.go
@@ -294,7 +294,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 
@@ -345,12 +345,12 @@ func (c *Client) DecryptMsg(ctx context.Context, encryptionPubkey, ciphertext st
 
 // SignArbitraryMsg signs a message with the specified verifying key.
 func (c *Client) SignArbitraryMsg(ctx context.Context, msg, verifyingKey string) (string, error) {
-	return unmarshal[string](c, ctx, "sign_arbitrary_msg", []interface{}{msg, verifyingKey})
+	return unmarshal[string](c, ctx, "sign_arbitrary_msg", []interface{}{verifyingKey, msg})
 }
 
 // SignArbitraryMsgAsAddr signs a message with the secret key for the given address.
 func (c *Client) SignArbitraryMsgAsAddr(ctx context.Context, msg, address string) (*SignatureResponse, error) {
-	r, err := unmarshal[SignatureResponse](c, ctx, "sign_arbitrary_msg_as_addr", []interface{}{msg, address})
+	r, err := unmarshal[SignatureResponse](c, ctx, "sign_arbitrary_msg_as_addr", []interface{}{address, msg})
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -166,7 +166,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil
@@ -389,7 +389,7 @@ func (h *Handler) ReadCommitment(ctx context.Context, req *connect.Request[pb.Re
 
 func (h *Handler) SignArbitraryMsg(ctx context.Context, req *connect.Request[pb.SignArbitraryMsgRequest]) (*connect.Response[pb.SignArbitraryMsgResponse], error) {
 	var signature string
-	params := []any{req.Msg.Msg, req.Msg.VerifyingKey}
+	params := []any{req.Msg.VerifyingKey, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg", params, &signature); err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (h *Handler) SignArbitraryMsgAsAddr(ctx context.Context, req *connect.Reque
 		VerifyingKey string `json:"verifying_key"`
 		Signature    string `json:"signature"`
 	}
-	params := []any{req.Msg.Msg, req.Msg.Address}
+	params := []any{req.Msg.Address, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg_as_addr", params, &result); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/rpc_params_test.go
+++ b/sidechain-orchestrator/sidechain/bitnames/rpc_params_test.go
@@ -1,0 +1,73 @@
+package bitnames
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordParams answers every call, and keeps the params of the last one.
+func recordParams(t *testing.T, result string) (*httptest.Server, *json.RawMessage) {
+	t.Helper()
+	var seen json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Params json.RawMessage `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		seen = req.Params
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"t","result":` + result + `}`))
+	}))
+	return srv, &seen
+}
+
+// The node reads params by position. A wrong order reaches the node as
+// "Invalid params", and the call never runs.
+func TestSignArbitraryMsgSendsTheKeyFirst(t *testing.T) {
+	srv, seen := recordParams(t, `"0xsignature"`)
+	defer srv.Close()
+
+	client := &Client{baseURL: srv.URL, http: srv.Client()}
+	_, err := client.SignArbitraryMsg(context.Background(), "the message", "bn-svk1key")
+	require.NoError(t, err)
+	assert.JSONEq(t, `["bn-svk1key","the message"]`, string(*seen))
+}
+
+func TestSignArbitraryMsgAsAddrSendsTheAddressFirst(t *testing.T) {
+	srv, seen := recordParams(t, `{"verifying_key":"bn-svk1key","signature":"0xsig"}`)
+	defer srv.Close()
+
+	client := &Client{baseURL: srv.URL, http: srv.Client()}
+	_, err := client.SignArbitraryMsgAsAddr(context.Background(), "the message", "3Dsq1WDmpX")
+	require.NoError(t, err)
+	assert.JSONEq(t, `["3Dsq1WDmpX","the message"]`, string(*seen))
+}
+
+// JSON-RPC carries params as an array. A bare string reaches the node as
+// "Invalid params".
+func TestConnectPeerSendsAnArray(t *testing.T) {
+	srv, seen := recordParams(t, `null`)
+	defer srv.Close()
+
+	client := &Client{baseURL: srv.URL, http: srv.Client()}
+	require.NoError(t, client.ConnectPeer(context.Background(), "127.0.0.1:4002"))
+	assert.True(t, strings.HasPrefix(string(*seen), "["), "params must be an array, and they are %s", *seen)
+	assert.JSONEq(t, `["127.0.0.1:4002"]`, string(*seen))
+}
+
+func TestEncryptMsgSendsTheKeyFirst(t *testing.T) {
+	srv, seen := recordParams(t, `"cipher"`)
+	defer srv.Close()
+
+	client := &Client{baseURL: srv.URL, http: srv.Client()}
+	_, err := client.EncryptMsg(context.Background(), "bn-enc1key", "the message")
+	require.NoError(t, err)
+	assert.JSONEq(t, `["bn-enc1key","the message"]`, string(*seen))
+}

--- a/sidechain-orchestrator/sidechain/coinshift/client.go
+++ b/sidechain-orchestrator/sidechain/coinshift/client.go
@@ -244,7 +244,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/coinshift/handler.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil

--- a/sidechain-orchestrator/sidechain/photon/client.go
+++ b/sidechain-orchestrator/sidechain/photon/client.go
@@ -244,7 +244,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/photon/handler.go
+++ b/sidechain-orchestrator/sidechain/photon/handler.go
@@ -181,7 +181,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil

--- a/sidechain-orchestrator/sidechain/truthcoin/client.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/client.go
@@ -244,7 +244,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/truthcoin/handler.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler.go
@@ -177,7 +177,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil
@@ -544,7 +544,7 @@ func (h *Handler) DecryptMsg(ctx context.Context, req *connect.Request[pb.Decryp
 
 func (h *Handler) SignArbitraryMsg(ctx context.Context, req *connect.Request[pb.SignArbitraryMsgRequest]) (*connect.Response[pb.SignArbitraryMsgResponse], error) {
 	var signature string
-	params := []any{req.Msg.Msg, req.Msg.VerifyingKey}
+	params := []any{req.Msg.VerifyingKey, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg", params, &signature); err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (h *Handler) SignArbitraryMsgAsAddr(ctx context.Context, req *connect.Reque
 		VerifyingKey string `json:"verifying_key"`
 		Signature    string `json:"signature"`
 	}
-	params := []any{req.Msg.Msg, req.Msg.Address}
+	params := []any{req.Msg.Address, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg_as_addr", params, &result); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/zside/client.go
+++ b/sidechain-orchestrator/sidechain/zside/client.go
@@ -244,7 +244,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/zside/handler.go
+++ b/sidechain-orchestrator/sidechain/zside/handler.go
@@ -173,7 +173,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "connect_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil


### PR DESCRIPTION
Three calls reach every sidechain node as `Invalid params`, so the feature
behind each one never runs. The node reads params by position, and the
orchestrator sends them in the wrong order.

Proved against the live nodes on the alphanet seed host:

| call | orchestrator sends | node answers |
|---|---|---|
| `connect_peer` | a bare string | `Invalid params` |
| `sign_arbitrary_msg` | `[msg, key]` | `Invalid params` |
| `sign_arbitrary_msg_as_addr` | `[msg, address]` | `Invalid params, bs58 error` |

The node signatures in `rpc-api/lib.rs` read `connect_peer(addr)`,
`sign_arbitrary_msg(verifying_key, msg)` and
`sign_arbitrary_msg_as_addr(address, msg)`. The same three calls are wrong on
bitnames, bitassets, coinshift, photon, truthcoin and zside. Thunder already
sends `connect_peer` as an array.

The OpenAPI document does not show this, because utoipa sorts the properties
by name. Only the Rust signature and a live call show the order.

## Tests

`rpc_params_test.go` records the params the client puts on the wire and pins
the order of each call. Each test fails on the old order:

```
expected: []interface {}{"bn-svk1key", "the message"}
actual  : []interface {}{"the message", "bn-svk1key"}
```

`go test ./sidechain/...` passes and `golangci-lint run ./sidechain/...`
reports 0 issues.