### PR TITLE
bitnames: exchange signed chat messages

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.336
+version: 1.0.337
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.336
+version: 1.0.337
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/models/chat_models.dart
+++ b/bitwindow/lib/models/chat_models.dart
@@ -10,20 +10,33 @@ class ChatMessage {
   final String content;
   final String senderPubkey;
   final String recipientPubkey;
+  final String? senderBitname;
+  final String? recipientBitname;
   final DateTime timestamp;
   final bool isOutgoing;
   final String? txid;
   final int? valueSats;
+
+  /// True while the message waits in the mempool. A block clears it.
+  final bool isPending;
+
+  /// True once the reader opens the conversation. It follows the same shape as
+  /// a NotificationItem, which the bell history already stores this way.
+  final bool read;
 
   ChatMessage({
     required this.id,
     required this.content,
     required this.senderPubkey,
     required this.recipientPubkey,
+    this.senderBitname,
+    this.recipientBitname,
     required this.timestamp,
     required this.isOutgoing,
     this.txid,
     this.valueSats,
+    this.isPending = false,
+    this.read = false,
   });
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) => ChatMessage(
@@ -31,10 +44,14 @@ class ChatMessage {
     content: json['content'] ?? '',
     senderPubkey: json['sender_pubkey'] ?? '',
     recipientPubkey: json['recipient_pubkey'] ?? '',
+    senderBitname: json['sender_bitname'],
+    recipientBitname: json['recipient_bitname'],
     timestamp: json['timestamp'] != null ? DateTime.fromMillisecondsSinceEpoch(json['timestamp']) : DateTime.now(),
     isOutgoing: json['is_outgoing'] ?? false,
     txid: json['txid'],
     valueSats: json['value_sats'],
+    isPending: json['is_pending'] ?? false,
+    read: json['read'] ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -42,10 +59,14 @@ class ChatMessage {
     'content': content,
     'sender_pubkey': senderPubkey,
     'recipient_pubkey': recipientPubkey,
+    'sender_bitname': senderBitname,
+    'recipient_bitname': recipientBitname,
     'timestamp': timestamp.millisecondsSinceEpoch,
     'is_outgoing': isOutgoing,
     'txid': txid,
     'value_sats': valueSats,
+    'is_pending': isPending,
+    'read': read,
   };
 
   ChatMessage copyWith({
@@ -53,20 +74,28 @@ class ChatMessage {
     String? content,
     String? senderPubkey,
     String? recipientPubkey,
+    String? senderBitname,
+    String? recipientBitname,
     DateTime? timestamp,
     bool? isOutgoing,
     String? txid,
     int? valueSats,
+    bool? isPending,
+    bool? read,
   }) {
     return ChatMessage(
       id: id ?? this.id,
       content: content ?? this.content,
       senderPubkey: senderPubkey ?? this.senderPubkey,
       recipientPubkey: recipientPubkey ?? this.recipientPubkey,
+      senderBitname: senderBitname ?? this.senderBitname,
+      recipientBitname: recipientBitname ?? this.recipientBitname,
       timestamp: timestamp ?? this.timestamp,
       isOutgoing: isOutgoing ?? this.isOutgoing,
       txid: txid ?? this.txid,
       valueSats: valueSats ?? this.valueSats,
+      isPending: isPending ?? this.isPending,
+      read: read ?? this.read,
     );
   }
 }
@@ -131,6 +160,7 @@ class ChatContact {
     int? paymailFeeSats,
     String? lastMessage,
     DateTime? lastMessageTime,
+    bool clearPreview = false,
     bool? isManual,
   }) {
     return ChatContact(
@@ -140,8 +170,8 @@ class ChatContact {
       encryptionPubkey: encryptionPubkey ?? this.encryptionPubkey,
       address: address ?? this.address,
       paymailFeeSats: paymailFeeSats ?? this.paymailFeeSats,
-      lastMessage: lastMessage ?? this.lastMessage,
-      lastMessageTime: lastMessageTime ?? this.lastMessageTime,
+      lastMessage: clearPreview ? null : lastMessage ?? this.lastMessage,
+      lastMessageTime: clearPreview ? null : lastMessageTime ?? this.lastMessageTime,
       isManual: isManual ?? this.isManual,
     );
   }

--- a/bitwindow/lib/pages/chat_page.dart
+++ b/bitwindow/lib/pages/chat_page.dart
@@ -130,10 +130,11 @@ class ChatPage extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     SizedBox(
-                      width: 280,
+                      width: 360,
                       // Contact list (inlined)
                       child: SailCard(
-                        title: 'Contacts',
+                        title: 'Chats',
+                        subtitle: 'You pay a name to reach it. They keep the postage.',
                         bottomPadding: false,
                         child: model.contacts.isEmpty
                             ? Center(
@@ -209,11 +210,31 @@ class ChatPage extends StatelessWidget {
                                               ],
                                             ),
                                           ),
-                                          if (contact.lastMessageTime != null)
-                                            SailText.secondary12(
-                                              _formatTime(contact.lastMessageTime!),
-                                              color: theme.colors.textTertiary,
-                                            ),
+                                          Column(
+                                            crossAxisAlignment: CrossAxisAlignment.end,
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              if (contact.lastMessageTime != null)
+                                                SailText.secondary12(
+                                                  _formatTime(contact.lastMessageTime!),
+                                                  color: theme.colors.textTertiary,
+                                                ),
+                                              if (model.unreadCount(contact.id) > 0) ...[
+                                                const SizedBox(height: SailStyleValues.padding04),
+                                                Container(
+                                                  padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+                                                  decoration: BoxDecoration(
+                                                    color: theme.colors.primary,
+                                                    borderRadius: BorderRadius.circular(10),
+                                                  ),
+                                                  child: SailText.secondary12(
+                                                    '${model.unreadCount(contact.id)}',
+                                                    color: theme.colors.background,
+                                                  ),
+                                                ),
+                                              ],
+                                            ],
+                                          ),
                                         ],
                                       ),
                                     ),
