### PR TITLE
orchestrator: send RPC parameters as arrays

### DIFF
--- a/sidechain-orchestrator/sidechain/bitassets/client.go
+++ b/sidechain-orchestrator/sidechain/bitassets/client.go
@@ -176,7 +176,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -264,7 +264,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/bitassets/handler.go
+++ b/sidechain-orchestrator/sidechain/bitassets/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) ListUtxos(ctx context.Context, req *connect.Request[pb.ListUtx
 }
 
 func (h *Handler) RemoveFromMempool(ctx context.Context, req *connect.Request[pb.RemoveFromMempoolRequest]) (*connect.Response[pb.RemoveFromMempoolResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", req.Msg.Txid, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", []any{req.Msg.Txid}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RemoveFromMempoolResponse{}), nil
@@ -186,7 +186,7 @@ func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.Conne
 }
 
 func (h *Handler) ForgetPeer(ctx context.Context, req *connect.Request[pb.ForgetPeerRequest]) (*connect.Response[pb.ForgetPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "forget_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "forget_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ForgetPeerResponse{}), nil
@@ -201,7 +201,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil
@@ -241,14 +241,14 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil
 }
 
 func (h *Handler) GetBitAssetData(ctx context.Context, req *connect.Request[pb.GetBitAssetDataRequest]) (*connect.Response[pb.GetBitAssetDataResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "bitasset_data", req.Msg.AssetId)
+	raw, err := h.proxy.Client.CallRaw(ctx, "bitasset_data", []any{req.Msg.AssetId})
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (h *Handler) DutchAuctionBid(ctx context.Context, req *connect.Request[pb.D
 
 func (h *Handler) DutchAuctionCollect(ctx context.Context, req *connect.Request[pb.DutchAuctionCollectRequest]) (*connect.Response[pb.DutchAuctionCollectResponse], error) {
 	var result []int64
-	if err := h.proxy.Client.Call(ctx, "dutch_auction_collect", req.Msg.DutchAuctionId, &result); err != nil {
+	if err := h.proxy.Client.Call(ctx, "dutch_auction_collect", []any{req.Msg.DutchAuctionId}, &result); err != nil {
 		return nil, err
 	}
 	resp := &pb.DutchAuctionCollectResponse{}

--- a/sidechain-orchestrator/sidechain/bitnames/client.go
+++ b/sidechain-orchestrator/sidechain/bitnames/client.go
@@ -181,7 +181,7 @@ func (c *Client) SidechainWealthSats(ctx context.Context) (int64, error) {
 
 // BitNameData retrieves data for a single BitName.
 func (c *Client) BitNameData(ctx context.Context, name string) (*BitNameData, error) {
-	raw, err := c.call(ctx, "bitname_data", name)
+	raw, err := c.call(ctx, "bitname_data", []any{name})
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -314,7 +314,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -181,7 +181,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil
@@ -221,7 +221,7 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil
@@ -229,7 +229,7 @@ func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[
 
 func (h *Handler) GetBitNameData(ctx context.Context, req *connect.Request[pb.GetBitNameDataRequest]) (*connect.Response[pb.GetBitNameDataResponse], error) {
 	var details nodeBitnameDetails
-	if err := h.proxy.Client.Call(ctx, "bitname_data", req.Msg.Name, &details); err != nil {
+	if err := h.proxy.Client.Call(ctx, "bitname_data", []any{req.Msg.Name}, &details); err != nil {
 		return nil, err
 	}
 	raw, err := json.Marshal(details.toClient())
@@ -343,7 +343,7 @@ func dataServerAddress(data BitNameData) (string, error) {
 
 func (h *Handler) ResolveCommit(ctx context.Context, req *connect.Request[pb.ResolveCommitRequest]) (*connect.Response[pb.ResolveCommitResponse], error) {
 	var details nodeBitnameDetails
-	if err := h.proxy.Client.Call(ctx, "bitname_data", req.Msg.Bitname, &details); err != nil {
+	if err := h.proxy.Client.Call(ctx, "bitname_data", []any{req.Msg.Bitname}, &details); err != nil {
 		return nil, err
 	}
 	data := details.toClient()

--- a/sidechain-orchestrator/sidechain/bitnames/rpc_params_test.go
+++ b/sidechain-orchestrator/sidechain/bitnames/rpc_params_test.go
@@ -3,8 +3,12 @@ package bitnames
 import (
 	"context"
 	"encoding/json"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -70,4 +74,57 @@ func TestEncryptMsgSendsTheKeyFirst(t *testing.T) {
 	_, err := client.EncryptMsg(context.Background(), "bn-enc1key", "the message")
 	require.NoError(t, err)
 	assert.JSONEq(t, `["bn-enc1key","the message"]`, string(*seen))
+}
+
+// JSON-RPC carries params as an array. A bare value reaches the node as
+// "Invalid params", so the call behind it never runs.
+func TestBitNameDataSendsAnArray(t *testing.T) {
+	srv, seen := recordParams(t, `{"seq_id":"1739-0029"}`)
+	defer srv.Close()
+
+	client := &Client{baseURL: srv.URL, http: srv.Client()}
+	_, err := client.BitNameData(context.Background(), "c2f54351")
+	require.NoError(t, err)
+	assert.JSONEq(t, `["c2f54351"]`, string(*seen))
+}
+
+func TestGetBlockSendsAnArray(t *testing.T) {
+	srv, seen := recordParams(t, `{"header":{}}`)
+	defer srv.Close()
+
+	client := &Client{baseURL: srv.URL, http: srv.Client()}
+	_, err := client.GetBlock(context.Background(), "2574f096")
+	require.NoError(t, err)
+	assert.JSONEq(t, `["2574f096"]`, string(*seen))
+}
+
+// The Dart client reaches the handler, not the typed client, so the handler
+// must send an array too. A bare value answers "Invalid params".
+func TestNoHandlerSendsABareParameter(t *testing.T) {
+	root := filepath.Join("..", "..", "sidechain")
+	// Only the params position matters. A trailing result argument must not
+	// exempt a bare value, so the allowance anchors on the method name too.
+	// A typed client calls c.call, and a handler calls Client.Call or CallRaw.
+	// Both reach the same node, so both must carry an array.
+	bare := regexp.MustCompile(`\.[Cc]all(Raw)?\(ctx, "[a-z_]+", (req\.Msg\.[A-Za-z]+|[a-z][A-Za-z]*)[,)]`)
+	allowed := regexp.MustCompile(`\.[Cc]all(Raw)?\(ctx, "[a-z_]+", (nil|params|body|request)[,)]`)
+
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, line := range strings.Split(string(source), "\n") {
+			if bare.MatchString(line) && !allowed.MatchString(line) {
+				offenders = append(offenders, strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, offenders, "every call must carry its params in an array")
 }

--- a/sidechain-orchestrator/sidechain/coinshift/client.go
+++ b/sidechain-orchestrator/sidechain/coinshift/client.go
@@ -176,7 +176,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -264,7 +264,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/coinshift/handler.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler.go
@@ -116,7 +116,7 @@ func (h *Handler) ListUtxos(ctx context.Context, req *connect.Request[pb.ListUtx
 }
 
 func (h *Handler) RemoveFromMempool(ctx context.Context, req *connect.Request[pb.RemoveFromMempoolRequest]) (*connect.Response[pb.RemoveFromMempoolResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", req.Msg.Txid, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", []any{req.Msg.Txid}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RemoveFromMempoolResponse{}), nil
@@ -139,7 +139,7 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil
@@ -186,7 +186,7 @@ func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.Conne
 }
 
 func (h *Handler) ForgetPeer(ctx context.Context, req *connect.Request[pb.ForgetPeerRequest]) (*connect.Response[pb.ForgetPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "forget_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "forget_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ForgetPeerResponse{}), nil
@@ -201,7 +201,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil
@@ -299,7 +299,7 @@ func (h *Handler) ListSwaps(ctx context.Context, req *connect.Request[pb.ListSwa
 }
 
 func (h *Handler) ListSwapsByRecipient(ctx context.Context, req *connect.Request[pb.ListSwapsByRecipientRequest]) (*connect.Response[pb.ListSwapsByRecipientResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "list_swaps_by_recipient", req.Msg.Recipient)
+	raw, err := h.proxy.Client.CallRaw(ctx, "list_swaps_by_recipient", []any{req.Msg.Recipient})
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/photon/client.go
+++ b/sidechain-orchestrator/sidechain/photon/client.go
@@ -176,7 +176,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -264,7 +264,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/photon/handler.go
+++ b/sidechain-orchestrator/sidechain/photon/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) ListUtxos(ctx context.Context, req *connect.Request[pb.ListUtx
 }
 
 func (h *Handler) RemoveFromMempool(ctx context.Context, req *connect.Request[pb.RemoveFromMempoolRequest]) (*connect.Response[pb.RemoveFromMempoolResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", req.Msg.Txid, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", []any{req.Msg.Txid}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RemoveFromMempoolResponse{}), nil
@@ -141,7 +141,7 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil
@@ -188,7 +188,7 @@ func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.Conne
 }
 
 func (h *Handler) ForgetPeer(ctx context.Context, req *connect.Request[pb.ForgetPeerRequest]) (*connect.Response[pb.ForgetPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "forget_peer", req.Msg.Address, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "forget_peer", []any{req.Msg.Address}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ForgetPeerResponse{}), nil
@@ -203,7 +203,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil

--- a/sidechain-orchestrator/sidechain/thunder/client.go
+++ b/sidechain-orchestrator/sidechain/thunder/client.go
@@ -176,7 +176,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -240,7 +240,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // RemoveFromMempool removes a transaction from the mempool.
 func (c *Client) RemoveFromMempool(ctx context.Context, txid string) error {
-	_, err := c.call(ctx, "remove_from_mempool", txid)
+	_, err := c.call(ctx, "remove_from_mempool", []any{txid})
 	return err
 }
 
@@ -250,7 +250,7 @@ func (c *Client) RemoveFromMempool(ctx context.Context, txid string) error {
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 
@@ -270,7 +270,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/thunder/handler.go
+++ b/sidechain-orchestrator/sidechain/thunder/handler.go
@@ -204,7 +204,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -229,14 +229,14 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil
 }
 
 func (h *Handler) RemoveFromMempool(ctx context.Context, req *connect.Request[pb.RemoveFromMempoolRequest]) (*connect.Response[pb.RemoveFromMempoolResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", req.Msg.Txid, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", []any{req.Msg.Txid}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RemoveFromMempoolResponse{}), nil
@@ -251,7 +251,7 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil

--- a/sidechain-orchestrator/sidechain/truthcoin/client.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/client.go
@@ -176,7 +176,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -264,7 +264,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/truthcoin/handler.go
+++ b/sidechain-orchestrator/sidechain/truthcoin/handler.go
@@ -114,7 +114,7 @@ func (h *Handler) ListUtxos(ctx context.Context, req *connect.Request[pb.ListUtx
 }
 
 func (h *Handler) RemoveFromMempool(ctx context.Context, req *connect.Request[pb.RemoveFromMempoolRequest]) (*connect.Response[pb.RemoveFromMempoolResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", req.Msg.Txid, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", []any{req.Msg.Txid}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RemoveFromMempoolResponse{}), nil
@@ -137,7 +137,7 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil
@@ -192,7 +192,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil
@@ -231,7 +231,7 @@ func (h *Handler) RefreshWallet(ctx context.Context, req *connect.Request[pb.Ref
 }
 
 func (h *Handler) GetTransaction(ctx context.Context, req *connect.Request[pb.GetTransactionRequest]) (*connect.Response[pb.GetTransactionResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_transaction", req.Msg.Txid)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_transaction", []any{req.Msg.Txid})
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (h *Handler) GetTransaction(ctx context.Context, req *connect.Request[pb.Ge
 }
 
 func (h *Handler) GetTransactionInfo(ctx context.Context, req *connect.Request[pb.GetTransactionInfoRequest]) (*connect.Response[pb.GetTransactionInfoResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_transaction_info", req.Msg.Txid)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_transaction_info", []any{req.Msg.Txid})
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (h *Handler) MarketList(ctx context.Context, req *connect.Request[pb.Market
 }
 
 func (h *Handler) MarketGet(ctx context.Context, req *connect.Request[pb.MarketGetRequest]) (*connect.Response[pb.MarketGetResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "market_get", req.Msg.MarketId)
+	raw, err := h.proxy.Client.CallRaw(ctx, "market_get", []any{req.Msg.MarketId})
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func (h *Handler) SlotList(ctx context.Context, req *connect.Request[pb.SlotList
 }
 
 func (h *Handler) SlotGet(ctx context.Context, req *connect.Request[pb.SlotGetRequest]) (*connect.Response[pb.SlotGetResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "slot_get", req.Msg.SlotId)
+	raw, err := h.proxy.Client.CallRaw(ctx, "slot_get", []any{req.Msg.SlotId})
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (h *Handler) VoteRegister(ctx context.Context, req *connect.Request[pb.Vote
 }
 
 func (h *Handler) VoteVoter(ctx context.Context, req *connect.Request[pb.VoteVoterRequest]) (*connect.Response[pb.VoteVoterResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "vote_voter", req.Msg.Address)
+	raw, err := h.proxy.Client.CallRaw(ctx, "vote_voter", []any{req.Msg.Address})
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (h *Handler) VoteList(ctx context.Context, req *connect.Request[pb.VoteList
 }
 
 func (h *Handler) VotePeriod(ctx context.Context, req *connect.Request[pb.VotePeriodRequest]) (*connect.Response[pb.VotePeriodResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "vote_period", req.Msg.PeriodId)
+	raw, err := h.proxy.Client.CallRaw(ctx, "vote_period", []any{req.Msg.PeriodId})
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (h *Handler) VotecoinTransfer(ctx context.Context, req *connect.Request[pb.
 
 func (h *Handler) VotecoinBalance(ctx context.Context, req *connect.Request[pb.VotecoinBalanceRequest]) (*connect.Response[pb.VotecoinBalanceResponse], error) {
 	var balance int64
-	if err := h.proxy.Client.Call(ctx, "votecoin_balance", req.Msg.Address, &balance); err != nil {
+	if err := h.proxy.Client.Call(ctx, "votecoin_balance", []any{req.Msg.Address}, &balance); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.VotecoinBalanceResponse{Balance: balance}), nil

--- a/sidechain-orchestrator/sidechain/zside/client.go
+++ b/sidechain-orchestrator/sidechain/zside/client.go
@@ -176,7 +176,7 @@ func (c *Client) GetBlockCount(ctx context.Context) (int, error) {
 
 // GetBlock returns block data for a given hash.
 func (c *Client) GetBlock(ctx context.Context, hash string) (json.RawMessage, error) {
-	return c.call(ctx, "get_block", hash)
+	return c.call(ctx, "get_block", []any{hash})
 }
 
 // GetBMMInclusions returns mainchain blocks that commit to the given block hash.
@@ -264,7 +264,7 @@ func (c *Client) GenerateMnemonic(ctx context.Context) (string, error) {
 
 // SetSeedFromMnemonic sets the wallet seed from a mnemonic phrase.
 func (c *Client) SetSeedFromMnemonic(ctx context.Context, mnemonic string) error {
-	_, err := c.call(ctx, "set_seed_from_mnemonic", mnemonic)
+	_, err := c.call(ctx, "set_seed_from_mnemonic", []any{mnemonic})
 	return err
 }
 

--- a/sidechain-orchestrator/sidechain/zside/handler.go
+++ b/sidechain-orchestrator/sidechain/zside/handler.go
@@ -110,7 +110,7 @@ func (h *Handler) ListUtxos(ctx context.Context, req *connect.Request[pb.ListUtx
 }
 
 func (h *Handler) RemoveFromMempool(ctx context.Context, req *connect.Request[pb.RemoveFromMempoolRequest]) (*connect.Response[pb.RemoveFromMempoolResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", req.Msg.Txid, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "remove_from_mempool", []any{req.Msg.Txid}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RemoveFromMempoolResponse{}), nil
@@ -133,7 +133,7 @@ func (h *Handler) GenerateMnemonic(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) SetSeedFromMnemonic(ctx context.Context, req *connect.Request[pb.SetSeedFromMnemonicRequest]) (*connect.Response[pb.SetSeedFromMnemonicResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", req.Msg.Mnemonic, nil); err != nil {
+	if err := h.proxy.Client.Call(ctx, "set_seed_from_mnemonic", []any{req.Msg.Mnemonic}, nil); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.SetSeedFromMnemonicResponse{}), nil
@@ -188,7 +188,7 @@ func (h *Handler) ListPeers(ctx context.Context, req *connect.Request[pb.ListPee
 }
 
 func (h *Handler) GetBlock(ctx context.Context, req *connect.Request[pb.GetBlockRequest]) (*connect.Response[pb.GetBlockResponse], error) {
-	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", req.Msg.Hash)
+	raw, err := h.proxy.Client.CallRaw(ctx, "get_block", []any{req.Msg.Hash})
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (h *Handler) GetBestSidechainBlockHash(ctx context.Context, req *connect.Re
 
 func (h *Handler) GetBmmInclusions(ctx context.Context, req *connect.Request[pb.GetBmmInclusionsRequest]) (*connect.Response[pb.GetBmmInclusionsResponse], error) {
 	var inclusions string
-	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", req.Msg.BlockHash, &inclusions); err != nil {
+	if err := h.proxy.Client.Call(ctx, "get_bmm_inclusions", []any{req.Msg.BlockHash}, &inclusions); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.GetBmmInclusionsResponse{Inclusions: inclusions}), nil


### PR DESCRIPTION
Users can read sidechain blocks, restore wallets, and resolve BitNames through sidechain RPCs.