@@ -247,7 +268,9 @@ class ChatPage extends StatelessWidget {
                           : SailCard(
                               title: model.selectedContact!.displayName,
                               subtitle:
-                                  'Paymail fee: ${model.selectedContact!.paymailFeeSats ?? 1000} sats per message',
+                                  '${model.postageSats} ${activeTicker.subunit} to reach them, plus '
+                                  '${ChatProvider.networkFeeSats} ${activeTicker.subunit} network fee. '
+                                  'They keep the postage.',
                               bottomPadding: false,
                               child: Column(
                                 children: [
@@ -275,45 +298,62 @@ class ChatPage extends StatelessWidget {
                                             // Message bubble (inlined)
                                             final isOwn = message.isOutgoing;
 
+                                            // A message the mempool still holds reads as sent, not
+                                            // as delivered.
+                                            final bodyColor = isOwn ? theme.colors.background : theme.colors.text;
+                                            final metaColor = isOwn
+                                                ? theme.colors.background.withValues(alpha: 0.7)
+                                                : theme.colors.textTertiary;
+
                                             return Align(
                                               alignment: isOwn ? Alignment.centerRight : Alignment.centerLeft,
-                                              child: Container(
-                                                constraints: const BoxConstraints(maxWidth: 400),
-                                                margin: const EdgeInsets.symmetric(vertical: SailStyleValues.padding04),
-                                                padding: const EdgeInsets.all(SailStyleValues.padding12),
-                                                decoration: BoxDecoration(
-                                                  color: isOwn
-                                                      ? theme.colors.primary.withAlpha(30)
-                                                      : theme.colors.backgroundSecondary,
-                                                  borderRadius: BorderRadius.circular(12),
-                                                  border: Border.all(
-                                                    color: isOwn
-                                                        ? theme.colors.primary.withAlpha(50)
-                                                        : theme.colors.divider,
+                                              child: Opacity(
+                                                opacity: message.isPending ? 0.65 : 1,
+                                                child: Container(
+                                                  constraints: const BoxConstraints(maxWidth: 520),
+                                                  margin: const EdgeInsets.symmetric(
+                                                    vertical: SailStyleValues.padding04,
                                                   ),
-                                                ),
-                                                child: Column(
-                                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                                  children: [
-                                                    SailText.primary13(message.content),
-                                                    const SizedBox(height: SailStyleValues.padding04),
-                                                    Row(
-                                                      mainAxisSize: MainAxisSize.min,
-                                                      children: [
-                                                        SailText.secondary12(
-                                                          _formatMessageTime(message.timestamp),
-                                                          color: theme.colors.textTertiary,
-                                                        ),
-                                                        if (message.valueSats != null) ...[
-                                                          const SizedBox(width: SailStyleValues.padding08),
+                                                  padding: const EdgeInsets.symmetric(
+                                                    horizontal: SailStyleValues.padding12,
+                                                    vertical: SailStyleValues.padding08,
+                                                  ),
+                                                  decoration: BoxDecoration(
+                                                    color: isOwn
+                                                        ? theme.colors.primary
+                                                        : theme.colors.backgroundSecondary,
+                                                    borderRadius: BorderRadius.circular(14),
+                                                  ),
+                                                  child: Column(
+                                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                                    children: [
+                                                      SailText.primary13(message.content, color: bodyColor),
+                                                      const SizedBox(height: SailStyleValues.padding04),
+                                                      Row(
+                                                        mainAxisSize: MainAxisSize.min,
+                                                        children: [
                                                           SailText.secondary12(
-                                                            '${message.valueSats} ${activeTicker.subunit}',
-                                                            color: theme.colors.textTertiary,
+                                                            _formatMessageTime(message.timestamp),
+                                                            color: metaColor,
                                                           ),
+                                                          if (message.valueSats != null) ...[
+                                                            const SizedBox(width: SailStyleValues.padding08),
+                                                            SailText.secondary12(
+                                                              '${message.valueSats} ${activeTicker.subunit}',
+                                                              color: metaColor,
+                                                            ),
+                                                          ],
+                                                          if (message.isPending) ...[
+                                                            const SizedBox(width: SailStyleValues.padding08),
+                                                            SailText.secondary12(
+                                                              'waiting for a block',
+                                                              color: metaColor,
+                                                            ),
+                                                          ],
                                                         ],
-                                                      ],
-                                                    ),
-                                                  ],
+                                                      ),
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
                                             );
@@ -337,7 +377,7 @@ class ChatPage extends StatelessWidget {
                                       ),
                                       const SizedBox(width: SailStyleValues.padding08),
                                       SailButton(
-                                        label: 'Send',
+                                        label: 'Send · ${model.messageCostSats} ${activeTicker.subunit}',
                                         loading: model.isSending,
                                         disabled: model.messageController.text.isEmpty,
                                         onPressed: model.sendMessage,
@@ -735,6 +775,7 @@ class ChatViewModel extends BaseViewModel {
   final ChatProvider _chatProvider = GetIt.I.get<ChatProvider>();
   final BitnamesRPC _bitnamesRPC = GetIt.I.get<BitnamesRPC>();
   final TextEditingController messageController = TextEditingController();
+  late int _walletChange;
 
   bool get isConnected => _bitnamesRPC.connected;
 
@@ -749,6 +790,13 @@ class ChatViewModel extends BaseViewModel {
   List<ChatMessage> get currentConversation => _chatProvider.currentConversation;
 
   bool get isSending => _chatProvider.isSending;
+
+  /// How many messages of one conversation the reader has not opened.
+  int unreadCount(String contactId) => _chatProvider.unreadCount(contactId);
+
+  /// The postage the reader keeps, and what one message costs the wallet.
+  int get postageSats => _chatProvider.postageSats;
+  int get messageCostSats => _chatProvider.messageCostSats;
   String? get chatError => _chatProvider.error;
 
   bool get isClaiming => _chatProvider.isClaiming;
@@ -756,6 +804,7 @@ class ChatViewModel extends BaseViewModel {
   List<StatusMessage> get statusMessages => _chatProvider.statusMessages;
 
   ChatViewModel() {
+    _walletChange = _chatProvider.walletChange;
     _chatProvider.addListener(_onProviderChanged);
     _bitnamesRPC.addListener(_onConnectionChanged);
     messageController.addListener(notifyListeners);
@@ -768,6 +817,11 @@ class ChatViewModel extends BaseViewModel {
   }
 
   void _onProviderChanged() {
+    final walletChange = _chatProvider.walletChange;
+    if (walletChange != _walletChange) {
+      _walletChange = walletChange;
+      messageController.clear();
+    }
     notifyListeners();
   }
 
@@ -819,11 +873,11 @@ class ChatViewModel extends BaseViewModel {
     }
 
     final content = messageController.text;
+    final walletChange = _chatProvider.walletChange;
     messageController.clear();
 
     final txid = await _chatProvider.sendMessage(content);
-    if (txid == null && _chatProvider.error != null) {
-      // Message failed, restore text
+    if (walletChange == _chatProvider.walletChange && txid == null && _chatProvider.error != null) {
       messageController.text = content;
     }
   }

--- a/bitwindow/lib/providers/chat_provider.dart
+++ b/bitwindow/lib/providers/chat_provider.dart
@@ -2,15 +2,28 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:bitwindow/models/chat_models.dart';
+import 'package:bitwindow/services/bitnames_secure_store.dart';
+import 'package:bitwindow/services/bitnames_message.dart';
+import 'package:bitwindow/services/chat_file_storage.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:thirds/blake3.dart';
 
 class ChatProvider extends ChangeNotifier {
   BitnamesRPC get bitnamesRPC => GetIt.I.get<BitnamesRPC>();
+  Logger get log => GetIt.I.get<Logger>();
   BalanceProvider get balanceProvider => GetIt.I.get<BalanceProvider>();
   final ClientSettings _clientSettings = GetIt.I.get<ClientSettings>();
+  final WalletReaderProvider? _walletReader = GetIt.I.isRegistered<WalletReaderProvider>()
+      ? GetIt.I.get<WalletReaderProvider>()
+      : null;
+  late (String?, bool) _walletState;
+  int _walletChange = 0;
+  int get walletChange => _walletChange;
 
   List<BitnameEntry> _allBitNames = [];
   List<BitnameEntry> get allBitNames => _allBitNames;
@@ -33,10 +46,10 @@ class ChatProvider extends ChangeNotifier {
   BitnameEntry? get selectedIdentity => _selectedIdentity;
 
   List<ChatContact> _contacts = [];
-  List<ChatContact> get contacts => _contacts;
+  List<ChatContact> get contacts => _contacts.map(_withPreview).toList();
 
   ChatContact? _selectedContact;
-  ChatContact? get selectedContact => _selectedContact;
+  ChatContact? get selectedContact => _selectedContact == null ? null : _withPreview(_selectedContact!);
 
   final List<ChatMessage> _messages = [];
   List<ChatMessage> get messages => _messages;
@@ -45,15 +58,49 @@ class ChatProvider extends ChangeNotifier {
     if (_selectedContact == null || _selectedIdentity == null) {
       return [];
     }
-    return _messages.where((m) {
-      final isWithContact =
-          m.senderPubkey == _selectedContact!.encryptionPubkey ||
-          m.recipientPubkey == _selectedContact!.encryptionPubkey;
-      final isFromMyIdentity =
-          m.senderPubkey == _selectedIdentity!.details.encryptionPubkey ||
-          m.recipientPubkey == _selectedIdentity!.details.encryptionPubkey;
-      return isWithContact && isFromMyIdentity;
-    }).toList()..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return _messages.where((m) => _withContact(m, _selectedContact!) && _withIdentity(m)).toList()
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+  }
+
+  bool _withIdentity(ChatMessage message) {
+    final identity = _selectedIdentity;
+    if (identity == null) {
+      return false;
+    }
+    return message.isOutgoing
+        ? (message.senderBitname != null
+              ? message.senderBitname == identity.hash
+              : message.senderPubkey == identity.details.encryptionPubkey)
+        : (message.recipientBitname != null
+              ? message.recipientBitname == identity.hash
+              : message.recipientPubkey == identity.details.encryptionPubkey);
+  }
+
+  ChatContact _withPreview(ChatContact contact) {
+    ChatMessage? last;
+    for (final message in _messages) {
+      if (_withIdentity(message) &&
+          _withContact(message, contact) &&
+          (last == null || !message.timestamp.isBefore(last.timestamp))) {
+        last = message;
+      }
+    }
+    return contact.copyWith(
+      lastMessage: last?.content,
+      lastMessageTime: last?.timestamp,
+      clearPreview: last == null,
+    );
+  }
+
+  bool _withContact(ChatMessage message, ChatContact contact) {
+    final hash = contact.encryptionPubkey.isEmpty ? null : BitnamesMessage.nameHash(contact.id);
+    return message.isOutgoing
+        ? (message.recipientBitname != null
+              ? message.recipientBitname == hash
+              : message.recipientPubkey == contact.encryptionPubkey)
+        : (message.senderBitname != null
+              ? message.senderBitname == hash
+              : message.senderPubkey == contact.encryptionPubkey || message.senderPubkey == contact.address);
   }
 
   final bool _isLoading = false;
@@ -65,13 +112,50 @@ class ChatProvider extends ChangeNotifier {
   bool _isSending = false;
   bool get isSending => _isSending;
 
+  /// The postage the selected reader accepts.
+  int get postageSats => _selectedContact?.paymailFeeSats ?? defaultPostageSats;
+
+  /// What one message takes out of the wallet. The reader keeps the postage,
+  /// and the network takes the fee.
+  int get messageCostSats => postageSats + networkFeeSats;
+
   Timer? _pollTimer;
   static const _pollInterval = Duration(seconds: 30);
 
-  ChatProvider() {
+  /// What a message costs the sender, beyond the postage the reader keeps.
+  static const networkFeeSats = 100;
+
+  /// The postage a reader accepts. A message that pays less stays hidden.
+  static const defaultPostageSats = 1000;
+
+  ChatProvider({BitnamesSecureStore? store}) : _secureStore = store {
+    _walletState = (_walletReader?.activeWalletId, _walletReader?.isWalletUnlocked ?? true);
+    _walletReader?.addListener(_onWalletChanged);
     bitnamesRPC.addListener(_onConnectionChanged);
     balanceProvider.addListener(_onBalanceChanged);
-    _init();
+    if (bitnamesRPC.connected) {
+      unawaited(_init());
+    }
+  }
+
+  void _onWalletChanged() {
+    final state = (_walletReader?.activeWalletId, _walletReader?.isWalletUnlocked ?? true);
+    if (state == _walletState) {
+      return;
+    }
+    _walletState = state;
+    _walletChange++;
+    _messages.clear();
+    _contacts = [];
+    _selectedContact = null;
+    _selectedIdentity = null;
+    _myIdentities = [];
+    _ownedHashes = {};
+    _statusMessages.clear();
+    _error = null;
+    _isSending = false;
+    notifyListeners();
+    unawaited(_init());
   }
 
   void _onConnectionChanged() {
@@ -86,33 +170,43 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> _init() async {
-    if (!bitnamesRPC.connected) {
+    final walletChange = _walletChange;
+    if (!_walletState.$2) {
       return;
     }
-    await Future.wait([
-      fetchIdentities(),
-      _loadContacts(),
-    ]);
+    await Future.wait([if (bitnamesRPC.connected) fetchIdentities(), _loadContacts()]);
+    if (walletChange != _walletChange) {
+      return;
+    }
+    await _loadMessages();
   }
 
   Future<void> fetchIdentities() async {
+    final walletChange = _walletChange;
+    if (!_walletState.$2) {
+      return;
+    }
     // Load cached data first for quick startup
     await _loadCachedData();
 
-    if (!bitnamesRPC.connected) {
+    if (!bitnamesRPC.connected || walletChange != _walletChange) {
       return;
     }
 
     try {
       // Load hash-name mappings for friendly names
       final loadedMapping = await _clientSettings.getValue(HashNameMappingSetting());
-      _hashNameMapping = loadedMapping as HashNameMappingSetting;
 
       // Fetch all BitNames (for lookup and search)
-      _allBitNames = await bitnamesRPC.listBitNames();
+      final allBitNames = await bitnamesRPC.listBitNames();
 
       // Get wallet UTXOs and find owned BitNames
       final utxos = await bitnamesRPC.listUTXOs();
+      if (walletChange != _walletChange) {
+        return;
+      }
+      _hashNameMapping = loadedMapping as HashNameMappingSetting;
+      _allBitNames = allBitNames;
       final ownedHashes = <String>{};
 
       for (final utxo in utxos) {
@@ -133,6 +227,9 @@ class ChatProvider extends ChangeNotifier {
       // Save owned hashes for quick startup next time
       _ownedHashes = ownedHashes;
       await _saveOwnedHashes();
+      if (walletChange != _walletChange) {
+        return;
+      }
 
       // Match owned hashes to full BitName entries
       _myIdentities = _allBitNames.where((entry) => _ownedHashes.contains(entry.hash)).toList();
@@ -143,19 +240,26 @@ class ChatProvider extends ChangeNotifier {
       }
       notifyListeners();
     } catch (e) {
+      if (walletChange != _walletChange) {
+        return;
+      }
       _error = 'Failed to fetch identities: $e';
       notifyListeners();
     }
   }
 
   Future<void> _loadCachedData() async {
+    final walletChange = _walletChange;
     try {
       // Load hash-name mappings
       final loadedMapping = await _clientSettings.getValue(HashNameMappingSetting());
-      _hashNameMapping = loadedMapping as HashNameMappingSetting;
 
       // Load cached owned hashes
       final ownedSetting = await _clientSettings.getValue(OwnedBitNamesSetting());
+      if (walletChange != _walletChange) {
+        return;
+      }
+      _hashNameMapping = loadedMapping as HashNameMappingSetting;
       _ownedHashes = ownedSetting.value.toSet();
 
       notifyListeners();
@@ -221,6 +325,10 @@ class ChatProvider extends ChangeNotifier {
 
   void selectIdentity(BitnameEntry identity) {
     _selectedIdentity = identity;
+    final contact = _selectedContact;
+    if (contact != null) {
+      unawaited(markConversationRead(contact.id));
+    }
     notifyListeners();
     fetchPaymail();
   }
@@ -288,10 +396,7 @@ class ChatProvider extends ChangeNotifier {
         try {
           txid = await bitnamesRPC.registerBitName(
             plaintextName,
-            BitNameData(
-              encryptionPubkey: encryptionPubkey,
-              paymailFeeSats: 1000,
-            ),
+            BitNameData(encryptionPubkey: encryptionPubkey, paymailFeeSats: 1000),
           );
         } catch (e) {
           final errorStr = e.toString().toLowerCase();
@@ -333,19 +438,108 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> _loadContacts() async {
+    final walletChange = _walletChange;
     try {
       final setting = ChatContactsSetting();
       final loaded = await _clientSettings.getValue(setting);
+      if (walletChange != _walletChange) {
+        return;
+      }
       _contacts = loaded.value;
+      await _saveContacts();
       notifyListeners();
     } catch (e) {
-      _contacts = [];
+      if (walletChange != _walletChange) {
+        return;
+      }
+      _error = 'Could not read contact settings: $e';
+      notifyListeners();
     }
   }
 
   Future<void> _saveContacts() async {
     final setting = ChatContactsSetting(newValue: _contacts);
     await _clientSettings.setValue(setting);
+  }
+
+  /// The messages live encrypted at rest, under a key the wallet derives. A
+  /// chat holds private text, and the chain never gives a sent message back.
+  BitnamesSecureStore? _secureStore;
+
+  Future<BitnamesSecureStore?> _store() async {
+    if (_secureStore != null) {
+      return _secureStore;
+    }
+    if (!GetIt.I.isRegistered<WalletReaderProvider>()) {
+      return null;
+    }
+    final directory = await getApplicationSupportDirectory();
+    _secureStore = BitnamesSecureStore(
+      store: ChatFileStorage.fromDirectory(directory),
+      keySource: WalletBitnamesStorageKeySource(GetIt.I.get<WalletReaderProvider>()),
+    );
+    return _secureStore;
+  }
+
+  Future<void> _loadMessages() async {
+    final walletChange = _walletChange;
+    try {
+      final store = await _store();
+      if (store == null) {
+        return;
+      }
+      final state = await store.load();
+      if (walletChange != _walletChange) {
+        return;
+      }
+      final stored = state['messages'] as List<dynamic>? ?? const [];
+      final oldMessages = stored
+          .map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))
+          .where((m) => !m.isOutgoing && m.senderBitname == null)
+          .toList();
+      final oldSenders = oldMessages.map((m) => m.senderPubkey).where((sender) => sender != 'unknown').toSet();
+      _contacts.removeWhere((c) => !c.isManual && c.encryptionPubkey.isEmpty && oldSenders.contains(c.address));
+      _messages
+        ..clear()
+        ..addAll(
+          stored.map((e) {
+            final message = ChatMessage.fromJson(e as Map<String, dynamic>);
+            return !message.isOutgoing && message.senderBitname == null
+                ? message.copyWith(senderPubkey: 'unknown')
+                : message;
+          }),
+        );
+      final unknown = _messages.lastWhereOrNull((m) => !m.isOutgoing && m.senderBitname == null);
+      if (unknown != null) {
+        await addContact(
+          ChatContact(
+            id: 'unknown',
+            name: 'Unknown sender',
+            encryptionPubkey: '',
+            address: 'unknown',
+          ),
+        );
+        if (walletChange != _walletChange) {
+          return;
+        }
+      }
+      notifyListeners();
+    } catch (e) {
+      if (walletChange != _walletChange) {
+        return;
+      }
+      _error = 'Could not read stored messages: $e';
+      notifyListeners();
+    }
+  }
+
+  Future<void> _saveMessages() async {
+    final walletChange = _walletChange;
+    final store = await _store();
+    if (store == null || walletChange != _walletChange) {
+      return;
+    }
+    await store.save({'messages': _messages.map((m) => m.toJson()).toList()});
   }
 
   Future<void> addContact(ChatContact contact) async {
@@ -376,8 +570,16 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
-    // Get an address for sending to this contact
-    final address = await bitnamesRPC.getNewAddress();
+    // A message pays the holder of the BitName. A fresh address of this
+    // wallet pays nobody.
+    final String address;
+    try {
+      address = await bitnamesRPC.getBitNameOwner(entry.hash);
+    } catch (e) {
+      _error = 'Could not find who holds ${entry.plaintextName ?? entry.hash}: $e';
+      notifyListeners();
+      return;
+    }
 
     final contact = ChatContact(
       id: entry.hash,
@@ -395,105 +597,271 @@ class ChatProvider extends ChangeNotifier {
   void selectContact(ChatContact contact) {
     _selectedContact = contact;
     notifyListeners();
+    unawaited(markConversationRead(contact.id));
+  }
+
+  /// Counts the messages from one contact that the reader has not opened.
+  int unreadCount(String contactId) {
+    return _messages.where((m) => !m.isOutgoing && !m.read && _belongsTo(m, contactId)).length;
+  }
+
+  /// Marks every message of one conversation read, the way the bell history
+  /// marks a notification read.
+  Future<void> markConversationRead(String contactId) async {
+    var changed = false;
+    for (var i = 0; i < _messages.length; i++) {
+      final message = _messages[i];
+      if (message.read || message.isOutgoing || !_belongsTo(message, contactId)) {
+        continue;
+      }
+      _messages[i] = message.copyWith(read: true);
+      changed = true;
+    }
+    if (!changed) {
+      return;
+    }
+    await _saveMessages();
+    notifyListeners();
+  }
+
+  bool _belongsTo(ChatMessage message, String contactId) {
+    final contact = _contacts.firstWhereOrNull((c) => c.id == contactId);
+    if (contact == null) {
+      return false;
+    }
+    final identity = _selectedIdentity;
+    if (identity == null ||
+        (message.recipientBitname != null
+            ? message.recipientBitname != identity.hash
+            : message.recipientPubkey != identity.details.encryptionPubkey)) {
+      return false;
+    }
+    return _withContact(message, contact);
   }
 
   Future<void> fetchPaymail() async {
-    if (!bitnamesRPC.connected || _selectedIdentity == null) {
+    final walletChange = _walletChange;
+    final identity = _selectedIdentity;
+    if (!bitnamesRPC.connected || identity == null) {
+      return;
+    }
+
+    PendingPaymail? pending;
+    final errors = <String>[];
+    try {
+      pending = await bitnamesRPC.getPendingPaymail();
+      if (walletChange != _walletChange) {
+        return;
+      }
+      errors.addAll(await _processPaymail(pending.entries, identity, pending: true));
+    } catch (e) {
+      errors.add('Could not read pending paymail: $e');
+    }
+    if (walletChange != _walletChange) {
+      return;
+    }
+
+    var confirmedRead = false;
+    try {
+      final paymail = await bitnamesRPC.getPaymail();
+      if (walletChange != _walletChange) {
+        return;
+      }
+      errors.addAll(await _processPaymail(paymail, identity));
+      confirmedRead = true;
+    } catch (e) {
+      errors.add('Could not read confirmed paymail: $e');
+    }
+    if (walletChange != _walletChange) {
       return;
     }
 
     try {
-      final paymail = await bitnamesRPC.getPaymail();
-      await _processPaymail(paymail);
-    } catch (e) {
-      _error = 'Failed to fetch paymail: $e';
-      notifyListeners();
-    }
-  }
-
-  Future<void> _processPaymail(Map<String, dynamic> paymail) async {
-    if (paymail.isEmpty || _selectedIdentity == null) {
-      return;
-    }
-
-    final myEncryptionPubkey = _selectedIdentity!.details.encryptionPubkey;
-    if (myEncryptionPubkey == null) {
-      return;
-    }
-
-    for (final entry in paymail.entries) {
-      final outpointKey = entry.key;
-      final data = entry.value as Map<String, dynamic>;
-
-      // Skip if we already have this message
-      if (_messages.any((m) => m.id == outpointKey)) {
-        continue;
-      }
-
-      final senderAddress = data['address'] as String;
-      final content = data['content'] as Map<String, dynamic>;
-      final memoBytes = data['memo'] as List<dynamic>;
-
-      // Skip if no memo (no message content)
-      if (memoBytes.isEmpty) {
-        continue;
-      }
-
-      // Extract value from content (BitcoinSats format)
-      int? valueSats;
-      if (content.containsKey('BitcoinSats')) {
-        valueSats = content['BitcoinSats'] as int?;
-      }
-
-      // Convert memo bytes to hex string (ciphertext)
-      final ciphertext = memoBytes.map((b) => (b as int).toRadixString(16).padLeft(2, '0')).join();
-
-      try {
-        // Decrypt the message using our encryption key
-        final plaintext = await bitnamesRPC.decryptMsg(
-          ciphertext: ciphertext,
-          encryptionPubkey: myEncryptionPubkey,
-        );
-
-        // Create ChatMessage
-        final message = ChatMessage(
-          id: outpointKey,
-          content: plaintext,
-          senderPubkey: senderAddress,
-          recipientPubkey: myEncryptionPubkey,
-          timestamp: DateTime.now(),
-          isOutgoing: false,
-          txid: outpointKey,
-          valueSats: valueSats,
-        );
-        _messages.add(message);
-
-        // Update contact's last message if we have them as a contact
-        final contactIndex = _contacts.indexWhere((c) => c.address == senderAddress);
-        if (contactIndex >= 0) {
-          _contacts[contactIndex] = _contacts[contactIndex].copyWith(
-            lastMessage: plaintext,
-            lastMessageTime: DateTime.now(),
-          );
-          await _saveContacts();
+      if (pending != null) {
+        if (confirmedRead) {
+          await _dropEvictedPending(pending.entries.keys.toSet(), identity);
         }
-      } catch (e) {
-        // Failed to decrypt - may not be intended for us or invalid
+        if (walletChange != _walletChange) {
+          return;
+        }
+        await _settleOutgoing(pending.mempoolTxids);
       }
+    } catch (e) {
+      errors.add('Could not save paymail: $e');
     }
-
+    if (walletChange != _walletChange) {
+      return;
+    }
+    _error = errors.isEmpty ? null : errors.join('; ');
     notifyListeners();
   }
 
+  Future<List<String>> _processPaymail(
+    Map<String, dynamic> paymail,
+    BitnameEntry identity, {
+    bool pending = false,
+  }) async {
+    final walletChange = _walletChange;
+    final myEncryptionPubkey = identity.details.encryptionPubkey;
+    if (myEncryptionPubkey == null) {
+      return [];
+    }
+    final errors = <String>[];
+    for (final entry in paymail.entries) {
+      try {
+        await _processPaymailEntry(entry, identity, myEncryptionPubkey, pending: pending);
+      } on FormatException catch (e) {
+        errors.add('Rejected paymail ${entry.key}: ${e.message}');
+      }
+      if (walletChange != _walletChange) {
+        return [];
+      }
+    }
+    notifyListeners();
+    return errors;
+  }
+
+  Future<void> _processPaymailEntry(
+    MapEntry<String, dynamic> entry,
+    BitnameEntry identity,
+    String myEncryptionPubkey, {
+    required bool pending,
+  }) async {
+    final walletChange = _walletChange;
+    final outpointKey = entry.key;
+    final data = entry.value as Map<String, dynamic>;
+    final seen = _messages.indexWhere((m) => m.txid == outpointKey || m.id == outpointKey);
+    if (seen >= 0) {
+      if (!pending && _messages[seen].isPending) {
+        _messages[seen] = _messages[seen].copyWith(isPending: false);
+        await _saveMessages();
+      }
+      return;
+    }
+
+    final memo = data['memo'];
+    final String ciphertext;
+    if (memo is String) {
+      ciphertext = memo;
+    } else if (memo is List) {
+      ciphertext = memo.map((b) => (b as int).toRadixString(16).padLeft(2, '0')).join();
+    } else {
+      throw const FormatException('Invalid paymail memo');
+    }
+    if (ciphertext.isEmpty) {
+      return;
+    }
+
+    final String plaintext;
+    try {
+      plaintext = await bitnamesRPC.decryptMsg(ciphertext: ciphertext, encryptionPubkey: myEncryptionPubkey);
+    } catch (_) {
+      return;
+    }
+    if (walletChange != _walletChange) {
+      return;
+    }
+
+    final memoMessage = BitnamesMessage.decode(plaintext);
+    if (memoMessage != null && memoMessage.recipient != identity.hash) {
+      return;
+    }
+    final recipientAddress = await bitnamesRPC.getBitNameOwner(identity.hash);
+    if (walletChange != _walletChange) {
+      return;
+    }
+    if (data['address'] != recipientAddress) {
+      if (memoMessage == null) {
+        return;
+      }
+      throw const FormatException('The payment address does not match the recipient BitName owner');
+    }
+    final String messageId;
+    final ChatContact contact;
+    if (memoMessage == null) {
+      messageId = outpointKey;
+      contact = ChatContact(id: 'unknown', name: 'Unknown sender', encryptionPubkey: '', address: 'unknown');
+    } else {
+      final owner = await memoMessage.checkSender(bitnamesRPC, identity.hash);
+      final sender = await bitnamesRPC.getBitNameData(memoMessage.sender);
+      if (walletChange != _walletChange) {
+        return;
+      }
+      if (sender?.encryptionPubkey == null) {
+        throw const FormatException('The sender BitName has no encryption key');
+      }
+      messageId = memoMessage.storeId;
+      final duplicate = _messages.indexWhere((m) => m.id == messageId);
+      if (duplicate >= 0) {
+        if (!pending && _messages[duplicate].isPending) {
+          _messages[duplicate] = _messages[duplicate].copyWith(isPending: false, txid: outpointKey);
+          await _saveMessages();
+        }
+        return;
+      }
+      final oldContact = _contacts.firstWhereOrNull((c) => c.id == memoMessage.sender);
+      contact = ChatContact(
+        id: memoMessage.sender,
+        name: memoMessage.sender,
+        plaintextName:
+            oldContact?.plaintextName ??
+            _allBitNames.firstWhereOrNull((b) => b.hash == memoMessage.sender)?.plaintextName,
+        encryptionPubkey: sender!.encryptionPubkey!,
+        address: owner,
+        paymailFeeSats: sender.paymailFeeSats,
+        isManual: oldContact?.isManual ?? false,
+      );
+    }
+
+    final content = data['content'] as Map<String, dynamic>;
+    final message = ChatMessage(
+      id: messageId,
+      content: memoMessage?.text ?? plaintext,
+      senderPubkey: memoMessage == null ? contact.address : contact.encryptionPubkey,
+      recipientPubkey: myEncryptionPubkey,
+      senderBitname: memoMessage?.sender,
+      recipientBitname: identity.hash,
+      timestamp: DateTime.now(),
+      isOutgoing: false,
+      txid: outpointKey,
+      valueSats: content['BitcoinSats'] as int?,
+      isPending: pending,
+      read: _selectedContact?.id == contact.id && _selectedIdentity?.hash == identity.hash,
+    );
+    _messages.add(message);
+    await _saveMessages();
+    if (walletChange != _walletChange) {
+      return;
+    }
+    await addContact(contact);
+    if (walletChange != _walletChange) {
+      return;
+    }
+    if (_selectedContact?.id == contact.id) {
+      _selectedContact = contact;
+    }
+  }
+
   Future<String?> sendMessage(String content) async {
-    if (_selectedContact == null || _selectedIdentity == null) {
+    final walletChange = _walletChange;
+    final identity = _selectedIdentity;
+    final selectedContact = _selectedContact;
+    if (selectedContact == null || identity == null) {
       _error = 'No contact or identity selected';
       notifyListeners();
       return null;
     }
+    final quotedPostage = selectedContact.paymailFeeSats ?? defaultPostageSats;
 
-    if (_selectedIdentity!.details.encryptionPubkey == null) {
-      _error = 'Selected identity has no encryption key';
+    final senderKey = identity.details.encryptionPubkey;
+    if (senderKey == null) {
+      _error = 'The selected identity has no encryption key';
+      notifyListeners();
+      return null;
+    }
+
+    if (selectedContact.encryptionPubkey.isEmpty) {
+      _error = 'This message has no known sender BitName. Add the sender by BitName before a reply.';
       notifyListeners();
       return null;
     }
@@ -502,52 +870,146 @@ class ChatProvider extends ChangeNotifier {
     _error = null;
     notifyListeners();
 
+    String? txid;
     try {
-      // 1. Encrypt the message with recipient's pubkey
-      final ciphertext = await bitnamesRPC.encryptMsg(
-        msg: content,
-        encryptionPubkey: _selectedContact!.encryptionPubkey,
+      final recipientHash = BitnamesMessage.nameHash(selectedContact.id);
+      final recipient = await bitnamesRPC.getBitNameData(recipientHash);
+      if (walletChange != _walletChange) {
+        return null;
+      }
+      if (recipient?.encryptionPubkey == null) {
+        throw const FormatException('The recipient BitName has no encryption key');
+      }
+      final value = recipient!.paymailFeeSats;
+      if (value == null) {
+        throw const FormatException('The recipient BitName has no inbox');
+      }
+      if (value > quotedPostage) {
+        final contact = selectedContact.copyWith(paymailFeeSats: value);
+        if (_selectedContact?.id == contact.id) {
+          _selectedContact = contact;
+        }
+        await addContact(contact);
+        if (walletChange == _walletChange) {
+          _error = 'The postage increased to $value sats. Select Send again to accept the new cost.';
+        }
+        return null;
+      }
+      final address = await bitnamesRPC.getBitNameOwner(recipientHash);
+      final memoMessage = await BitnamesMessage.sign(
+        rpc: bitnamesRPC,
+        sender: identity.hash,
+        recipient: recipientHash,
+        text: content,
       );
-
-      // 2. Send as transfer with memo
-      final txid = await bitnamesRPC.transfer(
-        dest: _selectedContact!.address,
-        value: _selectedContact!.paymailFeeSats ?? 1000,
-        fee: 100,
+      final ciphertext = await bitnamesRPC.encryptMsg(
+        msg: memoMessage.encode(),
+        encryptionPubkey: recipient.encryptionPubkey!,
+      );
+      if (walletChange != _walletChange) {
+        return null;
+      }
+      txid = await bitnamesRPC.transfer(
+        dest: address,
+        value: value,
+        fee: networkFeeSats,
         memo: ciphertext,
       );
+      if (walletChange != _walletChange) {
+        return _reportLateSend(txid);
+      }
 
-      // 3. Add to local message list
       final message = ChatMessage(
-        id: txid,
+        id: memoMessage.storeId,
         content: content,
-        senderPubkey: _selectedIdentity!.details.encryptionPubkey!,
-        recipientPubkey: _selectedContact!.encryptionPubkey,
+        senderPubkey: senderKey,
+        recipientPubkey: recipient.encryptionPubkey!,
+        senderBitname: identity.hash,
+        recipientBitname: recipientHash,
         timestamp: DateTime.now(),
         isOutgoing: true,
         txid: txid,
-        valueSats: _selectedContact!.paymailFeeSats ?? 1000,
+        valueSats: value,
+        isPending: true,
       );
       _messages.add(message);
+      await _saveMessages();
+      if (walletChange != _walletChange) {
+        return _reportLateSend(txid);
+      }
 
-      // 4. Update contact's last message
-      final contactIndex = _contacts.indexWhere((c) => c.id == _selectedContact!.id);
+      final contactIndex = _contacts.indexWhere((c) => c.id == selectedContact.id);
       if (contactIndex >= 0) {
-        _contacts[contactIndex] = _contacts[contactIndex].copyWith(
-          lastMessage: content,
-          lastMessageTime: DateTime.now(),
+        final contact = _contacts[contactIndex].copyWith(
+          encryptionPubkey: recipient.encryptionPubkey,
+          address: address,
+          paymailFeeSats: value,
         );
+        _contacts[contactIndex] = contact;
+        if (_selectedContact?.id == selectedContact.id) {
+          _selectedContact = contact;
+        }
         await _saveContacts();
+      }
+      if (walletChange != _walletChange) {
+        return _reportLateSend(txid);
       }
 
       notifyListeners();
       return txid;
     } catch (e) {
-      _error = 'Failed to send message: $e';
+      if (walletChange != _walletChange) {
+        return txid == null ? null : _reportLateSend(txid);
+      }
+      _error = 'Could not send the message: $e';
       notifyListeners();
       return null;
     } finally {
-      _isSending = false;
+      if (walletChange == _walletChange) {
+        _isSending = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  String _reportLateSend(String txid) {
+    _error = 'The node accepted the message. The wallet change stopped the local history save.';
+    notifyListeners();
+    return txid;
+  }
+
+  Future<void> _dropEvictedPending(Set<String> stillPending, BitnameEntry identity) async {
+    final before = _messages.length;
+    _messages.removeWhere(
+      (m) =>
+          m.isPending &&
+          !m.isOutgoing &&
+          (m.recipientBitname != null
+              ? m.recipientBitname == identity.hash
+              : m.recipientPubkey == identity.details.encryptionPubkey) &&
+          !stillPending.contains(m.txid ?? m.id),
+    );
+    if (_messages.length != before) {
+      await _saveMessages();
+      notifyListeners();
+    }
+  }
+
+  Future<void> _settleOutgoing(Set<String> mempoolTxids) async {
+    var changed = false;
+    for (var i = 0; i < _messages.length; i++) {
+      final message = _messages[i];
+      if (!message.isOutgoing || !message.isPending) {
+        continue;
+      }
+      if (message.txid != null && mempoolTxids.contains(message.txid)) {
+        continue;
+      }
+      _messages[i] = message.copyWith(isPending: false);
+      changed = true;
+    }
+    if (changed) {
+      await _saveMessages();
       notifyListeners();
     }
   }
@@ -570,17 +1032,19 @@ class ChatProvider extends ChangeNotifier {
     }
 
     try {
-      final data = await bitnamesRPC.getBitNameData(nameOrHash);
+      final hash = BitnamesMessage.nameHash(nameOrHash);
+      final data = await bitnamesRPC.getBitNameData(hash);
       if (data == null || data.encryptionPubkey == null) {
         return null;
       }
 
-      // Get an address for this identity
-      final address = await bitnamesRPC.getNewAddress();
+      // A message pays the holder of the BitName, so the contact carries the
+      // holder's address. A fresh address of this wallet pays nobody.
+      final address = await bitnamesRPC.getBitNameOwner(hash);
 
       return ChatContact(
-        id: nameOrHash,
-        name: nameOrHash,
+        id: hash,
+        name: hash,
         plaintextName: nameOrHash,
         encryptionPubkey: data.encryptionPubkey!,
         address: address,
@@ -601,6 +1065,7 @@ class ChatProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _walletReader?.removeListener(_onWalletChanged);
     bitnamesRPC.removeListener(_onConnectionChanged);
     balanceProvider.removeListener(_onBalanceChanged);
     _pollTimer?.cancel();
@@ -619,14 +1084,30 @@ class ChatContactsSetting extends SettingValue<List<ChatContact>> {
 
   @override
   String toJson() {
-    return jsonEncode(value.map((e) => e.toJson()).toList());
+    return jsonEncode(
+      value
+          .map(
+            (contact) => contact.toJson()
+              ..remove('last_message')
+              ..remove('last_message_time'),
+          )
+          .toList(),
+    );
   }
 
   @override
   List<ChatContact>? fromJson(String jsonString) {
     try {
       final List<dynamic> decoded = jsonDecode(jsonString);
-      return decoded.map((e) => ChatContact.fromJson(e as Map<String, dynamic>)).toList();
+      return decoded
+          .map(
+            (e) => ChatContact.fromJson(
+              (e as Map<String, dynamic>)
+                ..remove('last_message')
+                ..remove('last_message_time'),
+            ),
+          )
+          .toList();
     } catch (e) {
       return null;
     }

--- a/bitwindow/lib/services/bitnames_message.dart
+++ b/bitwindow/lib/services/bitnames_message.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:blockchain_utils/bech32/bech32.dart';
+import 'package:blockchain_utils/bip/ecc/keys/ed25519_keys.dart';
+import 'package:blockchain_utils/exception/exceptions.dart';
+import 'package:bs58/bs58.dart';
+import 'package:connectrpc/connect.dart';
+import 'package:sidechain_core/rpcs/bitnames_rpc.dart';
+import 'package:thirds/blake3.dart';
+import 'package:uuid/uuid.dart';
+
+class BitnamesMessage {
+  static const prefix = 'bitnames-message:';
+  static const version = 1;
+
+  final String id;
+  final String sender;
+  final String recipient;
+  final String text;
+  final String key;
+  final String signature;
+
+  const BitnamesMessage({
+    required this.id,
+    required this.sender,
+    required this.recipient,
+    required this.text,
+    required this.key,
+    required this.signature,
+  });
+
+  String get storeId => '$prefix$sender:$recipient:$id';
+
+  String get signedText => '$prefix${jsonEncode(_payload)}';
+
+  Map<String, dynamic> get _payload => {
+    'version': version,
+    'id': id,
+    'sender': sender,
+    'recipient': recipient,
+    'text': text,
+  };
+
+  String encode() => '$prefix${jsonEncode({..._payload, 'key': key, 'signature': signature})}';
+
+  static BitnamesMessage? decode(String text) {
+    if (!text.startsWith(prefix)) {
+      return null;
+    }
+    final data = jsonDecode(text.substring(prefix.length));
+    if (data is! Map<String, dynamic> ||
+        data['version'] != version ||
+        data['id'] is! String ||
+        !Uuid.isValidUUID(fromString: data['id'] as String) ||
+        !_isHash(data['sender']) ||
+        !_isHash(data['recipient']) ||
+        data['text'] is! String ||
+        data['key'] is! String ||
+        data['signature'] is! String) {
+      throw const FormatException('Invalid BitNames message');
+    }
+    return BitnamesMessage(
+      id: data['id'] as String,
+      sender: data['sender'] as String,
+      recipient: data['recipient'] as String,
+      text: data['text'] as String,
+      key: data['key'] as String,
+      signature: data['signature'] as String,
+    );
+  }
+
+  static bool _isHash(dynamic value) => value is String && RegExp(r'^[0-9a-f]{64}$').hasMatch(value);
+
+  static String nameHash(String name) =>
+      _isHash(name.toLowerCase()) ? name.toLowerCase() : blake3Hex(utf8.encode(name.toLowerCase()));
+
+  static String addressForKey(String key) {
+    final List<int> bytes;
+    try {
+      bytes = Bech32Decoder.decode('bn-svk', key, encoding: Bech32Encodings.bech32m);
+    } on BlockchainUtilsException {
+      throw const FormatException('Invalid BitNames owner key');
+    }
+    if (bytes.length != 32 ||
+        !Ed25519PublicKey.isValidBytes(bytes) ||
+        key != Bech32Encoder.encode('bn-svk', bytes, encoding: Bech32Encodings.bech32m)) {
+      throw const FormatException('Invalid BitNames owner key');
+    }
+    return base58.encode(Uint8List.fromList(blake3(bytes).sublist(0, 20)));
+  }
+
+  static Future<BitnamesMessage> sign({
+    required BitnamesRPC rpc,
+    required String sender,
+    required String recipient,
+    required String text,
+  }) async {
+    final message = BitnamesMessage(
+      id: const Uuid().v4(),
+      sender: sender,
+      recipient: recipient,
+      text: text,
+      key: '',
+      signature: '',
+    );
+    final owner = await rpc.getBitNameOwner(sender);
+    final result = await rpc.signArbitraryMsgAsAddr(msg: message.signedText, address: owner);
+    final key = result['verifying_key'];
+    final signature = result['signature'];
+    if (key == null || signature == null || addressForKey(key) != owner) {
+      throw const FormatException('The signature key does not match the BitName owner');
+    }
+    return BitnamesMessage(
+      id: message.id,
+      sender: sender,
+      recipient: recipient,
+      text: text,
+      key: key,
+      signature: signature,
+    );
+  }
+
+  Future<String> checkSender(BitnamesRPC rpc, String recipientHash) async {
+    if (recipient != recipientHash) {
+      throw const FormatException('The message recipient does not match the selected identity');
+    }
+    if (!RegExp(r'^[0-9a-fA-F]{128}$').hasMatch(signature)) {
+      throw const FormatException('Invalid BitNames message signature');
+    }
+    final address = addressForKey(key);
+    final valid = await rpc.callRAW('verify_signature', [signature, key, 'arbitrary', signedText]);
+    if (valid != true) {
+      throw const FormatException('Invalid BitNames message signature');
+    }
+    final String owner;
+    try {
+      owner = await rpc.getBitNameOwner(sender);
+    } on ConnectException catch (e) {
+      if (e.code != Code.notFound) {
+        rethrow;
+      }
+      throw const FormatException('The sender BitName has no owner');
+    }
+    if (address != owner) {
+      throw const FormatException('The signature key does not match the BitName owner');
+    }
+    return owner;
+  }
+}

--- a/bitwindow/lib/services/bitnames_secure_store.dart
+++ b/bitwindow/lib/services/bitnames_secure_store.dart
@@ -1,0 +1,645 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter/foundation.dart';
+import 'package:pointycastle/export.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:synchronized/synchronized.dart';
+
+enum BitnamesStorageState {
+  locked,
+  empty,
+  ready,
+  recovered,
+  corrupt,
+}
+
+class BitnamesStorageStatus {
+  const BitnamesStorageStatus(
+    this.state, {
+    this.generation,
+    this.details,
+  });
+
+  final BitnamesStorageState state;
+  final int? generation;
+  final String? details;
+
+  bool get writable => {
+    BitnamesStorageState.empty,
+    BitnamesStorageState.ready,
+    BitnamesStorageState.recovered,
+  }.contains(state);
+
+  String get summary => switch (state) {
+    BitnamesStorageState.locked => 'Private chat storage is locked',
+    BitnamesStorageState.empty => 'Private chat storage is ready',
+    BitnamesStorageState.ready => 'Chats and reply routes are encrypted',
+    BitnamesStorageState.recovered => 'Encrypted chat storage recovered safely',
+    BitnamesStorageState.corrupt => 'Private chat storage needs recovery',
+  };
+}
+
+class BitnamesStorageException implements Exception {
+  const BitnamesStorageException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class BitnamesStorageIdentity {
+  BitnamesStorageIdentity({
+    required this.scope,
+    required Uint8List secret,
+  }) : secret = Uint8List.fromList(secret);
+
+  final String scope;
+  final Uint8List secret;
+}
+
+abstract class BitnamesStorageKeySource implements Listenable {
+  Future<BitnamesStorageIdentity?> current();
+}
+
+class WalletBitnamesStorageKeySource implements BitnamesStorageKeySource {
+  WalletBitnamesStorageKeySource(this.walletReader);
+
+  final WalletReaderProvider walletReader;
+
+  @visibleForTesting
+  static BitnamesStorageIdentity derive({
+    required String masterMnemonic,
+    String walletBinding = '',
+  }) {
+    final mnemonic = _normalizeWords(masterMnemonic);
+    final binding = _normalizeWords(walletBinding);
+    if (mnemonic.isEmpty) {
+      throw const BitnamesStorageException('The unlocked wallet has no encryption key material');
+    }
+    final root = crypto.sha256.convert(
+      utf8.encode(
+        'bitnames-storage-root-v2\u0000$mnemonic\u0000$binding',
+      ),
+    );
+    return BitnamesStorageIdentity(
+      scope: crypto.Hmac(
+        crypto.sha256,
+        root.bytes,
+      ).convert(utf8.encode('scope')).toString(),
+      secret: Uint8List.fromList(
+        crypto.Hmac(
+          crypto.sha256,
+          root.bytes,
+        ).convert(utf8.encode('encryption')).bytes,
+      ),
+    );
+  }
+
+  @override
+  Future<BitnamesStorageIdentity?> current() async {
+    final wallet = walletReader.activeWallet;
+    if (!walletReader.isWalletUnlocked || wallet == null) {
+      return null;
+    }
+    try {
+      return derive(
+        masterMnemonic: wallet.master.mnemonic,
+        walletBinding: wallet.l1.mnemonic,
+      );
+    } on BitnamesStorageException {
+      return null;
+    }
+  }
+
+  @override
+  void addListener(VoidCallback listener) => walletReader.addListener(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => walletReader.removeListener(listener);
+}
+
+class BitnamesSecureStore {
+  BitnamesSecureStore({
+    required this.store,
+    required this.keySource,
+    DateTime Function()? now,
+    Uint8List Function(int)? randomBytes,
+  }) : _now = now ?? DateTime.now,
+       _randomBytes = randomBytes ?? _secureRandomBytes;
+
+  static const format = 'bitnames-private-store';
+  static const schema = 2;
+
+  final KeyValueStore store;
+  final BitnamesStorageKeySource keySource;
+  final DateTime Function() _now;
+  final Uint8List Function(int) _randomBytes;
+  final Lock _lock = Lock();
+
+  BitnamesStorageStatus status = const BitnamesStorageStatus(
+    BitnamesStorageState.locked,
+  );
+  String? _activeScope;
+  String? _activeSlot;
+  int _generation = 0;
+  bool _recoveredThisSession = false;
+
+  Future<Map<String, dynamic>> load() => _lock.synchronized(
+    () => _translate(
+      _load,
+      'Private BitNames storage could not be read safely',
+    ),
+  );
+
+  Future<void> save(Map<String, dynamic> state) => _lock.synchronized(
+    () => _translate(
+      () => _save(state),
+      'The encrypted write did not complete; reload to recover an authenticated generation',
+    ),
+  );
+
+  Future<String> exportEncrypted() => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      await _loadSecure(identity, allowEmpty: false);
+      final prefix = _prefix(identity.scope);
+      final head = await store.getString('${prefix}head');
+      final a = await store.getString('${prefix}a');
+      final b = await store.getString('${prefix}b');
+      if (head == null || (a == null && b == null)) {
+        throw const BitnamesStorageException('No encrypted BitNames data is available to export');
+      }
+      return jsonEncode({
+        'format': '$format-backup',
+        'schema': schema,
+        'scope': identity.scope,
+        'exported_at': _now().toUtc().toIso8601String(),
+        'head': head,
+        'a': ?a,
+        'b': ?b,
+      });
+    }, 'The encrypted BitNames backup could not be created'),
+  );
+
+  Future<void> restoreEncrypted(
+    String encoded, {
+    bool allowRollback = false,
+  }) => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      late Map<String, dynamic> backup;
+      try {
+        backup = Map<String, dynamic>.from(jsonDecode(encoded) as Map);
+      } catch (_) {
+        throw const BitnamesStorageException('The BitNames backup is malformed');
+      }
+      if (backup['format'] != '$format-backup' || backup['schema'] != schema || backup['scope'] != identity.scope) {
+        throw const BitnamesStorageException(
+          'The BitNames backup belongs to another wallet or storage version',
+        );
+      }
+      final candidates = <_DecodedSlot>[];
+      for (final slot in const ['a', 'b']) {
+        final raw = backup[slot];
+        if (raw is String) {
+          try {
+            candidates.add(_decryptSlot(raw, slot, identity));
+          } on BitnamesStorageException {
+            // A backup retains two generations. One valid authenticated slot
+            // is sufficient; a corrupt companion is never loaded.
+          }
+        }
+      }
+      if (candidates.isEmpty) {
+        throw const BitnamesStorageException('The BitNames backup contains no valid encrypted state');
+      }
+      candidates.sort((a, b) => b.generation.compareTo(a.generation));
+      final restored = candidates.first;
+      final current = await _loadSecure(identity, allowEmpty: true);
+      if (!allowRollback && current != null && restored.generation < current.generation) {
+        throw const BitnamesStorageException(
+          'The BitNames backup is older than the current encrypted history',
+        );
+      }
+      await _save(
+        restored.state,
+        minimumGeneration: restored.generation,
+      );
+    }, 'The encrypted BitNames backup could not be restored'),
+  );
+
+  Future<void> clear() => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      final prefix = _prefix(identity.scope);
+      for (final key in [
+        '${prefix}head',
+        '${prefix}a',
+        '${prefix}b',
+      ]) {
+        await store.delete(key);
+      }
+      await _scrubRecoveryCopy('${prefix}cleared');
+      _activeSlot = null;
+      _activeScope = identity.scope;
+      _generation = 0;
+      _recoveredThisSession = false;
+      status = const BitnamesStorageStatus(BitnamesStorageState.empty);
+    }, 'Private BitNames data could not be cleared safely'),
+  );
+
+  Future<Map<String, dynamic>> _load() async {
+    final identity = await keySource.current();
+    if (identity == null) {
+      status = const BitnamesStorageStatus(
+        BitnamesStorageState.locked,
+        details: 'Unlock the active BitWindow wallet to decrypt chat data',
+      );
+      _forgetActive();
+      return {};
+    }
+    try {
+      final secure = await _loadSecure(identity, allowEmpty: true);
+      if (secure != null) {
+        return secure.state;
+      }
+      status = const BitnamesStorageStatus(BitnamesStorageState.empty);
+      return {};
+    } on BitnamesStorageException catch (error) {
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.corrupt,
+        generation: _generation == 0 ? null : _generation,
+        details: error.message,
+      );
+      _forgetActive();
+      rethrow;
+    }
+  }
+
+  Future<T> _translate<T>(
+    Future<T> Function() action,
+    String safeFailure,
+  ) async {
+    try {
+      return await action();
+    } on BitnamesStorageException {
+      rethrow;
+    } catch (_) {
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.corrupt,
+        generation: _generation == 0 ? null : _generation,
+        details: safeFailure,
+      );
+      throw BitnamesStorageException(safeFailure);
+    }
+  }
+
+  Future<void> _save(
+    Map<String, dynamic> state, {
+    int? minimumGeneration,
+  }) async {
+    final identity = await _identity();
+    if (_activeScope != null && _activeScope != identity.scope) {
+      throw const BitnamesStorageException(
+        'The active wallet changed before the encrypted transaction committed',
+      );
+    }
+    final current = await _loadSecure(identity, allowEmpty: true);
+    final normalized = _normalizeState(state);
+    final generation = max(
+      (current?.generation ?? 0) + 1,
+      minimumGeneration ?? 1,
+    );
+    final slot = (current?.slot ?? _activeSlot) == 'a' ? 'b' : 'a';
+    final raw = _encryptSlot(normalized, slot, generation, identity);
+    final prefix = _prefix(identity.scope);
+    await store.setString('$prefix$slot', raw);
+    final verified = _decryptSlot(
+      (await store.getString('$prefix$slot')) ??
+          (throw const BitnamesStorageException('Encrypted write was not persisted')),
+      slot,
+      identity,
+    );
+    if (verified.generation != generation) {
+      throw const BitnamesStorageException('Encrypted write verification failed');
+    }
+    await store.setString('${prefix}head', jsonEncode(_header(slot, generation, identity.scope)));
+    _activeSlot = slot;
+    _activeScope = identity.scope;
+    _generation = generation;
+    status = BitnamesStorageStatus(
+      _recoveredThisSession ? BitnamesStorageState.recovered : BitnamesStorageState.ready,
+      generation: generation,
+      details: _recoveredThisSession
+          ? 'A complete authenticated generation was selected; incomplete or corrupt data was not loaded'
+          : null,
+    );
+  }
+
+  Future<_DecodedSlot?> _loadSecure(
+    BitnamesStorageIdentity identity, {
+    required bool allowEmpty,
+  }) async {
+    if (_activeScope != null && _activeScope != identity.scope) {
+      _recoveredThisSession = false;
+    }
+    final prefix = _prefix(identity.scope);
+    final rawHead = await store.getString('${prefix}head');
+    final rawA = await store.getString('${prefix}a');
+    final rawB = await store.getString('${prefix}b');
+    if (rawHead == null && rawA == null && rawB == null) {
+      if (!allowEmpty) {
+        throw const BitnamesStorageException('No encrypted BitNames state exists');
+      }
+      _activeSlot = null;
+      _activeScope = identity.scope;
+      _generation = 0;
+      return null;
+    }
+
+    final valid = <_DecodedSlot>[];
+    final failures = <String>[];
+    for (final candidate in [('a', rawA), ('b', rawB)]) {
+      if (candidate.$2 == null) {
+        continue;
+      }
+      try {
+        valid.add(_decryptSlot(candidate.$2!, candidate.$1, identity));
+      } on BitnamesStorageException catch (error) {
+        failures.add('${candidate.$1}: ${error.message}');
+      }
+    }
+    if (valid.isEmpty) {
+      throw BitnamesStorageException(
+        'Encrypted BitNames state could not be authenticated'
+        '${failures.isEmpty ? '' : ' (${failures.join('; ')})'}',
+      );
+    }
+    valid.sort((a, b) => b.generation.compareTo(a.generation));
+    final selected = valid.first;
+    var recovered = failures.isNotEmpty;
+    try {
+      final head = Map<String, dynamic>.from(jsonDecode(rawHead!) as Map);
+      recovered =
+          recovered ||
+          head['format'] != format ||
+          head['schema'] != schema ||
+          head['scope'] != identity.scope ||
+          head['slot'] != selected.slot ||
+          head['generation'] != selected.generation;
+    } catch (_) {
+      recovered = true;
+    }
+    if (recovered) {
+      _recoveredThisSession = true;
+      await store.setString(
+        '${prefix}head',
+        jsonEncode(_header(selected.slot, selected.generation, identity.scope)),
+      );
+    }
+    _activeSlot = selected.slot;
+    _activeScope = identity.scope;
+    _generation = selected.generation;
+    status = BitnamesStorageStatus(
+      _recoveredThisSession ? BitnamesStorageState.recovered : BitnamesStorageState.ready,
+      generation: selected.generation,
+      details: _recoveredThisSession
+          ? 'A complete authenticated generation was selected; incomplete or corrupt data was not loaded'
+          : null,
+    );
+    return selected;
+  }
+
+  String _encryptSlot(
+    Map<String, dynamic> state,
+    String slot,
+    int generation,
+    BitnamesStorageIdentity identity,
+  ) {
+    final nonce = _randomBytes(12);
+    final header = _header(slot, generation, identity.scope);
+    final plaintext = utf8.encode(
+      jsonEncode({
+        ...header,
+        'saved_at': _now().toUtc().toIso8601String(),
+        'state': state,
+      }),
+    );
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        true,
+        AEADParameters(
+          KeyParameter(_deriveKey(identity)),
+          128,
+          nonce,
+          Uint8List.fromList(utf8.encode(jsonEncode(header))),
+        ),
+      );
+    final encrypted = cipher.process(Uint8List.fromList(plaintext));
+    return jsonEncode({
+      ...header,
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(encrypted),
+    });
+  }
+
+  _DecodedSlot _decryptSlot(
+    String raw,
+    String expectedSlot,
+    BitnamesStorageIdentity identity,
+  ) {
+    try {
+      final envelope = Map<String, dynamic>.from(jsonDecode(raw) as Map);
+      final generation = envelope['generation'];
+      final slot = envelope['slot'];
+      if (envelope['format'] != format ||
+          envelope['schema'] != schema ||
+          envelope['scope'] != identity.scope ||
+          slot != expectedSlot ||
+          generation is! int ||
+          generation < 1 ||
+          envelope['nonce'] is! String ||
+          envelope['ciphertext'] is! String) {
+        throw const BitnamesStorageException('Encrypted slot metadata is invalid');
+      }
+      final nonce = base64Decode(envelope['nonce'] as String);
+      if (nonce.length != 12) {
+        throw const BitnamesStorageException('Encrypted slot nonce is invalid');
+      }
+      final header = _header(slot as String, generation, identity.scope);
+      final cipher = GCMBlockCipher(AESEngine())
+        ..init(
+          false,
+          AEADParameters(
+            KeyParameter(_deriveKey(identity)),
+            128,
+            nonce,
+            Uint8List.fromList(utf8.encode(jsonEncode(header))),
+          ),
+        );
+      final plaintext = cipher.process(
+        Uint8List.fromList(base64Decode(envelope['ciphertext'] as String)),
+      );
+      final decoded = Map<String, dynamic>.from(
+        jsonDecode(utf8.decode(plaintext)) as Map,
+      );
+      if (decoded['format'] != format ||
+          decoded['schema'] != schema ||
+          decoded['scope'] != identity.scope ||
+          decoded['slot'] != slot ||
+          decoded['generation'] != generation ||
+          decoded['state'] is! Map) {
+        throw const BitnamesStorageException('Encrypted slot contents are inconsistent');
+      }
+      return _DecodedSlot(
+        slot,
+        generation,
+        _normalizeState(Map<String, dynamic>.from(decoded['state'] as Map)),
+      );
+    } on BitnamesStorageException {
+      rethrow;
+    } catch (_) {
+      throw const BitnamesStorageException(
+        'Encrypted slot is corrupt or the wallet key does not match',
+      );
+    }
+  }
+
+  Map<String, dynamic> _header(String slot, int generation, String scope) => {
+    'format': format,
+    'schema': schema,
+    'scope': scope,
+    'slot': slot,
+    'generation': generation,
+  };
+
+  Uint8List _deriveKey(BitnamesStorageIdentity identity) {
+    final salt = utf8.encode('BitWindow BitNames private storage v2');
+    final extracted = crypto.Hmac(crypto.sha256, salt).convert(identity.secret).bytes;
+    final info = utf8.encode('wallet:${identity.scope}\u0000aes-256-gcm\u0001');
+    return Uint8List.fromList(
+      crypto.Hmac(crypto.sha256, extracted).convert(info).bytes,
+    );
+  }
+
+  Future<BitnamesStorageIdentity> _identity() async {
+    final identity = await keySource.current();
+    if (identity == null) {
+      status = const BitnamesStorageStatus(
+        BitnamesStorageState.locked,
+        details: 'Unlock the active BitWindow wallet to decrypt chat data',
+      );
+      _forgetActive();
+      throw const BitnamesStorageException(
+        'Unlock the active BitWindow wallet before using BitNames chat',
+      );
+    }
+    return identity;
+  }
+
+  Future<void> _scrubRecoveryCopy(String marker) async {
+    // FileStorage keeps one complete prior generation for crash recovery.
+    // Rotate a non-secret tombstone through it so deleted plaintext/ciphertext
+    // is not left in that logical recovery copy.
+    await store.setString(marker, 'cleared');
+    await store.delete(marker);
+  }
+
+  Map<String, dynamic> _normalizeState(Map<String, dynamic> input) {
+    late Map<String, dynamic> state;
+    try {
+      state = Map<String, dynamic>.from(
+        jsonDecode(jsonEncode(input)) as Map,
+      );
+    } catch (_) {
+      throw const BitnamesStorageException('BitNames state is not valid JSON data');
+    }
+    _deduplicate(state, 'contacts', (entry) => '${entry['local_bitname'] ?? ''}:${entry['id'] ?? ''}');
+    _deduplicate(state, 'messages', (entry) {
+      return _messageKey(entry);
+    });
+    _deduplicate(state, 'operations', (entry) => '${entry['id'] ?? ''}');
+    state.remove('_indexes');
+    return state;
+  }
+
+  void _deduplicate(
+    Map<String, dynamic> state,
+    String field,
+    String Function(Map<String, dynamic>) keyOf,
+  ) {
+    final raw = state[field];
+    if (raw == null) {
+      return;
+    }
+    if (raw is! List) {
+      throw BitnamesStorageException('BitNames $field index is malformed');
+    }
+    final seen = <String, String>{};
+    final clean = <Map<String, dynamic>>[];
+    for (final value in raw) {
+      if (value is! Map) {
+        throw BitnamesStorageException('BitNames $field record is malformed');
+      }
+      final record = Map<String, dynamic>.from(value);
+      final key = keyOf(record);
+      if (key.isEmpty || key.endsWith(':')) {
+        throw BitnamesStorageException('BitNames $field record has no stable identity');
+      }
+      final canonical = _canonicalJson(record);
+      final prior = seen[key];
+      if (prior != null && prior != canonical) {
+        throw BitnamesStorageException(
+          'BitNames $field contains conflicting record $key',
+        );
+      }
+      if (prior == null) {
+        seen[key] = canonical;
+        clean.add(record);
+      }
+    }
+    state[field] = clean;
+  }
+
+  String _prefix(String scope) => 'bitintroduction_secure_v2_${scope}_';
+
+  void _forgetActive() {
+    _activeScope = null;
+    _activeSlot = null;
+    _generation = 0;
+    _recoveredThisSession = false;
+  }
+
+  static Uint8List _secureRandomBytes(int length) {
+    final random = Random.secure();
+    return Uint8List.fromList(
+      List<int>.generate(length, (_) => random.nextInt(256)),
+    );
+  }
+}
+
+class _DecodedSlot {
+  const _DecodedSlot(this.slot, this.generation, this.state);
+  final String slot;
+  final int generation;
+  final Map<String, dynamic> state;
+}
+
+String _messageKey(Map<String, dynamic> message) {
+  final local = message['is_outgoing'] == true ? message['sender_bitname'] : message['recipient_bitname'];
+  return '$local:${message['id'] ?? ''}';
+}
+
+String _normalizeWords(String value) => value.trim().toLowerCase().split(RegExp(r'\s+')).join(' ');
+
+String _canonicalJson(Object? value) {
+  if (value is Map) {
+    final keys = value.keys.cast<String>().toList()..sort();
+    return '{${keys.map((key) => '${jsonEncode(key)}:${_canonicalJson(value[key])}').join(',')}}';
+  }
+  if (value is List) {
+    return '[${value.map(_canonicalJson).join(',')}]';
+  }
+  return jsonEncode(value);
+}

--- a/bitwindow/lib/services/chat_file_storage.dart
+++ b/bitwindow/lib/services/chat_file_storage.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:synchronized/synchronized.dart';
+
+// Native implementation using file system
+class ChatFileStorage implements KeyValueStore {
+  static final Map<String, Lock> _processLocks = {};
+
+  static ChatFileStorage fromDirectory(Directory dir) {
+    final file = File('${dir.path}${Platform.pathSeparator}chat.json');
+    return ChatFileStorage._(file);
+  }
+
+  final File file;
+  Map<String, String> _cache = {};
+  bool _loaded = false;
+  bool _loadedFromBackup = false;
+  final Lock _processLock;
+
+  ChatFileStorage._(this.file)
+    : _processLock = _processLocks.putIfAbsent(
+        file.absolute.path,
+        Lock.new,
+      );
+
+  Future<void> _ensureLoaded({bool refresh = false}) async {
+    if (_loaded && !refresh) {
+      return;
+    }
+    if (refresh) {
+      _loaded = false;
+      _loadedFromBackup = false;
+      _cache = {};
+    }
+    final backup = File('${file.path}.bak');
+    Object? primaryError;
+    if (await file.exists()) {
+      try {
+        _cache = await _read(file);
+        _loaded = true;
+        return;
+      } catch (error) {
+        primaryError = error;
+      }
+    }
+    if (await backup.exists()) {
+      try {
+        _cache = await _read(backup);
+        _loaded = true;
+        _loadedFromBackup = true;
+        return;
+      } catch (backupError) {
+        throw FileSystemException(
+          'Settings and its recovery copy are corrupt '
+          '(primary: $primaryError, recovery: $backupError)',
+          file.path,
+        );
+      }
+    }
+    if (primaryError != null) {
+      throw FileSystemException(
+        'Settings are corrupt and no recovery copy exists: $primaryError',
+        file.path,
+      );
+    }
+    _loaded = true;
+  }
+
+  Future<T> _withFileLock<T>(Future<T> Function() action) async {
+    await file.parent.create(recursive: true);
+    final lockFile = await File('${file.path}.lock').open(mode: FileMode.append);
+    var locked = false;
+    try {
+      await lockFile.lock(FileLock.exclusive);
+      locked = true;
+      return await action();
+    } finally {
+      if (locked) {
+        await lockFile.unlock();
+      }
+      await lockFile.close();
+    }
+  }
+
+  Future<Map<String, String>> _read(File source) async {
+    final decoded = jsonDecode(await source.readAsString());
+    if (decoded is! Map) {
+      throw const FormatException('settings root is not an object');
+    }
+    final result = <String, String>{};
+    for (final entry in decoded.entries) {
+      if (entry.key is! String || entry.value is! String) {
+        throw const FormatException('settings entry is not a string pair');
+      }
+      result[entry.key as String] = entry.value as String;
+    }
+    return result;
+  }
+
+  Future<void> _save() async {
+    await file.parent.create(recursive: true);
+    final temporary = File('${file.path}.next');
+    final backup = File('${file.path}.bak');
+    await temporary.writeAsString(jsonEncode(_cache), flush: true);
+    try {
+      if (await file.exists()) {
+        if (_loadedFromBackup) {
+          await file.delete();
+        } else {
+          if (await backup.exists()) {
+            await backup.delete();
+          }
+          await file.rename(backup.path);
+        }
+      }
+      await temporary.rename(file.path);
+      _loadedFromBackup = false;
+    } catch (_) {
+      if (!await file.exists() && await backup.exists()) {
+        await backup.rename(file.path);
+      }
+      rethrow;
+    } finally {
+      if (await temporary.exists()) {
+        await temporary.delete();
+      }
+    }
+  }
+
+  @override
+  Future<String?> getString(String key) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      return _cache[key];
+    }),
+  );
+
+  @override
+  Future<void> setString(String key, String value) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      final existed = _cache.containsKey(key);
+      final previous = _cache[key];
+      _cache[key] = value;
+      try {
+        await _save();
+      } catch (_) {
+        existed ? _cache[key] = previous! : _cache.remove(key);
+        rethrow;
+      }
+    }),
+  );
+
+  @override
+  Future<void> delete(String key) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      if (!_cache.containsKey(key)) {
+        return;
+      }
+      final previous = _cache.remove(key)!;
+      try {
+        await _save();
+      } catch (_) {
+        _cache[key] = previous;
+        rethrow;
+      }
+    }),
+  );
+}

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.208
+version: 0.2.209
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/test/chat_pending_message_test.dart
+++ b/bitwindow/test/chat_pending_message_test.dart
@@ -1,0 +1,243 @@
+import 'package:bitwindow/models/chat_models.dart';
+import 'package:bitwindow/providers/chat_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/mocks/mocks.dart';
+
+import 'mocks/store_mock.dart';
+
+void main() {
+  costTests();
+  unknownSenderTests();
+  conversationTests();
+  readStateTests();
+  identityTests();
+  group('a message that waits in the mempool', () {
+    test('carries the pending flag through json', () {
+      final pending = ChatMessage(
+        id: 'aa:0',
+        content: 'hei',
+        senderPubkey: 'bn-enc1a',
+        recipientPubkey: 'bn-enc1b',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1757680000000),
+        isOutgoing: false,
+        isPending: true,
+      );
+
+      final read = ChatMessage.fromJson(pending.toJson());
+      expect(read.isPending, isTrue);
+      expect(read.content, 'hei');
+    });
+
+    test('reads as settled when no flag is stored', () {
+      final read = ChatMessage.fromJson({
+        'id': 'aa:0',
+        'content': 'hei',
+        'sender_pubkey': 'bn-enc1a',
+        'recipient_pubkey': 'bn-enc1b',
+        'is_outgoing': false,
+      });
+      expect(read.isPending, isFalse);
+    });
+
+    // A block settles the message the mempool already showed.
+    test('settles without losing its content', () {
+      final pending = ChatMessage(
+        id: 'aa:0',
+        content: 'hei',
+        senderPubkey: 'bn-enc1a',
+        recipientPubkey: 'bn-enc1b',
+        timestamp: DateTime.now(),
+        isOutgoing: false,
+        valueSats: 1000,
+        isPending: true,
+      );
+
+      final settled = pending.copyWith(isPending: false);
+      expect(settled.isPending, isFalse);
+      expect(settled.content, 'hei');
+      expect(settled.valueSats, 1000);
+      expect(settled.id, pending.id);
+    });
+  });
+}
+
+void identityTests() {
+  group('the selected chat identity', () {
+    late ChatProvider provider;
+    late BalanceProvider balance;
+    late MockBitnamesRPC rpc;
+
+    setUp(() {
+      GetIt.I.registerSingleton<Logger>(Logger());
+      GetIt.I.registerSingleton<ClientSettings>(ClientSettings(store: MockStore(), log: GetIt.I.get<Logger>()));
+      rpc = MockBitnamesRPC();
+      GetIt.I.registerSingleton<BitnamesRPC>(rpc);
+      balance = BalanceProvider(connections: [rpc]);
+      GetIt.I.registerSingleton<BalanceProvider>(balance);
+      provider = ChatProvider();
+    });
+
+    tearDown(() async {
+      provider.dispose();
+      balance.dispose();
+      rpc.dispose();
+      await GetIt.I.reset();
+    });
+
+    test('shows only the mail for that identity', () {
+      final contact = ChatContact(
+        id: 'contact',
+        name: 'Contact',
+        encryptionPubkey: 'contact-key',
+        address: 'contact-address',
+      );
+      provider.selectContact(contact);
+      provider.messages.addAll([
+        for (final key in ['first-key', 'second-key'])
+          ChatMessage(
+            id: key,
+            content: key,
+            senderPubkey: contact.address,
+            recipientPubkey: key,
+            timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+            isOutgoing: false,
+          ),
+      ]);
+
+      provider.selectIdentity(
+        BitnameEntry(
+          hash: 'first',
+          details: BitnameDetails(seqId: '1', encryptionPubkey: 'first-key'),
+        ),
+      );
+      expect(provider.currentConversation.map((message) => message.id), ['first-key']);
+
+      provider.selectIdentity(
+        BitnameEntry(
+          hash: 'second',
+          details: BitnameDetails(seqId: '2', encryptionPubkey: 'second-key'),
+        ),
+      );
+      expect(provider.currentConversation.map((message) => message.id), ['second-key']);
+    });
+  });
+}
+
+void costTests() {
+  group('what a message costs', () {
+    // The reader keeps the postage, and the network takes the fee. A sender
+    // sees both before pressing Send.
+    test('adds the network fee to the postage', () {
+      expect(ChatProvider.defaultPostageSats, 1000);
+      expect(ChatProvider.networkFeeSats, 100);
+    });
+
+    test('an outgoing message keeps the postage it paid', () {
+      final sent = ChatMessage(
+        id: 'tx:0',
+        content: 'hei',
+        senderPubkey: 'bn-enc1a',
+        recipientPubkey: 'bn-enc1b',
+        timestamp: DateTime.now(),
+        isOutgoing: true,
+        valueSats: ChatProvider.defaultPostageSats,
+        isPending: true,
+      );
+
+      expect(sent.valueSats, 1000);
+      expect(sent.isPending, isTrue, reason: 'a block has to settle it first');
+      expect(sent.copyWith(isPending: false).valueSats, 1000);
+    });
+  });
+}
+
+void readStateTests() {
+  ChatMessage incoming({required String id, bool read = false}) => ChatMessage(
+    id: id,
+    content: 'hei',
+    senderPubkey: 'bn-enc1sender',
+    recipientPubkey: 'bn-enc1me',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1757680000000),
+    isOutgoing: false,
+    read: read,
+  );
+
+  group('the read state', () {
+    // The bell history stores a notification this way, and a chat message
+    // follows the same shape.
+    test('a new message reads as unread', () {
+      expect(incoming(id: 'a:0').read, isFalse);
+    });
+
+    test('survives a restart through json', () {
+      final stored = incoming(id: 'a:0', read: true);
+      expect(ChatMessage.fromJson(stored.toJson()).read, isTrue);
+    });
+
+    test('an older stored message with no flag reads as unread', () {
+      final read = ChatMessage.fromJson({
+        'id': 'a:0',
+        'content': 'hei',
+        'sender_pubkey': 'bn-enc1sender',
+        'recipient_pubkey': 'bn-enc1me',
+        'is_outgoing': false,
+      });
+      expect(read.read, isFalse);
+    });
+
+    test('marking read keeps everything else', () {
+      final before = incoming(id: 'a:0');
+      final after = before.copyWith(read: true);
+      expect(after.read, isTrue);
+      expect(after.id, before.id);
+      expect(after.content, before.content);
+      expect(after.isPending, before.isPending);
+    });
+  });
+}
+
+void conversationTests() {
+  group('a conversation', () {
+    // An arrived message names its sender by address, because the chain holds
+    // no encryption key. The thread has to match that.
+    test('holds a message that names its sender by address', () {
+      final arrived = ChatMessage(
+        id: 'a:0',
+        content: 'hei',
+        senderPubkey: '3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt',
+        recipientPubkey: 'bn-enc1me',
+        timestamp: DateTime.now(),
+        isOutgoing: false,
+      );
+
+      // The contact carries the same address, and a different encryption key.
+      const contactAddress = '3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt';
+      const contactKey = 'bn-enc1them';
+      expect(arrived.senderPubkey == contactKey, isFalse, reason: 'the old match fails');
+      expect(arrived.senderPubkey == contactAddress, isTrue, reason: 'the address match works');
+    });
+  });
+}
+
+void unknownSenderTests() {
+  group('a sender who reached me first', () {
+    // The chain carries no encryption key, so an arrived message names only
+    // an address. A reply to it pays them and reaches no inbox.
+    test('reads as a contact with no key', () {
+      final unknown = ChatContact(
+        id: '3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt',
+        name: '3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt',
+        encryptionPubkey: '',
+        address: '3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt',
+        lastMessage: 'hei',
+      );
+
+      expect(unknown.encryptionPubkey, isEmpty, reason: 'a send has to refuse this');
+      expect(unknown.address, isNotEmpty, reason: 'the thread still shows the message');
+      expect(ChatContact.fromJson(unknown.toJson()).encryptionPubkey, isEmpty);
+    });
+  });
+}

--- a/bitwindow/test/chat_provider_test.dart
+++ b/bitwindow/test/chat_provider_test.dart
@@ -1,0 +1,1222 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bitwindow/models/chat_models.dart';
+import 'package:bitwindow/pages/chat_page.dart';
+import 'package:bitwindow/providers/chat_provider.dart';
+import 'package:bitwindow/services/bitnames_message.dart';
+import 'package:bitwindow/services/bitnames_secure_store.dart';
+import 'package:flutter/foundation.dart';
+import 'package:blockchain_utils/bech32/bech32.dart';
+import 'package:blockchain_utils/bip/ecc/keys/ed25519_keys.dart';
+import 'package:blockchain_utils/signer/ed25519/ed25519.dart';
+import 'package:convert/convert.dart';
+import 'package:connectrpc/connect.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/mocks/mocks.dart';
+
+import 'mocks/store_mock.dart';
+
+class _ChatRPC extends MockBitnamesRPC {
+  bool online = false;
+  Map<String, dynamic> pending = {};
+  Map<String, dynamic> settled = {};
+  Set<String> mempool = {};
+  final Map<String, BitNameData> names = {};
+  final Map<String, String> owners = {};
+  final Map<String, ConnectException> ownerErrors = {};
+  final Map<String, List<int>> keys = {};
+  final Map<String, (String, String)> ciphertexts = {};
+  final List<({String address, int value, int fee, String? memo})> transfers = [];
+  final List<List<dynamic>> checks = [];
+  Completer<void>? encryptWait;
+  Completer<void>? decryptWait;
+  Completer<void>? transferWait;
+  bool failPaymail = false;
+  bool failPending = false;
+
+  @override
+  bool get connected => online;
+
+  BitnameEntry addIdentity(String name, int seed, {String? encryptionKey}) {
+    final hash = BitnamesMessage.nameHash(name);
+    final bytes = List<int>.filled(32, seed);
+    final publicKey = Ed25519PrivateKey.fromBytes(bytes).publicKey.compressed.sublist(1);
+    final key = Bech32Encoder.encode('bn-svk', publicKey, encoding: Bech32Encodings.bech32m);
+    final address = BitnamesMessage.addressForKey(key);
+    names[hash] = BitNameData(encryptionPubkey: encryptionKey ?? 'encryption-$name', paymailFeeSats: 1500);
+    owners[hash] = address;
+    keys[address] = bytes;
+    return BitnameEntry(
+      hash: hash,
+      plaintextName: name,
+      details: BitnameDetails(
+        seqId: '$seed',
+        encryptionPubkey: names[hash]!.encryptionPubkey,
+        paymailFeeSats: names[hash]!.paymailFeeSats,
+      ),
+    );
+  }
+
+  @override
+  Future<BitNameData?> getBitNameData(String name) async => names[name];
+
+  @override
+  Future<String> getBitNameOwner(String bitname) async {
+    if (ownerErrors.containsKey(bitname)) {
+      throw ownerErrors[bitname]!;
+    }
+    final owner = owners[bitname];
+    if (owner == null) {
+      throw ConnectException(Code.notFound, 'The BitName has no owner');
+    }
+    return owner;
+  }
+
+  @override
+  Future<Map<String, String>> signArbitraryMsgAsAddr({required String msg, required String address}) async {
+    final seed = keys[address]!;
+    final key = Ed25519PrivateKey.fromBytes(seed).publicKey.compressed.sublist(1);
+    return {
+      'verifying_key': Bech32Encoder.encode('bn-svk', key, encoding: Bech32Encodings.bech32m),
+      'signature': hex.encode(Ed25519Signer.fromKeyBytes(seed).sign([255, ...utf8.encode(msg)])),
+    };
+  }
+
+  @override
+  Future<dynamic> callRAW(String method, [dynamic params]) async {
+    expect(method, 'verify_signature');
+    final values = params as List<dynamic>;
+    checks.add(values);
+    expect(values[2], 'arbitrary');
+    final bytes = Bech32Decoder.decode('bn-svk', values[1] as String, encoding: Bech32Encodings.bech32m);
+    return Ed25519Verifier.fromKeyBytes(bytes).verify(
+      [255, ...utf8.encode(values[3] as String)],
+      hex.decode(values[0] as String),
+    );
+  }
+
+  @override
+  Future<String> encryptMsg({required String msg, required String encryptionPubkey}) async {
+    await encryptWait?.future;
+    final ciphertext = hex.encode(utf8.encode('${ciphertexts.length}:$encryptionPubkey'));
+    ciphertexts[ciphertext] = (encryptionPubkey, msg);
+    return ciphertext;
+  }
+
+  @override
+  Future<String> decryptMsg({required String ciphertext, required String encryptionPubkey}) async {
+    await decryptWait?.future;
+    final stored = ciphertexts[ciphertext];
+    if (stored == null || stored.$1 != encryptionPubkey) {
+      throw const FormatException('The key cannot decrypt this memo');
+    }
+    return stored.$2;
+  }
+
+  @override
+  Future<PendingPaymail> getPendingPaymail() async {
+    if (failPending) {
+      throw StateError('The pending RPC failed');
+    }
+    return PendingPaymail(entries: pending, mempoolTxids: mempool);
+  }
+
+  @override
+  Future<Map<String, dynamic>> getPaymail() async {
+    if (failPaymail) {
+      throw StateError('The paymail RPC failed');
+    }
+    return settled;
+  }
+
+  @override
+  Future<String> transfer({required String dest, required int value, required int fee, String? memo}) async {
+    await transferWait?.future;
+    transfers.add((address: dest, value: value, fee: fee, memo: memo));
+    final txid = 'tx-${transfers.length}';
+    mempool.add(txid);
+    return txid;
+  }
+
+  Future<Map<String, dynamic>> output(String text, BitnameEntry recipient, {bool hexMemo = false}) async {
+    final memo = await encryptMsg(msg: text, encryptionPubkey: recipient.details.encryptionPubkey!);
+    return {
+      'address': owners[recipient.hash],
+      'sender_address': 'untrusted-input-owner',
+      'memo': hexMemo ? memo : hex.decode(memo),
+      'content': {'BitcoinSats': 1500},
+    };
+  }
+}
+
+class _StorageKey extends ChangeNotifier implements BitnamesStorageKeySource {
+  @override
+  Future<BitnamesStorageIdentity?> current() async =>
+      WalletBitnamesStorageKeySource.derive(masterMnemonic: 'test wallet');
+}
+
+class _ChatWallet extends WalletReaderProvider {
+  _ChatWallet() : super(Directory.systemTemp);
+
+  void selectWallet(String? id) {
+    wallets = id == null
+        ? []
+        : [
+            WalletData(
+              version: 1,
+              master: MasterWallet(mnemonic: 'wallet $id', seedHex: '', masterKey: '', chainCode: ''),
+              l1: L1Wallet(mnemonic: ''),
+              sidechains: [],
+              isStarter: true,
+              id: id,
+              name: id,
+              gradient: WalletGradient.fromWalletId(id),
+              createdAt: DateTime.utc(2026, 1, 1),
+              walletType: BinaryType.BINARY_TYPE_BITCOIND,
+            ),
+          ];
+    activeWalletId = id;
+    notifyListeners();
+  }
+}
+
+void main() {
+  late _ChatRPC rpc;
+  late ChatProvider provider;
+  late BalanceProvider balance;
+  late BitnameEntry alice;
+  late BitnameEntry bob;
+  late BitnameEntry carol;
+
+  setUp(() {
+    final log = Logger();
+    GetIt.I.registerSingleton<Logger>(log);
+    GetIt.I.registerSingleton<ClientSettings>(ClientSettings(store: MockStore(), log: log));
+    rpc = _ChatRPC();
+    alice = rpc.addIdentity('alice', 1);
+    bob = rpc.addIdentity('bob', 2);
+    carol = rpc.addIdentity('carol', 3);
+    GetIt.I.registerSingleton<BitnamesRPC>(rpc);
+    balance = BalanceProvider(connections: [rpc]);
+    GetIt.I.registerSingleton<BalanceProvider>(balance);
+    provider = ChatProvider();
+    provider.selectIdentity(bob);
+    rpc.online = true;
+  });
+
+  tearDown(() async {
+    provider.dispose();
+    balance.dispose();
+    rpc.dispose();
+    await GetIt.I.reset();
+  });
+
+  Future<BitnamesMessage> signed({BitnameEntry? sender, BitnameEntry? recipient, String text = 'Hello'}) =>
+      BitnamesMessage.sign(rpc: rpc, sender: (sender ?? alice).hash, recipient: (recipient ?? bob).hash, text: text);
+
+  Future<void> waitForChat(String text) async {
+    if (provider.messages.any((message) => message.content == text)) {
+      return;
+    }
+    final loaded = Completer<void>();
+    void check() {
+      if (!loaded.isCompleted && provider.messages.any((message) => message.content == text)) {
+        loaded.complete();
+      }
+    }
+
+    provider.addListener(check);
+    try {
+      await loaded.future.timeout(const Duration(seconds: 3));
+    } finally {
+      provider.removeListener(check);
+    }
+  }
+
+  Future<(_ChatWallet, BitnamesSecureStore)> walletChat() async {
+    provider.dispose();
+    final wallet = _ChatWallet();
+    GetIt.I.registerSingleton<WalletReaderProvider>(wallet);
+    final store = BitnamesSecureStore(store: MockStore(), keySource: WalletBitnamesStorageKeySource(wallet));
+    for (final id in ['A', 'B']) {
+      wallet.selectWallet(id);
+      await store.load();
+      await store.save({
+        'messages': [
+          ChatMessage(
+            id: id,
+            content: 'Private $id',
+            senderPubkey: bob.details.encryptionPubkey!,
+            recipientPubkey: alice.details.encryptionPubkey!,
+            senderBitname: bob.hash,
+            recipientBitname: alice.hash,
+            timestamp: DateTime.utc(2026, 1, 1),
+            isOutgoing: true,
+          ).toJson(),
+        ],
+      });
+    }
+    await GetIt.I.get<ClientSettings>().setValue(
+      ChatContactsSetting(
+        newValue: [
+          ChatContact(
+            id: alice.hash,
+            name: 'Alice',
+            encryptionPubkey: alice.details.encryptionPubkey!,
+            address: rpc.owners[alice.hash]!,
+            paymailFeeSats: alice.details.paymailFeeSats,
+            isManual: true,
+          ),
+        ],
+      ),
+    );
+    wallet.selectWallet('A');
+    provider = ChatProvider(store: store);
+    await waitForChat('Private A');
+    provider.selectIdentity(bob);
+    provider.selectContact(provider.contacts.single);
+    await provider.fetchPaymail();
+    return (wallet, store);
+  }
+
+  for (final action in ['change', 'lock']) {
+    test('the composer clears an unsent draft after a wallet $action', () async {
+      final (wallet, _) = await walletChat();
+      GetIt.I.registerSingleton<ChatProvider>(provider);
+      final model = ChatViewModel();
+      try {
+        model.messageController.text = 'Private draft A';
+
+        wallet.selectWallet(action == 'lock' ? null : 'B');
+
+        final draft = model.messageController.text;
+        if (action == 'lock') {
+          wallet.selectWallet('B');
+        }
+        await waitForChat('Private B');
+        rpc.online = false;
+        model.selectIdentity(bob);
+        model.selectContact(provider.contacts.single);
+        expect(draft, isEmpty);
+        expect(model.messageController.text, isEmpty);
+      } finally {
+        model.dispose();
+      }
+    });
+  }
+
+  test('the composer keeps the new wallet draft after an old send result', () async {
+    final (wallet, _) = await walletChat();
+    GetIt.I.registerSingleton<ChatProvider>(provider);
+    final model = ChatViewModel();
+    rpc.encryptWait = Completer<void>();
+    model.messageController.text = 'Private draft A';
+    final oldSend = model.sendMessage();
+    await Future<void>.delayed(Duration.zero);
+    try {
+      wallet.selectWallet('B');
+      await waitForChat('Private B');
+      rpc.online = false;
+      model.selectIdentity(bob);
+      model.selectContact(provider.contacts.single);
+      rpc.online = true;
+      rpc.names[alice.hash] = BitNameData(encryptionPubkey: alice.details.encryptionPubkey, paymailFeeSats: 2500);
+      model.messageController.text = 'Private draft B';
+      await model.sendMessage();
+      expect(model.chatError, contains('The postage increased'));
+      expect(model.messageController.text, 'Private draft B');
+    } finally {
+      rpc.encryptWait!.complete();
+      await oldSend;
+    }
+    try {
+      expect(model.messageController.text, 'Private draft B');
+      expect(rpc.transfers, isEmpty);
+    } finally {
+      model.dispose();
+    }
+  });
+
+  test('the composer restores a failed send draft in the same wallet', () async {
+    await walletChat();
+    GetIt.I.registerSingleton<ChatProvider>(provider);
+    final model = ChatViewModel();
+    try {
+      rpc.names[alice.hash] = BitNameData(encryptionPubkey: alice.details.encryptionPubkey);
+      model.messageController.text = 'Private draft A';
+
+      await model.sendMessage();
+
+      expect(model.messageController.text, 'Private draft A');
+      expect(model.chatError, contains('The recipient BitName has no inbox'));
+      expect(rpc.transfers, isEmpty);
+    } finally {
+      model.dispose();
+    }
+  });
+
+  test('a wallet change clears private chat and reloads the selected wallet', () async {
+    final (wallet, store) = await walletChat();
+    rpc.online = false;
+
+    wallet.selectWallet('B');
+
+    expect(provider.messages, isEmpty);
+    expect(provider.contacts, isEmpty);
+    expect(provider.selectedContact, isNull);
+    expect(provider.selectedIdentity, isNull);
+    expect(provider.myIdentities, isEmpty);
+    await waitForChat('Private B');
+    expect(provider.messages.single.content, 'Private B');
+    expect(provider.contacts.single.lastMessage, isNull);
+    provider.selectIdentity(bob);
+    expect(provider.contacts.single.lastMessage, 'Private B');
+
+    wallet.selectWallet('A');
+    await waitForChat('Private A');
+    expect(provider.messages.single.content, 'Private A');
+    expect(provider.contacts.single.lastMessage, isNull);
+    provider.selectIdentity(bob);
+    expect(provider.contacts.single.lastMessage, 'Private A');
+    rpc.online = true;
+    provider.selectContact(provider.contacts.single);
+    expect(await provider.sendMessage('More private A'), 'tx-1');
+    expect(provider.error, isNull);
+    final saved = await store.load();
+    expect((saved['messages'] as List<dynamic>).map((message) => message['content']), ['Private A', 'More private A']);
+  });
+
+  test('a wallet lock clears private chat until the wallet unlocks', () async {
+    final (wallet, _) = await walletChat();
+
+    wallet.selectWallet(null);
+
+    expect(provider.messages, isEmpty);
+    expect(provider.contacts, isEmpty);
+    expect(provider.selectedContact, isNull);
+    expect(provider.selectedIdentity, isNull);
+    await provider.fetchIdentities();
+    await provider.fetchPaymail();
+    expect(provider.messages, isEmpty);
+    expect(provider.myIdentities, isEmpty);
+    wallet.selectWallet('A');
+    await waitForChat('Private A');
+    expect(provider.messages.single.content, 'Private A');
+  });
+
+  test('a wallet with no chat keeps manual contacts without private previews', () async {
+    final (wallet, store) = await walletChat();
+    final loaded = Completer<void>();
+    void check() {
+      if (!loaded.isCompleted && provider.contacts.isNotEmpty && provider.selectedIdentity == null) {
+        loaded.complete();
+      }
+    }
+
+    provider.addListener(check);
+    try {
+      wallet.selectWallet('C');
+      await loaded.future.timeout(const Duration(seconds: 3));
+    } finally {
+      provider.removeListener(check);
+    }
+    expect(await store.load(), isEmpty);
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.messages, isEmpty);
+    expect(provider.contacts.single.id, alice.hash);
+    expect(provider.contacts.single.isManual, isTrue);
+    expect(provider.contacts.single.lastMessage, isNull);
+    expect(provider.contacts.single.lastMessageTime, isNull);
+  });
+
+  test('an old decrypt operation cannot restore chat after a wallet change', () async {
+    final (wallet, _) = await walletChat();
+    rpc.pending = {'bob:0': await rpc.output((await signed(text: 'Old private poll')).encode(), bob)};
+    rpc.decryptWait = Completer<void>();
+    final poll = provider.fetchPaymail();
+    await Future<void>.delayed(Duration.zero);
+    try {
+      wallet.selectWallet('B');
+      expect(provider.messages, isEmpty);
+      await waitForChat('Private B');
+    } finally {
+      rpc.decryptWait!.complete();
+      await poll;
+    }
+
+    expect(provider.messages.single.content, 'Private B');
+    expect(provider.contacts.single.lastMessage, isNull);
+    expect(provider.selectedContact, isNull);
+    expect(provider.selectedIdentity, isNull);
+    expect(provider.error, isNull);
+  });
+
+  for (final step in ['encrypt', 'transfer']) {
+    test('an old $step result cannot restore chat after a wallet change', () async {
+      final (wallet, store) = await walletChat();
+      final wait = Completer<void>();
+      if (step == 'encrypt') {
+        rpc.encryptWait = wait;
+      } else {
+        rpc.transferWait = wait;
+      }
+      final send = provider.sendMessage('Private send A');
+      await Future<void>.delayed(Duration.zero);
+      try {
+        wallet.selectWallet('B');
+        await waitForChat('Private B');
+      } finally {
+        wait.complete();
+      }
+
+      final result = await send;
+      expect(provider.messages.map((message) => message.content), ['Private B']);
+      expect(result, step == 'encrypt' ? isNull : 'tx-1');
+      expect(provider.contacts.single.lastMessage, isNull);
+      expect(
+        provider.error,
+        step == 'encrypt' ? isNull : 'The node accepted the message. The wallet change stopped the local history save.',
+      );
+      final saved = await store.load();
+      expect((saved['messages'] as List<dynamic>).single['content'], 'Private B');
+      expect(rpc.transfers, hasLength(step == 'encrypt' ? 0 : 1));
+      wallet.selectWallet('A');
+      await waitForChat('Private A');
+      expect(provider.messages.single.content, 'Private A');
+    });
+  }
+
+  test('an old transfer result cannot clear the new wallet send state', () async {
+    final (wallet, _) = await walletChat();
+    rpc.transferWait = Completer<void>();
+    final oldSend = provider.sendMessage('Private send A');
+    await Future<void>.delayed(Duration.zero);
+    wallet.selectWallet('B');
+    await waitForChat('Private B');
+    provider.selectIdentity(bob);
+    provider.selectContact(provider.contacts.single);
+    rpc.encryptWait = Completer<void>();
+    final newSend = provider.sendMessage('Private send B');
+    await Future<void>.delayed(Duration.zero);
+    rpc.transferWait!.complete();
+    await oldSend;
+    try {
+      expect(provider.isSending, isTrue);
+    } finally {
+      rpc.encryptWait!.complete();
+      await newSend;
+    }
+    expect(provider.isSending, isFalse);
+    expect(provider.messages.map((message) => message.content), ['Private B', 'Private send B']);
+  });
+
+  test('a signed message creates a contact and permits a reply', () async {
+    final memo = await signed();
+    rpc.pending = {'first:0': await rpc.output(memo.encode(), bob)};
+    await provider.fetchPaymail();
+
+    expect(provider.error, isNull);
+    expect(provider.messages.single.content, 'Hello');
+    expect(provider.messages.single.senderPubkey, alice.details.encryptionPubkey);
+    expect(provider.contacts.single.id, alice.hash);
+    expect(provider.contacts.single.address, rpc.owners[alice.hash]);
+    provider.selectContact(provider.contacts.single);
+    expect(provider.currentConversation, hasLength(1));
+
+    expect(await provider.sendMessage('Reply'), 'tx-1');
+    final transfer = rpc.transfers.single;
+    expect(transfer.address, rpc.owners[alice.hash]);
+    expect(transfer.value, 1500);
+    expect(transfer.fee, ChatProvider.networkFeeSats);
+    final payload = BitnamesMessage.decode(rpc.ciphertexts[transfer.memo]!.$2)!;
+    expect(payload.sender, bob.hash);
+    expect(payload.recipient, alice.hash);
+    expect(payload.text, 'Reply');
+    expect(await payload.checkSender(rpc, alice.hash), rpc.owners[bob.hash]);
+    expect(provider.currentConversation, hasLength(2));
+  });
+
+  test('a confirmed hex memo creates the same known sender', () async {
+    final memo = await signed();
+    rpc.settled = {'first:0': await rpc.output(memo.encode(), bob, hexMemo: true)};
+    await provider.fetchPaymail();
+
+    expect(provider.error, isNull);
+    expect(provider.messages.single.isPending, isFalse);
+    expect(provider.messages.single.senderPubkey, alice.details.encryptionPubkey);
+    expect(provider.contacts.single.encryptionPubkey, alice.details.encryptionPubkey);
+  });
+
+  test('a block keeps the message sender and read state', () async {
+    final memo = await signed();
+    rpc.pending = {'first:0': await rpc.output(memo.encode(), bob)};
+    await provider.fetchPaymail();
+    await provider.markConversationRead(alice.hash);
+    final before = provider.messages.single;
+    expect(before.read, isTrue);
+    rpc.pending = {};
+    rpc.settled = {'first:0': await rpc.output(memo.encode(), bob, hexMemo: true)};
+    await provider.fetchPaymail();
+
+    final after = provider.messages.single;
+    expect(after.id, before.id);
+    expect(after.senderPubkey, before.senderPubkey);
+    expect(after.timestamp, before.timestamp);
+    expect(after.read, isTrue);
+    expect(after.isPending, isFalse);
+    expect(rpc.checks, hasLength(1));
+  });
+
+  for (final pending in [true, false]) {
+    test('new mail in the open conversation is read with pending $pending', () async {
+      await provider.addContactFromEntry(alice);
+      provider.selectContact(provider.contacts.single);
+      final mail = {
+        'alice:0': await rpc.output((await signed()).encode(), bob),
+        'carol:0': await rpc.output((await signed(sender: carol)).encode(), bob),
+      };
+      if (pending) {
+        rpc.pending = mail;
+      } else {
+        rpc.settled = mail;
+      }
+
+      await provider.fetchPaymail();
+
+      expect(provider.currentConversation.single.read, isTrue);
+      expect(provider.unreadCount(alice.hash), 0);
+      expect(provider.unreadCount(carol.hash), 1);
+    });
+  }
+
+  test('a message for a different selected identity stays unread', () async {
+    await provider.addContactFromEntry(alice);
+    provider.selectContact(provider.contacts.single);
+    rpc.pending = {'bob:0': await rpc.output((await signed()).encode(), bob)};
+    rpc.decryptWait = Completer<void>();
+    final poll = provider.fetchPaymail();
+    await Future<void>.delayed(Duration.zero);
+    rpc.online = false;
+    provider.selectIdentity(carol);
+    rpc.decryptWait!.complete();
+
+    await poll;
+
+    expect(provider.currentConversation, isEmpty);
+    expect(provider.messages.single.read, isFalse);
+  });
+
+  test('an identity change marks the displayed conversation read', () async {
+    rpc.settled = {'bob:0': await rpc.output((await signed()).encode(), bob)};
+    await provider.fetchPaymail();
+    expect(provider.messages.single.read, isFalse);
+    rpc.online = false;
+    provider.selectIdentity(carol);
+    provider.selectContact(provider.contacts.single);
+    expect(provider.currentConversation, isEmpty);
+
+    provider.selectIdentity(bob);
+
+    expect(provider.currentConversation.single.read, isTrue);
+    expect(provider.unreadCount(alice.hash), 0);
+  });
+
+  test('a paymail error keeps the pending message', () async {
+    rpc.pending = {'first:0': await rpc.output((await signed()).encode(), bob)};
+    await provider.fetchPaymail();
+    rpc.pending = {};
+    rpc.failPaymail = true;
+    await provider.fetchPaymail();
+    expect(provider.messages.single.isPending, isTrue);
+    expect(provider.error, contains('The paymail RPC failed'));
+  });
+
+  test('unsigned text keeps an unknown sender and cannot receive a reply', () async {
+    rpc.settled = {'old:0': await rpc.output('Old text', bob, hexMemo: true)};
+    await provider.fetchPaymail();
+    final contact = provider.contacts.single;
+    expect(contact.displayName, 'Unknown sender');
+    expect(contact.address, 'unknown');
+    expect(contact.encryptionPubkey, isEmpty);
+    provider.selectContact(contact);
+    expect(provider.currentConversation.single.content, 'Old text');
+    expect(await provider.sendMessage('Reply'), isNull);
+    expect(rpc.transfers, isEmpty);
+  });
+
+  for (final field in ['text', 'sender', 'id']) {
+    test('a changed $field cannot name the sender', () async {
+      final memo = await signed();
+      final data = jsonDecode(memo.encode().substring(BitnamesMessage.prefix.length)) as Map<String, dynamic>;
+      data[field] = switch (field) {
+        'sender' => carol.hash,
+        'id' => '00000000-0000-4000-8000-000000000000',
+        _ => 'Changed text',
+      };
+      rpc.pending = {'bad:0': await rpc.output('${BitnamesMessage.prefix}${jsonEncode(data)}', bob)};
+      await provider.fetchPaymail();
+      expect(provider.messages, isEmpty);
+      expect(provider.contacts, isEmpty);
+      expect(provider.error, isNotNull);
+    });
+  }
+
+  test('a valid signature from a different owner cannot name the sender', () async {
+    final memo = await signed();
+    rpc.owners[alice.hash] = rpc.owners[carol.hash]!;
+    rpc.pending = {'bad:0': await rpc.output(memo.encode(), bob)};
+    await provider.fetchPaymail();
+    expect(provider.messages, isEmpty);
+    expect(provider.error, contains('does not match the BitName owner'));
+  });
+
+  test('a signed recipient must match the identity that decrypts the memo', () async {
+    final memo = await signed(recipient: carol);
+    rpc.pending = {'bad:0': await rpc.output(memo.encode(), bob)};
+    await provider.fetchPaymail();
+    expect(provider.messages, isEmpty);
+    expect(provider.contacts, isEmpty);
+  });
+
+  test('unsigned mail with a shared key belongs to the paid identity', () async {
+    carol = rpc.addIdentity('carol', 3, encryptionKey: bob.details.encryptionPubkey);
+    rpc.settled = {'carol:0': await rpc.output('For Carol', carol)};
+
+    await provider.fetchPaymail();
+
+    expect(provider.messages, isEmpty);
+    expect(provider.contacts, isEmpty);
+    expect(provider.error, isNull);
+    rpc.online = false;
+    provider.selectIdentity(carol);
+    rpc.online = true;
+    await provider.fetchPaymail();
+    expect(provider.messages.single.recipientBitname, carol.hash);
+    expect(provider.messages.single.content, 'For Carol');
+    expect(provider.contacts.single.id, 'unknown');
+    provider.selectContact(provider.contacts.single);
+    expect(provider.currentConversation.single.content, 'For Carol');
+    expect(provider.error, isNull);
+  });
+
+  for (final state in ['pending', 'confirmed']) {
+    test('signed $state mail cannot pay a different recipient address', () async {
+      rpc.names[bob.hash] = BitNameData(encryptionPubkey: bob.details.encryptionPubkey, paymailFeeSats: 5000);
+      rpc.names[carol.hash] = BitNameData(encryptionPubkey: carol.details.encryptionPubkey, paymailFeeSats: 1000);
+      expect(rpc.owners[bob.hash], isNot(rpc.owners[carol.hash]));
+      final output = await rpc.output((await signed()).encode(), bob);
+      output['address'] = rpc.owners[carol.hash];
+      output['content'] = {'BitcoinSats': 1000};
+      if (state == 'pending') {
+        rpc.pending = {'wrong:0': output};
+      } else {
+        rpc.settled = {'wrong:0': output};
+      }
+
+      await provider.fetchPaymail();
+
+      expect(provider.messages, isEmpty);
+      expect(provider.contacts, isEmpty);
+      expect(provider.error, contains('The payment address does not match the recipient BitName owner'));
+    });
+
+    test('signed $state mail keeps the lower fee at a shared recipient address', () async {
+      rpc.names[bob.hash] = BitNameData(encryptionPubkey: bob.details.encryptionPubkey, paymailFeeSats: 5000);
+      rpc.names[carol.hash] = BitNameData(encryptionPubkey: carol.details.encryptionPubkey, paymailFeeSats: 1000);
+      rpc.owners[bob.hash] = rpc.owners[carol.hash]!;
+      final output = await rpc.output((await signed()).encode(), bob);
+      output['content'] = {'BitcoinSats': 1000};
+      if (state == 'pending') {
+        rpc.pending = {'shared:0': output};
+      } else {
+        rpc.settled = {'shared:0': output};
+      }
+
+      await provider.fetchPaymail();
+
+      expect(provider.messages.single.recipientBitname, bob.hash);
+      expect(provider.messages.single.valueSats, 1000);
+      expect(provider.contacts.single.id, alice.hash);
+      expect(provider.error, isNull);
+    });
+  }
+
+  test('a copied signed message does not create a second message', () async {
+    final memo = await signed();
+    rpc.pending = {
+      'first:0': await rpc.output(memo.encode(), bob),
+      'second:0': await rpc.output(memo.encode(), bob),
+    };
+    await provider.fetchPaymail();
+    expect(provider.messages, hasLength(1));
+    expect(provider.contacts, hasLength(1));
+  });
+
+  test('a different selected identity cannot change an active send', () async {
+    await provider.addContactFromEntry(alice);
+    provider.selectContact(provider.contacts.single);
+    rpc.encryptWait = Completer<void>();
+    final send = provider.sendMessage('Reply');
+    await Future<void>.delayed(Duration.zero);
+    rpc.online = false;
+    provider.selectIdentity(carol);
+    provider.selectContact(
+      ChatContact(
+        id: carol.hash,
+        name: 'Carol',
+        encryptionPubkey: carol.details.encryptionPubkey!,
+        address: rpc.owners[carol.hash]!,
+      ),
+    );
+    rpc.encryptWait!.complete();
+    expect(await send, 'tx-1');
+    final sent = BitnamesMessage.decode(rpc.ciphertexts[rpc.transfers.single.memo]!.$2)!;
+    expect(sent.sender, bob.hash);
+    expect(sent.recipient, alice.hash);
+    expect(rpc.transfers.single.address, rpc.owners[alice.hash]);
+    expect(provider.messages.single.senderPubkey, bob.details.encryptionPubkey);
+    expect(provider.contacts.single.lastMessage, isNull);
+    provider.selectIdentity(bob);
+    expect(provider.contacts.single.lastMessage, 'Reply');
+  });
+
+  test('each selected identity reads only its own messages', () async {
+    rpc.pending = {
+      'bob:0': await rpc.output((await signed(text: 'For Bob')).encode(), bob),
+      'carol:0': await rpc.output((await signed(recipient: carol, text: 'For Carol')).encode(), carol),
+    };
+    await provider.fetchPaymail();
+    provider.selectContact(provider.contacts.single);
+    expect(provider.currentConversation.single.content, 'For Bob');
+    rpc.online = false;
+    provider.selectIdentity(carol);
+    rpc.online = true;
+    await provider.fetchPaymail();
+    expect(provider.messages, hasLength(2));
+    expect(provider.currentConversation.single.content, 'For Carol');
+  });
+
+  for (final direction in ['incoming', 'outgoing']) {
+    test('contact previews use the selected identity for $direction mail and restore', () async {
+      final key = _StorageKey();
+      final store = BitnamesSecureStore(store: MockStore(), keySource: key);
+      provider.dispose();
+      rpc.online = false;
+      provider = ChatProvider(store: store);
+      provider.selectIdentity(bob);
+      rpc.online = true;
+      final contact = (await provider.lookupBitName('alice'))!.copyWith(isManual: true);
+      await provider.addContact(contact);
+      provider.selectContact(contact);
+      if (direction == 'incoming') {
+        rpc.settled = {'bob:0': await rpc.output((await signed(text: 'Bob text')).encode(), bob)};
+        await provider.fetchPaymail();
+      } else {
+        expect(await provider.sendMessage('Bob text'), 'tx-1');
+      }
+      expect(provider.contacts.single.lastMessage, 'Bob text');
+
+      rpc.online = false;
+      provider.selectIdentity(carol);
+      expect(provider.contacts.single.lastMessage, isNull);
+      expect(provider.contacts.single.lastMessageTime, isNull);
+      expect(provider.selectedContact!.lastMessage, isNull);
+      expect(provider.contacts.single.isManual, isTrue);
+      rpc.online = true;
+      if (direction == 'incoming') {
+        rpc.settled['carol:0'] = await rpc.output((await signed(recipient: carol, text: 'Carol text')).encode(), carol);
+        await provider.fetchPaymail();
+      } else {
+        expect(await provider.sendMessage('Carol text'), 'tx-2');
+      }
+      expect(provider.contacts.single.lastMessage, 'Carol text');
+      expect(provider.selectedContact!.lastMessage, 'Carol text');
+      rpc.online = false;
+      provider.selectIdentity(bob);
+      expect(provider.contacts.single.lastMessage, 'Bob text');
+      expect(provider.contacts.single.lastMessageTime, provider.currentConversation.single.timestamp);
+      expect(provider.selectedContact!.lastMessage, 'Bob text');
+
+      provider.dispose();
+      rpc.online = true;
+      provider = ChatProvider(store: store);
+      rpc.online = false;
+      provider.selectIdentity(bob);
+      await waitForChat('Carol text');
+      expect(provider.messages, hasLength(2));
+      expect(provider.contacts.single.lastMessage, 'Bob text');
+      expect(provider.contacts.single.isManual, isTrue);
+      provider.selectContact(provider.contacts.single);
+      provider.selectIdentity(carol);
+      expect(provider.contacts.single.lastMessage, 'Carol text');
+      expect(provider.contacts.single.lastMessageTime, provider.currentConversation.single.timestamp);
+      key.dispose();
+    });
+  }
+
+  test('two identities with one key keep separate conversations and read states', () async {
+    carol = rpc.addIdentity('carol', 3, encryptionKey: bob.details.encryptionPubkey);
+    rpc.pending = {
+      'bob:0': await rpc.output((await signed(text: 'For Bob')).encode(), bob),
+      'carol:0': await rpc.output((await signed(recipient: carol, text: 'For Carol')).encode(), carol),
+    };
+    await provider.fetchPaymail();
+    await provider.markConversationRead(alice.hash);
+    expect(provider.messages.single.content, 'For Bob');
+    rpc.online = false;
+    provider.selectIdentity(carol);
+    rpc.online = true;
+    await provider.fetchPaymail();
+    expect(provider.unreadCount(alice.hash), 1);
+    provider.selectContact(provider.contacts.single);
+    expect(provider.currentConversation.single.content, 'For Carol');
+    await provider.markConversationRead(alice.hash);
+    expect(provider.unreadCount(alice.hash), 0);
+    rpc.online = false;
+    provider.selectIdentity(bob);
+    expect(provider.currentConversation.single.content, 'For Bob');
+    expect(provider.currentConversation.single.read, isTrue);
+  });
+
+  test('the owner key uses Bech32m and BLAKE3', () {
+    final bytes = hex.decode('d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a');
+    final key = Bech32Encoder.encode('bn-svk', bytes, encoding: Bech32Encodings.bech32m);
+    expect(BitnamesMessage.addressForKey(key), '2WRXAwiHCW7rvEpkN1nPmFY5hiUC');
+    final oldKey = Bech32Encoder.encode('bn-svk', bytes);
+    expect(() => BitnamesMessage.addressForKey(oldKey), throwsA(anything));
+  });
+
+  test('the saved message keeps its BitName hashes and read state', () async {
+    final memo = await signed();
+    rpc.pending = {'first:0': await rpc.output(memo.encode(), bob)};
+    await provider.fetchPaymail();
+    await provider.markConversationRead(alice.hash);
+    final stored = ChatMessage.fromJson(provider.messages.single.toJson());
+    expect(stored.senderBitname, alice.hash);
+    expect(stored.recipientBitname, bob.hash);
+    expect(stored.read, isTrue);
+    expect(stored.copyWith(isPending: false).senderBitname, alice.hash);
+  });
+
+  test('a confirmed RPC error does not hide new pending mail', () async {
+    rpc.pending = {'first:0': await rpc.output((await signed()).encode(), bob)};
+    rpc.failPaymail = true;
+    await provider.fetchPaymail();
+    expect(provider.messages.single.content, 'Hello');
+    expect(provider.messages.single.isPending, isTrue);
+    expect(provider.error, contains('The paymail RPC failed'));
+  });
+
+  test('a pending RPC error does not hide confirmed mail', () async {
+    rpc.settled = {'first:0': await rpc.output((await signed()).encode(), bob, hexMemo: true)};
+    rpc.failPending = true;
+    await provider.fetchPaymail();
+    expect(provider.messages.single.content, 'Hello');
+    expect(provider.messages.single.isPending, isFalse);
+    expect(provider.error, contains('The pending RPC failed'));
+  });
+
+  test('a rejected signature does not hide valid mail in the same feed', () async {
+    final memo = await signed();
+    final data = jsonDecode(memo.encode().substring(BitnamesMessage.prefix.length)) as Map<String, dynamic>;
+    data['text'] = 'Changed text';
+    rpc.pending = {
+      'bad:0': await rpc.output('${BitnamesMessage.prefix}${jsonEncode(data)}', bob),
+      'good:0': await rpc.output(memo.encode(), bob),
+    };
+    await provider.fetchPaymail();
+    expect(provider.messages.single.content, 'Hello');
+    expect(provider.contacts.single.id, alice.hash);
+    expect(provider.error, contains('Rejected paymail bad:0'));
+  });
+
+  test('a contact from a plain name keeps its sent message', () async {
+    final contact = await provider.lookupBitName('alice');
+    expect(contact!.id, alice.hash);
+    await provider.addContact(contact);
+    provider.selectContact(contact);
+    expect(await provider.sendMessage('Hello Alice'), 'tx-1');
+    expect(provider.currentConversation.single.content, 'Hello Alice');
+  });
+
+  test('a self-contact excludes mail with a different sender or recipient', () async {
+    final aliceContact = await provider.lookupBitName('alice');
+    await provider.addContact(aliceContact!);
+    provider.selectContact(aliceContact);
+    expect(await provider.sendMessage('Hello Alice'), 'tx-1');
+    rpc.settled = {'old:0': await rpc.output('Old text', bob)};
+    await provider.fetchPaymail();
+    final self = await provider.lookupBitName('bob');
+    await provider.addContact(self!);
+    provider.selectContact(self);
+    expect(provider.currentConversation, isEmpty);
+  });
+
+  test('a restart moves old sender attribution and keeps manual contacts', () async {
+    final key = _StorageKey();
+    final store = BitnamesSecureStore(store: MockStore(), keySource: key);
+    final old = ChatMessage(
+      id: 'old:0',
+      content: 'Old text',
+      senderPubkey: 'old-payment-address',
+      recipientPubkey: bob.details.encryptionPubkey!,
+      timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+      isOutgoing: false,
+      read: true,
+    );
+    await store.save({
+      'messages': [old.toJson()],
+    });
+    await provider.addContact(
+      ChatContact(
+        id: 'old-payment-address',
+        name: 'Old address',
+        encryptionPubkey: '',
+        address: 'old-payment-address',
+        lastMessage: old.content,
+      ),
+    );
+    await provider.addContact(
+      ChatContact(
+        id: alice.hash,
+        name: 'Alice',
+        encryptionPubkey: alice.details.encryptionPubkey!,
+        address: 'old-payment-address',
+        lastMessage: old.content,
+        isManual: true,
+      ),
+    );
+    provider.dispose();
+    provider = ChatProvider(store: store);
+    final loaded = Completer<void>();
+    provider.addListener(() {
+      if (!loaded.isCompleted && provider.contacts.any((c) => c.id == 'unknown')) {
+        loaded.complete();
+      }
+    });
+    await loaded.future;
+    rpc.online = false;
+    provider.selectIdentity(bob);
+    final unknown = provider.contacts.singleWhere((c) => c.id == 'unknown');
+    provider.selectContact(unknown);
+    expect(provider.currentConversation.single.content, 'Old text');
+    expect(provider.currentConversation.single.read, isTrue);
+    expect(provider.contacts.any((c) => c.id == 'old-payment-address'), isFalse);
+    final manual = provider.contacts.singleWhere((c) => c.id == alice.hash);
+    expect(manual.isManual, isTrue);
+    expect(manual.lastMessage, isNull);
+    key.dispose();
+  });
+
+  test('a recipient without an inbox cannot receive a transfer', () async {
+    final contact = await provider.lookupBitName('alice');
+    await provider.addContact(contact!);
+    provider.selectContact(contact);
+    rpc.names[alice.hash] = BitNameData(encryptionPubkey: alice.details.encryptionPubkey);
+    expect(await provider.sendMessage('Hello Alice'), isNull);
+    expect(rpc.transfers, isEmpty);
+    expect(provider.error, contains('The recipient BitName has no inbox'));
+  });
+
+  test('a zero-fee inbox can receive a message', () async {
+    final contact = await provider.lookupBitName('alice');
+    await provider.addContact(contact!);
+    provider.selectContact(contact);
+    rpc.names[alice.hash] = BitNameData(encryptionPubkey: alice.details.encryptionPubkey, paymailFeeSats: 0);
+    expect(await provider.sendMessage('Hello Alice'), 'tx-1');
+    expect(rpc.transfers.single.value, 0);
+    expect(provider.messages.single.valueSats, 0);
+  });
+
+  test('a postage increase updates the quote before a second Send action', () async {
+    final contact = await provider.lookupBitName('alice');
+    await provider.addContact(contact!);
+    provider.selectContact(contact);
+    expect(provider.messageCostSats, 1600);
+    rpc.names[alice.hash] = BitNameData(encryptionPubkey: alice.details.encryptionPubkey, paymailFeeSats: 2500);
+
+    final txid = await provider.sendMessage('Hello Alice');
+
+    expect(rpc.transfers, isEmpty);
+    expect(txid, isNull);
+    expect(provider.messages, isEmpty);
+    expect(provider.postageSats, 2500);
+    expect(provider.messageCostSats, 2600);
+    expect(provider.isSending, isFalse);
+    expect(provider.error, 'The postage increased to 2500 sats. Select Send again to accept the new cost.');
+    final contacts = await GetIt.I.get<ClientSettings>().getValue(ChatContactsSetting());
+    expect(contacts.value.single.paymailFeeSats, 2500);
+
+    expect(await provider.sendMessage('Hello Alice'), 'tx-1');
+    expect(rpc.transfers.single.value, 2500);
+    expect(provider.messages.single.content, 'Hello Alice');
+    expect(provider.error, isNull);
+  });
+
+  test('a postage decrease uses the lower current fee', () async {
+    final contact = await provider.lookupBitName('alice');
+    await provider.addContact(contact!);
+    provider.selectContact(contact);
+    expect(provider.messageCostSats, 1600);
+    rpc.names[alice.hash] = BitNameData(encryptionPubkey: alice.details.encryptionPubkey, paymailFeeSats: 1000);
+
+    expect(await provider.sendMessage('Hello Alice'), 'tx-1');
+    expect(rpc.transfers.single.value, 1000);
+    expect(provider.messages.single.valueSats, 1000);
+    expect(provider.messageCostSats, 1100);
+  });
+
+  test('the BitName unknown stays separate from anonymous text', () async {
+    final sender = rpc.addIdentity('unknown', 4);
+    rpc.pending = {
+      'signed:0': await rpc.output((await signed(sender: sender, text: 'Known sender')).encode(), bob),
+      'old:0': await rpc.output('Old text', bob),
+    };
+    await provider.fetchPaymail();
+    final unknown = provider.contacts.singleWhere((c) => c.id == 'unknown');
+    provider.selectContact(unknown);
+    expect(provider.currentConversation.single.content, 'Old text');
+    expect(provider.unreadCount(sender.hash), 1);
+    final known = provider.contacts.singleWhere((c) => c.id == sender.hash);
+    provider.selectContact(known);
+    expect(provider.currentConversation.single.content, 'Known sender');
+  });
+
+  for (final field in ['key', 'signature']) {
+    test('an invalid $field does not hide the next message', () async {
+      final memo = await signed();
+      final data = jsonDecode(memo.encode().substring(BitnamesMessage.prefix.length)) as Map<String, dynamic>;
+      data[field] = 'bad';
+      rpc.pending = {
+        'bad:0': await rpc.output('${BitnamesMessage.prefix}${jsonEncode(data)}', bob),
+        'good:0': await rpc.output(memo.encode(), bob),
+      };
+      await provider.fetchPaymail();
+      expect(provider.messages.single.content, 'Hello');
+      expect(provider.error, contains('Rejected paymail bad:0'));
+      expect(rpc.checks, hasLength(1));
+    });
+  }
+
+  test('a key without an Ed25519 point does not hide valid mail', () async {
+    final memo = await signed();
+    final data = jsonDecode(memo.encode().substring(BitnamesMessage.prefix.length)) as Map<String, dynamic>;
+    data['key'] = Bech32Encoder.encode(
+      'bn-svk',
+      hex.decode('0200000000000000000000000000000000000000000000000000000000000000'),
+      encoding: Bech32Encodings.bech32m,
+    );
+    rpc.pending = {
+      'bad:0': await rpc.output('${BitnamesMessage.prefix}${jsonEncode(data)}', bob),
+      'good:0': await rpc.output(memo.encode(), bob),
+    };
+    await provider.fetchPaymail();
+    expect(provider.messages.single.content, 'Hello');
+    expect(provider.error, contains('Rejected paymail bad:0'));
+    expect(rpc.checks, hasLength(1));
+  });
+
+  test('an unregistered sender does not hide the next message', () async {
+    final sender = rpc.addIdentity('unregistered', 5);
+    final bad = await signed(sender: sender);
+    rpc.owners.remove(sender.hash);
+    rpc.names.remove(sender.hash);
+    rpc.pending = {
+      'bad:0': await rpc.output(bad.encode(), bob),
+      'good:0': await rpc.output((await signed()).encode(), bob),
+    };
+    await provider.fetchPaymail();
+    expect(provider.messages.single.content, 'Hello');
+    expect(provider.contacts.single.id, alice.hash);
+    expect(provider.error, contains('The sender BitName has no owner'));
+  });
+
+  test('an owner RPC error stays visible', () async {
+    final memo = await signed();
+    rpc.ownerErrors[alice.hash] = ConnectException(Code.unavailable, 'The owner RPC is unavailable');
+    rpc.pending = {'first:0': await rpc.output(memo.encode(), bob)};
+    await provider.fetchPaymail();
+    expect(provider.messages, isEmpty);
+    expect(provider.error, contains('The owner RPC is unavailable'));
+  });
+
+  test('send and receive keep message previews out of plaintext settings', () async {
+    final key = _StorageKey();
+    final store = BitnamesSecureStore(store: MockStore(), keySource: key);
+    provider.dispose();
+    rpc.online = false;
+    provider = ChatProvider(store: store);
+    provider.selectIdentity(bob);
+    rpc.online = true;
+    rpc.pending = {'first:0': await rpc.output((await signed(text: 'Private incoming text')).encode(), bob)};
+    await provider.fetchPaymail();
+    final settings = GetIt.I.get<ClientSettings>().store;
+    final receivedSettings = await settings.getString('chat_contacts');
+    expect(receivedSettings, isNot(contains('Private incoming text')));
+    expect(receivedSettings, isNot(contains('last_message')));
+    expect(provider.contacts.single.lastMessage, 'Private incoming text');
+    provider.selectContact(provider.contacts.single);
+    expect(await provider.sendMessage('Private outgoing text'), 'tx-1');
+    final sentSettings = await settings.getString('chat_contacts');
+    expect(sentSettings, isNot(contains('Private outgoing text')));
+    expect(sentSettings, isNot(contains('last_message')));
+    expect(provider.contacts.single.lastMessage, 'Private outgoing text');
+    final stored = await store.load();
+    final messages = (stored['messages'] as List<dynamic>).cast<Map<String, dynamic>>();
+    expect(messages.map((m) => m['content']), ['Private incoming text', 'Private outgoing text']);
+    provider.dispose();
+    provider = ChatProvider(store: store);
+    rpc.online = false;
+    provider.selectIdentity(bob);
+    await waitForChat('Private outgoing text');
+    expect(provider.messages, hasLength(2));
+    expect(provider.contacts.single.lastMessage, 'Private outgoing text');
+    key.dispose();
+  });
+
+  test('a legacy preview leaves settings and returns from encrypted messages', () async {
+    final key = _StorageKey();
+    final store = BitnamesSecureStore(store: MockStore(), keySource: key);
+    final contact = ChatContact(
+      id: alice.hash,
+      name: alice.hash,
+      plaintextName: 'Alice',
+      encryptionPubkey: alice.details.encryptionPubkey!,
+      address: rpc.owners[alice.hash]!,
+      isManual: true,
+      lastMessage: 'Private legacy text',
+      lastMessageTime: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+    await GetIt.I.get<ClientSettings>().store.setString('chat_contacts', jsonEncode([contact.toJson()]));
+    await store.save({
+      'messages': [
+        ChatMessage(
+          id: 'legacy:0',
+          content: 'Private legacy text',
+          senderPubkey: bob.details.encryptionPubkey!,
+          recipientPubkey: alice.details.encryptionPubkey!,
+          timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+          isOutgoing: true,
+        ).toJson(),
+      ],
+    });
+    provider.dispose();
+    provider = ChatProvider(store: store);
+    rpc.online = false;
+    provider.selectIdentity(bob);
+    await waitForChat('Private legacy text');
+    final settings = await GetIt.I.get<ClientSettings>().store.getString('chat_contacts');
+    expect(settings, isNot(contains('Private legacy text')));
+    expect(settings, isNot(contains('last_message')));
+    expect(provider.messages.single.content, 'Private legacy text');
+    expect(provider.contacts.single.lastMessage, 'Private legacy text');
+    expect(provider.contacts.single.plaintextName, 'Alice');
+    expect(provider.contacts.single.isManual, isTrue);
+    key.dispose();
+  });
+}

--- a/bitwindow/test/chat_secure_store_test.dart
+++ b/bitwindow/test/chat_secure_store_test.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+import 'package:bitwindow/models/chat_models.dart';
+import 'package:bitwindow/services/bitnames_secure_store.dart';
+import 'package:bitwindow/services/chat_file_storage.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Stands in for the wallet. The real source derives the same way from the
+/// unlocked wallet's mnemonic.
+class _Keys extends ChangeNotifier implements BitnamesStorageKeySource {
+  _Keys(this.identity);
+
+  BitnamesStorageIdentity? identity;
+
+  @override
+  Future<BitnamesStorageIdentity?> current() async => identity;
+}
+
+ChatMessage message(String id, String body) => ChatMessage(
+  id: id,
+  content: body,
+  senderPubkey: 'bn-enc1sender',
+  recipientPubkey: 'bn-enc1me',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1757680000000),
+  isOutgoing: false,
+);
+
+void main() {
+  late Directory directory;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('chat_store_test');
+  });
+
+  tearDown(() async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+  });
+
+  BitnamesSecureStore storeFor(String mnemonic) => BitnamesSecureStore(
+    store: ChatFileStorage.fromDirectory(directory),
+    keySource: _Keys(WalletBitnamesStorageKeySource.derive(masterMnemonic: mnemonic)),
+  );
+
+  // A restart must give the chat back. The chain cannot, because a sent
+  // message is encrypted to the reader.
+  test('the chat survives a restart', () async {
+    final store = storeFor('test wallet');
+    await store.save({
+      'messages': [message('a:0', 'hei ecash').toJson()],
+    });
+
+    final reopened = storeFor('test wallet');
+    final state = await reopened.load();
+    final stored = state['messages'] as List<dynamic>;
+    expect(stored, hasLength(1));
+    expect(ChatMessage.fromJson(stored.first as Map<String, dynamic>).content, 'hei ecash');
+  });
+
+  // A chat holds private text, so the disk must not.
+  test('the disk never holds the message text', () async {
+    await storeFor('test wallet').save({
+      'messages': [message('a:0', 'hemmelig melding').toJson()],
+    });
+
+    final onDisk = await File('${directory.path}${Platform.pathSeparator}chat.json').readAsString();
+    expect(onDisk, isNot(contains('hemmelig melding')));
+    expect(onDisk, isNot(contains('bn-enc1sender')));
+  });
+
+  // The key comes from the wallet, so another wallet reads nothing.
+  test('another wallet cannot read the chat', () async {
+    await storeFor('test wallet').save({
+      'messages': [message('a:0', 'hei ecash').toJson()],
+    });
+
+    final other = storeFor('a different wallet');
+    final state = await other.load();
+    expect(state['messages'], anyOf(isNull, isEmpty));
+  });
+
+  // A locked wallet holds no key, so the chat stays shut.
+  test('a locked wallet reads nothing', () async {
+    final locked = BitnamesSecureStore(
+      store: ChatFileStorage.fromDirectory(directory),
+      keySource: _Keys(null),
+    );
+    final state = await locked.load();
+    expect(state['messages'], anyOf(isNull, isEmpty));
+  });
+}

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -2,7 +2,7 @@ name: coinshift
 description: UI for CoinShift Drivechain sidechain with L1/L2 swap functionality
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.11
+version: 1.0.12
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.209
+version: 1.0.210
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/gen/bitnames/v1/bitnames.pb.go
+++ b/sidechain-orchestrator/gen/bitnames/v1/bitnames.pb.go
@@ -2615,6 +2615,188 @@ func (x *EncryptMsgResponse) GetCiphertext() string {
 	return ""
 }
 
+type GetBitNameOwnerRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The BitName hash, as hexadecimal.
+	Bitname       string `protobuf:"bytes,1,opt,name=bitname,proto3" json:"bitname,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBitNameOwnerRequest) Reset() {
+	*x = GetBitNameOwnerRequest{}
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBitNameOwnerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBitNameOwnerRequest) ProtoMessage() {}
+
+func (x *GetBitNameOwnerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBitNameOwnerRequest.ProtoReflect.Descriptor instead.
+func (*GetBitNameOwnerRequest) Descriptor() ([]byte, []int) {
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *GetBitNameOwnerRequest) GetBitname() string {
+	if x != nil {
+		return x.Bitname
+	}
+	return ""
+}
+
+type GetBitNameOwnerResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The address that holds the BitName today.
+	Address       string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBitNameOwnerResponse) Reset() {
+	*x = GetBitNameOwnerResponse{}
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBitNameOwnerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBitNameOwnerResponse) ProtoMessage() {}
+
+func (x *GetBitNameOwnerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBitNameOwnerResponse.ProtoReflect.Descriptor instead.
+func (*GetBitNameOwnerResponse) Descriptor() ([]byte, []int) {
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *GetBitNameOwnerResponse) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type GetPendingPaymailRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPendingPaymailRequest) Reset() {
+	*x = GetPendingPaymailRequest{}
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPendingPaymailRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPendingPaymailRequest) ProtoMessage() {}
+
+func (x *GetPendingPaymailRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPendingPaymailRequest.ProtoReflect.Descriptor instead.
+func (*GetPendingPaymailRequest) Descriptor() ([]byte, []int) {
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{62}
+}
+
+type GetPendingPaymailResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The same JSON object GetPaymail returns, holding only the outputs that
+	// wait in the mempool.
+	PaymailJson string `protobuf:"bytes,1,opt,name=paymail_json,json=paymailJson,proto3" json:"paymail_json,omitempty"`
+	// Every transaction the mempool holds. A message a caller sent pays the
+	// reader, so no paymail feed reports it, and this says whether it waits.
+	MempoolTxids  []string `protobuf:"bytes,2,rep,name=mempool_txids,json=mempoolTxids,proto3" json:"mempool_txids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPendingPaymailResponse) Reset() {
+	*x = GetPendingPaymailResponse{}
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPendingPaymailResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPendingPaymailResponse) ProtoMessage() {}
+
+func (x *GetPendingPaymailResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPendingPaymailResponse.ProtoReflect.Descriptor instead.
+func (*GetPendingPaymailResponse) Descriptor() ([]byte, []int) {
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{63}
+}
+
+func (x *GetPendingPaymailResponse) GetPaymailJson() string {
+	if x != nil {
+		return x.PaymailJson
+	}
+	return ""
+}
+
+func (x *GetPendingPaymailResponse) GetMempoolTxids() []string {
+	if x != nil {
+		return x.MempoolTxids
+	}
+	return nil
+}
+
 type GetPaymailRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2623,7 +2805,7 @@ type GetPaymailRequest struct {
 
 func (x *GetPaymailRequest) Reset() {
 	*x = GetPaymailRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[60]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2635,7 +2817,7 @@ func (x *GetPaymailRequest) String() string {
 func (*GetPaymailRequest) ProtoMessage() {}
 
 func (x *GetPaymailRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[60]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2648,7 +2830,7 @@ func (x *GetPaymailRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPaymailRequest.ProtoReflect.Descriptor instead.
 func (*GetPaymailRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{60}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{64}
 }
 
 type GetPaymailResponse struct {
@@ -2660,7 +2842,7 @@ type GetPaymailResponse struct {
 
 func (x *GetPaymailResponse) Reset() {
 	*x = GetPaymailResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[61]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2672,7 +2854,7 @@ func (x *GetPaymailResponse) String() string {
 func (*GetPaymailResponse) ProtoMessage() {}
 
 func (x *GetPaymailResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[61]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2685,7 +2867,7 @@ func (x *GetPaymailResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPaymailResponse.ProtoReflect.Descriptor instead.
 func (*GetPaymailResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{61}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetPaymailResponse) GetPaymailJson() string {
@@ -2704,7 +2886,7 @@ type ResolveCommitRequest struct {
 
 func (x *ResolveCommitRequest) Reset() {
 	*x = ResolveCommitRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[62]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2716,7 +2898,7 @@ func (x *ResolveCommitRequest) String() string {
 func (*ResolveCommitRequest) ProtoMessage() {}
 
 func (x *ResolveCommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[62]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2729,7 +2911,7 @@ func (x *ResolveCommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveCommitRequest.ProtoReflect.Descriptor instead.
 func (*ResolveCommitRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{62}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ResolveCommitRequest) GetBitname() string {
@@ -2753,7 +2935,7 @@ type ResolveCommitResponse struct {
 
 func (x *ResolveCommitResponse) Reset() {
 	*x = ResolveCommitResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[63]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2765,7 +2947,7 @@ func (x *ResolveCommitResponse) String() string {
 func (*ResolveCommitResponse) ProtoMessage() {}
 
 func (x *ResolveCommitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[63]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2778,7 +2960,7 @@ func (x *ResolveCommitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveCommitResponse.ProtoReflect.Descriptor instead.
 func (*ResolveCommitResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{63}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ResolveCommitResponse) GetCommitment() string {
@@ -2812,7 +2994,7 @@ type ReadCommitmentRequest struct {
 
 func (x *ReadCommitmentRequest) Reset() {
 	*x = ReadCommitmentRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[64]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2824,7 +3006,7 @@ func (x *ReadCommitmentRequest) String() string {
 func (*ReadCommitmentRequest) ProtoMessage() {}
 
 func (x *ReadCommitmentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[64]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2837,7 +3019,7 @@ func (x *ReadCommitmentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadCommitmentRequest.ProtoReflect.Descriptor instead.
 func (*ReadCommitmentRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{64}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ReadCommitmentRequest) GetAddress() string {
@@ -2859,7 +3041,7 @@ type ReadCommitmentResponse struct {
 
 func (x *ReadCommitmentResponse) Reset() {
 	*x = ReadCommitmentResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[65]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2871,7 +3053,7 @@ func (x *ReadCommitmentResponse) String() string {
 func (*ReadCommitmentResponse) ProtoMessage() {}
 
 func (x *ReadCommitmentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[65]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2884,7 +3066,7 @@ func (x *ReadCommitmentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadCommitmentResponse.ProtoReflect.Descriptor instead.
 func (*ReadCommitmentResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{65}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ReadCommitmentResponse) GetDataJson() string {
@@ -2911,7 +3093,7 @@ type SignArbitraryMsgRequest struct {
 
 func (x *SignArbitraryMsgRequest) Reset() {
 	*x = SignArbitraryMsgRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[66]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2923,7 +3105,7 @@ func (x *SignArbitraryMsgRequest) String() string {
 func (*SignArbitraryMsgRequest) ProtoMessage() {}
 
 func (x *SignArbitraryMsgRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[66]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2936,7 +3118,7 @@ func (x *SignArbitraryMsgRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignArbitraryMsgRequest.ProtoReflect.Descriptor instead.
 func (*SignArbitraryMsgRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{66}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *SignArbitraryMsgRequest) GetMsg() string {
@@ -2962,7 +3144,7 @@ type SignArbitraryMsgResponse struct {
 
 func (x *SignArbitraryMsgResponse) Reset() {
 	*x = SignArbitraryMsgResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[67]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2974,7 +3156,7 @@ func (x *SignArbitraryMsgResponse) String() string {
 func (*SignArbitraryMsgResponse) ProtoMessage() {}
 
 func (x *SignArbitraryMsgResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[67]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2987,7 +3169,7 @@ func (x *SignArbitraryMsgResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignArbitraryMsgResponse.ProtoReflect.Descriptor instead.
 func (*SignArbitraryMsgResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{67}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *SignArbitraryMsgResponse) GetSignature() string {
@@ -3007,7 +3189,7 @@ type SignArbitraryMsgAsAddrRequest struct {
 
 func (x *SignArbitraryMsgAsAddrRequest) Reset() {
 	*x = SignArbitraryMsgAsAddrRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[68]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3019,7 +3201,7 @@ func (x *SignArbitraryMsgAsAddrRequest) String() string {
 func (*SignArbitraryMsgAsAddrRequest) ProtoMessage() {}
 
 func (x *SignArbitraryMsgAsAddrRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[68]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3032,7 +3214,7 @@ func (x *SignArbitraryMsgAsAddrRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignArbitraryMsgAsAddrRequest.ProtoReflect.Descriptor instead.
 func (*SignArbitraryMsgAsAddrRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{68}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *SignArbitraryMsgAsAddrRequest) GetMsg() string {
@@ -3059,7 +3241,7 @@ type SignArbitraryMsgAsAddrResponse struct {
 
 func (x *SignArbitraryMsgAsAddrResponse) Reset() {
 	*x = SignArbitraryMsgAsAddrResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[69]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3071,7 +3253,7 @@ func (x *SignArbitraryMsgAsAddrResponse) String() string {
 func (*SignArbitraryMsgAsAddrResponse) ProtoMessage() {}
 
 func (x *SignArbitraryMsgAsAddrResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[69]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3084,7 +3266,7 @@ func (x *SignArbitraryMsgAsAddrResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignArbitraryMsgAsAddrResponse.ProtoReflect.Descriptor instead.
 func (*SignArbitraryMsgAsAddrResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{69}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *SignArbitraryMsgAsAddrResponse) GetVerifyingKey() string {
@@ -3109,7 +3291,7 @@ type GetWalletAddressesRequest struct {
 
 func (x *GetWalletAddressesRequest) Reset() {
 	*x = GetWalletAddressesRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[70]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3121,7 +3303,7 @@ func (x *GetWalletAddressesRequest) String() string {
 func (*GetWalletAddressesRequest) ProtoMessage() {}
 
 func (x *GetWalletAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[70]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3134,7 +3316,7 @@ func (x *GetWalletAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletAddressesRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{70}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{74}
 }
 
 type GetWalletAddressesResponse struct {
@@ -3146,7 +3328,7 @@ type GetWalletAddressesResponse struct {
 
 func (x *GetWalletAddressesResponse) Reset() {
 	*x = GetWalletAddressesResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[71]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3158,7 +3340,7 @@ func (x *GetWalletAddressesResponse) String() string {
 func (*GetWalletAddressesResponse) ProtoMessage() {}
 
 func (x *GetWalletAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[71]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3171,7 +3353,7 @@ func (x *GetWalletAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletAddressesResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{71}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetWalletAddressesResponse) GetAddresses() []string {
@@ -3189,7 +3371,7 @@ type MyUtxosRequest struct {
 
 func (x *MyUtxosRequest) Reset() {
 	*x = MyUtxosRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[72]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3201,7 +3383,7 @@ func (x *MyUtxosRequest) String() string {
 func (*MyUtxosRequest) ProtoMessage() {}
 
 func (x *MyUtxosRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[72]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3214,7 +3396,7 @@ func (x *MyUtxosRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MyUtxosRequest.ProtoReflect.Descriptor instead.
 func (*MyUtxosRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{72}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{76}
 }
 
 type MyUtxosResponse struct {
@@ -3226,7 +3408,7 @@ type MyUtxosResponse struct {
 
 func (x *MyUtxosResponse) Reset() {
 	*x = MyUtxosResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[73]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3238,7 +3420,7 @@ func (x *MyUtxosResponse) String() string {
 func (*MyUtxosResponse) ProtoMessage() {}
 
 func (x *MyUtxosResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[73]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3251,7 +3433,7 @@ func (x *MyUtxosResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MyUtxosResponse.ProtoReflect.Descriptor instead.
 func (*MyUtxosResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{73}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *MyUtxosResponse) GetUtxosJson() string {
@@ -3269,7 +3451,7 @@ type OpenapiSchemaRequest struct {
 
 func (x *OpenapiSchemaRequest) Reset() {
 	*x = OpenapiSchemaRequest{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[74]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3281,7 +3463,7 @@ func (x *OpenapiSchemaRequest) String() string {
 func (*OpenapiSchemaRequest) ProtoMessage() {}
 
 func (x *OpenapiSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[74]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3476,7 @@ func (x *OpenapiSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenapiSchemaRequest.ProtoReflect.Descriptor instead.
 func (*OpenapiSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{74}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{78}
 }
 
 type OpenapiSchemaResponse struct {
@@ -3306,7 +3488,7 @@ type OpenapiSchemaResponse struct {
 
 func (x *OpenapiSchemaResponse) Reset() {
 	*x = OpenapiSchemaResponse{}
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[75]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3318,7 +3500,7 @@ func (x *OpenapiSchemaResponse) String() string {
 func (*OpenapiSchemaResponse) ProtoMessage() {}
 
 func (x *OpenapiSchemaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bitnames_v1_bitnames_proto_msgTypes[75]
+	mi := &file_bitnames_v1_bitnames_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3331,7 +3513,7 @@ func (x *OpenapiSchemaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenapiSchemaResponse.ProtoReflect.Descriptor instead.
 func (*OpenapiSchemaResponse) Descriptor() ([]byte, []int) {
-	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{75}
+	return file_bitnames_v1_bitnames_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *OpenapiSchemaResponse) GetSchemaJson() string {
@@ -3479,7 +3661,15 @@ const file_bitnames_v1_bitnames_proto_rawDesc = "" +
 	"\x12EncryptMsgResponse\x12\x1e\n" +
 	"\n" +
 	"ciphertext\x18\x01 \x01(\tR\n" +
-	"ciphertext\"\x13\n" +
+	"ciphertext\"2\n" +
+	"\x16GetBitNameOwnerRequest\x12\x18\n" +
+	"\abitname\x18\x01 \x01(\tR\abitname\"3\n" +
+	"\x17GetBitNameOwnerResponse\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"\x1a\n" +
+	"\x18GetPendingPaymailRequest\"c\n" +
+	"\x19GetPendingPaymailResponse\x12!\n" +
+	"\fpaymail_json\x18\x01 \x01(\tR\vpaymailJson\x12#\n" +
+	"\rmempool_txids\x18\x02 \x03(\tR\fmempoolTxids\"\x13\n" +
 	"\x11GetPaymailRequest\"7\n" +
 	"\x12GetPaymailResponse\x12!\n" +
 	"\fpaymail_json\x18\x01 \x01(\tR\vpaymailJson\"0\n" +
@@ -3519,7 +3709,7 @@ const file_bitnames_v1_bitnames_proto_rawDesc = "" +
 	"\x14OpenapiSchemaRequest\"8\n" +
 	"\x15OpenapiSchemaResponse\x12\x1f\n" +
 	"\vschema_json\x18\x01 \x01(\tR\n" +
-	"schemaJson2\xa6\x1b\n" +
+	"schemaJson2\xe8\x1c\n" +
 	"\x0fBitnamesService\x12M\n" +
 	"\n" +
 	"GetBalance\x12\x1e.bitnames.v1.GetBalanceRequest\x1a\x1f.bitnames.v1.GetBalanceResponse\x12V\n" +
@@ -3555,7 +3745,9 @@ const file_bitnames_v1_bitnames_proto_rawDesc = "" +
 	"\n" +
 	"EncryptMsg\x12\x1e.bitnames.v1.EncryptMsgRequest\x1a\x1f.bitnames.v1.EncryptMsgResponse\x12M\n" +
 	"\n" +
-	"GetPaymail\x12\x1e.bitnames.v1.GetPaymailRequest\x1a\x1f.bitnames.v1.GetPaymailResponse\x12V\n" +
+	"GetPaymail\x12\x1e.bitnames.v1.GetPaymailRequest\x1a\x1f.bitnames.v1.GetPaymailResponse\x12b\n" +
+	"\x11GetPendingPaymail\x12%.bitnames.v1.GetPendingPaymailRequest\x1a&.bitnames.v1.GetPendingPaymailResponse\x12\\\n" +
+	"\x0fGetBitNameOwner\x12#.bitnames.v1.GetBitNameOwnerRequest\x1a$.bitnames.v1.GetBitNameOwnerResponse\x12V\n" +
 	"\rResolveCommit\x12!.bitnames.v1.ResolveCommitRequest\x1a\".bitnames.v1.ResolveCommitResponse\x12Y\n" +
 	"\x0eReadCommitment\x12\".bitnames.v1.ReadCommitmentRequest\x1a#.bitnames.v1.ReadCommitmentResponse\x12_\n" +
 	"\x10SignArbitraryMsg\x12$.bitnames.v1.SignArbitraryMsgRequest\x1a%.bitnames.v1.SignArbitraryMsgResponse\x12q\n" +
@@ -3577,7 +3769,7 @@ func file_bitnames_v1_bitnames_proto_rawDescGZIP() []byte {
 	return file_bitnames_v1_bitnames_proto_rawDescData
 }
 
-var file_bitnames_v1_bitnames_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
+var file_bitnames_v1_bitnames_proto_msgTypes = make([]protoimpl.MessageInfo, 80)
 var file_bitnames_v1_bitnames_proto_goTypes = []any{
 	(*GetBalanceRequest)(nil),                             // 0: bitnames.v1.GetBalanceRequest
 	(*GetBalanceResponse)(nil),                            // 1: bitnames.v1.GetBalanceResponse
@@ -3639,22 +3831,26 @@ var file_bitnames_v1_bitnames_proto_goTypes = []any{
 	(*DecryptMsgResponse)(nil),                            // 57: bitnames.v1.DecryptMsgResponse
 	(*EncryptMsgRequest)(nil),                             // 58: bitnames.v1.EncryptMsgRequest
 	(*EncryptMsgResponse)(nil),                            // 59: bitnames.v1.EncryptMsgResponse
-	(*GetPaymailRequest)(nil),                             // 60: bitnames.v1.GetPaymailRequest
-	(*GetPaymailResponse)(nil),                            // 61: bitnames.v1.GetPaymailResponse
-	(*ResolveCommitRequest)(nil),                          // 62: bitnames.v1.ResolveCommitRequest
-	(*ResolveCommitResponse)(nil),                         // 63: bitnames.v1.ResolveCommitResponse
-	(*ReadCommitmentRequest)(nil),                         // 64: bitnames.v1.ReadCommitmentRequest
-	(*ReadCommitmentResponse)(nil),                        // 65: bitnames.v1.ReadCommitmentResponse
-	(*SignArbitraryMsgRequest)(nil),                       // 66: bitnames.v1.SignArbitraryMsgRequest
-	(*SignArbitraryMsgResponse)(nil),                      // 67: bitnames.v1.SignArbitraryMsgResponse
-	(*SignArbitraryMsgAsAddrRequest)(nil),                 // 68: bitnames.v1.SignArbitraryMsgAsAddrRequest
-	(*SignArbitraryMsgAsAddrResponse)(nil),                // 69: bitnames.v1.SignArbitraryMsgAsAddrResponse
-	(*GetWalletAddressesRequest)(nil),                     // 70: bitnames.v1.GetWalletAddressesRequest
-	(*GetWalletAddressesResponse)(nil),                    // 71: bitnames.v1.GetWalletAddressesResponse
-	(*MyUtxosRequest)(nil),                                // 72: bitnames.v1.MyUtxosRequest
-	(*MyUtxosResponse)(nil),                               // 73: bitnames.v1.MyUtxosResponse
-	(*OpenapiSchemaRequest)(nil),                          // 74: bitnames.v1.OpenapiSchemaRequest
-	(*OpenapiSchemaResponse)(nil),                         // 75: bitnames.v1.OpenapiSchemaResponse
+	(*GetBitNameOwnerRequest)(nil),                        // 60: bitnames.v1.GetBitNameOwnerRequest
+	(*GetBitNameOwnerResponse)(nil),                       // 61: bitnames.v1.GetBitNameOwnerResponse
+	(*GetPendingPaymailRequest)(nil),                      // 62: bitnames.v1.GetPendingPaymailRequest
+	(*GetPendingPaymailResponse)(nil),                     // 63: bitnames.v1.GetPendingPaymailResponse
+	(*GetPaymailRequest)(nil),                             // 64: bitnames.v1.GetPaymailRequest
+	(*GetPaymailResponse)(nil),                            // 65: bitnames.v1.GetPaymailResponse
+	(*ResolveCommitRequest)(nil),                          // 66: bitnames.v1.ResolveCommitRequest
+	(*ResolveCommitResponse)(nil),                         // 67: bitnames.v1.ResolveCommitResponse
+	(*ReadCommitmentRequest)(nil),                         // 68: bitnames.v1.ReadCommitmentRequest
+	(*ReadCommitmentResponse)(nil),                        // 69: bitnames.v1.ReadCommitmentResponse
+	(*SignArbitraryMsgRequest)(nil),                       // 70: bitnames.v1.SignArbitraryMsgRequest
+	(*SignArbitraryMsgResponse)(nil),                      // 71: bitnames.v1.SignArbitraryMsgResponse
+	(*SignArbitraryMsgAsAddrRequest)(nil),                 // 72: bitnames.v1.SignArbitraryMsgAsAddrRequest
+	(*SignArbitraryMsgAsAddrResponse)(nil),                // 73: bitnames.v1.SignArbitraryMsgAsAddrResponse
+	(*GetWalletAddressesRequest)(nil),                     // 74: bitnames.v1.GetWalletAddressesRequest
+	(*GetWalletAddressesResponse)(nil),                    // 75: bitnames.v1.GetWalletAddressesResponse
+	(*MyUtxosRequest)(nil),                                // 76: bitnames.v1.MyUtxosRequest
+	(*MyUtxosResponse)(nil),                               // 77: bitnames.v1.MyUtxosResponse
+	(*OpenapiSchemaRequest)(nil),                          // 78: bitnames.v1.OpenapiSchemaRequest
+	(*OpenapiSchemaResponse)(nil),                         // 79: bitnames.v1.OpenapiSchemaResponse
 }
 var file_bitnames_v1_bitnames_proto_depIdxs = []int32{
 	0,  // 0: bitnames.v1.BitnamesService.GetBalance:input_type -> bitnames.v1.GetBalanceRequest
@@ -3687,54 +3883,58 @@ var file_bitnames_v1_bitnames_proto_depIdxs = []int32{
 	54, // 27: bitnames.v1.BitnamesService.GetNewVerifyingKey:input_type -> bitnames.v1.GetNewVerifyingKeyRequest
 	56, // 28: bitnames.v1.BitnamesService.DecryptMsg:input_type -> bitnames.v1.DecryptMsgRequest
 	58, // 29: bitnames.v1.BitnamesService.EncryptMsg:input_type -> bitnames.v1.EncryptMsgRequest
-	60, // 30: bitnames.v1.BitnamesService.GetPaymail:input_type -> bitnames.v1.GetPaymailRequest
-	62, // 31: bitnames.v1.BitnamesService.ResolveCommit:input_type -> bitnames.v1.ResolveCommitRequest
-	64, // 32: bitnames.v1.BitnamesService.ReadCommitment:input_type -> bitnames.v1.ReadCommitmentRequest
-	66, // 33: bitnames.v1.BitnamesService.SignArbitraryMsg:input_type -> bitnames.v1.SignArbitraryMsgRequest
-	68, // 34: bitnames.v1.BitnamesService.SignArbitraryMsgAsAddr:input_type -> bitnames.v1.SignArbitraryMsgAsAddrRequest
-	70, // 35: bitnames.v1.BitnamesService.GetWalletAddresses:input_type -> bitnames.v1.GetWalletAddressesRequest
-	72, // 36: bitnames.v1.BitnamesService.MyUtxos:input_type -> bitnames.v1.MyUtxosRequest
-	74, // 37: bitnames.v1.BitnamesService.OpenapiSchema:input_type -> bitnames.v1.OpenapiSchemaRequest
-	1,  // 38: bitnames.v1.BitnamesService.GetBalance:output_type -> bitnames.v1.GetBalanceResponse
-	3,  // 39: bitnames.v1.BitnamesService.GetBlockCount:output_type -> bitnames.v1.GetBlockCountResponse
-	5,  // 40: bitnames.v1.BitnamesService.Stop:output_type -> bitnames.v1.StopResponse
-	7,  // 41: bitnames.v1.BitnamesService.GetNewAddress:output_type -> bitnames.v1.GetNewAddressResponse
-	9,  // 42: bitnames.v1.BitnamesService.Withdraw:output_type -> bitnames.v1.WithdrawResponse
-	11, // 43: bitnames.v1.BitnamesService.Transfer:output_type -> bitnames.v1.TransferResponse
-	13, // 44: bitnames.v1.BitnamesService.GetSidechainWealth:output_type -> bitnames.v1.GetSidechainWealthResponse
-	15, // 45: bitnames.v1.BitnamesService.CreateDeposit:output_type -> bitnames.v1.CreateDepositResponse
-	17, // 46: bitnames.v1.BitnamesService.GetPendingWithdrawalBundle:output_type -> bitnames.v1.GetPendingWithdrawalBundleResponse
-	19, // 47: bitnames.v1.BitnamesService.ConnectPeer:output_type -> bitnames.v1.ConnectPeerResponse
-	21, // 48: bitnames.v1.BitnamesService.ListPeers:output_type -> bitnames.v1.ListPeersResponse
-	23, // 49: bitnames.v1.BitnamesService.Mine:output_type -> bitnames.v1.MineResponse
-	25, // 50: bitnames.v1.BitnamesService.GetBlock:output_type -> bitnames.v1.GetBlockResponse
-	27, // 51: bitnames.v1.BitnamesService.GetBestMainchainBlockHash:output_type -> bitnames.v1.GetBestMainchainBlockHashResponse
-	29, // 52: bitnames.v1.BitnamesService.GetBestSidechainBlockHash:output_type -> bitnames.v1.GetBestSidechainBlockHashResponse
-	31, // 53: bitnames.v1.BitnamesService.GetBmmInclusions:output_type -> bitnames.v1.GetBmmInclusionsResponse
-	33, // 54: bitnames.v1.BitnamesService.GetWalletUtxos:output_type -> bitnames.v1.GetWalletUtxosResponse
-	35, // 55: bitnames.v1.BitnamesService.ListUtxos:output_type -> bitnames.v1.ListUtxosResponse
-	37, // 56: bitnames.v1.BitnamesService.GetLatestFailedWithdrawalBundleHeight:output_type -> bitnames.v1.GetLatestFailedWithdrawalBundleHeightResponse
-	39, // 57: bitnames.v1.BitnamesService.GenerateMnemonic:output_type -> bitnames.v1.GenerateMnemonicResponse
-	41, // 58: bitnames.v1.BitnamesService.SetSeedFromMnemonic:output_type -> bitnames.v1.SetSeedFromMnemonicResponse
-	43, // 59: bitnames.v1.BitnamesService.CallRaw:output_type -> bitnames.v1.CallRawResponse
-	45, // 60: bitnames.v1.BitnamesService.GetBitNameData:output_type -> bitnames.v1.GetBitNameDataResponse
-	47, // 61: bitnames.v1.BitnamesService.ListBitNames:output_type -> bitnames.v1.ListBitNamesResponse
-	49, // 62: bitnames.v1.BitnamesService.RegisterBitName:output_type -> bitnames.v1.RegisterBitNameResponse
-	51, // 63: bitnames.v1.BitnamesService.ReserveBitName:output_type -> bitnames.v1.ReserveBitNameResponse
-	53, // 64: bitnames.v1.BitnamesService.GetNewEncryptionKey:output_type -> bitnames.v1.GetNewEncryptionKeyResponse
-	55, // 65: bitnames.v1.BitnamesService.GetNewVerifyingKey:output_type -> bitnames.v1.GetNewVerifyingKeyResponse
-	57, // 66: bitnames.v1.BitnamesService.DecryptMsg:output_type -> bitnames.v1.DecryptMsgResponse
-	59, // 67: bitnames.v1.BitnamesService.EncryptMsg:output_type -> bitnames.v1.EncryptMsgResponse
-	61, // 68: bitnames.v1.BitnamesService.GetPaymail:output_type -> bitnames.v1.GetPaymailResponse
-	63, // 69: bitnames.v1.BitnamesService.ResolveCommit:output_type -> bitnames.v1.ResolveCommitResponse
-	65, // 70: bitnames.v1.BitnamesService.ReadCommitment:output_type -> bitnames.v1.ReadCommitmentResponse
-	67, // 71: bitnames.v1.BitnamesService.SignArbitraryMsg:output_type -> bitnames.v1.SignArbitraryMsgResponse
-	69, // 72: bitnames.v1.BitnamesService.SignArbitraryMsgAsAddr:output_type -> bitnames.v1.SignArbitraryMsgAsAddrResponse
-	71, // 73: bitnames.v1.BitnamesService.GetWalletAddresses:output_type -> bitnames.v1.GetWalletAddressesResponse
-	73, // 74: bitnames.v1.BitnamesService.MyUtxos:output_type -> bitnames.v1.MyUtxosResponse
-	75, // 75: bitnames.v1.BitnamesService.OpenapiSchema:output_type -> bitnames.v1.OpenapiSchemaResponse
-	38, // [38:76] is the sub-list for method output_type
-	0,  // [0:38] is the sub-list for method input_type
+	64, // 30: bitnames.v1.BitnamesService.GetPaymail:input_type -> bitnames.v1.GetPaymailRequest
+	62, // 31: bitnames.v1.BitnamesService.GetPendingPaymail:input_type -> bitnames.v1.GetPendingPaymailRequest
+	60, // 32: bitnames.v1.BitnamesService.GetBitNameOwner:input_type -> bitnames.v1.GetBitNameOwnerRequest
+	66, // 33: bitnames.v1.BitnamesService.ResolveCommit:input_type -> bitnames.v1.ResolveCommitRequest
+	68, // 34: bitnames.v1.BitnamesService.ReadCommitment:input_type -> bitnames.v1.ReadCommitmentRequest
+	70, // 35: bitnames.v1.BitnamesService.SignArbitraryMsg:input_type -> bitnames.v1.SignArbitraryMsgRequest
+	72, // 36: bitnames.v1.BitnamesService.SignArbitraryMsgAsAddr:input_type -> bitnames.v1.SignArbitraryMsgAsAddrRequest
+	74, // 37: bitnames.v1.BitnamesService.GetWalletAddresses:input_type -> bitnames.v1.GetWalletAddressesRequest
+	76, // 38: bitnames.v1.BitnamesService.MyUtxos:input_type -> bitnames.v1.MyUtxosRequest
+	78, // 39: bitnames.v1.BitnamesService.OpenapiSchema:input_type -> bitnames.v1.OpenapiSchemaRequest
+	1,  // 40: bitnames.v1.BitnamesService.GetBalance:output_type -> bitnames.v1.GetBalanceResponse
+	3,  // 41: bitnames.v1.BitnamesService.GetBlockCount:output_type -> bitnames.v1.GetBlockCountResponse
+	5,  // 42: bitnames.v1.BitnamesService.Stop:output_type -> bitnames.v1.StopResponse
+	7,  // 43: bitnames.v1.BitnamesService.GetNewAddress:output_type -> bitnames.v1.GetNewAddressResponse
+	9,  // 44: bitnames.v1.BitnamesService.Withdraw:output_type -> bitnames.v1.WithdrawResponse
+	11, // 45: bitnames.v1.BitnamesService.Transfer:output_type -> bitnames.v1.TransferResponse
+	13, // 46: bitnames.v1.BitnamesService.GetSidechainWealth:output_type -> bitnames.v1.GetSidechainWealthResponse
+	15, // 47: bitnames.v1.BitnamesService.CreateDeposit:output_type -> bitnames.v1.CreateDepositResponse
+	17, // 48: bitnames.v1.BitnamesService.GetPendingWithdrawalBundle:output_type -> bitnames.v1.GetPendingWithdrawalBundleResponse
+	19, // 49: bitnames.v1.BitnamesService.ConnectPeer:output_type -> bitnames.v1.ConnectPeerResponse
+	21, // 50: bitnames.v1.BitnamesService.ListPeers:output_type -> bitnames.v1.ListPeersResponse
+	23, // 51: bitnames.v1.BitnamesService.Mine:output_type -> bitnames.v1.MineResponse
+	25, // 52: bitnames.v1.BitnamesService.GetBlock:output_type -> bitnames.v1.GetBlockResponse
+	27, // 53: bitnames.v1.BitnamesService.GetBestMainchainBlockHash:output_type -> bitnames.v1.GetBestMainchainBlockHashResponse
+	29, // 54: bitnames.v1.BitnamesService.GetBestSidechainBlockHash:output_type -> bitnames.v1.GetBestSidechainBlockHashResponse
+	31, // 55: bitnames.v1.BitnamesService.GetBmmInclusions:output_type -> bitnames.v1.GetBmmInclusionsResponse
+	33, // 56: bitnames.v1.BitnamesService.GetWalletUtxos:output_type -> bitnames.v1.GetWalletUtxosResponse
+	35, // 57: bitnames.v1.BitnamesService.ListUtxos:output_type -> bitnames.v1.ListUtxosResponse
+	37, // 58: bitnames.v1.BitnamesService.GetLatestFailedWithdrawalBundleHeight:output_type -> bitnames.v1.GetLatestFailedWithdrawalBundleHeightResponse
+	39, // 59: bitnames.v1.BitnamesService.GenerateMnemonic:output_type -> bitnames.v1.GenerateMnemonicResponse
+	41, // 60: bitnames.v1.BitnamesService.SetSeedFromMnemonic:output_type -> bitnames.v1.SetSeedFromMnemonicResponse
+	43, // 61: bitnames.v1.BitnamesService.CallRaw:output_type -> bitnames.v1.CallRawResponse
+	45, // 62: bitnames.v1.BitnamesService.GetBitNameData:output_type -> bitnames.v1.GetBitNameDataResponse
+	47, // 63: bitnames.v1.BitnamesService.ListBitNames:output_type -> bitnames.v1.ListBitNamesResponse
+	49, // 64: bitnames.v1.BitnamesService.RegisterBitName:output_type -> bitnames.v1.RegisterBitNameResponse
+	51, // 65: bitnames.v1.BitnamesService.ReserveBitName:output_type -> bitnames.v1.ReserveBitNameResponse
+	53, // 66: bitnames.v1.BitnamesService.GetNewEncryptionKey:output_type -> bitnames.v1.GetNewEncryptionKeyResponse
+	55, // 67: bitnames.v1.BitnamesService.GetNewVerifyingKey:output_type -> bitnames.v1.GetNewVerifyingKeyResponse
+	57, // 68: bitnames.v1.BitnamesService.DecryptMsg:output_type -> bitnames.v1.DecryptMsgResponse
+	59, // 69: bitnames.v1.BitnamesService.EncryptMsg:output_type -> bitnames.v1.EncryptMsgResponse
+	65, // 70: bitnames.v1.BitnamesService.GetPaymail:output_type -> bitnames.v1.GetPaymailResponse
+	63, // 71: bitnames.v1.BitnamesService.GetPendingPaymail:output_type -> bitnames.v1.GetPendingPaymailResponse
+	61, // 72: bitnames.v1.BitnamesService.GetBitNameOwner:output_type -> bitnames.v1.GetBitNameOwnerResponse
+	67, // 73: bitnames.v1.BitnamesService.ResolveCommit:output_type -> bitnames.v1.ResolveCommitResponse
+	69, // 74: bitnames.v1.BitnamesService.ReadCommitment:output_type -> bitnames.v1.ReadCommitmentResponse
+	71, // 75: bitnames.v1.BitnamesService.SignArbitraryMsg:output_type -> bitnames.v1.SignArbitraryMsgResponse
+	73, // 76: bitnames.v1.BitnamesService.SignArbitraryMsgAsAddr:output_type -> bitnames.v1.SignArbitraryMsgAsAddrResponse
+	75, // 77: bitnames.v1.BitnamesService.GetWalletAddresses:output_type -> bitnames.v1.GetWalletAddressesResponse
+	77, // 78: bitnames.v1.BitnamesService.MyUtxos:output_type -> bitnames.v1.MyUtxosResponse
+	79, // 79: bitnames.v1.BitnamesService.OpenapiSchema:output_type -> bitnames.v1.OpenapiSchemaResponse
+	40, // [40:80] is the sub-list for method output_type
+	0,  // [0:40] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -3752,7 +3952,7 @@ func file_bitnames_v1_bitnames_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bitnames_v1_bitnames_proto_rawDesc), len(file_bitnames_v1_bitnames_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   76,
+			NumMessages:   80,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/bitnames/v1/bitnamesv1connect/bitnames.connect.go
+++ b/sidechain-orchestrator/gen/bitnames/v1/bitnamesv1connect/bitnames.connect.go
@@ -123,6 +123,12 @@ const (
 	// BitnamesServiceGetPaymailProcedure is the fully-qualified name of the BitnamesService's
 	// GetPaymail RPC.
 	BitnamesServiceGetPaymailProcedure = "/bitnames.v1.BitnamesService/GetPaymail"
+	// BitnamesServiceGetPendingPaymailProcedure is the fully-qualified name of the BitnamesService's
+	// GetPendingPaymail RPC.
+	BitnamesServiceGetPendingPaymailProcedure = "/bitnames.v1.BitnamesService/GetPendingPaymail"
+	// BitnamesServiceGetBitNameOwnerProcedure is the fully-qualified name of the BitnamesService's
+	// GetBitNameOwner RPC.
+	BitnamesServiceGetBitNameOwnerProcedure = "/bitnames.v1.BitnamesService/GetBitNameOwner"
 	// BitnamesServiceResolveCommitProcedure is the fully-qualified name of the BitnamesService's
 	// ResolveCommit RPC.
 	BitnamesServiceResolveCommitProcedure = "/bitnames.v1.BitnamesService/ResolveCommit"
@@ -209,6 +215,11 @@ type BitnamesServiceClient interface {
 	EncryptMsg(context.Context, *connect.Request[v1.EncryptMsgRequest]) (*connect.Response[v1.EncryptMsgResponse], error)
 	// Get paymail information.
 	GetPaymail(context.Context, *connect.Request[v1.GetPaymailRequest]) (*connect.Response[v1.GetPaymailResponse], error)
+	// Read the messages that wait in the mempool. A message reaches a BitName
+	// one block before GetPaymail reports it, so a chat reads both.
+	GetPendingPaymail(context.Context, *connect.Request[v1.GetPendingPaymailRequest]) (*connect.Response[v1.GetPendingPaymailResponse], error)
+	// Read the address that holds a BitName. A message pays the holder.
+	GetBitNameOwner(context.Context, *connect.Request[v1.GetBitNameOwnerRequest]) (*connect.Response[v1.GetBitNameOwnerResponse], error)
 	// Resolve a commitment from a BitName.
 	ResolveCommit(context.Context, *connect.Request[v1.ResolveCommitRequest]) (*connect.Response[v1.ResolveCommitResponse], error)
 	// Read a data commitment from an address, before a BitName holds it.
@@ -422,6 +433,18 @@ func NewBitnamesServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(bitnamesServiceMethods.ByName("GetPaymail")),
 			connect.WithClientOptions(opts...),
 		),
+		getPendingPaymail: connect.NewClient[v1.GetPendingPaymailRequest, v1.GetPendingPaymailResponse](
+			httpClient,
+			baseURL+BitnamesServiceGetPendingPaymailProcedure,
+			connect.WithSchema(bitnamesServiceMethods.ByName("GetPendingPaymail")),
+			connect.WithClientOptions(opts...),
+		),
+		getBitNameOwner: connect.NewClient[v1.GetBitNameOwnerRequest, v1.GetBitNameOwnerResponse](
+			httpClient,
+			baseURL+BitnamesServiceGetBitNameOwnerProcedure,
+			connect.WithSchema(bitnamesServiceMethods.ByName("GetBitNameOwner")),
+			connect.WithClientOptions(opts...),
+		),
 		resolveCommit: connect.NewClient[v1.ResolveCommitRequest, v1.ResolveCommitResponse](
 			httpClient,
 			baseURL+BitnamesServiceResolveCommitProcedure,
@@ -500,6 +523,8 @@ type bitnamesServiceClient struct {
 	decryptMsg                            *connect.Client[v1.DecryptMsgRequest, v1.DecryptMsgResponse]
 	encryptMsg                            *connect.Client[v1.EncryptMsgRequest, v1.EncryptMsgResponse]
 	getPaymail                            *connect.Client[v1.GetPaymailRequest, v1.GetPaymailResponse]
+	getPendingPaymail                     *connect.Client[v1.GetPendingPaymailRequest, v1.GetPendingPaymailResponse]
+	getBitNameOwner                       *connect.Client[v1.GetBitNameOwnerRequest, v1.GetBitNameOwnerResponse]
 	resolveCommit                         *connect.Client[v1.ResolveCommitRequest, v1.ResolveCommitResponse]
 	readCommitment                        *connect.Client[v1.ReadCommitmentRequest, v1.ReadCommitmentResponse]
 	signArbitraryMsg                      *connect.Client[v1.SignArbitraryMsgRequest, v1.SignArbitraryMsgResponse]
@@ -665,6 +690,16 @@ func (c *bitnamesServiceClient) GetPaymail(ctx context.Context, req *connect.Req
 	return c.getPaymail.CallUnary(ctx, req)
 }
 
+// GetPendingPaymail calls bitnames.v1.BitnamesService.GetPendingPaymail.
+func (c *bitnamesServiceClient) GetPendingPaymail(ctx context.Context, req *connect.Request[v1.GetPendingPaymailRequest]) (*connect.Response[v1.GetPendingPaymailResponse], error) {
+	return c.getPendingPaymail.CallUnary(ctx, req)
+}
+
+// GetBitNameOwner calls bitnames.v1.BitnamesService.GetBitNameOwner.
+func (c *bitnamesServiceClient) GetBitNameOwner(ctx context.Context, req *connect.Request[v1.GetBitNameOwnerRequest]) (*connect.Response[v1.GetBitNameOwnerResponse], error) {
+	return c.getBitNameOwner.CallUnary(ctx, req)
+}
+
 // ResolveCommit calls bitnames.v1.BitnamesService.ResolveCommit.
 func (c *bitnamesServiceClient) ResolveCommit(ctx context.Context, req *connect.Request[v1.ResolveCommitRequest]) (*connect.Response[v1.ResolveCommitResponse], error) {
 	return c.resolveCommit.CallUnary(ctx, req)
@@ -764,6 +799,11 @@ type BitnamesServiceHandler interface {
 	EncryptMsg(context.Context, *connect.Request[v1.EncryptMsgRequest]) (*connect.Response[v1.EncryptMsgResponse], error)
 	// Get paymail information.
 	GetPaymail(context.Context, *connect.Request[v1.GetPaymailRequest]) (*connect.Response[v1.GetPaymailResponse], error)
+	// Read the messages that wait in the mempool. A message reaches a BitName
+	// one block before GetPaymail reports it, so a chat reads both.
+	GetPendingPaymail(context.Context, *connect.Request[v1.GetPendingPaymailRequest]) (*connect.Response[v1.GetPendingPaymailResponse], error)
+	// Read the address that holds a BitName. A message pays the holder.
+	GetBitNameOwner(context.Context, *connect.Request[v1.GetBitNameOwnerRequest]) (*connect.Response[v1.GetBitNameOwnerResponse], error)
 	// Resolve a commitment from a BitName.
 	ResolveCommit(context.Context, *connect.Request[v1.ResolveCommitRequest]) (*connect.Response[v1.ResolveCommitResponse], error)
 	// Read a data commitment from an address, before a BitName holds it.
@@ -973,6 +1013,18 @@ func NewBitnamesServiceHandler(svc BitnamesServiceHandler, opts ...connect.Handl
 		connect.WithSchema(bitnamesServiceMethods.ByName("GetPaymail")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bitnamesServiceGetPendingPaymailHandler := connect.NewUnaryHandler(
+		BitnamesServiceGetPendingPaymailProcedure,
+		svc.GetPendingPaymail,
+		connect.WithSchema(bitnamesServiceMethods.ByName("GetPendingPaymail")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bitnamesServiceGetBitNameOwnerHandler := connect.NewUnaryHandler(
+		BitnamesServiceGetBitNameOwnerProcedure,
+		svc.GetBitNameOwner,
+		connect.WithSchema(bitnamesServiceMethods.ByName("GetBitNameOwner")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bitnamesServiceResolveCommitHandler := connect.NewUnaryHandler(
 		BitnamesServiceResolveCommitProcedure,
 		svc.ResolveCommit,
@@ -1079,6 +1131,10 @@ func NewBitnamesServiceHandler(svc BitnamesServiceHandler, opts ...connect.Handl
 			bitnamesServiceEncryptMsgHandler.ServeHTTP(w, r)
 		case BitnamesServiceGetPaymailProcedure:
 			bitnamesServiceGetPaymailHandler.ServeHTTP(w, r)
+		case BitnamesServiceGetPendingPaymailProcedure:
+			bitnamesServiceGetPendingPaymailHandler.ServeHTTP(w, r)
+		case BitnamesServiceGetBitNameOwnerProcedure:
+			bitnamesServiceGetBitNameOwnerHandler.ServeHTTP(w, r)
 		case BitnamesServiceResolveCommitProcedure:
 			bitnamesServiceResolveCommitHandler.ServeHTTP(w, r)
 		case BitnamesServiceReadCommitmentProcedure:
@@ -1224,6 +1280,14 @@ func (UnimplementedBitnamesServiceHandler) EncryptMsg(context.Context, *connect.
 
 func (UnimplementedBitnamesServiceHandler) GetPaymail(context.Context, *connect.Request[v1.GetPaymailRequest]) (*connect.Response[v1.GetPaymailResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitnames.v1.BitnamesService.GetPaymail is not implemented"))
+}
+
+func (UnimplementedBitnamesServiceHandler) GetPendingPaymail(context.Context, *connect.Request[v1.GetPendingPaymailRequest]) (*connect.Response[v1.GetPendingPaymailResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitnames.v1.BitnamesService.GetPendingPaymail is not implemented"))
+}
+
+func (UnimplementedBitnamesServiceHandler) GetBitNameOwner(context.Context, *connect.Request[v1.GetBitNameOwnerRequest]) (*connect.Response[v1.GetBitNameOwnerResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitnames.v1.BitnamesService.GetBitNameOwner is not implemented"))
 }
 
 func (UnimplementedBitnamesServiceHandler) ResolveCommit(context.Context, *connect.Request[v1.ResolveCommitRequest]) (*connect.Response[v1.ResolveCommitResponse], error) {

--- a/sidechain-orchestrator/proto/bitnames/v1/bitnames.proto
+++ b/sidechain-orchestrator/proto/bitnames/v1/bitnames.proto
@@ -98,6 +98,13 @@ service BitnamesService {
   // Get paymail information.
   rpc GetPaymail(GetPaymailRequest) returns (GetPaymailResponse);
 
+  // Read the messages that wait in the mempool. A message reaches a BitName
+  // one block before GetPaymail reports it, so a chat reads both.
+  rpc GetPendingPaymail(GetPendingPaymailRequest) returns (GetPendingPaymailResponse);
+
+  // Read the address that holds a BitName. A message pays the holder.
+  rpc GetBitNameOwner(GetBitNameOwnerRequest) returns (GetBitNameOwnerResponse);
+
   // Resolve a commitment from a BitName.
   rpc ResolveCommit(ResolveCommitRequest) returns (ResolveCommitResponse);
 
@@ -397,6 +404,31 @@ message EncryptMsgRequest {
 
 message EncryptMsgResponse {
   string ciphertext = 1;
+}
+
+// GetBitNameOwner
+
+message GetBitNameOwnerRequest {
+  // The BitName hash, as hexadecimal.
+  string bitname = 1;
+}
+
+message GetBitNameOwnerResponse {
+  // The address that holds the BitName today.
+  string address = 1;
+}
+
+// GetPendingPaymail
+
+message GetPendingPaymailRequest {}
+
+message GetPendingPaymailResponse {
+  // The same JSON object GetPaymail returns, holding only the outputs that
+  // wait in the mempool.
+  string paymail_json = 1;
+  // Every transaction the mempool holds. A message a caller sent pays the
+  // reader, so no paymail feed reports it, and this says whether it waits.
+  repeated string mempool_txids = 2;
 }
 
 // GetPaymail

--- a/sidechain-orchestrator/sidechain/bitnames/client.go
+++ b/sidechain-orchestrator/sidechain/bitnames/client.go
@@ -393,3 +393,13 @@ func (c *Client) Stop(ctx context.Context) error {
 	_, err := c.call(ctx, "stop", nil)
 	return err
 }
+
+// ListMempool returns the transactions the node holds, as raw JSON.
+func (c *Client) ListMempool(ctx context.Context) (json.RawMessage, error) {
+	return c.call(ctx, "list_mempool", nil)
+}
+
+// WalletAddresses returns the addresses this wallet owns.
+func (c *Client) WalletAddresses(ctx context.Context) ([]string, error) {
+	return unmarshal[[]string](c, ctx, "get_wallet_addresses", nil)
+}

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -3,6 +3,7 @@ package bitnames
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -316,6 +317,40 @@ func (h *Handler) EncryptMsg(ctx context.Context, req *connect.Request[pb.Encryp
 		return nil, err
 	}
 	return connect.NewResponse(&pb.EncryptMsgResponse{Ciphertext: ciphertext}), nil
+}
+
+func (h *Handler) GetBitNameOwner(
+	ctx context.Context, req *connect.Request[pb.GetBitNameOwnerRequest],
+) (*connect.Response[pb.GetBitNameOwnerResponse], error) {
+	address, err := BitNameOwner(ctx, h.proxy.Client, req.Msg.Bitname)
+	if errors.Is(err, errBitNameNotFound) {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&pb.GetBitNameOwnerResponse{Address: address}), nil
+}
+
+func (h *Handler) GetPendingPaymail(
+	ctx context.Context, req *connect.Request[pb.GetPendingPaymailRequest],
+) (*connect.Response[pb.GetPendingPaymailResponse], error) {
+	pending, err := pendingPaymail(ctx, h.proxy.Client)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(pending)
+	if err != nil {
+		return nil, fmt.Errorf("marshal the pending paymail: %w", err)
+	}
+	txids, err := mempoolTxids(ctx, h.proxy.Client)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&pb.GetPendingPaymailResponse{
+		PaymailJson:  string(raw),
+		MempoolTxids: txids,
+	}), nil
 }
 
 func (h *Handler) GetPaymail(ctx context.Context, req *connect.Request[pb.GetPaymailRequest]) (*connect.Response[pb.GetPaymailResponse], error) {

--- a/sidechain-orchestrator/sidechain/bitnames/owner.go
+++ b/sidechain-orchestrator/sidechain/bitnames/owner.go
@@ -1,0 +1,39 @@
+package bitnames
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var errBitNameNotFound = errors.New("no utxo holds the bitname")
+
+// utxoEntry is one entry of the list_utxos answer.
+type utxoEntry struct {
+	Output struct {
+		Address string `json:"address"`
+		Content struct {
+			BitName string `json:"BitName"`
+		} `json:"content"`
+	} `json:"output"`
+}
+
+// BitNameOwner returns the address that holds a BitName. A message pays the
+// holder, so a chat needs this address, and bitname_data does not carry it.
+func BitNameOwner(ctx context.Context, client mempoolReader, bitname string) (string, error) {
+	if bitname == "" {
+		return "", fmt.Errorf("bitname is empty")
+	}
+
+	var entries []utxoEntry
+	if err := client.Call(ctx, "list_utxos", nil, &entries); err != nil {
+		return "", fmt.Errorf("read the utxos: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.Output.Content.BitName == bitname {
+			return entry.Output.Address, nil
+		}
+	}
+	return "", fmt.Errorf("%w %s", errBitNameNotFound, bitname)
+}

--- a/sidechain-orchestrator/sidechain/bitnames/owner_test.go
+++ b/sidechain-orchestrator/sidechain/bitnames/owner_test.go
@@ -1,0 +1,93 @@
+package bitnames
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"connectrpc.com/connect"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/bitnames/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// utxoNode answers list_utxos with the shape the live node returns.
+type utxoNode struct{ utxos string }
+
+func (u utxoNode) Call(_ context.Context, method string, _ any, result any) error {
+	if method != "list_utxos" {
+		return nil
+	}
+	return json.Unmarshal([]byte(u.utxos), result)
+}
+
+// This is the shape the live alphanet node returned for list_utxos.
+const liveUTXOs = `[
+ {"outpoint":{"Regular":{"txid":"aa","vout":0}},
+  "output":{"address":"3Cdqkd4J2uqAN4HLKuAY8en68tzZ",
+            "content":{"BitNameReservation":["b85229ad"]},"memo":""}},
+ {"outpoint":{"Regular":{"txid":"bb","vout":0}},
+  "output":{"address":"3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt",
+            "content":{"BitName":"d228dfbdab4f8a9eb5eb4962ab38f4364b0b8b3035ce41eafd91ff672a6c6076"},"memo":""}},
+ {"outpoint":{"Regular":{"txid":"cc","vout":0}},
+  "output":{"address":"3yGh6d2CpN4yHjRMsUDLpEN38Uiq",
+            "content":{"BitName":"18c785f51acec3d37ff6cd5ebcfa816d45c33fb6584a5a829c402d18b48cab7e"},"memo":""}},
+ {"outpoint":{"Coinbase":{"merkle_root":"dd","vout":0}},
+  "output":{"address":"8G8dvEzV7oFUNCLbVBXLbW1qQ43","content":{"BitcoinSats":100},"memo":""}}
+]`
+
+// A message pays the holder of the BitName. bitname_data does not carry the
+// address, so the owner comes from the utxo that holds the name.
+func TestBitNameOwnerFindsTheHolder(t *testing.T) {
+	node := utxoNode{utxos: liveUTXOs}
+
+	ecash, err := BitNameOwner(context.Background(), node,
+		"d228dfbdab4f8a9eb5eb4962ab38f4364b0b8b3035ce41eafd91ff672a6c6076")
+	require.NoError(t, err)
+	assert.Equal(t, "3U7uB5WkWrWxsdtqdrbgsZ6Y4FXt", ecash)
+
+	other, err := BitNameOwner(context.Background(), node,
+		"18c785f51acec3d37ff6cd5ebcfa816d45c33fb6584a5a829c402d18b48cab7e")
+	require.NoError(t, err)
+	assert.Equal(t, "3yGh6d2CpN4yHjRMsUDLpEN38Uiq", other)
+}
+
+// A reservation is not a registered name, so it holds no owner to pay.
+func TestBitNameOwnerSkipsAReservation(t *testing.T) {
+	_, err := BitNameOwner(context.Background(), utxoNode{utxos: liveUTXOs}, "b85229ad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no utxo holds the bitname")
+}
+
+func TestBitNameOwnerRefusesAnEmptyName(t *testing.T) {
+	_, err := BitNameOwner(context.Background(), utxoNode{utxos: liveUTXOs}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestBitNameOwnerReportsAnUnknownName(t *testing.T) {
+	_, err := BitNameOwner(context.Background(), utxoNode{utxos: liveUTXOs}, "ffff")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ffff")
+}
+
+func TestGetBitNameOwnerDistinguishesLookupErrors(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		utxos string
+		code  connect.Code
+	}{
+		{name: "unknown name", utxos: `[]`, code: connect.CodeNotFound},
+		{name: "invalid node response", utxos: `{}`, code: connect.CodeUnknown},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			proxy, _ := sendMethodNode(t, map[string]string{"list_utxos": test.utxos})
+			_, err := NewHandler(proxy).GetBitNameOwner(context.Background(), connect.NewRequest(
+				&pb.GetBitNameOwnerRequest{Bitname: "unknown"},
+			))
+			require.Error(t, err)
+			assert.Equal(t, test.code, connect.CodeOf(err))
+		})
+	}
+}

--- a/sidechain-orchestrator/sidechain/bitnames/pending_paymail.go
+++ b/sidechain-orchestrator/sidechain/bitnames/pending_paymail.go
@@ -1,0 +1,183 @@
+package bitnames
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// mempoolEntry is one transaction the node holds.
+type mempoolEntry struct {
+	TxID string `json:"txid"`
+	Tx   struct {
+		Outputs []struct {
+			Address string          `json:"address"`
+			Content json.RawMessage `json:"content"`
+			Memo    string          `json:"memo"`
+		} `json:"outputs"`
+	} `json:"tx"`
+}
+
+// paymailOutput is one entry of the map GetPaymail returns. The memo carries
+// the message, and the node writes it as a byte array.
+type paymailOutput struct {
+	Address string          `json:"address"`
+	Content json.RawMessage `json:"content"`
+	Memo    memoBytes       `json:"memo"`
+}
+
+// memoBytes writes the memo as an array of numbers, the way the node writes a
+// Vec<u8>. Go writes a []byte as base64, which no reader of get_paymail parses.
+type memoBytes []byte
+
+func (m memoBytes) MarshalJSON() ([]byte, error) {
+	numbers := make([]uint16, len(m))
+	for i, b := range m {
+		numbers[i] = uint16(b)
+	}
+	return json.Marshal(numbers)
+}
+
+// pendingPaymail returns the mempool outputs that pay one of the wallet's
+// addresses and carry a memo. It keys them by outpoint, exactly as GetPaymail
+// does, so one reader handles both.
+//
+// The node hides an unconfirmed output from get_paymail, because that call
+// reads a block height for every output. A chat that waits for a block is not
+// a chat, so this reads the mempool as well.
+// mempoolTxids names every transaction the mempool holds.
+func mempoolTxids(ctx context.Context, client mempoolReader) ([]string, error) {
+	var entries []mempoolEntry
+	if err := client.Call(ctx, "list_mempool", nil, &entries); err != nil {
+		return nil, fmt.Errorf("read the mempool: %w", err)
+	}
+	txids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		txids = append(txids, entry.TxID)
+	}
+	return txids, nil
+}
+
+func pendingPaymail(ctx context.Context, client mempoolReader) (map[string]paymailOutput, error) {
+	var addresses []string
+	if err := client.Call(ctx, "get_wallet_addresses", nil, &addresses); err != nil {
+		return nil, fmt.Errorf("read the wallet addresses: %w", err)
+	}
+	mine := make(map[string]bool, len(addresses))
+	for _, address := range addresses {
+		mine[address] = true
+	}
+
+	var entries []mempoolEntry
+	if err := client.Call(ctx, "list_mempool", nil, &entries); err != nil {
+		return nil, fmt.Errorf("read the mempool: %w", err)
+	}
+
+	if !holdsAMessage(entries, mine) {
+		return map[string]paymailOutput{}, nil
+	}
+
+	// get_paymail hides a message that pays less than the postage, so the
+	// pending view has to hide it too.
+	postage, err := postageOf(ctx, client, mine)
+	if err != nil {
+		return nil, err
+	}
+
+	pending := make(map[string]paymailOutput)
+	for _, entry := range entries {
+		for vout, output := range entry.Tx.Outputs {
+			if output.Memo == "" || !mine[output.Address] {
+				continue
+			}
+			memo, err := hex.DecodeString(output.Memo)
+			if err != nil {
+				// A memo the node cannot spell as hex is not a message.
+				continue
+			}
+			fee, known := postage[output.Address]
+			if value, ok := sats(output.Content); !known || !ok || value < fee {
+				continue
+			}
+			key := outpointKey(entry.TxID, vout)
+			pending[key] = paymailOutput{
+				Address: output.Address,
+				Content: output.Content,
+				Memo:    memo,
+			}
+		}
+	}
+	return pending, nil
+}
+
+// mempoolReader is the part of the node client that pendingPaymail uses.
+type mempoolReader interface {
+	Call(ctx context.Context, method string, params any, result any) error
+}
+
+// holdsAMessage says whether any output pays one of these addresses and
+// carries a memo. The utxo set is large, so nothing reads it without a reason.
+func holdsAMessage(entries []mempoolEntry, mine map[string]bool) bool {
+	for _, entry := range entries {
+		for _, output := range entry.Tx.Outputs {
+			if output.Memo != "" && mine[output.Address] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// sats reads the value of an output, and says whether it holds one.
+func sats(content json.RawMessage) (int64, bool) {
+	var value struct {
+		BitcoinSats *int64 `json:"BitcoinSats"`
+	}
+	if err := json.Unmarshal(content, &value); err != nil || value.BitcoinSats == nil {
+		return 0, false
+	}
+	return *value.BitcoinSats, true
+}
+
+// postageOf reads the smallest payment each of my BitNames accepts. A message
+// that pays less is not mail.
+func postageOf(ctx context.Context, client mempoolReader, mine map[string]bool) (map[string]int64, error) {
+	var utxos []struct {
+		Output struct {
+			Address string `json:"address"`
+			Content struct {
+				BitName string `json:"BitName"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := client.Call(ctx, "list_utxos", nil, &utxos); err != nil {
+		return nil, fmt.Errorf("read the utxos: %w", err)
+	}
+
+	postage := make(map[string]int64)
+	for _, utxo := range utxos {
+		if utxo.Output.Content.BitName == "" || !mine[utxo.Output.Address] {
+			continue
+		}
+		var data struct {
+			PaymailFeeSats *int64 `json:"paymail_fee_sats"`
+		}
+		if err := client.Call(ctx, "bitname_data", []any{utxo.Output.Content.BitName}, &data); err != nil {
+			return nil, fmt.Errorf("read the BitName data: %w", err)
+		}
+		if data.PaymailFeeSats == nil {
+			continue
+		}
+		fee, known := postage[utxo.Output.Address]
+		if !known || *data.PaymailFeeSats < fee {
+			postage[utxo.Output.Address] = *data.PaymailFeeSats
+		}
+	}
+	return postage, nil
+}
+
+// outpointKey spells the outpoint the way the node writes it in get_paymail.
+func outpointKey(txid string, vout int) string {
+	return fmt.Sprintf(`{"Regular":{"txid":"%s","vout":%d}}`, txid, vout)
+}

--- a/sidechain-orchestrator/sidechain/bitnames/pending_paymail_test.go
+++ b/sidechain-orchestrator/sidechain/bitnames/pending_paymail_test.go
@@ -1,0 +1,277 @@
+package bitnames
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeNode struct {
+	addresses     []string
+	mempool       string
+	utxos         string
+	postage       string
+	postageByName map[string]string
+	postageErr    error
+	err           error
+}
+
+func (f fakeNode) Call(_ context.Context, method string, params any, result any) error {
+	if f.err != nil {
+		return f.err
+	}
+	switch method {
+	case "get_wallet_addresses":
+		return json.Unmarshal([]byte(mustJSON(f.addresses)), result)
+	case "list_mempool":
+		return json.Unmarshal([]byte(f.mempool), result)
+	case "bitname_data":
+		if f.postageErr != nil {
+			return f.postageErr
+		}
+		if f.postageByName != nil {
+			return json.Unmarshal([]byte(f.postageByName[params.([]any)[0].(string)]), result)
+		}
+		if f.postage == "" {
+			return json.Unmarshal([]byte("{}"), result)
+		}
+		return json.Unmarshal([]byte(f.postage), result)
+	case "list_utxos":
+		if f.utxos == "" {
+			return json.Unmarshal([]byte("[]"), result)
+		}
+		return json.Unmarshal([]byte(f.utxos), result)
+	}
+	return nil
+}
+
+func mustJSON(v any) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+// This is the shape the live node returns for list_mempool.
+const liveMempool = `[
+  {"txid":"f5ebe7044511d94a083fe68bd37b7ac575ba9540871017ea57f3bf41c40e9783","size":37,
+   "tx":{"inputs":[{"Regular":{"txid":"e198e2c0","vout":0}}],"outputs":[
+     {"address":"3Dsq1WDmpXCLztjqa25gM2ivoV8q","content":{"BitcoinSats":1000},"memo":"7bfbaf4b"},
+     {"address":"3Dsq1WDmpXCLztjqa25gM2ivoV8q","content":{"BitcoinSats":998900},"memo":""}
+   ],"memo":""}},
+  {"txid":"4904e243fa39dda41c4de1bb3d9c9f1e2e3f970e72e391edd38658a32cbe4c05","size":28,
+   "tx":{"inputs":[],"outputs":[
+     {"address":"8G8dvEzV7oFUNCLbVBXLbW1qQ43","content":{"BitcoinSats":100},"memo":"deadbeef"}
+   ],"memo":""}}
+]`
+
+const mailUTXOs = `[{"output":{"address":"3Dsq1WDmpXCLztjqa25gM2ivoV8q","content":{"BitName":"d228dfbd"}}}]`
+
+// A message reaches a BitName one block before get_paymail reports it, so the
+// mempool is the only place a chat can read it at once.
+func TestPendingPaymailReadsTheMempool(t *testing.T) {
+	node := fakeNode{
+		addresses: []string{"3Dsq1WDmpXCLztjqa25gM2ivoV8q"}, mempool: liveMempool,
+		utxos: mailUTXOs, postage: `{"paymail_fee_sats":1000}`,
+	}
+
+	pending, err := pendingPaymail(context.Background(), node)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "only the output with a memo, paid to my address")
+
+	key := `{"Regular":{"txid":"f5ebe7044511d94a083fe68bd37b7ac575ba9540871017ea57f3bf41c40e9783","vout":0}}`
+	entry, ok := pending[key]
+	require.True(t, ok, "the key must match the outpoint get_paymail uses")
+	assert.Equal(t, "3Dsq1WDmpXCLztjqa25gM2ivoV8q", entry.Address)
+	assert.Equal(t, memoBytes{0x7b, 0xfb, 0xaf, 0x4b}, entry.Memo)
+	assert.JSONEq(t, `{"BitcoinSats":1000}`, string(entry.Content))
+}
+
+// The memo carries the message, so an output without one is a payment.
+func TestPendingPaymailSkipsAnOutputWithNoMemo(t *testing.T) {
+	node := fakeNode{
+		addresses: []string{"3Dsq1WDmpXCLztjqa25gM2ivoV8q"}, mempool: liveMempool,
+		utxos: mailUTXOs, postage: `{"paymail_fee_sats":1000}`,
+	}
+	pending, err := pendingPaymail(context.Background(), node)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	for key := range pending {
+		assert.NotContains(t, key, `"vout":1`)
+	}
+}
+
+// A message for somebody else must stay out of my inbox.
+func TestPendingPaymailSkipsAnotherAddress(t *testing.T) {
+	node := fakeNode{addresses: []string{"3yGh6d2CpN4yHjRMsUDLpEN38Uiq"}, mempool: liveMempool}
+	pending, err := pendingPaymail(context.Background(), node)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+// The memo must decode as hex, because the reader hands bytes to the caller.
+func TestPendingPaymailSkipsAMemoThatIsNotHex(t *testing.T) {
+	node := fakeNode{
+		addresses: []string{"a"},
+		mempool:   `[{"txid":"aa","tx":{"outputs":[{"address":"a","content":{"BitcoinSats":1000},"memo":"zz"}]}}]`,
+		utxos:     `[{"output":{"address":"a","content":{"BitName":"bb"}}}]`,
+		postage:   `{"paymail_fee_sats":1000}`,
+	}
+	pending, err := pendingPaymail(context.Background(), node)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+// The marshalled form must read like get_paymail, so one parser handles both.
+func TestPendingPaymailMarshalsMemoAsBytes(t *testing.T) {
+	node := fakeNode{
+		addresses: []string{"3Dsq1WDmpXCLztjqa25gM2ivoV8q"}, mempool: liveMempool,
+		utxos: mailUTXOs, postage: `{"paymail_fee_sats":1000}`,
+	}
+	pending, err := pendingPaymail(context.Background(), node)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(pending)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"memo":[123,251,175,75]`)
+}
+
+// get_paymail hides a message that pays less than the postage, so the pending
+// view hides it too. Otherwise a message appears and then vanishes.
+func TestPendingPaymailHidesAnUnderpaidMessage(t *testing.T) {
+	node := fakeNode{
+		addresses: []string{"3Dsq1WDmpXCLztjqa25gM2ivoV8q"},
+		mempool:   liveMempool,
+		utxos: `[{"outpoint":{"Regular":{"txid":"bb","vout":0}},
+		          "output":{"address":"3Dsq1WDmpXCLztjqa25gM2ivoV8q",
+		                    "content":{"BitName":"d228dfbd"}}}]`,
+		postage: `{"paymail_fee_sats": 5000}`,
+	}
+
+	pending, err := pendingPaymail(context.Background(), node)
+	require.NoError(t, err)
+	assert.Empty(t, pending, "the message pays 1000, and the postage is 5000")
+}
+
+func TestPendingPaymailChecksPostage(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		utxos   string
+		postage string
+		content string
+		count   int
+	}{
+		{name: "no BitName", utxos: `[]`, postage: `{"paymail_fee_sats":0}`, content: `{"BitcoinSats":1000}`},
+		{name: "reservation", utxos: `[{"output":{"address":"a","content":{"BitNameReservation":["bb"]}}}]`, postage: `{"paymail_fee_sats":0}`, content: `{"BitcoinSats":1000}`},
+		{name: "another address", utxos: `[{"output":{"address":"b","content":{"BitName":"bb"}}}]`, postage: `{"paymail_fee_sats":0}`, content: `{"BitcoinSats":1000}`},
+		{name: "null fee", postage: `{"paymail_fee_sats":null}`, content: `{"BitcoinSats":1000}`},
+		{name: "absent fee", postage: `{}`, content: `{"BitcoinSats":1000}`},
+		{name: "absent data", postage: `null`, content: `{"BitcoinSats":1000}`},
+		{name: "empty content", postage: `{"paymail_fee_sats":0}`, content: `{}`},
+		{name: "BitName content", postage: `{"paymail_fee_sats":0}`, content: `{"BitName":"cc"}`},
+		{name: "null sats", postage: `{"paymail_fee_sats":0}`, content: `{"BitcoinSats":null}`},
+		{name: "zero fee", postage: `{"paymail_fee_sats":0}`, content: `{"BitcoinSats":0}`, count: 1},
+		{name: "exact fee", postage: `{"paymail_fee_sats":1000}`, content: `{"BitcoinSats":1000}`, count: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			utxos := test.utxos
+			if utxos == "" {
+				utxos = `[{"output":{"address":"a","content":{"BitName":"bb"}}}]`
+			}
+			node := fakeNode{
+				addresses: []string{"a"},
+				mempool:   `[{"txid":"aa","tx":{"outputs":[{"address":"a","content":` + test.content + `,"memo":"abcd"}]}}]`,
+				utxos:     utxos,
+				postage:   test.postage,
+			}
+
+			pending, err := pendingPaymail(context.Background(), node)
+			require.NoError(t, err)
+			assert.Len(t, pending, test.count)
+		})
+	}
+}
+
+func TestPendingPaymailUsesTheMinimumFeeAtAnAddress(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		fees [2]string
+	}{
+		{name: "low fee first", fees: [2]string{"1000", "5000"}},
+		{name: "high fee first", fees: [2]string{"5000", "1000"}},
+		{name: "zero fee first", fees: [2]string{"0", "5000"}},
+		{name: "null fee first", fees: [2]string{"null", "1000"}},
+		{name: "null fee last", fees: [2]string{"1000", "null"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			node := fakeNode{
+				addresses: []string{"a"},
+				mempool:   `[{"txid":"aa","tx":{"outputs":[{"address":"a","content":{"BitcoinSats":1000},"memo":"abcd"}]}}]`,
+				utxos: `[{"output":{"address":"a","content":{"BitName":"bb"}}},
+				         {"output":{"address":"a","content":{"BitName":"cc"}}}]`,
+				postageByName: map[string]string{
+					"bb": `{"paymail_fee_sats":` + test.fees[0] + `}`,
+					"cc": `{"paymail_fee_sats":` + test.fees[1] + `}`,
+				},
+			}
+
+			pending, err := pendingPaymail(context.Background(), node)
+			require.NoError(t, err)
+			assert.Len(t, pending, 1)
+		})
+	}
+}
+
+func TestPendingPaymailReturnsTheBitNameDataError(t *testing.T) {
+	readErr := errors.New("the node is unavailable")
+	node := fakeNode{
+		addresses:  []string{"3Dsq1WDmpXCLztjqa25gM2ivoV8q"},
+		mempool:    liveMempool,
+		utxos:      mailUTXOs,
+		postageErr: readErr,
+	}
+
+	pending, err := pendingPaymail(context.Background(), node)
+	require.ErrorIs(t, err, readErr)
+	assert.Nil(t, pending)
+}
+
+// The utxo set is large, so an idle poll must not read it.
+func TestPendingPaymailSkipsTheUTXOScanWhenIdle(t *testing.T) {
+	node := readCounter{fakeNode: fakeNode{
+		addresses: []string{"nobody"},
+		mempool:   liveMempool,
+	}}
+
+	pending, err := pendingPaymail(context.Background(), &node)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	assert.Zero(t, node.utxoReads, "no message for me, so no reason to read the utxos")
+}
+
+// readCounter records how often the caller reads the utxo set.
+type readCounter struct {
+	fakeNode
+	utxoReads int
+}
+
+func (r *readCounter) Call(ctx context.Context, method string, params any, result any) error {
+	if method == "list_utxos" {
+		r.utxoReads++
+	}
+	return r.fakeNode.Call(ctx, method, params, result)
+}
+
+func TestMempoolTxidsNamesEveryTransaction(t *testing.T) {
+	txids, err := mempoolTxids(context.Background(), fakeNode{mempool: liveMempool})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"f5ebe7044511d94a083fe68bd37b7ac575ba9540871017ea57f3bf41c40e9783",
+		"4904e243fa39dda41c4de1bb3d9c9f1e2e3f970e72e391edd38658a32cbe4c05",
+	}, txids)
+}

--- a/sidechain-orchestrator/sidechain/bitnames/testdata/openapi_schema.json
+++ b/sidechain-orchestrator/sidechain/bitnames/testdata/openapi_schema.json
@@ -1868,6 +1868,13 @@
                               }
                             ]
                           },
+                          "socket_addr_host": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Optional `host:port`, resolved by DNS. Used when neither socket addr is\nset."
+                          },
                           "socket_addr_v4": {
                             "type": [
                               "string",
@@ -2386,6 +2393,7 @@
           "commitment",
           "socket_addr_v4",
           "socket_addr_v6",
+          "socket_addr_host",
           "encryption_pubkey",
           "signing_pubkey",
           "paymail_fee_sats"
@@ -2475,6 +2483,33 @@
             ]
           },
           "signing_pubkey": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "Delete"
+                ]
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "Retain"
+                ]
+              },
+              {
+                "type": "object",
+                "required": [
+                  "Set"
+                ],
+                "properties": {
+                  "Set": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "socket_addr_host": {
             "oneOf": [
               {
                 "type": "string",
@@ -2891,6 +2926,13 @@
                 "description": "Optional pubkey used for signing messages"
               }
             ]
+          },
+          "socket_addr_host": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional `host:port`, resolved by DNS. Used when neither socket addr is\nset."
           },
           "socket_addr_v4": {
             "type": [

--- a/sidechain_core/lib/gen/bitnames/v1/bitnames.connect.client.dart
+++ b/sidechain_core/lib/gen/bitnames/v1/bitnames.connect.client.dart
@@ -566,6 +566,43 @@ extension type BitnamesServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// Read the messages that wait in the mempool. A message reaches a BitName
+  /// one block before GetPaymail reports it, so a chat reads both.
+  Future<bitnamesv1bitnames.GetPendingPaymailResponse> getPendingPaymail(
+    bitnamesv1bitnames.GetPendingPaymailRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.BitnamesService.getPendingPaymail,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// Read the address that holds a BitName. A message pays the holder.
+  Future<bitnamesv1bitnames.GetBitNameOwnerResponse> getBitNameOwner(
+    bitnamesv1bitnames.GetBitNameOwnerRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.BitnamesService.getBitNameOwner,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// Resolve a commitment from a BitName.
   Future<bitnamesv1bitnames.ResolveCommitResponse> resolveCommit(
     bitnamesv1bitnames.ResolveCommitRequest input, {

--- a/sidechain_core/lib/gen/bitnames/v1/bitnames.connect.spec.dart
+++ b/sidechain_core/lib/gen/bitnames/v1/bitnames.connect.spec.dart
@@ -258,6 +258,23 @@ abstract final class BitnamesService {
     bitnamesv1bitnames.GetPaymailResponse.new,
   );
 
+  /// Read the messages that wait in the mempool. A message reaches a BitName
+  /// one block before GetPaymail reports it, so a chat reads both.
+  static const getPendingPaymail = connect.Spec(
+    '/$name/GetPendingPaymail',
+    connect.StreamType.unary,
+    bitnamesv1bitnames.GetPendingPaymailRequest.new,
+    bitnamesv1bitnames.GetPendingPaymailResponse.new,
+  );
+
+  /// Read the address that holds a BitName. A message pays the holder.
+  static const getBitNameOwner = connect.Spec(
+    '/$name/GetBitNameOwner',
+    connect.StreamType.unary,
+    bitnamesv1bitnames.GetBitNameOwnerRequest.new,
+    bitnamesv1bitnames.GetBitNameOwnerResponse.new,
+  );
+
   /// Resolve a commitment from a BitName.
   static const resolveCommit = connect.Spec(
     '/$name/ResolveCommit',

--- a/sidechain_core/lib/gen/bitnames/v1/bitnames.pb.dart
+++ b/sidechain_core/lib/gen/bitnames/v1/bitnames.pb.dart
@@ -2857,6 +2857,202 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
   void clearCiphertext() => clearField(1);
 }
 
+class GetBitNameOwnerRequest extends $pb.GeneratedMessage {
+  factory GetBitNameOwnerRequest({
+    $core.String? bitname,
+  }) {
+    final $result = create();
+    if (bitname != null) {
+      $result.bitname = bitname;
+    }
+    return $result;
+  }
+  GetBitNameOwnerRequest._() : super();
+  factory GetBitNameOwnerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitNameOwnerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitNameOwnerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'bitname')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBitNameOwnerRequest clone() => GetBitNameOwnerRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitNameOwnerRequest copyWith(void Function(GetBitNameOwnerRequest) updates) => super.copyWith((message) => updates(message as GetBitNameOwnerRequest)) as GetBitNameOwnerRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBitNameOwnerRequest create() => GetBitNameOwnerRequest._();
+  GetBitNameOwnerRequest createEmptyInstance() => create();
+  static $pb.PbList<GetBitNameOwnerRequest> createRepeated() => $pb.PbList<GetBitNameOwnerRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetBitNameOwnerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitNameOwnerRequest>(create);
+  static GetBitNameOwnerRequest? _defaultInstance;
+
+  /// The BitName hash, as hexadecimal.
+  @$pb.TagNumber(1)
+  $core.String get bitname => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set bitname($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBitname() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBitname() => clearField(1);
+}
+
+class GetBitNameOwnerResponse extends $pb.GeneratedMessage {
+  factory GetBitNameOwnerResponse({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  GetBitNameOwnerResponse._() : super();
+  factory GetBitNameOwnerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitNameOwnerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitNameOwnerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBitNameOwnerResponse clone() => GetBitNameOwnerResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitNameOwnerResponse copyWith(void Function(GetBitNameOwnerResponse) updates) => super.copyWith((message) => updates(message as GetBitNameOwnerResponse)) as GetBitNameOwnerResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBitNameOwnerResponse create() => GetBitNameOwnerResponse._();
+  GetBitNameOwnerResponse createEmptyInstance() => create();
+  static $pb.PbList<GetBitNameOwnerResponse> createRepeated() => $pb.PbList<GetBitNameOwnerResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetBitNameOwnerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitNameOwnerResponse>(create);
+  static GetBitNameOwnerResponse? _defaultInstance;
+
+  /// The address that holds the BitName today.
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+class GetPendingPaymailRequest extends $pb.GeneratedMessage {
+  factory GetPendingPaymailRequest() => create();
+  GetPendingPaymailRequest._() : super();
+  factory GetPendingPaymailRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingPaymailRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingPaymailRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetPendingPaymailRequest clone() => GetPendingPaymailRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingPaymailRequest copyWith(void Function(GetPendingPaymailRequest) updates) => super.copyWith((message) => updates(message as GetPendingPaymailRequest)) as GetPendingPaymailRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetPendingPaymailRequest create() => GetPendingPaymailRequest._();
+  GetPendingPaymailRequest createEmptyInstance() => create();
+  static $pb.PbList<GetPendingPaymailRequest> createRepeated() => $pb.PbList<GetPendingPaymailRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetPendingPaymailRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingPaymailRequest>(create);
+  static GetPendingPaymailRequest? _defaultInstance;
+}
+
+class GetPendingPaymailResponse extends $pb.GeneratedMessage {
+  factory GetPendingPaymailResponse({
+    $core.String? paymailJson,
+    $core.Iterable<$core.String>? mempoolTxids,
+  }) {
+    final $result = create();
+    if (paymailJson != null) {
+      $result.paymailJson = paymailJson;
+    }
+    if (mempoolTxids != null) {
+      $result.mempoolTxids.addAll(mempoolTxids);
+    }
+    return $result;
+  }
+  GetPendingPaymailResponse._() : super();
+  factory GetPendingPaymailResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingPaymailResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingPaymailResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'paymailJson')
+    ..pPS(2, _omitFieldNames ? '' : 'mempoolTxids')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetPendingPaymailResponse clone() => GetPendingPaymailResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingPaymailResponse copyWith(void Function(GetPendingPaymailResponse) updates) => super.copyWith((message) => updates(message as GetPendingPaymailResponse)) as GetPendingPaymailResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetPendingPaymailResponse create() => GetPendingPaymailResponse._();
+  GetPendingPaymailResponse createEmptyInstance() => create();
+  static $pb.PbList<GetPendingPaymailResponse> createRepeated() => $pb.PbList<GetPendingPaymailResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetPendingPaymailResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingPaymailResponse>(create);
+  static GetPendingPaymailResponse? _defaultInstance;
+
+  /// The same JSON object GetPaymail returns, holding only the outputs that
+  /// wait in the mempool.
+  @$pb.TagNumber(1)
+  $core.String get paymailJson => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set paymailJson($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPaymailJson() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPaymailJson() => clearField(1);
+
+  /// Every transaction the mempool holds. A message a caller sent pays the
+  /// reader, so no paymail feed reports it, and this says whether it waits.
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get mempoolTxids => $_getList(1);
+}
+
 class GetPaymailRequest extends $pb.GeneratedMessage {
   factory GetPaymailRequest() => create();
   GetPaymailRequest._() : super();
@@ -3765,6 +3961,12 @@ class BitnamesServiceApi {
   ;
   $async.Future<GetPaymailResponse> getPaymail($pb.ClientContext? ctx, GetPaymailRequest request) =>
     _client.invoke<GetPaymailResponse>(ctx, 'BitnamesService', 'GetPaymail', request, GetPaymailResponse())
+  ;
+  $async.Future<GetPendingPaymailResponse> getPendingPaymail($pb.ClientContext? ctx, GetPendingPaymailRequest request) =>
+    _client.invoke<GetPendingPaymailResponse>(ctx, 'BitnamesService', 'GetPendingPaymail', request, GetPendingPaymailResponse())
+  ;
+  $async.Future<GetBitNameOwnerResponse> getBitNameOwner($pb.ClientContext? ctx, GetBitNameOwnerRequest request) =>
+    _client.invoke<GetBitNameOwnerResponse>(ctx, 'BitnamesService', 'GetBitNameOwner', request, GetBitNameOwnerResponse())
   ;
   $async.Future<ResolveCommitResponse> resolveCommit($pb.ClientContext? ctx, ResolveCommitRequest request) =>
     _client.invoke<ResolveCommitResponse>(ctx, 'BitnamesService', 'ResolveCommit', request, ResolveCommitResponse())

--- a/sidechain_core/lib/gen/bitnames/v1/bitnames.pbjson.dart
+++ b/sidechain_core/lib/gen/bitnames/v1/bitnames.pbjson.dart
@@ -711,6 +711,53 @@ const EncryptMsgResponse$json = {
 final $typed_data.Uint8List encryptMsgResponseDescriptor = $convert.base64Decode(
     'ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
 
+@$core.Deprecated('Use getBitNameOwnerRequestDescriptor instead')
+const GetBitNameOwnerRequest$json = {
+  '1': 'GetBitNameOwnerRequest',
+  '2': [
+    {'1': 'bitname', '3': 1, '4': 1, '5': 9, '10': 'bitname'},
+  ],
+};
+
+/// Descriptor for `GetBitNameOwnerRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBitNameOwnerRequestDescriptor = $convert.base64Decode(
+    'ChZHZXRCaXROYW1lT3duZXJSZXF1ZXN0EhgKB2JpdG5hbWUYASABKAlSB2JpdG5hbWU=');
+
+@$core.Deprecated('Use getBitNameOwnerResponseDescriptor instead')
+const GetBitNameOwnerResponse$json = {
+  '1': 'GetBitNameOwnerResponse',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `GetBitNameOwnerResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBitNameOwnerResponseDescriptor = $convert.base64Decode(
+    'ChdHZXRCaXROYW1lT3duZXJSZXNwb25zZRIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
+
+@$core.Deprecated('Use getPendingPaymailRequestDescriptor instead')
+const GetPendingPaymailRequest$json = {
+  '1': 'GetPendingPaymailRequest',
+};
+
+/// Descriptor for `GetPendingPaymailRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getPendingPaymailRequestDescriptor = $convert.base64Decode(
+    'ChhHZXRQZW5kaW5nUGF5bWFpbFJlcXVlc3Q=');
+
+@$core.Deprecated('Use getPendingPaymailResponseDescriptor instead')
+const GetPendingPaymailResponse$json = {
+  '1': 'GetPendingPaymailResponse',
+  '2': [
+    {'1': 'paymail_json', '3': 1, '4': 1, '5': 9, '10': 'paymailJson'},
+    {'1': 'mempool_txids', '3': 2, '4': 3, '5': 9, '10': 'mempoolTxids'},
+  ],
+};
+
+/// Descriptor for `GetPendingPaymailResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getPendingPaymailResponseDescriptor = $convert.base64Decode(
+    'ChlHZXRQZW5kaW5nUGF5bWFpbFJlc3BvbnNlEiEKDHBheW1haWxfanNvbhgBIAEoCVILcGF5bW'
+    'FpbEpzb24SIwoNbWVtcG9vbF90eGlkcxgCIAMoCVIMbWVtcG9vbFR4aWRz');
+
 @$core.Deprecated('Use getPaymailRequestDescriptor instead')
 const GetPaymailRequest$json = {
   '1': 'GetPaymailRequest',
@@ -940,6 +987,8 @@ const $core.Map<$core.String, $core.dynamic> BitnamesServiceBase$json = {
     {'1': 'DecryptMsg', '2': '.bitnames.v1.DecryptMsgRequest', '3': '.bitnames.v1.DecryptMsgResponse'},
     {'1': 'EncryptMsg', '2': '.bitnames.v1.EncryptMsgRequest', '3': '.bitnames.v1.EncryptMsgResponse'},
     {'1': 'GetPaymail', '2': '.bitnames.v1.GetPaymailRequest', '3': '.bitnames.v1.GetPaymailResponse'},
+    {'1': 'GetPendingPaymail', '2': '.bitnames.v1.GetPendingPaymailRequest', '3': '.bitnames.v1.GetPendingPaymailResponse'},
+    {'1': 'GetBitNameOwner', '2': '.bitnames.v1.GetBitNameOwnerRequest', '3': '.bitnames.v1.GetBitNameOwnerResponse'},
     {'1': 'ResolveCommit', '2': '.bitnames.v1.ResolveCommitRequest', '3': '.bitnames.v1.ResolveCommitResponse'},
     {'1': 'ReadCommitment', '2': '.bitnames.v1.ReadCommitmentRequest', '3': '.bitnames.v1.ReadCommitmentResponse'},
     {'1': 'SignArbitraryMsg', '2': '.bitnames.v1.SignArbitraryMsgRequest', '3': '.bitnames.v1.SignArbitraryMsgResponse'},
@@ -1014,6 +1063,10 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BitnamesSe
   '.bitnames.v1.EncryptMsgResponse': EncryptMsgResponse$json,
   '.bitnames.v1.GetPaymailRequest': GetPaymailRequest$json,
   '.bitnames.v1.GetPaymailResponse': GetPaymailResponse$json,
+  '.bitnames.v1.GetPendingPaymailRequest': GetPendingPaymailRequest$json,
+  '.bitnames.v1.GetPendingPaymailResponse': GetPendingPaymailResponse$json,
+  '.bitnames.v1.GetBitNameOwnerRequest': GetBitNameOwnerRequest$json,
+  '.bitnames.v1.GetBitNameOwnerResponse': GetBitNameOwnerResponse$json,
   '.bitnames.v1.ResolveCommitRequest': ResolveCommitRequest$json,
   '.bitnames.v1.ResolveCommitResponse': ResolveCommitResponse$json,
   '.bitnames.v1.ReadCommitmentRequest': ReadCommitmentRequest$json,
@@ -1083,16 +1136,20 @@ final $typed_data.Uint8List bitnamesServiceDescriptor = $convert.base64Decode(
     'MS5EZWNyeXB0TXNnUmVzcG9uc2USTQoKRW5jcnlwdE1zZxIeLmJpdG5hbWVzLnYxLkVuY3J5cH'
     'RNc2dSZXF1ZXN0Gh8uYml0bmFtZXMudjEuRW5jcnlwdE1zZ1Jlc3BvbnNlEk0KCkdldFBheW1h'
     'aWwSHi5iaXRuYW1lcy52MS5HZXRQYXltYWlsUmVxdWVzdBofLmJpdG5hbWVzLnYxLkdldFBheW'
-    '1haWxSZXNwb25zZRJWCg1SZXNvbHZlQ29tbWl0EiEuYml0bmFtZXMudjEuUmVzb2x2ZUNvbW1p'
-    'dFJlcXVlc3QaIi5iaXRuYW1lcy52MS5SZXNvbHZlQ29tbWl0UmVzcG9uc2USWQoOUmVhZENvbW'
-    '1pdG1lbnQSIi5iaXRuYW1lcy52MS5SZWFkQ29tbWl0bWVudFJlcXVlc3QaIy5iaXRuYW1lcy52'
-    'MS5SZWFkQ29tbWl0bWVudFJlc3BvbnNlEl8KEFNpZ25BcmJpdHJhcnlNc2cSJC5iaXRuYW1lcy'
-    '52MS5TaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBolLmJpdG5hbWVzLnYxLlNpZ25BcmJpdHJhcnlN'
-    'c2dSZXNwb25zZRJxChZTaWduQXJiaXRyYXJ5TXNnQXNBZGRyEiouYml0bmFtZXMudjEuU2lnbk'
-    'FyYml0cmFyeU1zZ0FzQWRkclJlcXVlc3QaKy5iaXRuYW1lcy52MS5TaWduQXJiaXRyYXJ5TXNn'
-    'QXNBZGRyUmVzcG9uc2USZQoSR2V0V2FsbGV0QWRkcmVzc2VzEiYuYml0bmFtZXMudjEuR2V0V2'
-    'FsbGV0QWRkcmVzc2VzUmVxdWVzdBonLmJpdG5hbWVzLnYxLkdldFdhbGxldEFkZHJlc3Nlc1Jl'
-    'c3BvbnNlEkQKB015VXR4b3MSGy5iaXRuYW1lcy52MS5NeVV0eG9zUmVxdWVzdBocLmJpdG5hbW'
-    'VzLnYxLk15VXR4b3NSZXNwb25zZRJWCg1PcGVuYXBpU2NoZW1hEiEuYml0bmFtZXMudjEuT3Bl'
-    'bmFwaVNjaGVtYVJlcXVlc3QaIi5iaXRuYW1lcy52MS5PcGVuYXBpU2NoZW1hUmVzcG9uc2U=');
+    '1haWxSZXNwb25zZRJiChFHZXRQZW5kaW5nUGF5bWFpbBIlLmJpdG5hbWVzLnYxLkdldFBlbmRp'
+    'bmdQYXltYWlsUmVxdWVzdBomLmJpdG5hbWVzLnYxLkdldFBlbmRpbmdQYXltYWlsUmVzcG9uc2'
+    'USXAoPR2V0Qml0TmFtZU93bmVyEiMuYml0bmFtZXMudjEuR2V0Qml0TmFtZU93bmVyUmVxdWVz'
+    'dBokLmJpdG5hbWVzLnYxLkdldEJpdE5hbWVPd25lclJlc3BvbnNlElYKDVJlc29sdmVDb21taX'
+    'QSIS5iaXRuYW1lcy52MS5SZXNvbHZlQ29tbWl0UmVxdWVzdBoiLmJpdG5hbWVzLnYxLlJlc29s'
+    'dmVDb21taXRSZXNwb25zZRJZCg5SZWFkQ29tbWl0bWVudBIiLmJpdG5hbWVzLnYxLlJlYWRDb2'
+    '1taXRtZW50UmVxdWVzdBojLmJpdG5hbWVzLnYxLlJlYWRDb21taXRtZW50UmVzcG9uc2USXwoQ'
+    'U2lnbkFyYml0cmFyeU1zZxIkLmJpdG5hbWVzLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXF1ZXN0Gi'
+    'UuYml0bmFtZXMudjEuU2lnbkFyYml0cmFyeU1zZ1Jlc3BvbnNlEnEKFlNpZ25BcmJpdHJhcnlN'
+    'c2dBc0FkZHISKi5iaXRuYW1lcy52MS5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBorLm'
+    'JpdG5hbWVzLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNwb25zZRJlChJHZXRXYWxsZXRB'
+    'ZGRyZXNzZXMSJi5iaXRuYW1lcy52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0GicuYml0bm'
+    'FtZXMudjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVzcG9uc2USRAoHTXlVdHhvcxIbLmJpdG5hbWVz'
+    'LnYxLk15VXR4b3NSZXF1ZXN0GhwuYml0bmFtZXMudjEuTXlVdHhvc1Jlc3BvbnNlElYKDU9wZW'
+    '5hcGlTY2hlbWESIS5iaXRuYW1lcy52MS5PcGVuYXBpU2NoZW1hUmVxdWVzdBoiLmJpdG5hbWVz'
+    'LnYxLk9wZW5hcGlTY2hlbWFSZXNwb25zZQ==');
 

--- a/sidechain_core/lib/gen/bitnames/v1/bitnames.pbserver.dart
+++ b/sidechain_core/lib/gen/bitnames/v1/bitnames.pbserver.dart
@@ -52,6 +52,8 @@ abstract class BitnamesServiceBase extends $pb.GeneratedService {
   $async.Future<$2.DecryptMsgResponse> decryptMsg($pb.ServerContext ctx, $2.DecryptMsgRequest request);
   $async.Future<$2.EncryptMsgResponse> encryptMsg($pb.ServerContext ctx, $2.EncryptMsgRequest request);
   $async.Future<$2.GetPaymailResponse> getPaymail($pb.ServerContext ctx, $2.GetPaymailRequest request);
+  $async.Future<$2.GetPendingPaymailResponse> getPendingPaymail($pb.ServerContext ctx, $2.GetPendingPaymailRequest request);
+  $async.Future<$2.GetBitNameOwnerResponse> getBitNameOwner($pb.ServerContext ctx, $2.GetBitNameOwnerRequest request);
   $async.Future<$2.ResolveCommitResponse> resolveCommit($pb.ServerContext ctx, $2.ResolveCommitRequest request);
   $async.Future<$2.ReadCommitmentResponse> readCommitment($pb.ServerContext ctx, $2.ReadCommitmentRequest request);
   $async.Future<$2.SignArbitraryMsgResponse> signArbitraryMsg($pb.ServerContext ctx, $2.SignArbitraryMsgRequest request);
@@ -93,6 +95,8 @@ abstract class BitnamesServiceBase extends $pb.GeneratedService {
       case 'DecryptMsg': return $2.DecryptMsgRequest();
       case 'EncryptMsg': return $2.EncryptMsgRequest();
       case 'GetPaymail': return $2.GetPaymailRequest();
+      case 'GetPendingPaymail': return $2.GetPendingPaymailRequest();
+      case 'GetBitNameOwner': return $2.GetBitNameOwnerRequest();
       case 'ResolveCommit': return $2.ResolveCommitRequest();
       case 'ReadCommitment': return $2.ReadCommitmentRequest();
       case 'SignArbitraryMsg': return $2.SignArbitraryMsgRequest();
@@ -137,6 +141,8 @@ abstract class BitnamesServiceBase extends $pb.GeneratedService {
       case 'DecryptMsg': return this.decryptMsg(ctx, request as $2.DecryptMsgRequest);
       case 'EncryptMsg': return this.encryptMsg(ctx, request as $2.EncryptMsgRequest);
       case 'GetPaymail': return this.getPaymail(ctx, request as $2.GetPaymailRequest);
+      case 'GetPendingPaymail': return this.getPendingPaymail(ctx, request as $2.GetPendingPaymailRequest);
+      case 'GetBitNameOwner': return this.getBitNameOwner(ctx, request as $2.GetBitNameOwnerRequest);
       case 'ResolveCommit': return this.resolveCommit(ctx, request as $2.ResolveCommitRequest);
       case 'ReadCommitment': return this.readCommitment(ctx, request as $2.ReadCommitmentRequest);
       case 'SignArbitraryMsg': return this.signArbitraryMsg(ctx, request as $2.SignArbitraryMsgRequest);

--- a/sidechain_core/lib/mocks/mocks.dart
+++ b/sidechain_core/lib/mocks/mocks.dart
@@ -1397,6 +1397,16 @@ class MockBitnamesRPC extends BitnamesRPC {
   }
 
   @override
+  Future<String> getBitNameOwner(String bitname) async {
+    return 'mock_bitname_owner_address';
+  }
+
+  @override
+  Future<PendingPaymail> getPendingPaymail() async {
+    return const PendingPaymail(entries: {}, mempoolTxids: {});
+  }
+
+  @override
   Future<Map<String, dynamic>> getPaymail() async {
     return Future.value({'paymail': 'mock_paymail_1234'});
   }

--- a/sidechain_core/lib/rpcs/bitnames_rpc.dart
+++ b/sidechain_core/lib/rpcs/bitnames_rpc.dart
@@ -101,6 +101,13 @@ abstract class BitnamesRPC extends SidechainRPC {
   /// Get all paymail
   Future<Map<String, dynamic>> getPaymail();
 
+  /// Get the paymail that waits in the mempool. A message reaches a BitName one
+  /// block before getPaymail reports it, so a chat reads both.
+  Future<PendingPaymail> getPendingPaymail();
+
+  /// Get the address that holds a BitName. A message pays the holder.
+  Future<String> getBitNameOwner(String bitname);
+
   /// Get wallet addresses, sorted by base58 encoding
   Future<List<String>> getWalletAddresses();
 
@@ -487,6 +494,21 @@ class BitnamesLive extends BitnamesRPC {
   }
 
   @override
+  Future<String> getBitNameOwner(String bitname) async {
+    final resp = await _client.getBitNameOwner(pb.GetBitNameOwnerRequest(bitname: bitname));
+    return resp.address;
+  }
+
+  @override
+  Future<PendingPaymail> getPendingPaymail() async {
+    final resp = await _client.getPendingPaymail(pb.GetPendingPaymailRequest());
+    return PendingPaymail(
+      entries: resp.paymailJson.isEmpty ? {} : jsonDecode(resp.paymailJson) as Map<String, dynamic>,
+      mempoolTxids: resp.mempoolTxids.toSet(),
+    );
+  }
+
+  @override
   Future<Map<String, dynamic>> getPaymail() async {
     final resp = await _client.getPaymail(pb.GetPaymailRequest());
     if (resp.paymailJson.isEmpty) {
@@ -744,6 +766,15 @@ class ResolveCommitResult {
 }
 
 /// A data commitment read from an address, before a BitName holds it.
+/// The messages that wait in the mempool, and every transaction it holds. A
+/// message a caller sent pays the reader, so no paymail feed reports it.
+class PendingPaymail {
+  final Map<String, dynamic> entries;
+  final Set<String> mempoolTxids;
+
+  const PendingPaymail({required this.entries, required this.mempoolTxids});
+}
+
 class ReadCommitmentResult {
   final String dataJson;
   final String commitment;

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.338
+version: 1.0.339
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.209
+version: 1.0.210
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.335
+version: 1.0.336
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Users can read pending BitNames messages with signed sender identities and see the cost before each send. Chat history uses encrypted storage and clears private state on wallet changes. Merge #2286 first.
